### PR TITLE
feat: 配当金・国内株式・投資信託のDB取込機能とAgent Skillsを追加

### DIFF
--- a/.claude/skills/backend-api/SKILL.md
+++ b/.claude/skills/backend-api/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: backend-api
+description: |
+  Axum REST API エンドポイントの実装パターン。
+  認証付きCRUD、バリデーション、エラーハンドリング。
+  Use when: API追加、エンドポイント実装、ハンドラー作成を依頼された時。
+---
+
+# バックエンド API 実装
+
+## ハンドラー構造
+
+```rust
+use axum::{extract::State, response::IntoResponse, Json};
+use crate::{
+    errors::ApiError,
+    extractors::auth::AuthenticatedUser,
+    models::YourModel,
+    state::AppState,
+};
+
+pub async fn list(
+    State(state): State<AppState>,
+    auth_user: AuthenticatedUser,
+) -> Result<impl IntoResponse, ApiError> {
+    let items = sqlx::query_as!(
+        YourModel,
+        "SELECT * FROM your_table WHERE user_id = $1",
+        auth_user.id()
+    )
+    .fetch_all(&state.pool)
+    .await?;
+
+    Ok(Json(items))
+}
+```
+
+## ルート登録 (main.rs)
+
+```rust
+use axum::routing::{get, post, delete};
+
+let app = Router::new()
+    .route("/your-route", get(handlers::your::list))
+    .route("/your-route/bulk", post(handlers::your::bulk_create))
+    .route("/your-route/all", delete(handlers::your::delete_all));
+```
+
+## モデル定義
+
+```rust
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct YourModel {
+    pub id: Uuid,
+    #[serde(skip_serializing)]
+    #[allow(dead_code)]
+    pub user_id: Uuid,
+    // 他のフィールド
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateRequest {
+    // リクエストフィールド
+}
+```
+
+## バルク作成（重複スキップ）
+
+```rust
+pub async fn bulk_create(
+    State(state): State<AppState>,
+    auth_user: AuthenticatedUser,
+    Json(payload): Json<BulkCreateRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    let mut inserted = 0;
+    for item in payload.items {
+        let result = sqlx::query!(
+            r#"
+            INSERT INTO your_table (user_id, field1, field2)
+            VALUES ($1, $2, $3)
+            ON CONFLICT DO NOTHING
+            "#,
+            auth_user.id(),
+            item.field1,
+            item.field2
+        )
+        .execute(&state.pool)
+        .await?;
+
+        if result.rows_affected() > 0 {
+            inserted += 1;
+        }
+    }
+
+    Ok(Json(BulkCreateResponse {
+        inserted,
+        total: payload.items.len(),
+    }))
+}
+```

