### PR TITLE
fix: 明細ページのAPI多重呼び出し・タイムアウト・データ不整合を修正

### DIFF
--- a/frontend/src/lib/api/__tests__/client.test.ts
+++ b/frontend/src/lib/api/__tests__/client.test.ts
@@ -242,7 +242,7 @@ describe('ApiClient', () => {
 
       expect(mockedAxios.create).toHaveBeenCalledWith({
         baseURL: import.meta.env.VITE_SHOKEN_WEBAPI_API_URL,
-        timeout: 10000,
+        timeout: 30000,
         headers: {
           'Content-Type': 'application/json',
           'Accept': 'application/json',

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -29,7 +29,7 @@ class ApiClient {
   constructor(config: ApiClientConfig = {}) {
     const {
       baseURL = import.meta.env.VITE_SHOKEN_WEBAPI_API_URL,
-      timeout = 10000,
+      timeout = 30000, // fly.ioの起動待ち時間を考慮して30秒に設定
       retry = {},
       headers = {},
     } = config;

--- a/frontend/src/pages/Receipts.tsx
+++ b/frontend/src/pages/Receipts.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { Layout } from '../components/templates/Layout';
 import { CSVFileInput } from '../components/molecules/CSVFileInput';
 import { useCSVReader } from '../hooks/useCSVReader';
@@ -50,9 +50,17 @@ export function ReceiptsPage() {
   const domesticStockCSV = useCSVReader();
   const mutualfundCSV = useCSVReader();
 
+  // フェッチ済みフラグ（多重実行防止）
+  const hasFetched = useRef(false);
+
   // DBからデータを取得
-  const fetchFromDB = useCallback(async () => {
-    if (!isAuthenticated || authLoading) return;
+  const fetchFromDB = useCallback(async (force = false) => {
+    // 認証状態が確定していない場合は待機
+    if (authLoading) return;
+    // 未認証の場合はスキップ
+    if (!isAuthenticated) return;
+    // 既にフェッチ済みで強制更新でない場合はスキップ
+    if (hasFetched.current && !force) return;
 
     setDbLoading(true);
     setDbError(null);
@@ -67,6 +75,7 @@ export function ReceiptsPage() {
       setDividendDBData(dividends.map(d => transformDBDividend(d as unknown as Record<string, unknown>)));
       setDomesticStockDBData(stocks.map(d => transformDBDomesticStock(d as unknown as Record<string, unknown>)));
       setMutualfundDBData(funds.map(d => transformDBMutualfund(d as unknown as Record<string, unknown>)));
+      hasFetched.current = true;
     } catch (err) {
       setDbError(err instanceof Error ? err.message : 'データ取得に失敗しました');
     } finally {
@@ -74,10 +83,12 @@ export function ReceiptsPage() {
     }
   }, [isAuthenticated, authLoading]);
 
-  // 初回ロード時にDBからデータを取得
+  // 認証状態が確定したらDBからデータを取得
   useEffect(() => {
-    fetchFromDB();
-  }, [fetchFromDB]);
+    if (!authLoading) {
+      fetchFromDB();
+    }
+  }, [authLoading, fetchFromDB]);
 
   /**
    * 現在選択中のタブに応じてCSV処理を切り替える
@@ -133,7 +144,7 @@ export function ReceiptsPage() {
           break;
         }
       }
-      await fetchFromDB();
+      await fetchFromDB(true);
     } catch (err) {
       setDbError(err instanceof Error ? err.message : '保存に失敗しました');
     } finally {
@@ -281,7 +292,7 @@ export function ReceiptsPage() {
           </div>
         )}
 
-        {(isLoading || dbLoading) && (
+        {(isLoading || dbLoading || authLoading) && (
           <div className="text-center my-4">
             <div className="spinner-border text-primary" role="status">
               <span className="visually-hidden">Loading...</span>


### PR DESCRIPTION
## 概要
明細ページでのAPI呼び出しに関する複数の問題を修正。

## 変更種別
- [x] バグ修正

## 問題と対応

### 1. API多重呼び出し
**原因**: `fetchFromDB`が`useCallback`の依存配列変化で再作成され、`useEffect`が複数回実行される

**対応**: `useRef`でフェッチ済みフラグを管理し、初回のみ実行

### 2. データ不整合（リロード時）
**原因**: 認証状態確定前に表示ロジックが実行され、空データが表示される

**対応**: 認証状態確定前（`authLoading: true`）はローディング表示を維持

### 3. タイムアウトエラー
**原因**: デフォルト10秒では、fly.ioのマシン起動待ち＋API処理に不十分

**対応**: タイムアウトを30秒に延長

## 修正箇所
- `frontend/src/pages/Receipts.tsx` - フェッチ制御ロジック改善
- `frontend/src/lib/api/client.ts` - タイムアウト延長

## テスト
- [x] ユニットテスト実行（全パス）
- [x] 手動テスト実施

## チェックリスト
- [x] CIパス確認
- [x] 既存仕様を壊さないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)