### PR TITLE
feat: 配当金・国内株式ページのUI改善と銘柄検索リンク追加

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -44,3 +44,4 @@ coverage
 
 # TypeScript
 *.tsbuildinfo
+.vercel

--- a/frontend/src/components/organisms/ReceiptTable/ReceiptTable.tsx
+++ b/frontend/src/components/organisms/ReceiptTable/ReceiptTable.tsx
@@ -13,27 +13,67 @@ interface ReceiptTableProps<T extends DataItem, S extends SummaryItem> {
     columns: TableColumnConfig[];
     summaryColumns: SummaryColumnConfig[];
     getGroupKey: (item: T) => string;
+    formatGroupHeader?: (key: string) => string;
+    onSearch?: (query: string) => void;
 }
 
 /**
  * 明細表示用テーブルコンポーネント
- * 数値のフォーマットやマイナス値の赤文字表示に対応
- * Context APIを使用してリサイズイベントを受信
  */
+const defaultFormatGroupHeader = (key: string): string => {
+    if (/^\d{4}-\d{2}-\d{2}$/.test(key)) {
+        const date = new Date(key);
+        return `${date.getFullYear()}年${date.getMonth() + 1}月${date.getDate()}日`;
+    }
+    if (/^\d{4}-\d{2}$/.test(key)) {
+        const [year, month] = key.split('-');
+        return `${year}年${parseInt(month, 10)}月`;
+    }
+    if (/^\d{4}$/.test(key)) {
+        return `${key}年`;
+    }
+    return key;
+};
+
+// 件数バッジのスタイル
+const badgeStyle: React.CSSProperties = {
+    display: 'inline-block',
+    background: 'rgba(255, 255, 255, 0.2)',
+    color: 'white',
+    padding: '3px 10px',
+    borderRadius: '4px',
+    fontSize: '0.85em',
+    fontWeight: '600',
+    marginLeft: '12px',
+    verticalAlign: 'middle',
+};
+
 export function ReceiptTable<T extends DataItem, S extends SummaryItem>({
     data,
     summary,
     columns,
     summaryColumns,
-    getGroupKey
+    getGroupKey,
+    formatGroupHeader = defaultFormatGroupHeader,
+    onSearch
 }: ReceiptTableProps<T, S>) {
-    // Context からの forceResize を取得
     const forceResize = useForceResize();
+
+    // テーブル内のクリックイベントをハンドル（銘柄コードリンク用）
+    const handleTableClick = (e: React.MouseEvent<HTMLTableElement>) => {
+        const target = e.target as HTMLElement;
+        if (target.classList.contains('security-code-link') && onSearch) {
+            const searchValue = target.dataset.search;
+            if (searchValue) {
+                onSearch(searchValue);
+            }
+        }
+    };
 
     const renderCell = (value: unknown, column: ColumnConfig, key: string, style?: React.CSSProperties) => {
         const formattedValue = column.format ? column.format(value) : value;
         const isHtml = typeof formattedValue === 'string' && /<[^>]*>/.test(formattedValue);
-        
+
         const cellStyle: React.CSSProperties = {
             width: 'width' in column ? column.width : undefined,
             textAlign: column.textAlign,
@@ -53,7 +93,7 @@ export function ReceiptTable<T extends DataItem, S extends SummaryItem>({
         );
     };
 
-    const renderDataRows = (items: T[], keyPrefix: string) => 
+    const renderDataRows = (items: T[], keyPrefix: string) =>
         items.map((item, itemIndex) => (
             <TableRow key={`${keyPrefix}-${itemIndex}`}>
                 {columns.map((column, colIndex) =>
@@ -62,29 +102,109 @@ export function ReceiptTable<T extends DataItem, S extends SummaryItem>({
             </TableRow>
         ));
 
-    const renderGroupedRows = () => 
+    // サマリー値のフォーマット
+    const formatSummaryValue = (value: unknown, column: SummaryColumnConfig) => {
+        return column.format ? column.format(value) : value;
+    };
+
+    // サマリーのラベルを取得
+    const getSummaryLabel = (key: string): string => {
+        const labels: Record<string, string> = {
+            'total_realized_profit_and_loss': '損益',
+            'dividends_before_tax': '配当',
+            'total_taxes': '税額',
+            'taxes': '税額',
+            'total_realized_profit_and_loss_after_tax': '税引後',
+            'net_amount_received': '受取額',
+        };
+        return labels[key] || key;
+    };
+
+    const renderGroupedRows = () =>
         summary.map((summaryItem, summaryIndex) => {
             const groupItems = data.filter(item => getGroupKey(item) === summaryItem.filter);
-            
+            const headerText = formatGroupHeader(summaryItem.filter);
+            const itemCount = groupItems.length;
+
+            // サマリー値の取得
+            const summaryValues = summaryColumns.map(column => ({
+                key: column.key,
+                label: getSummaryLabel(column.key),
+                value: formatSummaryValue(summaryItem[column.key], column)
+            }));
+
+            // 左側セルのスタイル（年月＋件数）- 検索オプションと同じ青
+            const summaryLeftCellStyle: React.CSSProperties = {
+                padding: '10px 16px',
+                backgroundColor: '#0d6efd',
+                borderLeft: '4px solid #0a58ca',
+                borderTop: summaryIndex > 0 ? '2px solid #3d8bfd' : undefined,
+            };
+
+            // 右側セルのスタイル（サマリー値）
+            const summaryValueCellStyle: React.CSSProperties = {
+                padding: '10px 16px',
+                backgroundColor: '#0d6efd',
+                borderTop: summaryIndex > 0 ? '2px solid #3d8bfd' : undefined,
+                textAlign: 'right',
+                fontWeight: '700',
+                fontSize: '1.05em',
+                color: '#ffffff',
+            };
+
             return (
                 <React.Fragment key={`group-${summaryIndex}`}>
-                    {renderDataRows(groupItems, `item-${summaryIndex}`)}
-                    <TableRow className="table-info">
-                        {summaryColumns.map((column, colIndex) =>
-                            renderCell(
-                                summaryItem[column.key],
-                                column,
-                                `summary-${summaryIndex}-${colIndex}`,
-                                { fontWeight: 'bold' }
-                            )
-                        )}
-                    </TableRow>
+                    {/* グループサマリー行 */}
+                    {summaryColumns.length > 0 && (
+                        <TableRow>
+                            <TableCell
+                                colSpan={columns.length - summaryColumns.length}
+                                style={summaryLeftCellStyle}
+                            >
+                                <span style={{ fontSize: '1.05em', fontWeight: '700', color: '#ffffff' }}>
+                                    {headerText}
+                                </span>
+                                <span style={badgeStyle}>
+                                    {itemCount}件
+                                </span>
+                            </TableCell>
+                            {summaryValues.map((sv, idx) => (
+                                <TableCell key={idx} style={summaryValueCellStyle}>
+                                    {String(sv.value)}
+                                </TableCell>
+                            ))}
+                        </TableRow>
+                    )}
+                    {/* サマリーがない場合のヘッダー */}
+                    {summaryColumns.length === 0 && (
+                        <TableRow>
+                            <TableCell
+                                colSpan={columns.length}
+                                style={summaryLeftCellStyle}
+                            >
+                                <span style={{ fontSize: '1.05em', fontWeight: '700', color: '#ffffff' }}>
+                                    {headerText}
+                                </span>
+                                <span style={badgeStyle}>
+                                    {itemCount}件
+                                </span>
+                            </TableCell>
+                        </TableRow>
+                    )}
+                    {/* 明細行 */}
+                    {groupItems.map((item, itemIndex) => (
+                        <TableRow key={`item-${summaryIndex}-${itemIndex}`}>
+                            {columns.map((column, colIndex) =>
+                                renderCell(item[column.key], column, `item-${summaryIndex}-${itemIndex}-${colIndex}`)
+                            )}
+                        </TableRow>
+                    ))}
                 </React.Fragment>
             );
         });
 
     return (
-        <Table className="mb-0" bordered small responsive forceResize={forceResize}>
+        <Table className="mb-0" bordered small responsive forceResize={forceResize} onClick={handleTableClick}>
             <TableHeader>
                 <TableRow className="table-warning">
                     {columns.map((column, index) => (

--- a/frontend/src/components/organisms/StockInfo.tsx
+++ b/frontend/src/components/organisms/StockInfo.tsx
@@ -31,7 +31,7 @@ export function StockInfo({ stockData }: StockInfoProps) {
   return (
     <div className="stock-info">
       <div className="card mb-4">
-        <div className="card-header bg-info text-white">
+        <div className="card-header bg-primary text-white">
           <h5 className="mb-0">{name} ({code})</h5>
         </div>
         <div className="card-body">

--- a/frontend/src/features/stock/hooks/useStockSearch.ts
+++ b/frontend/src/features/stock/hooks/useStockSearch.ts
@@ -3,9 +3,9 @@ import { useQuery } from '@tanstack/react-query';
 import { fetchStockData } from '../api';
 import { StockData } from '../types';
 
-export function useStockSearch() {
-  const [stockCode, setStockCode] = useState('');
-  const [searchQuery, setSearchQuery] = useState('');
+export function useStockSearch(initialCode?: string) {
+  const [stockCode, setStockCode] = useState(initialCode || '');
+  const [searchQuery, setSearchQuery] = useState(initialCode || '');
 
   const {
     data: stockData,
@@ -23,6 +23,12 @@ export function useStockSearch() {
     setSearchQuery(stockCode);
   };
 
+  // 検索を直接実行（URLパラメータからの自動検索用）
+  const searchByCode = (code: string) => {
+    setStockCode(code);
+    setSearchQuery(code);
+  };
+
   const resetSearch = () => {
     setStockCode('');
     setSearchQuery('');
@@ -36,6 +42,7 @@ export function useStockSearch() {
     isLoading,
     isError,
     handleSearch,
+    searchByCode,
     resetSearch
   };
 }

--- a/frontend/src/lib/interfaces/dividend.ts
+++ b/frontend/src/lib/interfaces/dividend.ts
@@ -5,6 +5,7 @@ export interface DividendData extends ReceiptBase {
     account: string;
     security_code: string;
     security_name: string;
+    security_info: string; // 銘柄コード + 銘柄名の表示用HTML
     unit_price: number;
     shares: number;
     dividends_before_tax: number;

--- a/frontend/src/lib/interfaces/domesticStock.ts
+++ b/frontend/src/lib/interfaces/domesticStock.ts
@@ -4,12 +4,15 @@ export interface DomesticStockData extends ReceiptBase {
     trade_date: Date;
     security_code: string;
     security_name: string;
+    security_info: string; // 銘柄コード + 銘柄名の表示用HTML
     account: string;
     shares: number;
     asked_price: number;
     proceeds: number;
     purchase_price: number;
     realized_profit_and_loss: number;
+    taxes: number;
+    realized_profit_and_loss_after_tax: number;
     // インデックスシグネチャを追加して汎用的なアクセスを許可
     [key: string]: unknown;
 }

--- a/frontend/src/pages/Receipt/Dividend.tsx
+++ b/frontend/src/pages/Receipt/Dividend.tsx
@@ -31,18 +31,28 @@ import {
 import { DividendInfo } from '@/components/molecules/DividendInfo/DividendInfo';
 
 // CSVアイテムをDividendDataに変換
-const parseCsvItem = (item: Record<string, unknown>): DividendData => ({
-    settlement_date: new Date(item['入金日'] as string),
-    product: String(item['商品'] || ''),
-    account: String(item['口座'] || ''),
-    security_code: String(item['銘柄コード'] || ''),
-    security_name: String(item['銘柄'] || ''),
-    unit_price: parseNumber(item['単価[円/現地通貨]']),
-    shares: parseNumber(item['数量[株/口]']),
-    dividends_before_tax: parseNumber(item['配当・分配金合計（税引前）[円/現地通貨]']),
-    taxes: parseNumber(item['税額合計[円/現地通貨]']),
-    net_amount_received: parseNumber(item['受取金額[円/現地通貨]']),
-});
+const parseCsvItem = (item: Record<string, unknown>): DividendData => {
+    const securityCode = String(item['銘柄コード'] || '');
+    const securityName = String(item['銘柄'] || '');
+    // 銘柄コードをリンク形式で表示（/searchページに遷移）
+    const securityCodeLink = `<a href="/search?code=${securityCode}" class="security-code-link" style="color: #0d6efd; font-weight: 600;">${securityCode}</a>`;
+    // security_infoは後方互換性のため残す
+    const securityInfo = securityCodeLink;
+
+    return {
+        settlement_date: new Date(item['入金日'] as string),
+        product: String(item['商品'] || ''),
+        account: String(item['口座'] || ''),
+        security_code: securityCode,
+        security_name: securityName,
+        security_info: securityInfo,
+        unit_price: parseNumber(item['単価[円/現地通貨]']),
+        shares: parseNumber(item['数量[株/口]']),
+        dividends_before_tax: parseNumber(item['配当・分配金合計（税引前）[円/現地通貨]']),
+        taxes: parseNumber(item['税額合計[円/現地通貨]']),
+        net_amount_received: parseNumber(item['受取金額[円/現地通貨]']),
+    };
+};
 
 // 決済日でソート
 const sortBySettlementDate = (data: DividendData[]): DividendData[] => {
@@ -201,19 +211,16 @@ export const Dividend: React.FC<DividendProps> = ({ csvData }) => {
 
     // テーブルカラムの定義（検索タイプに応じて表示順序を調整）
     const baseColumns: TableColumnConfig[] = [
-        { key: 'settlement_date', header: '入金日', format: formatJPDate },
-        { key: 'product', header: '商品' },
-        { key: 'account', header: '口座', width: '100px' },
-        { key: 'security_code', header: '銘柄コード' },
-        { key: 'security_name', header: '銘柄名', width: '250px' },
-        { key: 'unit_price', header: '単価', width: '80px', textAlign: 'right', format: formatCurrency },
-        { key: 'shares', header: '数量[株]', width: '100px', textAlign: 'right', format: formatNumber },
-        { key: 'dividends_before_tax', header: '配当・分配金', width: '150px', textAlign: 'right', format: formatCurrency },
-        { key: 'taxes', header: '税額', width: '100px', textAlign: 'right', format: formatCurrency },
-        { key: 'net_amount_received', header: '受取金額', width: '100px', textAlign: 'right', format: formatCurrency },
-        { key: 'total_dividends_before_tax', header: '合計配当・分配金' },
-        { key: 'total_taxes', header: '合計税額' },
-        { key: 'total_net_amount_received', header: '合計受取金額' }
+        { key: 'settlement_date', header: '入金日', width: '90px', format: formatJPDate },
+        { key: 'product', header: '商品', width: '80px' },
+        { key: 'account', header: '口座', width: '70px' },
+        { key: 'security_info', header: '銘柄コード', width: '80px', textAlign: 'center' },
+        { key: 'security_name', header: '銘柄名', width: '200px' },
+        { key: 'unit_price', header: '単価', width: '70px', textAlign: 'right', format: formatCurrency },
+        { key: 'shares', header: '数量', width: '60px', textAlign: 'right', format: formatNumber },
+        { key: 'dividends_before_tax', header: '配当金', width: '90px', textAlign: 'right', format: formatCurrency },
+        { key: 'taxes', header: '税額', width: '70px', textAlign: 'right', format: formatCurrency },
+        { key: 'net_amount_received', header: '受取額', width: '90px', textAlign: 'right', format: formatCurrency },
     ];
 
     // 検索タイプに応じて重要なカラムを前面に配置

--- a/frontend/src/pages/Receipt/DomesticStock.tsx
+++ b/frontend/src/pages/Receipt/DomesticStock.tsx
@@ -27,18 +27,37 @@ import {
 } from '@/lib/utils/searchUtils';
 
 // CSVアイテムをDomesticStockDataに変換
-const parseCsvItem = (item: Record<string, unknown>): DomesticStockData => ({
-    trade_date: new Date(item['約定日'] as string),
-    settlement_date: new Date(item['受渡日'] as string),
-    security_code: String(item['銘柄コード']),
-    security_name: String(item['銘柄名']),
-    account: String(item['口座']),
-    shares: parseNumber(item['数量[株]']),
-    asked_price: parseNumber(item['売却/決済単価[円]']),
-    proceeds: parseNumber(item['売却/決済額[円]']),
-    purchase_price: parseNumber(item['平均取得価額[円]']),
-    realized_profit_and_loss: parseNumber(item['実現損益[円]']),
-});
+const parseCsvItem = (item: Record<string, unknown>): DomesticStockData => {
+    const account = String(item['口座'] || '');
+    const realizedPnL = parseNumber(item['実現損益[円]']);
+    // 特定口座の場合のみ税金を計算（利益がある場合のみ）
+    const isSpecificAccount = account.includes('特定');
+    const taxes = isSpecificAccount ? Math.floor(Math.max(0, realizedPnL) * TAX_RATE) : 0;
+    const realizedPnLAfterTax = realizedPnL - taxes;
+
+    const securityCode = String(item['銘柄コード']);
+    const securityName = String(item['銘柄名']);
+    // 銘柄コードをリンク形式で表示（/searchページに遷移）
+    const securityCodeLink = `<a href="/search?code=${securityCode}" class="security-code-link" style="color: #0d6efd; font-weight: 600;">${securityCode}</a>`;
+    // security_infoは後方互換性のため残す
+    const securityInfo = securityCodeLink;
+
+    return {
+        trade_date: new Date(item['約定日'] as string),
+        settlement_date: new Date(item['受渡日'] as string),
+        security_code: securityCode,
+        security_name: securityName,
+        security_info: securityInfo,
+        account,
+        shares: parseNumber(item['数量[株]']),
+        asked_price: parseNumber(item['売却/決済単価[円]']),
+        proceeds: parseNumber(item['売却/決済額[円]']),
+        purchase_price: parseNumber(item['平均取得価額[円]']),
+        realized_profit_and_loss: realizedPnL,
+        taxes,
+        realized_profit_and_loss_after_tax: realizedPnLAfterTax,
+    };
+};
 
 // 取引日でソート
 const sortByTradeDate = (data: DomesticStockData[]): DomesticStockData[] => {
@@ -182,20 +201,19 @@ export const DomesticStock: React.FC<DomesticStockProps> = ({ csvData }) => {
     ];
 
     // テーブルカラムの定義（検索タイプに応じて表示順序を調整）
+    // サマリーと一致するよう、最後の3カラムは「実現損益」「税額」「税引後」にする
     const baseColumns: TableColumnConfig[] = [
-        { key: 'trade_date', header: '約定日', format: formatJPDate },
-        { key: 'settlement_date', header: '受渡日', format: formatJPDate },
-        { key: 'security_code', header: '銘柄コード' },
-        { key: 'security_name', header: '銘柄名', width: '250px' },
-        { key: 'account', header: '口座', width: '100px' },
-        { key: 'shares', header: '数量[株]', textAlign: 'right', format: formatNumber },
-        { key: 'asked_price', header: '売却単価', textAlign: 'right', format: formatCurrency },
-        { key: 'proceeds', header: '売却額', textAlign: 'right', format: formatCurrency },
-        { key: 'purchase_price', header: '平均取得価額', textAlign: 'right', format: formatCurrency },
-        { key: 'realized_profit_and_loss', header: '実現損益', textAlign: 'right', format: formatCurrency },
-        { key: 'total_realized_profit_and_loss', header: '合計実現損益' },
-        { key: 'total_taxes', header: '合計税額' },
-        { key: 'total_realized_profit_and_loss_after_tax', header: '合計実現損益(税引)' },
+        { key: 'trade_date', header: '約定日', width: '90px', format: formatJPDate },
+        { key: 'security_info', header: '銘柄コード', width: '80px', textAlign: 'center' },
+        { key: 'security_name', header: '銘柄名', width: '180px' },
+        { key: 'account', header: '口座', width: '70px' },
+        { key: 'shares', header: '数量', width: '60px', textAlign: 'right', format: formatNumber },
+        { key: 'asked_price', header: '売却単価', width: '85px', textAlign: 'right', format: formatCurrency },
+        { key: 'proceeds', header: '売却額', width: '90px', textAlign: 'right', format: formatCurrency },
+        { key: 'purchase_price', header: '取得価額', width: '85px', textAlign: 'right', format: formatCurrency },
+        { key: 'realized_profit_and_loss', header: '損益', width: '90px', textAlign: 'right', format: formatCurrency },
+        { key: 'taxes', header: '税額', width: '70px', textAlign: 'right', format: formatCurrency },
+        { key: 'realized_profit_and_loss_after_tax', header: '税引後', width: '90px', textAlign: 'right', format: formatCurrency },
     ];
 
     // 検索タイプに応じて重要なカラムを前面に配置
@@ -212,9 +230,9 @@ export const DomesticStock: React.FC<DomesticStockProps> = ({ csvData }) => {
         return baseColumns;
     })();
 
-    // サマリーカラムの定義
+    // サマリーカラムの定義（最後の3カラムと一致）
     const summaryColumns: SummaryColumnConfig[] = [
-        { key: 'total_realized_profit_and_loss', colSpan: columns.length - 2, textAlign: 'right', format: formatCurrency },
+        { key: 'total_realized_profit_and_loss', textAlign: 'right', format: formatCurrency },
         { key: 'total_taxes', textAlign: 'right', format: formatCurrency },
         { key: 'total_realized_profit_and_loss_after_tax', textAlign: 'right', format: formatCurrency },
     ];

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -1,9 +1,14 @@
+import { useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { Layout } from '../components/templates/Layout';
 import { SearchForm } from '../components/organisms/SearchForm';
 import { StockInfo } from '../components/organisms/StockInfo';
 import { useStockSearch } from '../features/stock/hooks/useStockSearch';
 
 export function SearchPage() {
+  const [searchParams] = useSearchParams();
+  const codeParam = searchParams.get('code');
+
   const {
     stockCode,
     setStockCode,
@@ -11,8 +16,16 @@ export function SearchPage() {
     error,
     isLoading,
     isError,
-    handleSearch
-  } = useStockSearch();
+    handleSearch,
+    searchByCode
+  } = useStockSearch(codeParam || undefined);
+
+  // URLパラメータが変更された場合に検索を実行
+  useEffect(() => {
+    if (codeParam && codeParam !== stockCode) {
+      searchByCode(codeParam);
+    }
+  }, [codeParam]);
 
   return (
     <Layout>


### PR DESCRIPTION
## 概要
配当金と国内株式ページのUI/UX改善を行いました。

## 変更内容
- 日次/月次サマリー行のデザインを改善（青色テーマに統一）
- サマリー値をヘッダーカラムと一致するよう修正
- 銘柄コードと銘柄名を別カラムに分割
- 銘柄コードをクリックで検索ページに遷移する機能を追加
- 検索ページでURLパラメータ(?code=XXXX)による自動検索に対応
- 国内株式に税額・税引後カラムを追加
- 各種カラム幅を最適化
- 検索結果のヘッダー色を統一（bg-primary）

## 変更種別
- [x] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] その他

## テスト
- [x] ビルド成功確認
- [x] 手動テスト実施

🤖 Generated with [Claude Code](https://claude.com/claude-code)