--- a/.claude/skills/backend-build-test/SKILL.md
+++ b/.claude/skills/backend-build-test/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: backend-build-test
+description: |
+  Rust/Axum バックエンドのビルドとテスト実行。
+  cargo fmt, clippy, test, build を実行。
+  Use when: バックエンドのテスト、cargo test、Rustビルドを依頼された時。
+---
+
+# バックエンド ビルド・テスト
+
+## 作業ディレクトリ
+`backend/`
+
+## コマンド
+
+### フォーマットチェック
+```bash
+cd backend && cargo fmt --check
+```
+
+### フォーマット適用
+```bash
+cd backend && cargo fmt
+```
+
+### Lint (Clippy)
+```bash
+cd backend && cargo clippy -- -D warnings
+```
+
+### テスト実行
+```bash
+cd backend && cargo test
+```
+
+### 開発ビルド
+```bash
+cd backend && cargo build
+```
+
+### リリースビルド
+```bash
+cd backend && cargo build --release
+```
+
+## 推奨実行順序
+
+1. `cargo fmt --check` - フォーマット確認
+2. `cargo clippy -- -D warnings` - Lint
+3. `cargo test` - テスト
+4. `cargo build` - ビルド
+
+## よくあるエラー
+
+### 未使用変数警告
+```rust
+#[allow(dead_code)]  // FromRow で使用される場合
+pub field: Type,
+```
+
+### 借用チェッカーエラー
+- `&self` vs `self` の確認
+- ライフタイム注釈の追加
+
+### sqlx コンパイルエラー
+- マイグレーション実行済みか確認
+- DATABASE_URL が正しいか確認

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: commit
+description: |
+  Git コミット作成。日本語コミットメッセージで規約に従う。
+  Use when: コミット、commit、変更をコミットを依頼された時。
+---
+
+# コミット作成
+
+## コミットメッセージ形式
+
+```
+<種別>: <変更内容の要約>
+
+<詳細説明（任意）>
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
+```
+
+## 種別
+
+- `feat`: 新機能
+- `fix`: バグ修正
+- `refactor`: リファクタリング
+- `docs`: ドキュメント
+- `test`: テスト
+- `chore`: ビルド・設定変更
+
+## 手順
+
+1. 変更状況確認
+```bash
+git status
+git diff
+```
+
+2. 最近のコミットスタイル確認
+```bash
+git log --oneline -10
+```
+
+3. ファイルをステージング（個別に追加）
+```bash
+git add <file1> <file2>
+```
+
+4. コミット作成
+```bash
+git commit -m "$(cat <<'EOF'
+feat: 機能の説明
+
+詳細な説明（必要に応じて）
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+## 注意事項
+
+- `git add -A` は避け、ファイルを個別に追加
+- .env, credentials などの機密ファイルをコミットしない
+- pre-commit hook 失敗時は --amend ではなく新規コミット
+- ユーザーが明示的に依頼しない限りコミットしない

--- a/.claude/skills/db-migration/SKILL.md
+++ b/.claude/skills/db-migration/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: db-migration
+description: |
+  PostgreSQL マイグレーションの作成と実行。
+  Use when: マイグレーション、テーブル作成、スキーマ変更を依頼された時。
+---
+
+# データベースマイグレーション
+
+## マイグレーションファイル
+
+### 配置場所
+`backend/migrations/` ディレクトリ
+
+### 命名規則
+```
+NNNN_<説明>.sql
+例: 0004_create_dividends.sql
+```
+
+## 新規テーブル作成テンプレート
+
+```sql
+-- マイグレーション: テーブル名の説明
+CREATE TABLE IF NOT EXISTS table_name (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    -- 他のカラム
+);
+
+-- インデックス
+CREATE INDEX IF NOT EXISTS idx_table_name_user_id ON table_name(user_id);
+
+-- ユニーク制約（重複防止用）
+CREATE UNIQUE INDEX IF NOT EXISTS idx_table_name_unique
+ON table_name(user_id, some_column);
+```
+
+## 型マッピング
+
+| Rust | PostgreSQL |
+|------|------------|
+| Uuid | UUID |
+| String | TEXT / VARCHAR |
+| i32 | INTEGER |
+| i64 | BIGINT |
+| f64 | DOUBLE PRECISION |
+| NaiveDate | DATE |
+| DateTime<Utc> | TIMESTAMPTZ |
+| bool | BOOLEAN |
+
+## マイグレーション実行
+
+Shuttle は起動時に自動実行。ローカルでは：
+```bash
+sqlx migrate run
+```
+
+## 注意事項
+
+- 本番DBに影響する変更は慎重に
+- DROP TABLE は避け、必要なら別マイグレーションで
+- 外部キー制約で `ON DELETE CASCADE` を適切に使用

--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: deploy
+description: |
+  Fly.io (backend) と Vercel (frontend) へのデプロイ。
+  Use when: デプロイ、本番反映、fly deploy を依頼された時。
+---
+
+# デプロイ
+
+## バックエンド (Fly.io)
+
+### 自動デプロイ
+- `main` ブランチへの push で自動デプロイ（GitHub Actions）
+- `backend/**` の変更時のみトリガー
+
+### 手動デプロイ
+```bash
+cd backend && flyctl deploy --remote-only
+```
+
+### 確認
+```bash
+flyctl status
+flyctl logs
+```
+
+## フロントエンド (Vercel)
+
+### 自動デプロイ
+- `main` ブランチへのマージで自動デプロイ
+- PR作成時にプレビューデプロイ
+
+### 手動デプロイ（必要な場合）
+```bash
+cd frontend && vercel --prod
+```
+
+## デプロイ前チェックリスト
+
+- [ ] テストがすべてパス
+- [ ] ビルドが成功
+- [ ] 環境変数が正しく設定されている
+- [ ] マイグレーションが必要な場合は先に実行
+
+## ロールバック
+
+### Fly.io
+```bash
+flyctl releases list
+flyctl deploy --image <previous-image>
+```
+
+### Vercel
+Vercel ダッシュボードから以前のデプロイを選択して再デプロイ

--- a/.claude/skills/frontend-api/SKILL.md
+++ b/.claude/skills/frontend-api/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: frontend-api
+description: |
+  React フロントエンドの API クライアント実装パターン。
+  axios、型定義、認証付きリクエスト。
+  Use when: API呼び出し、フェッチ処理、APIクライアント作成を依頼された時。
+---
+
+# フロントエンド API 実装
+
+## API クライアント構造
+
+```typescript
+// api/yourApi.ts
+import { apiClient } from '@/lib/apiClient';
+
+export interface YourData {
+  id: string;
+  field1: string;
+  field2: number;
+}
+
+export interface BulkCreateResponse {
+  inserted: number;
+  total: number;
+}
+
+export const yourApi = {
+  list: () =>
+    apiClient.get<YourData[]>('/your-route', { withCredentials: true }),
+
+  bulkCreate: (items: Omit<YourData, 'id'>[]) =>
+    apiClient.post<BulkCreateResponse>(
+      '/your-route/bulk',
+      { items },
+      { withCredentials: true }
+    ),
+
+  deleteAll: () =>
+    apiClient.delete('/your-route/all', { withCredentials: true }),
+};
+```
+
+## データ取得フック
+
+```typescript
+// hooks/useYourData.ts
+import { useState, useEffect } from 'react';
+import { yourApi, YourData } from '@/api/yourApi';
+import { useAuth } from '@/hooks/useAuth';
+
+export function useYourData() {
+  const { isAuthenticated } = useAuth();
+  const [data, setData] = useState<YourData[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+
+    const fetchData = async () => {
+      setLoading(true);
+      try {
+        const response = await yourApi.list();
+        setData(response.data);
+      } catch (e) {
+        setError('データの取得に失敗しました');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [isAuthenticated]);
+
+  return { data, loading, error, setData };
+}
+```
+
+## 日付変換
+
+```typescript
+// DB から取得した日付文字列を Date に変換
+export function transformDBData(dbItem: DBYourData): YourData {
+  return {
+    ...dbItem,
+    date: new Date(dbItem.date),
+  };
+}
+```
+
+## withCredentials
+
+認証が必要なリクエストには必ず `withCredentials: true` を付与。
+Cookie ベースのセッション認証で必要。

--- a/.claude/skills/frontend-build-test/SKILL.md
+++ b/.claude/skills/frontend-build-test/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: frontend-build-test
+description: |
+  React/TypeScript フロントエンドのビルドとテスト実行。
+  npm lint, tsc, test, build を実行。
+  Use when: フロントエンドのテスト、npm test、TypeScriptビルドを依頼された時。
+---
+
+# フロントエンド ビルド・テスト
+
+## 作業ディレクトリ
+`frontend/`
+
+## コマンド
+
+### 依存関係インストール
+```bash
+cd frontend && npm install
+```
+
+### Lint
+```bash
+cd frontend && npm run lint
+```
+
+### Lint 自動修正
+```bash
+cd frontend && npm run lint -- --fix
+```
+
+### 型チェック
+```bash
+cd frontend && npx tsc --noEmit
+```
+
+### テスト実行
+```bash
+cd frontend && npm test
+```
+
+### 開発サーバー起動
+```bash
+cd frontend && npm run dev
+```
+
+### 本番ビルド
+```bash
+cd frontend && npm run build
+```
+
+## 推奨実行順序
+
+1. `npm run lint` - Lint
+2. `npx tsc --noEmit` - 型チェック
+3. `npm test` - テスト
+4. `npm run build` - ビルド
+
+## よくあるエラー
+
+### 型エラー
+- `as` キャストより型ガードを優先
+- `unknown` 型には型アサーションが必要
+
+### インポートエラー
+- パスエイリアス `@/` の確認
+- 拡張子 `.ts` / `.tsx` の確認
+
+### React Hook エラー
+- `useEffect` の依存配列確認
+- `useMemo` / `useCallback` の適切な使用

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: pr-workflow
+description: |
+  コミット分割とPR作成のワークフロー。
+  機能ごとにコミットを分け、PRを作成する。
+  Use when: コミット、PR作成、プルリクエストを依頼された時。
+---
+
+# PR ワークフロー
+
+## コミット分割の原則
+
+1. **機能単位で分割** - 1コミット = 1機能
+2. **共通基盤は最初のコミットに含める**
+3. **統合ファイルは最後のコミットに含める**
+
+## 分割例（複数機能追加時）
+
+```
+1. 共通基盤 + 機能A
+   - 認証エクストラクター、APIクライアント基盤
+   - 機能A固有ファイル
+
+2. 機能B
+   - 機能B固有ファイル
+
+3. 機能C + 統合
+   - 機能C固有ファイル
+   - main.rs、handlers.rs などの統合ファイル
+```
+
+## コミット手順
+
+```bash
+# 1. 変更状況確認
+git status
+git diff
+
+# 2. 機能ごとにステージング・コミット
+git add <files>
+git commit -m "$(cat <<'EOF'
+feat: 機能の説明
+
+- 変更点1
+- 変更点2
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
+EOF
+)"
+
+# 3. 繰り返し
+```
+
+## PR作成手順
+
+```bash
+# 1. プッシュ
+git push origin <branch>
+
+# 2. PR作成
+gh pr create --base main --head <branch> --title "タイトル" --body "$(cat <<'EOF'
+## 概要
+変更内容の説明
+
+## 変更種別
+- [x] 新機能
+- [ ] バグ修正
+
+## 主な変更内容
+- 項目1
+- 項目2
+
+## テスト
+- [x] テスト実行確認
+- [x] ビルド確認
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+## よくあるパターン
+
+### Skills + 機能追加
+```
+1. feat: Agent Skills を追加
+2. feat: 機能AのDB取込機能を追加
+3. feat: 機能BのDB取込機能を追加
+4. feat: 機能CのDB取込機能を追加
+```
+
+### リファクタリング + 機能追加
+```
+1. refactor: 共通処理を抽出
+2. feat: 新機能を追加
+```
+
+## 注意事項
+
+- ユーザーが明示的に依頼しない限りコミット・PRを作成しない
+- `git add -A` は避け、ファイルを個別に追加
+- 機密ファイル（.env等）をコミットしない

--- a/.claude/skills/security-review/SKILL.md
+++ b/.claude/skills/security-review/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: security-review
+description: |
+  OWASP API Security Top 10 に基づくセキュリティレビュー。
+  認証・認可、入力検証、機密情報管理をチェック。
+  Use when: セキュリティレビュー、脆弱性チェック、認証関連を依頼された時。
+---
+
+# セキュリティレビュー
+
+## チェック項目
+
+### 1. 認証・認可
+- [ ] エンドポイントに適切な認証チェックがあるか
+- [ ] AuthenticatedUser extractor が正しく使用されているか
+- [ ] セッション管理が適切か
+
+### 2. 入力検証
+- [ ] ユーザー入力のバリデーションが実装されているか
+- [ ] SQLインジェクション対策（パラメータバインディング使用）
+- [ ] XSS対策（出力エスケープ）
+
+### 3. 機密情報管理
+- [ ] APIキー、シークレットがハードコードされていないか
+- [ ] .env ファイルが .gitignore に含まれているか
+- [ ] ログに機密情報が出力されていないか
+
+### 4. CORS設定
+- [ ] 本番環境で適切なオリジンのみ許可されているか
+
+### 5. エラーハンドリング
+- [ ] スタックトレースがユーザーに露出していないか
+- [ ] エラーメッセージが過度に詳細でないか
+
+## 確認コマンド
+
+### 機密情報の検索
+```bash
+grep -r "password\|secret\|api_key\|token" --include="*.rs" --include="*.ts" --include="*.tsx" | grep -v "test\|\.d\.ts"
+```
+
+### ハードコードされた認証情報
+```bash
+grep -rn "Bearer \|Authorization:" --include="*.rs" --include="*.ts"
+```
+
+## 参考: OWASP API Security Top 10
+
+1. Broken Object Level Authorization
+2. Broken Authentication
+3. Broken Object Property Level Authorization
+4. Unrestricted Resource Consumption
+5. Broken Function Level Authorization
+6. Unrestricted Access to Sensitive Business Flows
+7. Server Side Request Forgery
+8. Security Misconfiguration
+9. Improper Inventory Management
+10. Unsafe Consumption of APIs

--- a/backend/migrations/0004_create_dividends.sql
+++ b/backend/migrations/0004_create_dividends.sql
@@ -1,0 +1,24 @@
+-- 配当金テーブルを作成
+CREATE TABLE IF NOT EXISTS dividends (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    settlement_date DATE NOT NULL,
+    product VARCHAR(100) NOT NULL,
+    account VARCHAR(100) NOT NULL,
+    security_code VARCHAR(10) NOT NULL,
+    security_name VARCHAR(200) NOT NULL,
+    unit_price DOUBLE PRECISION NOT NULL,
+    shares DOUBLE PRECISION NOT NULL,
+    dividends_before_tax DOUBLE PRECISION NOT NULL,
+    taxes DOUBLE PRECISION NOT NULL,
+    net_amount_received DOUBLE PRECISION NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ユーザーごとのデータ取得用インデックス
+CREATE INDEX IF NOT EXISTS idx_dividends_user_id ON dividends (user_id);
+
+-- 重複判定用ユニーク制約
+CREATE UNIQUE INDEX IF NOT EXISTS idx_dividends_unique
+    ON dividends (user_id, settlement_date, security_code, shares, dividends_before_tax);

--- a/backend/migrations/0005_create_domestic_stocks.sql
+++ b/backend/migrations/0005_create_domestic_stocks.sql
@@ -1,0 +1,26 @@
+-- 国内株式取引テーブルを作成
+CREATE TABLE IF NOT EXISTS domestic_stocks (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    trade_date DATE NOT NULL,
+    settlement_date DATE NOT NULL,
+    security_code VARCHAR(10) NOT NULL,
+    security_name VARCHAR(200) NOT NULL,
+    account VARCHAR(100) NOT NULL,
+    shares DOUBLE PRECISION NOT NULL,
+    asked_price DOUBLE PRECISION NOT NULL,
+    proceeds DOUBLE PRECISION NOT NULL,
+    purchase_price DOUBLE PRECISION NOT NULL,
+    realized_profit_and_loss DOUBLE PRECISION NOT NULL,
+    taxes DOUBLE PRECISION NOT NULL,
+    realized_profit_and_loss_after_tax DOUBLE PRECISION NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ユーザーごとのデータ取得用インデックス
+CREATE INDEX IF NOT EXISTS idx_domestic_stocks_user_id ON domestic_stocks (user_id);
+
+-- 重複判定用ユニーク制約
+CREATE UNIQUE INDEX IF NOT EXISTS idx_domestic_stocks_unique
+    ON domestic_stocks (user_id, trade_date, security_code, shares, proceeds);

--- a/backend/migrations/0006_create_mutualfunds.sql
+++ b/backend/migrations/0006_create_mutualfunds.sql
@@ -1,0 +1,27 @@
+-- 投資信託テーブルを作成
+CREATE TABLE IF NOT EXISTS mutualfunds (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    trade_date DATE NOT NULL,
+    settlement_date DATE NOT NULL,
+    fund_name VARCHAR(300) NOT NULL,
+    dividends VARCHAR(100),
+    account VARCHAR(100) NOT NULL,
+    shares DOUBLE PRECISION NOT NULL,
+    exchange_rate DOUBLE PRECISION NOT NULL,
+    cancellation_unit_price_yen DOUBLE PRECISION NOT NULL,
+    cancellation_amount_yen DOUBLE PRECISION NOT NULL,
+    average_acquisition_price_yen DOUBLE PRECISION NOT NULL,
+    realized_profit_and_loss DOUBLE PRECISION NOT NULL,
+    taxes DOUBLE PRECISION NOT NULL,
+    realized_profit_and_loss_after_tax DOUBLE PRECISION NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ユーザーごとのデータ取得用インデックス
+CREATE INDEX IF NOT EXISTS idx_mutualfunds_user_id ON mutualfunds (user_id);
+
+-- 重複判定用ユニーク制約
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mutualfunds_unique
+    ON mutualfunds (user_id, trade_date, fund_name, shares, cancellation_amount_yen);

--- a/backend/src/extractors.rs
+++ b/backend/src/extractors.rs
@@ -1,2 +1,3 @@
+pub mod auth;
 pub mod char_width_converter;
 pub mod validated_json;

--- a/backend/src/extractors/auth.rs
+++ b/backend/src/extractors/auth.rs
@@ -1,0 +1,76 @@
+use crate::errors::ApiError;
+use crate::models::user::User;
+use crate::state::AppState;
+use axum::extract::FromRef;
+use axum_extra::extract::CookieJar;
+
+const SESSION_COOKIE_NAME: &str = "session_token";
+
+/// 認証済みユーザーを表すエクストラクター
+/// ハンドラーの引数に指定することで、認証チェックを自動的に行う
+#[derive(Debug, Clone)]
+pub struct AuthenticatedUser(pub User);
+
+impl AuthenticatedUser {
+    /// ユーザーIDを取得
+    pub fn id(&self) -> uuid::Uuid {
+        self.0.id
+    }
+}
+
+impl<S> axum::extract::FromRequestParts<S> for AuthenticatedUser
+where
+    AppState: FromRef<S>,
+    S: Send + Sync,
+{
+    type Rejection = ApiError;
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        state: &S,
+    ) -> Result<Self, Self::Rejection> {
+        let app_state = AppState::from_ref(state);
+
+        // CookieJarを取得
+        let jar = CookieJar::from_request_parts(parts, state)
+            .await
+            .map_err(|_| ApiError::Unauthorized("Cookieの取得に失敗しました".to_string()))?;
+
+        // セッショントークンを取得
+        let session_token = jar
+            .get(SESSION_COOKIE_NAME)
+            .map(|c| c.value().to_string())
+            .ok_or_else(|| ApiError::Unauthorized("ログインが必要です".to_string()))?;
+
+        // セッションIDをパース
+        let session_id: uuid::Uuid = session_token
+            .parse()
+            .map_err(|_| ApiError::Unauthorized("無効なセッショントークンです".to_string()))?;
+
+        // セッションテーブルからユーザーを取得（期限切れでないセッションのみ）
+        let user = sqlx::query_as::<_, User>(
+            r#"
+            SELECT u.id, u.google_id, u.email, u.name, u.picture_url, u.created_at, u.updated_at
+            FROM users u
+            INNER JOIN sessions s ON u.id = s.user_id
+            WHERE s.id = $1 AND s.expires_at > NOW()
+            "#,
+        )
+        .bind(session_id)
+        .fetch_optional(&app_state.pool)
+        .await
+        .map_err(|_| ApiError::Unauthorized("セッション検証に失敗しました".to_string()))?
+        .ok_or_else(|| ApiError::Unauthorized("セッションが無効または期限切れです".to_string()))?;
+
+        Ok(AuthenticatedUser(user))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_module_compilation() {
+        // モジュールが正常にコンパイルされることを確認
+        assert!(true);
+    }
+}

--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -1,3 +1,6 @@
 pub mod auth;
+pub mod dividend;
+pub mod domestic_stock;
 pub mod jquants;
+pub mod mutualfund;
 pub mod stock;

--- a/backend/src/handlers/dividend.rs
+++ b/backend/src/handlers/dividend.rs
@@ -1,0 +1,102 @@
+use crate::{
+    errors::ApiError,
+    extractors::auth::AuthenticatedUser,
+    extractors::validated_json::ValidatedJson,
+    models::dividend::{BulkCreateDividendRequest, BulkCreateResponse, Dividend},
+    state::AppState,
+};
+use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
+
+/// 認証ユーザーの配当金一覧を取得
+pub async fn list(
+    State(state): State<AppState>,
+    auth_user: AuthenticatedUser,
+) -> Result<impl IntoResponse, ApiError> {
+    let dividends = sqlx::query_as::<_, Dividend>(
+        r#"
+        SELECT id, user_id, settlement_date, product, account, security_code, security_name,
+               unit_price, shares, dividends_before_tax, taxes, net_amount_received,
+               created_at, updated_at
+        FROM dividends
+        WHERE user_id = $1
+        ORDER BY settlement_date DESC
+        "#,
+    )
+    .bind(auth_user.id())
+    .fetch_all(&state.pool)
+    .await?;
+
+    Ok((StatusCode::OK, Json(dividends)))
+}
+
+/// 配当金を一括追加（重複はスキップ）
+pub async fn bulk_create(
+    State(state): State<AppState>,
+    auth_user: AuthenticatedUser,
+    ValidatedJson(data): ValidatedJson<BulkCreateDividendRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    let user_id = auth_user.id();
+    let mut inserted = 0;
+    let mut skipped = 0;
+
+    for item in data.items {
+        let result = sqlx::query(
+            r#"
+            INSERT INTO dividends (user_id, settlement_date, product, account, security_code,
+                                   security_name, unit_price, shares, dividends_before_tax,
+                                   taxes, net_amount_received)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+            ON CONFLICT (user_id, settlement_date, security_code, shares, dividends_before_tax)
+            DO NOTHING
+            "#,
+        )
+        .bind(user_id)
+        .bind(item.settlement_date)
+        .bind(&item.product)
+        .bind(&item.account)
+        .bind(&item.security_code)
+        .bind(&item.security_name)
+        .bind(item.unit_price)
+        .bind(item.shares)
+        .bind(item.dividends_before_tax)
+        .bind(item.taxes)
+        .bind(item.net_amount_received)
+        .execute(&state.pool)
+        .await?;
+
+        if result.rows_affected() > 0 {
+            inserted += 1;
+        } else {
+            skipped += 1;
+        }
+    }
+
+    Ok((
+        StatusCode::CREATED,
+        Json(BulkCreateResponse { inserted, skipped }),
+    ))
+}
+
+/// 認証ユーザーの配当金を全削除
+pub async fn delete_all(
+    State(state): State<AppState>,
+    auth_user: AuthenticatedUser,
+) -> Result<impl IntoResponse, ApiError> {
+    sqlx::query("DELETE FROM dividends WHERE user_id = $1")
+        .bind(auth_user.id())
+        .execute(&state.pool)
+        .await?;
+
+    Ok((
+        StatusCode::OK,
+        Json(serde_json::json!({"message": "全ての配当金データを削除しました"})),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_module_compilation() {
+        assert!(true);
+    }
+}

--- a/backend/src/handlers/domestic_stock.rs
+++ b/backend/src/handlers/domestic_stock.rs
@@ -1,0 +1,107 @@
+use crate::{
+    errors::ApiError,
+    extractors::auth::AuthenticatedUser,
+    extractors::validated_json::ValidatedJson,
+    models::dividend::BulkCreateResponse,
+    models::domestic_stock::{BulkCreateDomesticStockRequest, DomesticStock},
+    state::AppState,
+};
+use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
+
+/// 認証ユーザーの国内株式取引一覧を取得
+pub async fn list(
+    State(state): State<AppState>,
+    auth_user: AuthenticatedUser,
+) -> Result<impl IntoResponse, ApiError> {
+    let stocks = sqlx::query_as::<_, DomesticStock>(
+        r#"
+        SELECT id, user_id, trade_date, settlement_date, security_code, security_name,
+               account, shares, asked_price, proceeds, purchase_price,
+               realized_profit_and_loss, taxes, realized_profit_and_loss_after_tax,
+               created_at, updated_at
+        FROM domestic_stocks
+        WHERE user_id = $1
+        ORDER BY trade_date DESC
+        "#,
+    )
+    .bind(auth_user.id())
+    .fetch_all(&state.pool)
+    .await?;
+
+    Ok((StatusCode::OK, Json(stocks)))
+}
+
+/// 国内株式取引を一括追加（重複はスキップ）
+pub async fn bulk_create(
+    State(state): State<AppState>,
+    auth_user: AuthenticatedUser,
+    ValidatedJson(data): ValidatedJson<BulkCreateDomesticStockRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    let user_id = auth_user.id();
+    let mut inserted = 0;
+    let mut skipped = 0;
+
+    for item in data.items {
+        let result = sqlx::query(
+            r#"
+            INSERT INTO domestic_stocks (user_id, trade_date, settlement_date, security_code,
+                                         security_name, account, shares, asked_price, proceeds,
+                                         purchase_price, realized_profit_and_loss, taxes,
+                                         realized_profit_and_loss_after_tax)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+            ON CONFLICT (user_id, trade_date, security_code, shares, proceeds)
+            DO NOTHING
+            "#,
+        )
+        .bind(user_id)
+        .bind(item.trade_date)
+        .bind(item.settlement_date)
+        .bind(&item.security_code)
+        .bind(&item.security_name)
+        .bind(&item.account)
+        .bind(item.shares)
+        .bind(item.asked_price)
+        .bind(item.proceeds)
+        .bind(item.purchase_price)
+        .bind(item.realized_profit_and_loss)
+        .bind(item.taxes)
+        .bind(item.realized_profit_and_loss_after_tax)
+        .execute(&state.pool)
+        .await?;
+
+        if result.rows_affected() > 0 {
+            inserted += 1;
+        } else {
+            skipped += 1;
+        }
+    }
+
+    Ok((
+        StatusCode::CREATED,
+        Json(BulkCreateResponse { inserted, skipped }),
+    ))
+}
+
+/// 認証ユーザーの国内株式取引を全削除
+pub async fn delete_all(
+    State(state): State<AppState>,
+    auth_user: AuthenticatedUser,
+) -> Result<impl IntoResponse, ApiError> {
+    sqlx::query("DELETE FROM domestic_stocks WHERE user_id = $1")
+        .bind(auth_user.id())
+        .execute(&state.pool)
+        .await?;
+
+    Ok((
+        StatusCode::OK,
+        Json(serde_json::json!({"message": "全ての国内株式取引データを削除しました"})),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_module_compilation() {
+        assert!(true);
+    }
+}

--- a/backend/src/handlers/mutualfund.rs
+++ b/backend/src/handlers/mutualfund.rs
@@ -1,0 +1,108 @@
+use crate::{
+    errors::ApiError,
+    extractors::auth::AuthenticatedUser,
+    extractors::validated_json::ValidatedJson,
+    models::dividend::BulkCreateResponse,
+    models::mutualfund::{BulkCreateMutualfundRequest, Mutualfund},
+    state::AppState,
+};
+use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
+
+/// 認証ユーザーの投資信託一覧を取得
+pub async fn list(
+    State(state): State<AppState>,
+    auth_user: AuthenticatedUser,
+) -> Result<impl IntoResponse, ApiError> {
+    let funds = sqlx::query_as::<_, Mutualfund>(
+        r#"
+        SELECT id, user_id, trade_date, settlement_date, fund_name, dividends, account,
+               shares, exchange_rate, cancellation_unit_price_yen, cancellation_amount_yen,
+               average_acquisition_price_yen, realized_profit_and_loss, taxes,
+               realized_profit_and_loss_after_tax, created_at, updated_at
+        FROM mutualfunds
+        WHERE user_id = $1
+        ORDER BY trade_date DESC
+        "#,
+    )
+    .bind(auth_user.id())
+    .fetch_all(&state.pool)
+    .await?;
+
+    Ok((StatusCode::OK, Json(funds)))
+}
+
+/// 投資信託を一括追加（重複はスキップ）
+pub async fn bulk_create(
+    State(state): State<AppState>,
+    auth_user: AuthenticatedUser,
+    ValidatedJson(data): ValidatedJson<BulkCreateMutualfundRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    let user_id = auth_user.id();
+    let mut inserted = 0;
+    let mut skipped = 0;
+
+    for item in data.items {
+        let result = sqlx::query(
+            r#"
+            INSERT INTO mutualfunds (user_id, trade_date, settlement_date, fund_name, dividends,
+                                     account, shares, exchange_rate, cancellation_unit_price_yen,
+                                     cancellation_amount_yen, average_acquisition_price_yen,
+                                     realized_profit_and_loss, taxes, realized_profit_and_loss_after_tax)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+            ON CONFLICT (user_id, trade_date, fund_name, shares, cancellation_amount_yen)
+            DO NOTHING
+            "#,
+        )
+        .bind(user_id)
+        .bind(item.trade_date)
+        .bind(item.settlement_date)
+        .bind(&item.fund_name)
+        .bind(&item.dividends)
+        .bind(&item.account)
+        .bind(item.shares)
+        .bind(item.exchange_rate)
+        .bind(item.cancellation_unit_price_yen)
+        .bind(item.cancellation_amount_yen)
+        .bind(item.average_acquisition_price_yen)
+        .bind(item.realized_profit_and_loss)
+        .bind(item.taxes)
+        .bind(item.realized_profit_and_loss_after_tax)
+        .execute(&state.pool)
+        .await?;
+
+        if result.rows_affected() > 0 {
+            inserted += 1;
+        } else {
+            skipped += 1;
+        }
+    }
+
+    Ok((
+        StatusCode::CREATED,
+        Json(BulkCreateResponse { inserted, skipped }),
+    ))
+}
+
+/// 認証ユーザーの投資信託を全削除
+pub async fn delete_all(
+    State(state): State<AppState>,
+    auth_user: AuthenticatedUser,
+) -> Result<impl IntoResponse, ApiError> {
+    sqlx::query("DELETE FROM mutualfunds WHERE user_id = $1")
+        .bind(auth_user.id())
+        .execute(&state.pool)
+        .await?;
+
+    Ok((
+        StatusCode::OK,
+        Json(serde_json::json!({"message": "全ての投資信託データを削除しました"})),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_module_compilation() {
+        assert!(true);
+    }
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -7,7 +7,7 @@ mod services;
 mod state;
 
 use axum::{
-    routing::{get, post},
+    routing::{delete, get, post},
     Router,
 };
 use config::Config;
@@ -75,6 +75,18 @@ async fn main() {
         .route("/auth/google/callback", get(handlers::auth::google_callback))
         .route("/auth/me", get(handlers::auth::get_current_user))
         .route("/auth/logout", post(handlers::auth::logout))
+        // 配当金エンドポイント
+        .route("/dividends", get(handlers::dividend::list))
+        .route("/dividends/bulk", post(handlers::dividend::bulk_create))
+        .route("/dividends/all", delete(handlers::dividend::delete_all))
+        // 国内株式エンドポイント
+        .route("/domestic-stocks", get(handlers::domestic_stock::list))
+        .route("/domestic-stocks/bulk", post(handlers::domestic_stock::bulk_create))
+        .route("/domestic-stocks/all", delete(handlers::domestic_stock::delete_all))
+        // 投資信託エンドポイント
+        .route("/mutualfunds", get(handlers::mutualfund::list))
+        .route("/mutualfunds/bulk", post(handlers::mutualfund::bulk_create))
+        .route("/mutualfunds/all", delete(handlers::mutualfund::delete_all))
         // ヘルスチェック
         .route("/health", get(|| async { "OK" }))
         .layer(cors)

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -1,3 +1,6 @@
+pub mod dividend;
+pub mod domestic_stock;
 pub mod jquants;
+pub mod mutualfund;
 pub mod stock;
 pub mod user;

--- a/backend/src/models/dividend.rs
+++ b/backend/src/models/dividend.rs
@@ -1,0 +1,82 @@
+use chrono::{DateTime, NaiveDate, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+use uuid::Uuid;
+use validator::Validate;
+
+/// 配当金モデル（DB + APIレスポンス兼用）
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct Dividend {
+    pub id: Uuid,
+    #[serde(skip_serializing)]
+    #[allow(dead_code)]
+    pub user_id: Uuid,
+    pub settlement_date: NaiveDate,
+    pub product: String,
+    pub account: String,
+    pub security_code: String,
+    pub security_name: String,
+    pub unit_price: f64,
+    pub shares: f64,
+    pub dividends_before_tax: f64,
+    pub taxes: f64,
+    pub net_amount_received: f64,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// 配当金作成リクエスト
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+pub struct CreateDividendRequest {
+    pub settlement_date: NaiveDate,
+    #[validate(length(min = 1, max = 100))]
+    pub product: String,
+    #[validate(length(min = 1, max = 100))]
+    pub account: String,
+    #[validate(length(min = 1, max = 10))]
+    pub security_code: String,
+    #[validate(length(min = 1, max = 200))]
+    pub security_name: String,
+    pub unit_price: f64,
+    pub shares: f64,
+    pub dividends_before_tax: f64,
+    pub taxes: f64,
+    pub net_amount_received: f64,
+}
+
+/// 配当金一括作成リクエスト
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+pub struct BulkCreateDividendRequest {
+    #[validate(length(min = 1))]
+    pub items: Vec<CreateDividendRequest>,
+}
+
+/// 一括作成レスポンス
+#[derive(Debug, Clone, Serialize)]
+pub struct BulkCreateResponse {
+    pub inserted: usize,
+    pub skipped: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_dividend_request_validation() {
+        let request = CreateDividendRequest {
+            settlement_date: NaiveDate::from_ymd_opt(2024, 1, 15).unwrap(),
+            product: "国内株式".to_string(),
+            account: "特定".to_string(),
+            security_code: "1234".to_string(),
+            security_name: "テスト株式会社".to_string(),
+            unit_price: 100.0,
+            shares: 100.0,
+            dividends_before_tax: 1000.0,
+            taxes: 200.0,
+            net_amount_received: 800.0,
+        };
+
+        assert!(request.validate().is_ok());
+    }
+}

--- a/backend/src/models/domestic_stock.rs
+++ b/backend/src/models/domestic_stock.rs
@@ -1,0 +1,80 @@
+use chrono::{DateTime, NaiveDate, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+use uuid::Uuid;
+use validator::Validate;
+
+/// 国内株式取引モデル（DB + APIレスポンス兼用）
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct DomesticStock {
+    pub id: Uuid,
+    #[serde(skip_serializing)]
+    #[allow(dead_code)]
+    pub user_id: Uuid,
+    pub trade_date: NaiveDate,
+    pub settlement_date: NaiveDate,
+    pub security_code: String,
+    pub security_name: String,
+    pub account: String,
+    pub shares: f64,
+    pub asked_price: f64,
+    pub proceeds: f64,
+    pub purchase_price: f64,
+    pub realized_profit_and_loss: f64,
+    pub taxes: f64,
+    pub realized_profit_and_loss_after_tax: f64,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// 国内株式取引作成リクエスト
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+pub struct CreateDomesticStockRequest {
+    pub trade_date: NaiveDate,
+    pub settlement_date: NaiveDate,
+    #[validate(length(min = 1, max = 10))]
+    pub security_code: String,
+    #[validate(length(min = 1, max = 200))]
+    pub security_name: String,
+    #[validate(length(min = 1, max = 100))]
+    pub account: String,
+    pub shares: f64,
+    pub asked_price: f64,
+    pub proceeds: f64,
+    pub purchase_price: f64,
+    pub realized_profit_and_loss: f64,
+    pub taxes: f64,
+    pub realized_profit_and_loss_after_tax: f64,
+}
+
+/// 国内株式取引一括作成リクエスト
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+pub struct BulkCreateDomesticStockRequest {
+    #[validate(length(min = 1))]
+    pub items: Vec<CreateDomesticStockRequest>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_domestic_stock_request_validation() {
+        let request = CreateDomesticStockRequest {
+            trade_date: NaiveDate::from_ymd_opt(2024, 1, 15).unwrap(),
+            settlement_date: NaiveDate::from_ymd_opt(2024, 1, 17).unwrap(),
+            security_code: "1234".to_string(),
+            security_name: "テスト株式会社".to_string(),
+            account: "特定".to_string(),
+            shares: 100.0,
+            asked_price: 1500.0,
+            proceeds: 150000.0,
+            purchase_price: 1400.0,
+            realized_profit_and_loss: 10000.0,
+            taxes: 2000.0,
+            realized_profit_and_loss_after_tax: 8000.0,
+        };
+
+        assert!(request.validate().is_ok());
+    }
+}

--- a/backend/src/models/mutualfund.rs
+++ b/backend/src/models/mutualfund.rs
@@ -1,0 +1,83 @@
+use chrono::{DateTime, NaiveDate, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+use uuid::Uuid;
+use validator::Validate;
+
+/// 投資信託モデル（DB + APIレスポンス兼用）
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct Mutualfund {
+    pub id: Uuid,
+    #[serde(skip_serializing)]
+    #[allow(dead_code)]
+    pub user_id: Uuid,
+    pub trade_date: NaiveDate,
+    pub settlement_date: NaiveDate,
+    pub fund_name: String,
+    pub dividends: Option<String>,
+    pub account: String,
+    pub shares: f64,
+    pub exchange_rate: f64,
+    pub cancellation_unit_price_yen: f64,
+    pub cancellation_amount_yen: f64,
+    pub average_acquisition_price_yen: f64,
+    pub realized_profit_and_loss: f64,
+    pub taxes: f64,
+    pub realized_profit_and_loss_after_tax: f64,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// 投資信託作成リクエスト
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+pub struct CreateMutualfundRequest {
+    pub trade_date: NaiveDate,
+    pub settlement_date: NaiveDate,
+    #[validate(length(min = 1, max = 300))]
+    pub fund_name: String,
+    #[validate(length(max = 100))]
+    pub dividends: Option<String>,
+    #[validate(length(min = 1, max = 100))]
+    pub account: String,
+    pub shares: f64,
+    pub exchange_rate: f64,
+    pub cancellation_unit_price_yen: f64,
+    pub cancellation_amount_yen: f64,
+    pub average_acquisition_price_yen: f64,
+    pub realized_profit_and_loss: f64,
+    pub taxes: f64,
+    pub realized_profit_and_loss_after_tax: f64,
+}
+
+/// 投資信託一括作成リクエスト
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+pub struct BulkCreateMutualfundRequest {
+    #[validate(length(min = 1))]
+    pub items: Vec<CreateMutualfundRequest>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_mutualfund_request_validation() {
+        let request = CreateMutualfundRequest {
+            trade_date: NaiveDate::from_ymd_opt(2024, 1, 15).unwrap(),
+            settlement_date: NaiveDate::from_ymd_opt(2024, 1, 19).unwrap(),
+            fund_name: "テストファンド".to_string(),
+            dividends: Some("再投資型".to_string()),
+            account: "特定".to_string(),
+            shares: 10000.0,
+            exchange_rate: 1.0,
+            cancellation_unit_price_yen: 15000.0,
+            cancellation_amount_yen: 150000.0,
+            average_acquisition_price_yen: 14000.0,
+            realized_profit_and_loss: 10000.0,
+            taxes: 2000.0,
+            realized_profit_and_loss_after_tax: 8000.0,
+        };
+
+        assert!(request.validate().is_ok());
+    }
+}

--- a/frontend/src/features/receipt/api/receiptApi.ts
+++ b/frontend/src/features/receipt/api/receiptApi.ts
@@ -1,0 +1,46 @@
+import { apiClient } from '@/lib/api/client';
+import { DividendData } from '@/lib/interfaces/dividend';
+import { DomesticStockData } from '@/lib/interfaces/domesticStock';
+import { MutualfundData } from '@/lib/interfaces/mutualfund';
+
+// APIレスポンス型
+interface BulkCreateResponse {
+  inserted: number;
+  skipped: number;
+}
+
+// 配当金API
+export const dividendApi = {
+  list: () =>
+    apiClient.get<DividendData[]>('/dividends', { withCredentials: true }),
+
+  bulkCreate: (items: Omit<DividendData, 'id' | 'security_info' | 'created_at' | 'updated_at'>[]) =>
+    apiClient.post<BulkCreateResponse>('/dividends/bulk', { items }, { withCredentials: true }),
+
+  deleteAll: () =>
+    apiClient.delete('/dividends/all', { withCredentials: true }),
+};
+
+// 国内株式API
+export const domesticStockApi = {
+  list: () =>
+    apiClient.get<DomesticStockData[]>('/domestic-stocks', { withCredentials: true }),
+
+  bulkCreate: (items: Omit<DomesticStockData, 'id' | 'security_info' | 'created_at' | 'updated_at'>[]) =>
+    apiClient.post<BulkCreateResponse>('/domestic-stocks/bulk', { items }, { withCredentials: true }),
+
+  deleteAll: () =>
+    apiClient.delete('/domestic-stocks/all', { withCredentials: true }),
+};
+
+// 投資信託API
+export const mutualfundApi = {
+  list: () =>
+    apiClient.get<MutualfundData[]>('/mutualfunds', { withCredentials: true }),
+
+  bulkCreate: (items: Omit<MutualfundData, 'id' | 'created_at' | 'updated_at'>[]) =>
+    apiClient.post<BulkCreateResponse>('/mutualfunds/bulk', { items }, { withCredentials: true }),
+
+  deleteAll: () =>
+    apiClient.delete('/mutualfunds/all', { withCredentials: true }),
+};

--- a/frontend/src/features/receipt/parsers/dividendParser.ts
+++ b/frontend/src/features/receipt/parsers/dividendParser.ts
@@ -32,3 +32,25 @@ export const sortDividendBySettlementDate = (data: DividendData[]): DividendData
         a.settlement_date.getTime() - b.settlement_date.getTime()
     );
 };
+
+/**
+ * DBレスポンスをDividendDataに変換
+ */
+export const transformDBDividend = (item: Record<string, unknown>): DividendData => {
+    const securityCode = String(item.security_code || '');
+    const securityName = String(item.security_name || '');
+
+    return {
+        settlement_date: new Date(item.settlement_date as string),
+        product: String(item.product || ''),
+        account: String(item.account || ''),
+        security_code: securityCode,
+        security_name: securityName,
+        security_info: createSecurityCodeLink(securityCode),
+        unit_price: Number(item.unit_price) || 0,
+        shares: Number(item.shares) || 0,
+        dividends_before_tax: Number(item.dividends_before_tax) || 0,
+        taxes: Number(item.taxes) || 0,
+        net_amount_received: Number(item.net_amount_received) || 0,
+    };
+};

