### PR TITLE
perf: bulk_create処理のパフォーマンス改善

### DIFF
--- a/backend/src/handlers/dividend.rs
+++ b/backend/src/handlers/dividend.rs
@@ -6,6 +6,7 @@ use crate::{
     state::AppState,
 };
 use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
+use std::time::Instant;
 use tracing::info;
 
 /// 認証ユーザーの配当金一覧を取得
@@ -37,44 +38,75 @@ pub async fn bulk_create(
     auth_user: AuthenticatedUser,
     ValidatedJson(data): ValidatedJson<BulkCreateDividendRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
-    info!("[dividend.bulk_create] リクエスト受信: {}件", data.items.len());
-    let user_id = auth_user.id();
-    let mut inserted = 0;
-    let mut skipped = 0;
+    let total = data.items.len();
+    info!("[dividend.bulk_create] リクエスト受信: {}件", total);
+    let start = Instant::now();
 
-    for item in data.items {
-        let result = sqlx::query(
-            r#"
-            INSERT INTO dividends (user_id, settlement_date, product, account, security_code,
-                                   security_name, unit_price, shares, dividends_before_tax,
-                                   taxes, net_amount_received)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-            ON CONFLICT (user_id, settlement_date, security_code, shares, dividends_before_tax)
-            DO NOTHING
-            "#,
-        )
-        .bind(user_id)
-        .bind(item.settlement_date)
-        .bind(&item.product)
-        .bind(&item.account)
-        .bind(&item.security_code)
-        .bind(&item.security_name)
-        .bind(item.unit_price)
-        .bind(item.shares)
-        .bind(item.dividends_before_tax)
-        .bind(item.taxes)
-        .bind(item.net_amount_received)
-        .execute(&state.pool)
-        .await?;
-
-        if result.rows_affected() > 0 {
-            inserted += 1;
-        } else {
-            skipped += 1;
-        }
+    if data.items.is_empty() {
+        return Ok((
+            StatusCode::CREATED,
+            Json(BulkCreateResponse {
+                inserted: 0,
+                skipped: 0,
+            }),
+        ));
     }
 
-    info!("[dividend.bulk_create] 完了: inserted={}, skipped={}", inserted, skipped);
+    let user_id = auth_user.id();
+
+    // 各フィールドを配列に変換
+    let user_ids: Vec<uuid::Uuid> = vec![user_id; total];
+    let settlement_dates: Vec<chrono::NaiveDate> =
+        data.items.iter().map(|i| i.settlement_date).collect();
+    let products: Vec<&str> = data.items.iter().map(|i| i.product.as_str()).collect();
+    let accounts: Vec<&str> = data.items.iter().map(|i| i.account.as_str()).collect();
+    let security_codes: Vec<&str> = data.items.iter().map(|i| i.security_code.as_str()).collect();
+    let security_names: Vec<&str> = data.items.iter().map(|i| i.security_name.as_str()).collect();
+    let unit_prices: Vec<f64> = data.items.iter().map(|i| i.unit_price).collect();
+    let shares: Vec<f64> = data.items.iter().map(|i| i.shares).collect();
+    let dividends_before_taxes: Vec<f64> = data.items.iter().map(|i| i.dividends_before_tax).collect();
+    let taxes: Vec<f64> = data.items.iter().map(|i| i.taxes).collect();
+    let net_amounts: Vec<f64> = data.items.iter().map(|i| i.net_amount_received).collect();
+
+    // UNNESTを使ったバルクINSERT（1回のクエリで全件挿入）
+    let result = sqlx::query(
+        r#"
+        INSERT INTO dividends (user_id, settlement_date, product, account, security_code,
+                               security_name, unit_price, shares, dividends_before_tax,
+                               taxes, net_amount_received)
+        SELECT * FROM UNNEST(
+            $1::uuid[], $2::date[], $3::text[], $4::text[], $5::text[],
+            $6::text[], $7::float8[], $8::float8[], $9::float8[],
+            $10::float8[], $11::float8[]
+        )
+        ON CONFLICT (user_id, settlement_date, security_code, shares, dividends_before_tax)
+        DO NOTHING
+        "#,
+    )
+    .bind(&user_ids)
+    .bind(&settlement_dates)
+    .bind(&products)
+    .bind(&accounts)
+    .bind(&security_codes)
+    .bind(&security_names)
+    .bind(&unit_prices)
+    .bind(&shares)
+    .bind(&dividends_before_taxes)
+    .bind(&taxes)
+    .bind(&net_amounts)
+    .execute(&state.pool)
+    .await?;
+
+    let inserted = result.rows_affected() as usize;
+    let skipped = total - inserted;
+    let elapsed = start.elapsed();
+
+    info!(
+        "[dividend.bulk_create] 完了: inserted={}, skipped={}, 処理時間={:.2}ms",
+        inserted,
+        skipped,
+        elapsed.as_secs_f64() * 1000.0
+    );
     Ok((
         StatusCode::CREATED,
         Json(BulkCreateResponse { inserted, skipped }),

--- a/backend/src/handlers/domestic_stock.rs
+++ b/backend/src/handlers/domestic_stock.rs
@@ -7,6 +7,7 @@ use crate::{
     state::AppState,
 };
 use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
+use std::time::Instant;
 use tracing::info;
 
 /// 認証ユーザーの国内株式取引一覧を取得
@@ -39,47 +40,84 @@ pub async fn bulk_create(
     auth_user: AuthenticatedUser,
     ValidatedJson(data): ValidatedJson<BulkCreateDomesticStockRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
-    info!("[domestic_stock.bulk_create] リクエスト受信: {}件", data.items.len());
-    let user_id = auth_user.id();
-    let mut inserted = 0;
-    let mut skipped = 0;
+    let total = data.items.len();
+    info!("[domestic_stock.bulk_create] リクエスト受信: {}件", total);
+    let start = Instant::now();
 
-    for item in data.items {
-        let result = sqlx::query(
-            r#"
-            INSERT INTO domestic_stocks (user_id, trade_date, settlement_date, security_code,
-                                         security_name, account, shares, asked_price, proceeds,
-                                         purchase_price, realized_profit_and_loss, taxes,
-                                         realized_profit_and_loss_after_tax)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
-            ON CONFLICT (user_id, trade_date, security_code, shares, proceeds)
-            DO NOTHING
-            "#,
-        )
-        .bind(user_id)
-        .bind(item.trade_date)
-        .bind(item.settlement_date)
-        .bind(&item.security_code)
-        .bind(&item.security_name)
-        .bind(&item.account)
-        .bind(item.shares)
-        .bind(item.asked_price)
-        .bind(item.proceeds)
-        .bind(item.purchase_price)
-        .bind(item.realized_profit_and_loss)
-        .bind(item.taxes)
-        .bind(item.realized_profit_and_loss_after_tax)
-        .execute(&state.pool)
-        .await?;
-
-        if result.rows_affected() > 0 {
-            inserted += 1;
-        } else {
-            skipped += 1;
-        }
+    if data.items.is_empty() {
+        return Ok((
+            StatusCode::CREATED,
+            Json(BulkCreateResponse {
+                inserted: 0,
+                skipped: 0,
+            }),
+        ));
     }
 
-    info!("[domestic_stock.bulk_create] 完了: inserted={}, skipped={}", inserted, skipped);
+    let user_id = auth_user.id();
+
+    // 各フィールドを配列に変換
+    let user_ids: Vec<uuid::Uuid> = vec![user_id; total];
+    let trade_dates: Vec<chrono::NaiveDate> = data.items.iter().map(|i| i.trade_date).collect();
+    let settlement_dates: Vec<chrono::NaiveDate> =
+        data.items.iter().map(|i| i.settlement_date).collect();
+    let security_codes: Vec<&str> = data.items.iter().map(|i| i.security_code.as_str()).collect();
+    let security_names: Vec<&str> = data.items.iter().map(|i| i.security_name.as_str()).collect();
+    let accounts: Vec<&str> = data.items.iter().map(|i| i.account.as_str()).collect();
+    let shares: Vec<f64> = data.items.iter().map(|i| i.shares).collect();
+    let asked_prices: Vec<f64> = data.items.iter().map(|i| i.asked_price).collect();
+    let proceeds: Vec<f64> = data.items.iter().map(|i| i.proceeds).collect();
+    let purchase_prices: Vec<f64> = data.items.iter().map(|i| i.purchase_price).collect();
+    let realized_pls: Vec<f64> = data.items.iter().map(|i| i.realized_profit_and_loss).collect();
+    let taxes: Vec<f64> = data.items.iter().map(|i| i.taxes).collect();
+    let realized_pls_after_tax: Vec<f64> = data
+        .items
+        .iter()
+        .map(|i| i.realized_profit_and_loss_after_tax)
+        .collect();
+
+    // UNNESTを使ったバルクINSERT（1回のクエリで全件挿入）
+    let result = sqlx::query(
+        r#"
+        INSERT INTO domestic_stocks (user_id, trade_date, settlement_date, security_code,
+                                     security_name, account, shares, asked_price, proceeds,
+                                     purchase_price, realized_profit_and_loss, taxes,
+                                     realized_profit_and_loss_after_tax)
+        SELECT * FROM UNNEST(
+            $1::uuid[], $2::date[], $3::date[], $4::text[],
+            $5::text[], $6::text[], $7::float8[], $8::float8[], $9::float8[],
+            $10::float8[], $11::float8[], $12::float8[], $13::float8[]
+        )
+        ON CONFLICT (user_id, trade_date, security_code, shares, proceeds)
+        DO NOTHING
+        "#,
+    )
+    .bind(&user_ids)
+    .bind(&trade_dates)
+    .bind(&settlement_dates)
+    .bind(&security_codes)
+    .bind(&security_names)
+    .bind(&accounts)
+    .bind(&shares)
+    .bind(&asked_prices)
+    .bind(&proceeds)
+    .bind(&purchase_prices)
+    .bind(&realized_pls)
+    .bind(&taxes)
+    .bind(&realized_pls_after_tax)
+    .execute(&state.pool)
+    .await?;
+
+    let inserted = result.rows_affected() as usize;
+    let skipped = total - inserted;
+    let elapsed = start.elapsed();
+
+    info!(
+        "[domestic_stock.bulk_create] 完了: inserted={}, skipped={}, 処理時間={:.2}ms",
+        inserted,
+        skipped,
+        elapsed.as_secs_f64() * 1000.0
+    );
     Ok((
         StatusCode::CREATED,
         Json(BulkCreateResponse { inserted, skipped }),

--- a/backend/src/handlers/mutualfund.rs
+++ b/backend/src/handlers/mutualfund.rs
@@ -7,6 +7,7 @@ use crate::{
     state::AppState,
 };
 use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
+use std::time::Instant;
 use tracing::info;
 
 /// 認証ユーザーの投資信託一覧を取得
@@ -39,48 +40,102 @@ pub async fn bulk_create(
     auth_user: AuthenticatedUser,
     ValidatedJson(data): ValidatedJson<BulkCreateMutualfundRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
-    info!("[mutualfund.bulk_create] リクエスト受信: {}件", data.items.len());
-    let user_id = auth_user.id();
-    let mut inserted = 0;
-    let mut skipped = 0;
+    let total = data.items.len();
+    info!("[mutualfund.bulk_create] リクエスト受信: {}件", total);
+    let start = Instant::now();
 
-    for item in data.items {
-        let result = sqlx::query(
-            r#"
-            INSERT INTO mutualfunds (user_id, trade_date, settlement_date, fund_name, dividends,
-                                     account, shares, exchange_rate, cancellation_unit_price_yen,
-                                     cancellation_amount_yen, average_acquisition_price_yen,
-                                     realized_profit_and_loss, taxes, realized_profit_and_loss_after_tax)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
-            ON CONFLICT (user_id, trade_date, fund_name, shares, cancellation_amount_yen)
-            DO NOTHING
-            "#,
-        )
-        .bind(user_id)
-        .bind(item.trade_date)
-        .bind(item.settlement_date)
-        .bind(&item.fund_name)
-        .bind(&item.dividends)
-        .bind(&item.account)
-        .bind(item.shares)
-        .bind(item.exchange_rate)
-        .bind(item.cancellation_unit_price_yen)
-        .bind(item.cancellation_amount_yen)
-        .bind(item.average_acquisition_price_yen)
-        .bind(item.realized_profit_and_loss)
-        .bind(item.taxes)
-        .bind(item.realized_profit_and_loss_after_tax)
-        .execute(&state.pool)
-        .await?;
-
-        if result.rows_affected() > 0 {
-            inserted += 1;
-        } else {
-            skipped += 1;
-        }
+    if data.items.is_empty() {
+        return Ok((
+            StatusCode::CREATED,
+            Json(BulkCreateResponse {
+                inserted: 0,
+                skipped: 0,
+            }),
+        ));
     }
 
-    info!("[mutualfund.bulk_create] 完了: inserted={}, skipped={}", inserted, skipped);
+    let user_id = auth_user.id();
+
+    // 各フィールドを配列に変換
+    let user_ids: Vec<uuid::Uuid> = vec![user_id; total];
+    let trade_dates: Vec<chrono::NaiveDate> = data.items.iter().map(|i| i.trade_date).collect();
+    let settlement_dates: Vec<chrono::NaiveDate> =
+        data.items.iter().map(|i| i.settlement_date).collect();
+    let fund_names: Vec<&str> = data.items.iter().map(|i| i.fund_name.as_str()).collect();
+    let dividends: Vec<Option<&str>> = data
+        .items
+        .iter()
+        .map(|i| i.dividends.as_deref())
+        .collect();
+    let accounts: Vec<&str> = data.items.iter().map(|i| i.account.as_str()).collect();
+    let shares: Vec<f64> = data.items.iter().map(|i| i.shares).collect();
+    let exchange_rates: Vec<f64> = data.items.iter().map(|i| i.exchange_rate).collect();
+    let cancellation_unit_prices: Vec<f64> = data
+        .items
+        .iter()
+        .map(|i| i.cancellation_unit_price_yen)
+        .collect();
+    let cancellation_amounts: Vec<f64> = data
+        .items
+        .iter()
+        .map(|i| i.cancellation_amount_yen)
+        .collect();
+    let avg_acquisition_prices: Vec<f64> = data
+        .items
+        .iter()
+        .map(|i| i.average_acquisition_price_yen)
+        .collect();
+    let realized_pls: Vec<f64> = data.items.iter().map(|i| i.realized_profit_and_loss).collect();
+    let taxes: Vec<f64> = data.items.iter().map(|i| i.taxes).collect();
+    let realized_pls_after_tax: Vec<f64> = data
+        .items
+        .iter()
+        .map(|i| i.realized_profit_and_loss_after_tax)
+        .collect();
+
+    // UNNESTを使ったバルクINSERT（1回のクエリで全件挿入）
+    let result = sqlx::query(
+        r#"
+        INSERT INTO mutualfunds (user_id, trade_date, settlement_date, fund_name, dividends,
+                                 account, shares, exchange_rate, cancellation_unit_price_yen,
+                                 cancellation_amount_yen, average_acquisition_price_yen,
+                                 realized_profit_and_loss, taxes, realized_profit_and_loss_after_tax)
+        SELECT * FROM UNNEST(
+            $1::uuid[], $2::date[], $3::date[], $4::text[], $5::text[],
+            $6::text[], $7::float8[], $8::float8[], $9::float8[],
+            $10::float8[], $11::float8[], $12::float8[], $13::float8[], $14::float8[]
+        )
+        ON CONFLICT (user_id, trade_date, fund_name, shares, cancellation_amount_yen)
+        DO NOTHING
+        "#,
+    )
+    .bind(&user_ids)
+    .bind(&trade_dates)
+    .bind(&settlement_dates)
+    .bind(&fund_names)
+    .bind(&dividends)
+    .bind(&accounts)
+    .bind(&shares)
+    .bind(&exchange_rates)
+    .bind(&cancellation_unit_prices)
+    .bind(&cancellation_amounts)
+    .bind(&avg_acquisition_prices)
+    .bind(&realized_pls)
+    .bind(&taxes)
+    .bind(&realized_pls_after_tax)
+    .execute(&state.pool)
+    .await?;
+
+    let inserted = result.rows_affected() as usize;
+    let skipped = total - inserted;
+    let elapsed = start.elapsed();
+
+    info!(
+        "[mutualfund.bulk_create] 完了: inserted={}, skipped={}, 処理時間={:.2}ms",
+        inserted,
+        skipped,
+        elapsed.as_secs_f64() * 1000.0
+    );
     Ok((
         StatusCode::CREATED,
         Json(BulkCreateResponse { inserted, skipped }),


### PR DESCRIPTION
## 概要
- bulk_create処理でN回のクエリ発行を1回に削減
- PostgreSQLのUNNESTを使ったバルクINSERTに変更
- 処理時間の計測ログを追加

## 変更種別
- [x] パフォーマンス改善

## 対象ファイル
- `backend/src/handlers/dividend.rs`
- `backend/src/handlers/domestic_stock.rs`
- `backend/src/handlers/mutualfund.rs`

## 改善内容
| Before | After |
|--------|-------|
| N件 → N回のクエリ発行 | N件 → 1回のクエリ発行 |

## テスト
- [x] cargo check 通過
- [x] cargo test 通過

## チェックリスト
- [x] 既存仕様を維持
- [x] コーディング規約に準拠

🤖 Generated with [Claude Code](https://claude.com/claude-code)