### PR TITLE
feat: 明細削除機能とCSV取込機能の追加

### DIFF
--- a/backend/src/extractors/validated_json.rs
+++ b/backend/src/extractors/validated_json.rs
@@ -1,6 +1,7 @@
 use crate::errors::ApiError;
 use axum::{extract::FromRequest, http::Request, Json};
 use serde::de::DeserializeOwned;
+use tracing::error;
 use validator::Validate;
 
 #[derive(Debug)]
@@ -20,10 +21,15 @@ where
     ) -> Result<Self, Self::Rejection> {
         let Json(value) = Json::<T>::from_request(req, state)
             .await
-            .map_err(|_| ApiError::JsonParseError)?;
+            .map_err(|_| {
+                error!("[ValidatedJson] JSONパースエラー");
+                ApiError::JsonParseError
+            })?;
 
         value.validate().map_err(|rejection| {
-            ApiError::ValidationError(format!("{}", rejection).replace('\n', ", "))
+            let msg = format!("{}", rejection).replace('\n', ", ");
+            error!("[ValidatedJson] バリデーションエラー: {}", msg);
+            ApiError::ValidationError(msg)
         })?;
 
         Ok(ValidatedJson(value))

--- a/backend/src/handlers/dividend.rs
+++ b/backend/src/handlers/dividend.rs
@@ -86,11 +86,13 @@ pub async fn delete_all(
     State(state): State<AppState>,
     auth_user: AuthenticatedUser,
 ) -> Result<impl IntoResponse, ApiError> {
-    sqlx::query("DELETE FROM dividends WHERE user_id = $1")
+    info!("[dividend.delete_all] リクエスト受信");
+    let result = sqlx::query("DELETE FROM dividends WHERE user_id = $1")
         .bind(auth_user.id())
         .execute(&state.pool)
         .await?;
 
+    info!("[dividend.delete_all] 完了: {}件削除", result.rows_affected());
     Ok((
         StatusCode::OK,
         Json(serde_json::json!({"message": "全ての配当金データを削除しました"})),

--- a/backend/src/handlers/domestic_stock.rs
+++ b/backend/src/handlers/domestic_stock.rs
@@ -91,11 +91,13 @@ pub async fn delete_all(
     State(state): State<AppState>,
     auth_user: AuthenticatedUser,
 ) -> Result<impl IntoResponse, ApiError> {
-    sqlx::query("DELETE FROM domestic_stocks WHERE user_id = $1")
+    info!("[domestic_stock.delete_all] リクエスト受信");
+    let result = sqlx::query("DELETE FROM domestic_stocks WHERE user_id = $1")
         .bind(auth_user.id())
         .execute(&state.pool)
         .await?;
 
+    info!("[domestic_stock.delete_all] 完了: {}件削除", result.rows_affected());
     Ok((
         StatusCode::OK,
         Json(serde_json::json!({"message": "全ての国内株式取引データを削除しました"})),

--- a/backend/src/handlers/mutualfund.rs
+++ b/backend/src/handlers/mutualfund.rs
@@ -92,11 +92,13 @@ pub async fn delete_all(
     State(state): State<AppState>,
     auth_user: AuthenticatedUser,
 ) -> Result<impl IntoResponse, ApiError> {
-    sqlx::query("DELETE FROM mutualfunds WHERE user_id = $1")
+    info!("[mutualfund.delete_all] リクエスト受信");
+    let result = sqlx::query("DELETE FROM mutualfunds WHERE user_id = $1")
         .bind(auth_user.id())
         .execute(&state.pool)
         .await?;
 
+    info!("[mutualfund.delete_all] 完了: {}件削除", result.rows_affected());
     Ok((
         StatusCode::OK,
         Json(serde_json::json!({"message": "全ての投資信託データを削除しました"})),

--- a/frontend/src/features/receipt/api/receiptApi.ts
+++ b/frontend/src/features/receipt/api/receiptApi.ts
@@ -46,8 +46,17 @@ export const dividendApi = {
     }
   },
 
-  deleteAll: () =>
-    apiClient.delete('/dividends/all', { withCredentials: true }),
+  deleteAll: async () => {
+    console.log('[dividendApi.deleteAll] 開始');
+    try {
+      const response = await apiClient.delete('/dividends/all', { withCredentials: true });
+      console.log('[dividendApi.deleteAll] 成功');
+      return response;
+    } catch (error) {
+      console.error('[dividendApi.deleteAll] 失敗:', error);
+      throw error;
+    }
+  },
 };
 
 // 国内株式API
@@ -81,8 +90,17 @@ export const domesticStockApi = {
     }
   },
 
-  deleteAll: () =>
-    apiClient.delete('/domestic-stocks/all', { withCredentials: true }),
+  deleteAll: async () => {
+    console.log('[domesticStockApi.deleteAll] 開始');
+    try {
+      const response = await apiClient.delete('/domestic-stocks/all', { withCredentials: true });
+      console.log('[domesticStockApi.deleteAll] 成功');
+      return response;
+    } catch (error) {
+      console.error('[domesticStockApi.deleteAll] 失敗:', error);
+      throw error;
+    }
+  },
 };
 
 // 投資信託API
@@ -117,6 +135,15 @@ export const mutualfundApi = {
     }
   },
 
-  deleteAll: () =>
-    apiClient.delete('/mutualfunds/all', { withCredentials: true }),
+  deleteAll: async () => {
+    console.log('[mutualfundApi.deleteAll] 開始');
+    try {
+      const response = await apiClient.delete('/mutualfunds/all', { withCredentials: true });
+      console.log('[mutualfundApi.deleteAll] 成功');
+      return response;
+    } catch (error) {
+      console.error('[mutualfundApi.deleteAll] 失敗:', error);
+      throw error;
+    }
+  },
 };

--- a/frontend/src/pages/Receipts.tsx
+++ b/frontend/src/pages/Receipts.tsx
@@ -43,6 +43,7 @@ export function ReceiptsPage() {
   const [dbLoading, setDbLoading] = useState(false);
   const [dbError, setDbError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
 
   // 各明細種類ごとにCSVリーダーフックを作成
   const dividendCSV = useCSVReader();
@@ -141,6 +142,41 @@ export function ReceiptsPage() {
   };
 
   /**
+   * DBデータを全削除
+   */
+  const handleDeleteAll = async () => {
+    if (!isAuthenticated) return;
+    if (!window.confirm('現在のタブのデータをすべて削除しますか？')) return;
+
+    setDeleting(true);
+    setDbError(null);
+    console.log(`[handleDeleteAll] 開始: ${receiptsType}`);
+
+    try {
+      switch (receiptsType) {
+        case 'dividend':
+          await dividendApi.deleteAll();
+          setDividendDBData([]);
+          break;
+        case 'domesticstock':
+          await domesticStockApi.deleteAll();
+          setDomesticStockDBData([]);
+          break;
+        case 'mutualfund':
+          await mutualfundApi.deleteAll();
+          setMutualfundDBData([]);
+          break;
+      }
+      console.log(`[handleDeleteAll] 成功: ${receiptsType}`);
+    } catch (err) {
+      console.error(`[handleDeleteAll] 失敗: ${receiptsType}`, err);
+      setDbError(err instanceof Error ? err.message : '削除に失敗しました');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  /**
    * 現在選択中のタブに対応するエラーとローディング状態を取得
    */
   const getCurrentCSVState = () => {
@@ -156,6 +192,15 @@ export function ReceiptsPage() {
 
   const { isLoading, error, fileName, csvData } = getCurrentCSVState();
   const hasCsvData = csvData.length > 0;
+
+  // 現在のタブのDBデータがあるか判定
+  const hasDbData = (() => {
+    switch (receiptsType) {
+      case 'dividend': return dividendDBData.length > 0;
+      case 'domesticstock': return domesticStockDBData.length > 0;
+      case 'mutualfund': return mutualfundDBData.length > 0;
+    }
+  })();
 
   // 表示用データを決定（ログイン時はDB優先、未ログイン時はCSV）
   const getDividendData = () => {
@@ -202,18 +247,31 @@ export function ReceiptsPage() {
         </ul>
       </nav>
       <div className="receipt-page mt-2">
-        <div className="d-flex align-items-center gap-2">
-          <div style={{ maxWidth: '400px' }}>
+        <div className="d-flex align-items-center gap-2 flex-wrap">
+          <div style={{ width: '350px' }}>
             <CSVFileInput onFileSelect={handleFileSelect} selectedFileName={fileName} />
           </div>
-          {isAuthenticated && hasCsvData && (
-            <button
-              className="btn btn-primary"
-              onClick={handleSaveToDB}
-              disabled={saving}
-            >
-              {saving ? '保存中...' : '保存'}
-            </button>
+          {isAuthenticated && (
+            <div className="btn-group">
+              {hasCsvData && (
+                <button
+                  className="btn btn-primary btn-sm"
+                  onClick={handleSaveToDB}
+                  disabled={saving || deleting}
+                >
+                  {saving ? '保存中...' : '保存'}
+                </button>
+              )}
+              {hasDbData && (
+                <button
+                  className="btn btn-outline-danger btn-sm"
+                  onClick={handleDeleteAll}
+                  disabled={saving || deleting}
+                >
+                  {deleting ? '削除中...' : '削除'}
+                </button>
+              )}
+            </div>
           )}
         </div>
 


### PR DESCRIPTION
## 概要
複数の機能追加とバグ修正を含むリリースです。

### 主な変更内容
- 明細ページに削除機能を追加・UI改善
- 配当金・国内株式・投資信託CSVのDB取込機能を追加
- J-Quants API を V1 から V2 に移行
- バリデーションエラーの詳細ログを追加
- CSV保存時の400エラーを修正

## 変更種別
- [x] 新機能
- [x] バグ修正
- [ ] リファクタリング
- [ ] その他

## テスト
- [x] ユニットテスト追加/更新
- [x] 手動テスト実施

## チェックリスト
- [x] CIパス確認
- [x] ドキュメント更新（必要な場合）

🤖 Generated with [Claude Code](https://claude.com/claude-code)