--- a/frontend/src/features/receipt/parsers/domesticStockParser.ts
+++ b/frontend/src/features/receipt/parsers/domesticStockParser.ts
@@ -41,3 +41,27 @@ export const sortDomesticStockByTradeDate = (data: DomesticStockData[]): Domesti
         a.trade_date.getTime() - b.trade_date.getTime()
     );
 };
+
+/**
+ * DBレスポンスをDomesticStockDataに変換
+ */
+export const transformDBDomesticStock = (item: Record<string, unknown>): DomesticStockData => {
+    const securityCode = String(item.security_code || '');
+    const securityName = String(item.security_name || '');
+
+    return {
+        trade_date: new Date(item.trade_date as string),
+        settlement_date: new Date(item.settlement_date as string),
+        security_code: securityCode,
+        security_name: securityName,
+        security_info: createSecurityCodeLink(securityCode),
+        account: String(item.account || ''),
+        shares: Number(item.shares) || 0,
+        asked_price: Number(item.asked_price) || 0,
+        proceeds: Number(item.proceeds) || 0,
+        purchase_price: Number(item.purchase_price) || 0,
+        realized_profit_and_loss: Number(item.realized_profit_and_loss) || 0,
+        taxes: Number(item.taxes) || 0,
+        realized_profit_and_loss_after_tax: Number(item.realized_profit_and_loss_after_tax) || 0,
+    };
+};

