### PR TITLE
fix: 受取金保存時のJSONパースエラーを修正

### DIFF
--- a/backend/src/extractors/validated_json.rs
+++ b/backend/src/extractors/validated_json.rs
@@ -1,5 +1,9 @@
 use crate::errors::ApiError;
-use axum::{extract::FromRequest, http::Request, Json};
+use axum::{
+    extract::{rejection::JsonRejection, FromRequest},
+    http::Request,
+    Json,
+};
 use serde::de::DeserializeOwned;
 use tracing::error;
 use validator::Validate;
@@ -10,7 +14,6 @@ pub struct ValidatedJson<T>(pub T);
 impl<T, S> FromRequest<S> for ValidatedJson<T>
 where
     T: DeserializeOwned + Validate,
-    Json<T>: FromRequest<S>,
     S: Send + Sync,
 {
     type Rejection = ApiError;
@@ -19,12 +22,11 @@ where
         req: Request<axum::body::Body>,
         state: &S,
     ) -> Result<Self, Self::Rejection> {
-        let Json(value) = Json::<T>::from_request(req, state)
-            .await
-            .map_err(|_| {
-                error!("[ValidatedJson] JSONパースエラー");
-                ApiError::JsonParseError
-            })?;
+        let result: Result<Json<T>, JsonRejection> = Json::<T>::from_request(req, state).await;
+        let Json(value) = result.map_err(|e| {
+            error!("[ValidatedJson] JSONパースエラー: {}", e);
+            ApiError::JsonParseError
+        })?;
 
         value.validate().map_err(|rejection| {
             let msg = format!("{}", rejection).replace('\n', ", ");

--- a/frontend/src/features/receipt/api/receiptApi.ts
+++ b/frontend/src/features/receipt/api/receiptApi.ts
@@ -17,6 +17,12 @@ const formatDate = (date: Date): string => {
   return `${year}-${month}-${day}`;
 };
 
+// 数値を安全に変換（NaN, null, undefinedを0に変換）
+const safeNumber = (value: unknown): number => {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : 0;
+};
+
 // 配当金API
 export const dividendApi = {
   list: () =>
@@ -30,11 +36,11 @@ export const dividendApi = {
       account: item.account,
       security_code: item.security_code,
       security_name: item.security_name,
-      unit_price: item.unit_price,
-      shares: item.shares,
-      dividends_before_tax: item.dividends_before_tax,
-      taxes: item.taxes,
-      net_amount_received: item.net_amount_received,
+      unit_price: safeNumber(item.unit_price),
+      shares: safeNumber(item.shares),
+      dividends_before_tax: safeNumber(item.dividends_before_tax),
+      taxes: safeNumber(item.taxes),
+      net_amount_received: safeNumber(item.net_amount_received),
     }));
     try {
       const response = await apiClient.post<BulkCreateResponse>('/dividends/bulk', { items: payload }, { withCredentials: true });
@@ -72,13 +78,13 @@ export const domesticStockApi = {
       security_code: item.security_code,
       security_name: item.security_name,
       account: item.account,
-      shares: item.shares,
-      asked_price: item.asked_price,
-      proceeds: item.proceeds,
-      purchase_price: item.purchase_price,
-      realized_profit_and_loss: item.realized_profit_and_loss,
-      taxes: item.taxes,
-      realized_profit_and_loss_after_tax: item.realized_profit_and_loss_after_tax,
+      shares: safeNumber(item.shares),
+      asked_price: safeNumber(item.asked_price),
+      proceeds: safeNumber(item.proceeds),
+      purchase_price: safeNumber(item.purchase_price),
+      realized_profit_and_loss: safeNumber(item.realized_profit_and_loss),
+      taxes: safeNumber(item.taxes),
+      realized_profit_and_loss_after_tax: safeNumber(item.realized_profit_and_loss_after_tax),
     }));
     try {
       const response = await apiClient.post<BulkCreateResponse>('/domestic-stocks/bulk', { items: payload }, { withCredentials: true });
@@ -116,14 +122,14 @@ export const mutualfundApi = {
       fund_name: item.fund_name,
       dividends: item.dividends || null,
       account: item.account,
-      shares: item.shares,
-      exchange_rate: item.exchange_rate,
-      cancellation_unit_price_yen: item.cancellation_unit_price_yen,
-      cancellation_amount_yen: item.cancellation_amount_yen,
-      average_acquisition_price_yen: item.average_acquisition_price_yen,
-      realized_profit_and_loss: item.realized_profit_and_loss,
-      taxes: item.taxes,
-      realized_profit_and_loss_after_tax: item.realized_profit_and_loss_after_tax,
+      shares: safeNumber(item.shares),
+      exchange_rate: safeNumber(item.exchange_rate),
+      cancellation_unit_price_yen: safeNumber(item.cancellation_unit_price_yen),
+      cancellation_amount_yen: safeNumber(item.cancellation_amount_yen),
+      average_acquisition_price_yen: safeNumber(item.average_acquisition_price_yen),
+      realized_profit_and_loss: safeNumber(item.realized_profit_and_loss),
+      taxes: safeNumber(item.taxes),
+      realized_profit_and_loss_after_tax: safeNumber(item.realized_profit_and_loss_after_tax),
     }));
     try {
       const response = await apiClient.post<BulkCreateResponse>('/mutualfunds/bulk', { items: payload }, { withCredentials: true });


### PR DESCRIPTION
## 概要
受取金の「保存」ボタン実行時にバックエンドでJSONパースエラーが発生する問題を修正。

## 変更種別
- [x] バグ修正

## 原因
CSVの数値フィールド（`unit_price`等）が空の場合、フロントエンドで`NaN`となり、JSONシリアライズ時に`null`に変換される。バックエンドは`f64`を期待するためパースエラーが発生。

## 対応内容
1. **バックエンド**: `ValidatedJson`のエラーログに詳細情報を追加（デバッグ改善）
2. **フロントエンド**: `safeNumber`関数を追加し、`NaN`/`null`/`undefined`を`0`に変換

## 修正箇所
- `backend/src/extractors/validated_json.rs` - エラー詳細ログ出力
- `frontend/src/features/receipt/api/receiptApi.ts` - 数値フィールドの安全な変換

## テスト
- [x] 手動テスト実施（受取金保存が正常に完了することを確認）

## チェックリスト
- [x] CIパス確認
- [x] 既存仕様を壊さないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)