### PR TITLE
feat: Googleログイン導線改善と自動ログアウト機能

### DIFF
--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -88,8 +88,8 @@ fn get_backend_url() -> String {
     })
 }
 
-/// Google OAuth認証を開始
-pub async fn google_auth(State(state): State<AppState>) -> Result<Json<AuthUrlResponse>, ApiError> {
+/// Google OAuth認証を開始（直接リダイレクト）
+pub async fn google_auth(State(state): State<AppState>) -> Result<Redirect, ApiError> {
     let client = create_oauth_client(&state)?;
 
     let (auth_url, _csrf_token) = client
@@ -99,9 +99,7 @@ pub async fn google_auth(State(state): State<AppState>) -> Result<Json<AuthUrlRe
         .add_scope(Scope::new("profile".to_string()))
         .url();
 
-    Ok(Json(AuthUrlResponse {
-        auth_url: auth_url.to_string(),
-    }))
+    Ok(Redirect::to(auth_url.as_str()))
 }
 
 /// Google OAuthコールバックを処理

--- a/frontend/src/components/molecules/CSVFileInput.tsx
+++ b/frontend/src/components/molecules/CSVFileInput.tsx
@@ -39,7 +39,7 @@ export function CSVFileInput({ onFileSelect, selectedFileName = '' }: CSVFileInp
         type="text"
         className="form-control form-control-sm"
         readOnly
-        placeholder="CSVファイルを選択してください。"
+        placeholder="ファイル未選択"
         value={selectedFileName}
       />
     </div>

--- a/frontend/src/components/molecules/ReceiptHeader/ReceiptHeader.tsx
+++ b/frontend/src/components/molecules/ReceiptHeader/ReceiptHeader.tsx
@@ -14,8 +14,8 @@ interface ReceiptHeaderProps {
 export const ReceiptHeader: React.FC<ReceiptHeaderProps> = ({ items }) => {
     return (
         <div className="card shadow-sm mt-1">
-            <div className="card-header bg-primary text-white">
-                <h5 className="mb-0">集計情報</h5>
+            <div className="card-header bg-primary text-white py-2">
+                <h5 className="mb-0 lh-base">集計情報</h5>
             </div>
             <div className="card-body">
                 <div className="row">

--- a/frontend/src/components/organisms/Header.tsx
+++ b/frontend/src/components/organisms/Header.tsx
@@ -3,7 +3,7 @@ import { Button } from '../atoms/Button';
 import { useAuth } from '../../features/auth/hooks/useAuth';
 
 export function Header() {
-  const { user, logout, isAuthenticated, isLoading } = useAuth();
+  const { user, login, logout, isAuthenticated, isLoading } = useAuth();
 
   const handleLogout = async () => {
     try {
@@ -50,11 +50,9 @@ export function Header() {
                 </Button>
               </div>
             ) : (
-              <Link to="/login">
-                <Button variant="outline-light" size="sm">
-                  ログイン
-                </Button>
-              </Link>
+              <Button variant="outline-light" size="sm" onClick={login}>
+                ログイン
+              </Button>
             )}
           </div>
         </div>

--- a/frontend/src/components/templates/ReceiptTemplate.tsx
+++ b/frontend/src/components/templates/ReceiptTemplate.tsx
@@ -50,12 +50,8 @@ const ReceiptTemplateContent: React.FC<ReceiptTemplateProps> = ({
 
       {/* メインコンテンツ */}
       <div className="card shadow-sm mt-1">
-        <div className="card-header bg-primary text-white">
-          <div className="row align-items-center">
-            <div className="col-12">
-              <h5 className='mb-0'>{title}</h5>
-            </div>
-          </div>
+        <div className="card-header bg-primary text-white py-2">
+          <h5 className="mb-0 lh-base">{title}</h5>
         </div>
 
         <div className="card-body p-0">{children}</div>

--- a/frontend/src/features/auth/context/AuthContext.tsx
+++ b/frontend/src/features/auth/context/AuthContext.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, ReactNode } from 'react';
-import { UserInfo, AuthUrlResponse } from '../types';
+import { UserInfo } from '../types';
 import { AuthContext } from './context';
 import { apiClient } from '@/lib/api/client';
 
@@ -34,19 +34,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     checkSession();
   }, []);
 
-  const login = async () => {
-    try {
-      // Google OAuth認証URLを取得
-      const response = await apiClient.get<AuthUrlResponse>('/auth/google', {
-        withCredentials: true,
-      });
-
-      // Googleの認証ページにリダイレクト
-      window.location.href = response.auth_url;
-    } catch (error) {
-      console.error('ログイン開始に失敗しました:', error);
-      throw error;
-    }
+  const login = () => {
+    // バックエンドの認証エンドポイントに直接リダイレクト
+    // バックエンドがGoogleの認証ページにリダイレクトする
+    const apiBaseUrl = import.meta.env.VITE_SHOKEN_WEBAPI_API_URL;
+    window.location.href = `${apiBaseUrl}/auth/google`;
   };
 
   const logout = async () => {

--- a/frontend/src/features/auth/context/AuthContext.tsx
+++ b/frontend/src/features/auth/context/AuthContext.tsx
@@ -1,7 +1,11 @@
-import { useState, useEffect, ReactNode } from 'react';
+import { useState, useEffect, useCallback, ReactNode } from 'react';
 import { UserInfo } from '../types';
 import { AuthContext } from './context';
 import { apiClient } from '@/lib/api/client';
+import { useIdleTimer } from '../hooks/useIdleTimer';
+
+// アイドルタイムアウト: 30分
+const IDLE_TIMEOUT = 30 * 60 * 1000;
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<UserInfo | null>(null);
@@ -41,7 +45,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     window.location.href = `${apiBaseUrl}/auth/google`;
   };
 
-  const logout = async () => {
+  const logout = useCallback(async () => {
     try {
       await apiClient.post('/auth/logout', {}, {
         withCredentials: true,
@@ -51,7 +55,22 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     } finally {
       setUser(null);
     }
-  };
+  }, []);
+
+  // 自動ログアウト処理
+  const handleIdle = useCallback(() => {
+    if (user) {
+      console.log('アイドルタイムアウトにより自動ログアウトします');
+      logout();
+    }
+  }, [user, logout]);
+
+  // アイドルタイマーを設定（ログイン中のみ有効）
+  useIdleTimer({
+    timeout: IDLE_TIMEOUT,
+    onIdle: handleIdle,
+    enabled: !!user,
+  });
 
   return (
     <AuthContext.Provider value={{

--- a/frontend/src/features/auth/hooks/useIdleTimer.ts
+++ b/frontend/src/features/auth/hooks/useIdleTimer.ts
@@ -1,0 +1,72 @@
+import { useEffect, useRef, useCallback } from 'react';
+
+interface UseIdleTimerOptions {
+  timeout: number; // ミリ秒
+  onIdle: () => void;
+  enabled?: boolean;
+}
+
+/**
+ * ユーザーのアイドル状態を監視するフック
+ * 一定時間操作がない場合にコールバックを実行
+ */
+export function useIdleTimer({ timeout, onIdle, enabled = true }: UseIdleTimerOptions) {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onIdleRef = useRef(onIdle);
+
+  // コールバックを最新に保つ
+  useEffect(() => {
+    onIdleRef.current = onIdle;
+  }, [onIdle]);
+
+  const resetTimer = useCallback(() => {
+    if (!enabled) return;
+
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+
+    timerRef.current = setTimeout(() => {
+      onIdleRef.current();
+    }, timeout);
+  }, [timeout, enabled]);
+
+  useEffect(() => {
+    if (!enabled) {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+      return;
+    }
+
+    // 監視するイベント
+    const events = [
+      'mousedown',
+      'mousemove',
+      'keydown',
+      'scroll',
+      'touchstart',
+      'click',
+    ];
+
+    // イベントリスナーを登録
+    events.forEach((event) => {
+      document.addEventListener(event, resetTimer, { passive: true });
+    });
+
+    // 初回タイマー開始
+    resetTimer();
+
+    return () => {
+      events.forEach((event) => {
+        document.removeEventListener(event, resetTimer);
+      });
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, [resetTimer, enabled]);
+
+  return { resetTimer };
+}

--- a/frontend/src/pages/Receipts.tsx
+++ b/frontend/src/pages/Receipts.tsx
@@ -259,7 +259,7 @@ export function ReceiptsPage() {
       </nav>
       <div className="receipt-page mt-2">
         <div className="d-flex align-items-center gap-2 flex-wrap">
-          <div style={{ width: '350px' }}>
+          <div style={{ width: '400px' }}>
             <CSVFileInput onFileSelect={handleFileSelect} selectedFileName={fileName} />
           </div>
           {isAuthenticated && (


### PR DESCRIPTION
## 概要
1. Googleログイン導線の改善
2. 一定時間操作がない場合の自動ログアウト機能

## 1. Googleログイン導線の改善

### 変更前
1. ログインボタンをクリック
2. フロントエンドがAPI呼び出し
3. auth_urlを取得
4. Googleにリダイレクト

### 変更後
1. ログインボタンをクリック
2. 直接バックエンドにリダイレクト → Googleに転送

### 対象ファイル
- `backend/src/handlers/auth.rs` - JSONレスポンスからリダイレクトに変更
- `frontend/src/features/auth/context/AuthContext.tsx` - 直接リダイレクトに変更

## 2. 自動ログアウト機能

### 仕様
- 30分間ユーザー操作がない場合に自動ログアウト
- 監視イベント: マウス、キーボード、スクロール、タッチ
- ログイン中のみタイマーが有効

### 対象ファイル
- `frontend/src/features/auth/hooks/useIdleTimer.ts` - 新規作成
- `frontend/src/features/auth/context/AuthContext.tsx` - フック統合

## 変更種別
- [x] 新機能
- [x] UX改善

## テスト
- [x] cargo check 通過
- [x] npm run build 通過

## チェックリスト
- [x] 既存仕様を維持
- [x] セキュリティ要件を維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)