--- a/frontend/src/features/receipt/parsers/index.ts
+++ b/frontend/src/features/receipt/parsers/index.ts
@@ -1,3 +1,4 @@
 export { createSecurityCodeLink } from './securityLink';
-export { parseDividendCsvItem, sortDividendBySettlementDate } from './dividendParser';
-export { parseDomesticStockCsvItem, sortDomesticStockByTradeDate } from './domesticStockParser';
+export { parseDividendCsvItem, sortDividendBySettlementDate, transformDBDividend } from './dividendParser';
+export { parseDomesticStockCsvItem, sortDomesticStockByTradeDate, transformDBDomesticStock } from './domesticStockParser';
+export { parseMutualfundCsvItem, sortMutualfundByTradeDate, transformDBMutualfund } from './mutualfundParser';

--- a/frontend/src/features/receipt/parsers/mutualfundParser.ts
+++ b/frontend/src/features/receipt/parsers/mutualfundParser.ts
@@ -1,0 +1,59 @@
+import { MutualfundData } from '@/lib/interfaces/mutualfund';
+import { parseNumber, TAX_RATE } from '@/lib/utils/formatters';
+
+/**
+ * CSVアイテムをMutualfundDataに変換
+ */
+export const parseMutualfundCsvItem = (item: Record<string, unknown>): MutualfundData => {
+    const account = String(item['口座'] || '');
+    const realizedPnL = parseNumber(item['実現損益［円］']);
+    const isSpecificAccount = account.includes('特定');
+    const taxes = isSpecificAccount ? Math.floor(Math.max(0, realizedPnL) * TAX_RATE) : 0;
+    const realizedPnLAfterTax = realizedPnL - taxes;
+
+    return {
+        trade_date: new Date(item['約定日'] as string),
+        settlement_date: new Date(item['受渡日'] as string),
+        fund_name: String(item['ファンド名'] || ''),
+        dividends: String(item['分配金'] || ''),
+        account,
+        shares: parseNumber(item['数量[口]']),
+        exchange_rate: parseNumber(item['為替レート［円］']),
+        cancellation_unit_price_yen: parseNumber(item['解約単価［円］']),
+        cancellation_amount_yen: parseNumber(item['解約額［円］']),
+        average_acquisition_price_yen: parseNumber(item['平均取得価額［円］']),
+        realized_profit_and_loss: realizedPnL,
+        taxes,
+        realized_profit_and_loss_after_tax: realizedPnLAfterTax,
+    };
+};
+
+/**
+ * 取引日でソート
+ */
+export const sortMutualfundByTradeDate = (data: MutualfundData[]): MutualfundData[] => {
+    return [...data].sort((a, b) =>
+        a.trade_date.getTime() - b.trade_date.getTime()
+    );
+};
+
+/**
+ * DBレスポンスをMutualfundDataに変換
+ */
+export const transformDBMutualfund = (item: Record<string, unknown>): MutualfundData => {
+    return {
+        trade_date: new Date(item.trade_date as string),
+        settlement_date: new Date(item.settlement_date as string),
+        fund_name: String(item.fund_name || ''),
+        dividends: String(item.dividends || ''),
+        account: String(item.account || ''),
+        shares: Number(item.shares) || 0,
+        exchange_rate: Number(item.exchange_rate) || 0,
+        cancellation_unit_price_yen: Number(item.cancellation_unit_price_yen) || 0,
+        cancellation_amount_yen: Number(item.cancellation_amount_yen) || 0,
+        average_acquisition_price_yen: Number(item.average_acquisition_price_yen) || 0,
+        realized_profit_and_loss: Number(item.realized_profit_and_loss) || 0,
+        taxes: Number(item.taxes) || 0,
+        realized_profit_and_loss_after_tax: Number(item.realized_profit_and_loss_after_tax) || 0,
+    };
+};

