### PR TITLE
fix: DBデータ表示の不整合を修正

### DIFF
--- a/frontend/src/features/receipt/parsers/dividendParser.ts
+++ b/frontend/src/features/receipt/parsers/dividendParser.ts
@@ -3,9 +3,37 @@ import { parseNumber } from '@/lib/utils/formatters';
 import { createSecurityCodeLink } from './securityLink';
 
 /**
- * CSVアイテムをDividendDataに変換
+ * データがDB形式かどうかを判定
+ */
+const isDBFormat = (item: Record<string, unknown>): boolean => {
+    return 'settlement_date' in item && 'security_code' in item;
+};
+
+/**
+ * CSVまたはDBアイテムをDividendDataに変換
  */
 export const parseDividendCsvItem = (item: Record<string, unknown>): DividendData => {
+    // DB形式の場合はそのまま返す（既に変換済み）
+    if (isDBFormat(item)) {
+        const securityCode = String(item.security_code || '');
+        return {
+            settlement_date: item.settlement_date instanceof Date
+                ? item.settlement_date
+                : new Date(item.settlement_date as string),
+            product: String(item.product || ''),
+            account: String(item.account || ''),
+            security_code: securityCode,
+            security_name: String(item.security_name || ''),
+            security_info: item.security_info || createSecurityCodeLink(securityCode),
+            unit_price: Number(item.unit_price) || 0,
+            shares: Number(item.shares) || 0,
+            dividends_before_tax: Number(item.dividends_before_tax) || 0,
+            taxes: Number(item.taxes) || 0,
+            net_amount_received: Number(item.net_amount_received) || 0,
+        };
+    }
+
+    // CSV形式の場合
     const securityCode = String(item['銘柄コード'] || '');
     const securityName = String(item['銘柄'] || '');
 

--- a/frontend/src/features/receipt/parsers/domesticStockParser.ts
+++ b/frontend/src/features/receipt/parsers/domesticStockParser.ts
@@ -3,9 +3,41 @@ import { parseNumber, TAX_RATE } from '@/lib/utils/formatters';
 import { createSecurityCodeLink } from './securityLink';
 
 /**
- * CSVアイテムをDomesticStockDataに変換
+ * データがDB形式かどうかを判定
+ */
+const isDBFormat = (item: Record<string, unknown>): boolean => {
+    return 'trade_date' in item && 'security_code' in item && !('約定日' in item);
+};
+
+/**
+ * CSVまたはDBアイテムをDomesticStockDataに変換
  */
 export const parseDomesticStockCsvItem = (item: Record<string, unknown>): DomesticStockData => {
+    // DB形式の場合はそのまま返す（既に変換済み）
+    if (isDBFormat(item)) {
+        const securityCode = String(item.security_code || '');
+        return {
+            trade_date: item.trade_date instanceof Date
+                ? item.trade_date
+                : new Date(item.trade_date as string),
+            settlement_date: item.settlement_date instanceof Date
+                ? item.settlement_date
+                : new Date(item.settlement_date as string),
+            security_code: securityCode,
+            security_name: String(item.security_name || ''),
+            security_info: item.security_info || createSecurityCodeLink(securityCode),
+            account: String(item.account || ''),
+            shares: Number(item.shares) || 0,
+            asked_price: Number(item.asked_price) || 0,
+            proceeds: Number(item.proceeds) || 0,
+            purchase_price: Number(item.purchase_price) || 0,
+            realized_profit_and_loss: Number(item.realized_profit_and_loss) || 0,
+            taxes: Number(item.taxes) || 0,
+            realized_profit_and_loss_after_tax: Number(item.realized_profit_and_loss_after_tax) || 0,
+        };
+    }
+
+    // CSV形式の場合
     const account = String(item['口座'] || '');
     const realizedPnL = parseNumber(item['実現損益[円]']);
     // 特定口座の場合のみ税金を計算（利益がある場合のみ）

--- a/frontend/src/features/receipt/parsers/mutualfundParser.ts
+++ b/frontend/src/features/receipt/parsers/mutualfundParser.ts
@@ -2,9 +2,40 @@ import { MutualfundData } from '@/lib/interfaces/mutualfund';
 import { parseNumber, TAX_RATE } from '@/lib/utils/formatters';
 
 /**
- * CSVアイテムをMutualfundDataに変換
+ * データがDB形式かどうかを判定
+ */
+const isDBFormat = (item: Record<string, unknown>): boolean => {
+    return 'trade_date' in item && 'fund_name' in item && !('約定日' in item);
+};
+
+/**
+ * CSVまたはDBアイテムをMutualfundDataに変換
  */
 export const parseMutualfundCsvItem = (item: Record<string, unknown>): MutualfundData => {
+    // DB形式の場合はそのまま返す（既に変換済み）
+    if (isDBFormat(item)) {
+        return {
+            trade_date: item.trade_date instanceof Date
+                ? item.trade_date
+                : new Date(item.trade_date as string),
+            settlement_date: item.settlement_date instanceof Date
+                ? item.settlement_date
+                : new Date(item.settlement_date as string),
+            fund_name: String(item.fund_name || ''),
+            dividends: String(item.dividends || ''),
+            account: String(item.account || ''),
+            shares: Number(item.shares) || 0,
+            exchange_rate: Number(item.exchange_rate) || 0,
+            cancellation_unit_price_yen: Number(item.cancellation_unit_price_yen) || 0,
+            cancellation_amount_yen: Number(item.cancellation_amount_yen) || 0,
+            average_acquisition_price_yen: Number(item.average_acquisition_price_yen) || 0,
+            realized_profit_and_loss: Number(item.realized_profit_and_loss) || 0,
+            taxes: Number(item.taxes) || 0,
+            realized_profit_and_loss_after_tax: Number(item.realized_profit_and_loss_after_tax) || 0,
+        };
+    }
+
+    // CSV形式の場合
     const account = String(item['口座'] || '');
     const realizedPnL = parseNumber(item['実現損益［円］']);
     const isSpecificAccount = account.includes('特定');

--- a/frontend/src/pages/Receipt/Mutualfund.tsx
+++ b/frontend/src/pages/Receipt/Mutualfund.tsx
@@ -11,11 +11,11 @@ import { createSearchOptions, groupAndSummarizeData } from '@/lib/utils/dataTran
 import {
     formatJPDate,
     createYearMonthKey,
-    TAX_RATE,
     formatCurrency,
     formatNumber
 } from '@/lib/utils/formatters';
 import { createYearOptions, matchesYear } from '@/lib/utils/searchUtils';
+import { parseMutualfundCsvItem, sortMutualfundByTradeDate } from '@/features/receipt/parsers';
 
 interface MutualfundProps {
     csvData: Record<string, unknown>[];
@@ -28,29 +28,11 @@ export const Mutualfund: React.FC<MutualfundProps> = ({ csvData }) => {
     const [searchQuery, setSearchQuery] = useState('');
 
     /**
-     * CSVデータをMutualfundData形式に変換
+     * CSVまたはDBデータをMutualfundData形式に変換
      */
-    const mutualfundData: MutualfundData[] = (() => {
-        const parsedData = csvData.map((item) => ({
-            trade_date: new Date(item['約定日'] as string || ''),
-            settlement_date: new Date(item['受渡日'] as string || ''),
-            fund_name: String(item['ファンド名'] || ''),
-            dividends: String(item['分配金'] || ''),
-            account: String(item['口座'] || ''),
-            shares: Number(String(item['数量[口]'] || '0').replace(/,/g, '')),
-            exchange_rate: Number(String(item['為替レート［円］'] || '0').replace(/,/g, '')),
-            cancellation_unit_price_yen: Number(String(item['解約単価［円］'] || '0').replace(/,/g, '')),
-            cancellation_amount_yen: Number(String(item['解約額［円］'] || '0').replace(/,/g, '')),
-            average_acquisition_price_yen: Number(String(item['平均取得価額［円］'] || '0').replace(/,/g, '')),
-            realized_profit_and_loss: Number(String(item['実現損益［円］'] || '0').replace(/,/g, '')),
-            taxes: String(item['口座'] || '').includes('特定') ? Math.floor(Number(String(item['実現損益［円］'] || '0').replace(/,/g, '')) * TAX_RATE) : 0,
-            realized_profit_and_loss_after_tax: Math.floor(Number(String(item['実現損益［円］'] || '0').replace(/,/g, '')) * (String(item['口座'] || '').includes('特定') ? (1 - TAX_RATE) : 1)),
-        }));
-
-        return [...parsedData].sort((a, b) =>
-            a.trade_date.getTime() - b.trade_date.getTime()
-        );
-    })();
+    const mutualfundData: MutualfundData[] = sortMutualfundByTradeDate(
+        csvData.map(parseMutualfundCsvItem)
+    );
 
     /**
      * 全体の集計


### PR DESCRIPTION
## 概要
DBから取得したデータが画面上で全て¥0・空白で表示される問題を修正

## 原因
1. DBデータは`transformDBDividend`等で`DividendData`形式（スネークケース）に変換済み
2. 表示コンポーネントで`parseDividendCsvItem`が再度呼ばれる
3. `parseDividendCsvItem`は日本語キー（`入金日`等）を探すが、DBデータはスネークケース（`settlement_date`等）
4. 結果、すべての値が`0`や空文字になる

## 対応
パーサーをDB/CSV両対応に修正し、データ形式を自動判定して適切に処理

## 変更種別
- [x] バグ修正

## 対象ファイル
- `frontend/src/features/receipt/parsers/dividendParser.ts`
- `frontend/src/features/receipt/parsers/domesticStockParser.ts`
- `frontend/src/features/receipt/parsers/mutualfundParser.ts`

## テスト
- [x] npm run build 通過
- [x] リロード後も正しく表示されることを確認

## チェックリスト
- [x] 既存仕様を維持
- [x] コーディング規約に準拠

🤖 Generated with [Claude Code](https://claude.com/claude-code)