--- a/frontend/src/hooks/receipt/useReceiptDataSource.ts
+++ b/frontend/src/hooks/receipt/useReceiptDataSource.ts
@@ -1,0 +1,99 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useAuth } from '@/features/auth/hooks/useAuth';
+
+interface UseReceiptDataSourceOptions<T, R> {
+  csvData: Record<string, unknown>[];
+  parseCSVItem: (item: Record<string, unknown>) => T;
+  sortFn: (data: T[]) => T[];
+  fetchFromDB: () => Promise<R[]>;
+  transformDBItem: (item: R) => T;
+  bulkCreate: (items: T[]) => Promise<{ inserted: number; skipped: number }>;
+}
+
+interface UseReceiptDataSourceResult<T> {
+  data: T[];
+  isLoading: boolean;
+  error: string | null;
+  isFromDB: boolean;
+  saveToDB: () => Promise<void>;
+  refetch: () => Promise<void>;
+}
+
+/**
+ * ログイン状態に応じてDB/CSVからデータを取得するフック
+ * - ログイン時: DBからデータを取得
+ * - 未ログイン時: CSVからデータを取得
+ */
+export function useReceiptDataSource<T, R>(
+  options: UseReceiptDataSourceOptions<T, R>
+): UseReceiptDataSourceResult<T> {
+  const { csvData, parseCSVItem, sortFn, fetchFromDB, transformDBItem, bulkCreate } = options;
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
+
+  const [data, setData] = useState<T[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isFromDB, setIsFromDB] = useState(false);
+
+  // DBからデータを取得
+  const fetchData = useCallback(async () => {
+    if (authLoading) return;
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      if (isAuthenticated) {
+        const dbData = await fetchFromDB();
+        if (dbData.length > 0) {
+          const transformed = dbData.map(transformDBItem);
+          setData(sortFn(transformed));
+          setIsFromDB(true);
+        } else {
+          // DBにデータがない場合はCSVから
+          const parsedData = csvData.map(parseCSVItem);
+          setData(sortFn(parsedData));
+          setIsFromDB(false);
+        }
+      } else {
+        // 未ログイン時はCSVから
+        const parsedData = csvData.map(parseCSVItem);
+        setData(sortFn(parsedData));
+        setIsFromDB(false);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '取得に失敗しました');
+      // エラー時はCSVから
+      const parsedData = csvData.map(parseCSVItem);
+      setData(sortFn(parsedData));
+      setIsFromDB(false);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [authLoading, isAuthenticated, csvData, parseCSVItem, sortFn, fetchFromDB, transformDBItem]);
+
+  // CSVデータをDBに保存
+  const saveToDB = useCallback(async () => {
+    if (!isAuthenticated) {
+      throw new Error('ログインが必要です');
+    }
+
+    const parsedData = csvData.map(parseCSVItem);
+    await bulkCreate(parsedData);
+    await fetchData();
+  }, [isAuthenticated, csvData, parseCSVItem, bulkCreate, fetchData]);
+
+  // 初回ロードとcsvData変更時にデータを取得
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  return {
+    data,
+    isLoading: isLoading || authLoading,
+    error,
+    isFromDB,
+    saveToDB,
+    refetch: fetchData,
+  };
+}

--- a/frontend/src/pages/Receipts.tsx
+++ b/frontend/src/pages/Receipts.tsx
@@ -1,29 +1,82 @@
-import { useState } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Layout } from '../components/templates/Layout';
 import { CSVFileInput } from '../components/molecules/CSVFileInput';
 import { useCSVReader } from '../hooks/useCSVReader';
+import { useAuth } from '@/features/auth/hooks/useAuth';
 import { Dividend } from './Receipt/Dividend';
 import { DomesticStock } from './Receipt/DomesticStock';
 import { Mutualfund } from './Receipt/Mutualfund';
+import { dividendApi, domesticStockApi, mutualfundApi } from '@/features/receipt/api/receiptApi';
+import {
+  parseDividendCsvItem,
+  parseDomesticStockCsvItem,
+  parseMutualfundCsvItem,
+  transformDBDividend,
+  transformDBDomesticStock,
+  transformDBMutualfund,
+} from '@/features/receipt/parsers';
+import { DividendData } from '@/lib/interfaces/dividend';
+import { DomesticStockData } from '@/lib/interfaces/domesticStock';
+import { MutualfundData } from '@/lib/interfaces/mutualfund';
 
 type ReceiptsType = 'dividend' | 'domesticstock' | 'mutualfund';
 
 /**
  * 明細種類ごとにCSVデータを管理するページコンポーネント
+ * ログイン時はDBからデータを取得、未ログイン時はCSVから取得
  */
 export function ReceiptsPage() {
-  // アクティブなタブの状態管理
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
   const [receiptsType, setReceiptsType] = useState<ReceiptsType>('dividend');
 
-  // 各明細種類ごとのCSVデータを個別に管理
+  // CSVから読み込んだデータ
   const [dividendCsvData, setDividendCsvData] = useState<Record<string, unknown>[]>([]);
   const [domesticStockCsvData, setDomesticStockCsvData] = useState<Record<string, unknown>[]>([]);
   const [mutualfundCsvData, setMutualfundCsvData] = useState<Record<string, unknown>[]>([]);
+
+  // DBから読み込んだデータ
+  const [dividendDBData, setDividendDBData] = useState<DividendData[]>([]);
+  const [domesticStockDBData, setDomesticStockDBData] = useState<DomesticStockData[]>([]);
+  const [mutualfundDBData, setMutualfundDBData] = useState<MutualfundData[]>([]);
+
+  // DB読み込み状態
+  const [dbLoading, setDbLoading] = useState(false);
+  const [dbError, setDbError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
 
   // 各明細種類ごとにCSVリーダーフックを作成
   const dividendCSV = useCSVReader();
   const domesticStockCSV = useCSVReader();
   const mutualfundCSV = useCSVReader();
+
+  // DBからデータを取得
+  const fetchFromDB = useCallback(async () => {
+    if (!isAuthenticated || authLoading) return;
+
+    setDbLoading(true);
+    setDbError(null);
+
+    try {
+      const [dividends, stocks, funds] = await Promise.all([
+        dividendApi.list(),
+        domesticStockApi.list(),
+        mutualfundApi.list(),
+      ]);
+
+      setDividendDBData(dividends.map(d => transformDBDividend(d as unknown as Record<string, unknown>)));
+      setDomesticStockDBData(stocks.map(d => transformDBDomesticStock(d as unknown as Record<string, unknown>)));
+      setMutualfundDBData(funds.map(d => transformDBMutualfund(d as unknown as Record<string, unknown>)));
+    } catch (err) {
+      setDbError(err instanceof Error ? err.message : 'データ取得に失敗しました');
+    } finally {
+      setDbLoading(false);
+    }
+  }, [isAuthenticated, authLoading]);
+
+  // 初回ロード時にDBからデータを取得
+  useEffect(() => {
+    fetchFromDB();
+  }, [fetchFromDB]);
 
   /**
    * 現在選択中のタブに応じてCSV処理を切り替える
@@ -50,20 +103,73 @@ export function ReceiptsPage() {
   };
 
   /**
+   * CSVデータをDBに保存
+   */
+  const handleSaveToDB = async () => {
+    if (!isAuthenticated) return;
+
+    setSaving(true);
+    setDbError(null);
+
+    try {
+      switch (receiptsType) {
+        case 'dividend': {
+          const items = dividendCsvData.map(parseDividendCsvItem);
+          await dividendApi.bulkCreate(items);
+          setDividendCsvData([]);
+          break;
+        }
+        case 'domesticstock': {
+          const items = domesticStockCsvData.map(parseDomesticStockCsvItem);
+          await domesticStockApi.bulkCreate(items);
+          setDomesticStockCsvData([]);
+          break;
+        }
+        case 'mutualfund': {
+          const items = mutualfundCsvData.map(parseMutualfundCsvItem);
+          await mutualfundApi.bulkCreate(items);
+          setMutualfundCsvData([]);
+          break;
+        }
+      }
+      await fetchFromDB();
+    } catch (err) {
+      setDbError(err instanceof Error ? err.message : '保存に失敗しました');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  /**
    * 現在選択中のタブに対応するエラーとローディング状態を取得
    */
   const getCurrentCSVState = () => {
     switch (receiptsType) {
       case 'dividend':
-        return { isLoading: dividendCSV.isLoading, error: dividendCSV.error, fileName: dividendCSV.fileName };
+        return { isLoading: dividendCSV.isLoading, error: dividendCSV.error, fileName: dividendCSV.fileName, csvData: dividendCsvData };
       case 'domesticstock':
-        return { isLoading: domesticStockCSV.isLoading, error: domesticStockCSV.error, fileName: domesticStockCSV.fileName };
+        return { isLoading: domesticStockCSV.isLoading, error: domesticStockCSV.error, fileName: domesticStockCSV.fileName, csvData: domesticStockCsvData };
       case 'mutualfund':
-        return { isLoading: mutualfundCSV.isLoading, error: mutualfundCSV.error, fileName: mutualfundCSV.fileName };
+        return { isLoading: mutualfundCSV.isLoading, error: mutualfundCSV.error, fileName: mutualfundCSV.fileName, csvData: mutualfundCsvData };
     }
   };
 
-  const { isLoading, error, fileName } = getCurrentCSVState();
+  const { isLoading, error, fileName, csvData } = getCurrentCSVState();
+  const hasCsvData = csvData.length > 0;
+
+  // 表示用データを決定（ログイン時はDB優先、未ログイン時はCSV）
+  const getDividendData = () => {
+    if (isAuthenticated && dividendDBData.length > 0) return dividendDBData;
+    return dividendCsvData;
+  };
+  const getDomesticStockData = () => {
+    if (isAuthenticated && domesticStockDBData.length > 0) return domesticStockDBData;
+    return domesticStockCsvData;
+  };
+  const getMutualfundData = () => {
+    if (isAuthenticated && mutualfundDBData.length > 0) return mutualfundDBData;
+    return mutualfundCsvData;
+  };
 
   return (
     <Layout>
@@ -96,17 +202,30 @@ export function ReceiptsPage() {
         </ul>
       </nav>
       <div className="receipt-page mt-2">
-        <div className="row">
-          <div className='col'><CSVFileInput onFileSelect={handleFileSelect} selectedFileName={fileName} /></div>
+        <div className="row align-items-center">
+          <div className='col'>
+            <CSVFileInput onFileSelect={handleFileSelect} selectedFileName={fileName} />
+          </div>
+          {isAuthenticated && hasCsvData && (
+            <div className='col-auto'>
+              <button
+                className="btn btn-primary"
+                onClick={handleSaveToDB}
+                disabled={saving}
+              >
+                {saving ? 'DBに保存中...' : 'DBに保存'}
+              </button>
+            </div>
+          )}
         </div>
 
-        {error && (
+        {(error || dbError) && (
           <div className="alert alert-danger my-3" role="alert">
-            <strong>エラー:</strong> {error}
+            <strong>エラー:</strong> {error || dbError}
           </div>
         )}
 
-        {isLoading && (
+        {(isLoading || dbLoading) && (
           <div className="text-center my-4">
             <div className="spinner-border text-primary" role="status">
               <span className="visually-hidden">Loading...</span>
@@ -114,9 +233,9 @@ export function ReceiptsPage() {
           </div>
         )}
 
-        {receiptsType === 'dividend' && <Dividend csvData={dividendCsvData} />}
-        {receiptsType === 'domesticstock' && <DomesticStock csvData={domesticStockCsvData} />}
-        {receiptsType === 'mutualfund' && <Mutualfund csvData={mutualfundCsvData} />}
+        {receiptsType === 'dividend' && <Dividend csvData={getDividendData() as Record<string, unknown>[]} />}
+        {receiptsType === 'domesticstock' && <DomesticStock csvData={getDomesticStockData() as Record<string, unknown>[]} />}
+        {receiptsType === 'mutualfund' && <Mutualfund csvData={getMutualfundData() as Record<string, unknown>[]} />}
       </div>
     </Layout>
   );


### PR DESCRIPTION
## 概要
- ログイン時はDBからデータ取得、未ログイン時はCSVから読み込む機能を追加
- Claude Code用のAgent Skillsを追加

## 変更種別
- [x] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] その他

## 主な変更内容

### DB取込機能
- 配当金、国内株式、投資信託のCRUD + bulk API追加
- マイグレーション追加（dividends, domestic_stocks, mutualfunds）
- 認証エクストラクター（AuthenticatedUser）追加
- フロントエンドAPIクライアント・データソース切り替えフック追加
- Receipts.tsxにDB連携機能統合

### Agent Skills
- backend-build-test / frontend-build-test
- backend-api / frontend-api
- db-migration / commit / deploy / security-review

## テスト
- [x] バックエンドテスト実行（40件パス）
- [x] フロントエンドビルド確認

## チェックリスト
- [x] CIパス確認
- [ ] コードレビュー依頼済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)