### PR TITLE
J-Quants API V2対応と開発フロー改善

### DIFF
--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -7,37 +7,52 @@ description: |
 
 # デプロイ
 
+## 重要: 自動デプロイが基本
+
+main ブランチへのマージで自動デプロイが実行されるため、
+**通常は手動デプロイ不要**。
+
 ## バックエンド (Fly.io)
 
-### 自動デプロイ
-- `main` ブランチへの push で自動デプロイ（GitHub Actions）
+### 自動デプロイ（推奨）
+- `main` ブランチへのマージで自動デプロイ（GitHub Actions）
 - `backend/**` の変更時のみトリガー
+- **手動デプロイは不要**
 
-### 手動デプロイ
+### 手動デプロイ（緊急時のみ）
 ```bash
 cd backend && flyctl deploy --remote-only
 ```
 
-### 確認
+### ログ確認
 ```bash
-flyctl status
-flyctl logs
+flyctl logs -a shoken-backend
+flyctl status -a shoken-backend
 ```
 
 ## フロントエンド (Vercel)
 
-### 自動デプロイ
+### 自動デプロイ（推奨）
 - `main` ブランチへのマージで自動デプロイ
 - PR作成時にプレビューデプロイ
+- **手動デプロイは不要**
 
-### 手動デプロイ（必要な場合）
+### 手動デプロイ（緊急時のみ）
 ```bash
 cd frontend && vercel --prod
 ```
 
+## 開発フロー
+
+1. ローカルでテスト（cargo test, npm test）
+2. PR作成
+3. レビュー・マージ
+4. **自動デプロイ実行**（手動操作不要）
+5. 本番で動作確認
+
 ## デプロイ前チェックリスト
 
-- [ ] テストがすべてパス
+- [ ] ローカルテストがすべてパス
 - [ ] ビルドが成功
 - [ ] 環境変数が正しく設定されている
 - [ ] マイグレーションが必要な場合は先に実行
@@ -46,7 +61,7 @@ cd frontend && vercel --prod
 
 ### Fly.io
 ```bash
-flyctl releases list
+flyctl releases list -a shoken-backend
 flyctl deploy --image <previous-image>
 ```
 

--- a/.claude/skills/local-testing/SKILL.md
+++ b/.claude/skills/local-testing/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: local-testing
+description: |
+  ローカル環境でのテスト実行方針。
+  デプロイ前にローカルで確認すべき項目と、デプロイが必要な項目を整理。
+  Use when: テスト、動作確認、開発フローを確認したい時。
+---
+
+# ローカルテスト重視の開発フロー
+
+## 基本方針
+
+- デプロイ前にローカルで確認できることは全てローカルで確認
+- fly.io/Vercel へのデプロイは main ブランチマージ時に自動実行
+- 手動デプロイは緊急時のみ
+
+## ローカルで確認可能な項目
+
+### バックエンド
+
+```bash
+cd backend
+
+# フォーマット・Lint
+cargo fmt --check
+cargo clippy -- -D warnings
+
+# ユニットテスト
+cargo test
+
+# ビルド確認
+cargo build
+```
+
+| 項目 | ローカル可能 | 備考 |
+|------|-------------|------|
+| コンパイル | ○ | `cargo build` |
+| ユニットテスト | ○ | `cargo test` |
+| モデル・型定義 | ○ | コンパイルで確認 |
+| API構造テスト | ○ | モックで可能 |
+| DB接続テスト | △ | ローカルDB必要 |
+| 外部API連携 | △ | APIキー必要 |
+
+### フロントエンド
+
+```bash
+cd frontend
+
+# Lint
+npm run lint
+
+# 型チェック
+npm run tsc
+
+# テスト
+npm test
+
+# ビルド
+npm run build
+```
+
+| 項目 | ローカル可能 | 備考 |
+|------|-------------|------|
+| TypeScript型チェック | ○ | `npm run tsc` |
+| ユニットテスト | ○ | `npm test` |
+| コンポーネントテスト | ○ | Vitest + RTL |
+| API呼び出しモック | ○ | vi.mock使用 |
+| 実API連携 | × | 本番環境必要 |
+
+## デプロイが必要な確認項目
+
+- OAuth認証フロー（Google連携）
+- 本番DB接続
+- 外部API連携（J-Quants等）
+- CORS設定
+- 本番環境変数
+
+## 推奨開発フロー
+
+1. **機能実装**
+   - ローカルでコード作成
+   - ユニットテスト作成
+
+2. **ローカル確認**
+   ```bash
+   # バックエンド
+   cd backend && cargo fmt && cargo clippy -- -D warnings && cargo test
+
+   # フロントエンド
+   cd frontend && npm run lint && npm run tsc && npm test
+   ```
+
+3. **PRマージ → 自動デプロイ**
+   - main へマージで fly.io/Vercel に自動デプロイ
+   - 手動デプロイ不要
+
+4. **本番確認**
+   - 外部連携部分のみ本番で確認
+
+## J-Quants API テスト
+
+### ローカルテスト（モック使用）
+
+```rust
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_fin_summary_data_deserialize_v2_format() {
+        let json_data = json!({
+            "DiscDate": "2023-11-14",
+            "Code": "72030",
+            "NxFDivAnn": "50.00",
+        });
+        let data: FinSummaryData = serde_json::from_value(json_data).unwrap();
+        assert_eq!(data.disclosed_date, "2023-11-14");
+    }
+}
+```
+
+### 実API確認が必要な場合
+
+```bash
+# .env に JQUANTS_API_KEY を設定後
+cd backend && cargo run
+# 別ターミナルで curl や Postman でテスト
+```

--- a/backend/src/handlers/jquants.rs
+++ b/backend/src/handlers/jquants.rs
@@ -1,5 +1,5 @@
 use crate::errors::ApiError;
-use crate::models::jquants::{StatementsQuery, StatementsResponse};
+use crate::models::jquants::{FinSummaryQuery, FinSummaryResponse};
 use crate::services::jquants::JQuantsService;
 use crate::state::AppState;
 use axum::{
@@ -7,19 +7,19 @@ use axum::{
     response::Json,
 };
 
-/// 財務諸表を取得（J-Quants API V2）
-pub async fn get_statements(
+/// 決算サマリーを取得（J-Quants API V2）
+/// V2では fins/statements → fins/summary に変更
+pub async fn get_fin_summary(
     State(state): State<AppState>,
-    Query(params): Query<StatementsQuery>,
-) -> Result<Json<StatementsResponse>, ApiError> {
-    tracing::info!("財務諸表取得パラメータ: {:?}", params);
+    Query(params): Query<FinSummaryQuery>,
+) -> Result<Json<FinSummaryResponse>, ApiError> {
+    tracing::info!("決算サマリー取得パラメータ: {:?}", params);
 
-    let api_key =
-        state.secrets.jquants_api_key.as_ref().ok_or_else(|| {
-            ApiError::ApiError("JQUANTS_API_KEY が設定されていません".to_string())
-        })?;
+    let api_key = state.secrets.jquants_api_key.as_ref().ok_or_else(|| {
+        ApiError::ApiError("JQUANTS_API_KEY が設定されていません".to_string())
+    })?;
 
-    let response = JQuantsService::get_statements(&state.client, params, api_key).await?;
+    let response = JQuantsService::get_fin_summary(&state.client, params, api_key).await?;
     Ok(Json(response))
 }
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -66,9 +66,11 @@ async fn main() {
         .route("/stock", post(handlers::stock::add_stock_info))
         .route("/stock/{query}", get(handlers::stock::select_stock_info))
         // JQuantsのエンドポイント（V2 APIキー認証）
+        // V2では fins/statements → fins/summary に変更されたが、
+        // フロントエンド互換性のためURLパスは維持
         .route(
             "/jquants/fins/statements",
-            get(handlers::jquants::get_statements),
+            get(handlers::jquants::get_fin_summary),
         )
         // 認証エンドポイント
         .route("/auth/google", get(handlers::auth::google_auth))
@@ -163,7 +165,7 @@ mod tests {
             .route("/stock/{query}", get(handlers::stock::select_stock_info))
             .route(
                 "/jquants/fins/statements",
-                get(handlers::jquants::get_statements),
+                get(handlers::jquants::get_fin_summary),
             )
             .with_state(state)
     }

--- a/backend/src/models/jquants.rs
+++ b/backend/src/models/jquants.rs
@@ -10,6 +10,9 @@ pub struct StatementsQuery {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct StatementsResponse {
     pub statements: Vec<StatementsData>,
+    /// ページネーションキー（データが大量の場合に設定される）
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pagination_key: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/backend/src/models/jquants.rs
+++ b/backend/src/models/jquants.rs
@@ -1,22 +1,28 @@
 use serde::{Deserialize, Serialize};
 
+/// 決算サマリー取得パラメータ（J-Quants API V2）
 #[derive(Debug, Deserialize)]
-pub struct StatementsQuery {
+pub struct FinSummaryQuery {
     pub code: String,
     pub from: Option<String>,
     pub to: Option<String>,
 }
 
+/// 決算サマリーレスポンス（J-Quants API V2）
+/// V1の fins/statements → V2の fins/summary に対応
 #[derive(Debug, Serialize, Deserialize)]
-pub struct StatementsResponse {
-    pub statements: Vec<StatementsData>,
+pub struct FinSummaryResponse {
+    /// 決算サマリーデータの配列
+    #[serde(rename = "fin_summary")]
+    pub fin_summary: Vec<FinSummaryData>,
     /// ページネーションキー（データが大量の場合に設定される）
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pagination_key: Option<String>,
 }
 
+/// 決算サマリーデータ（J-Quants API V2）
 #[derive(Debug, Serialize, Deserialize)]
-pub struct StatementsData {
+pub struct FinSummaryData {
     #[serde(rename = "DisclosedDate")]
     pub disclosed_date: String,
 
@@ -348,8 +354,8 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn test_statements_query_deserialize() {
-        let query = StatementsQuery {
+    fn test_fin_summary_query_deserialize() {
+        let query = FinSummaryQuery {
             code: "7203".to_string(),
             from: Some("2023-01-01".to_string()),
             to: Some("2023-12-31".to_string()),
@@ -361,8 +367,8 @@ mod tests {
     }
 
     #[test]
-    fn test_statements_query_optional_params() {
-        let query = StatementsQuery {
+    fn test_fin_summary_query_optional_params() {
+        let query = FinSummaryQuery {
             code: "7203".to_string(),
             from: None,
             to: None,
@@ -374,7 +380,7 @@ mod tests {
     }
 
     #[test]
-    fn test_statements_data_deserialize() {
+    fn test_fin_summary_data_deserialize() {
         let json_data = json!({
             "DisclosedDate": "2023-11-14",
             "DisclosedTime": "15:00:00",
@@ -393,24 +399,25 @@ mod tests {
             "NextYearForecastDividendPerShareAnnual": "50.00"
         });
 
-        let statements_data: StatementsData = serde_json::from_value(json_data).unwrap();
+        let fin_summary_data: FinSummaryData = serde_json::from_value(json_data).unwrap();
 
-        assert_eq!(statements_data.disclosed_date, "2023-11-14");
-        assert_eq!(statements_data.local_code, "72030");
+        assert_eq!(fin_summary_data.disclosed_date, "2023-11-14");
+        assert_eq!(fin_summary_data.local_code, "72030");
         assert_eq!(
-            statements_data.net_sales,
+            fin_summary_data.net_sales,
             Some("18733067000000".to_string())
         );
         assert_eq!(
-            statements_data.next_year_forecast_dividend_per_share_annual,
+            fin_summary_data.next_year_forecast_dividend_per_share_annual,
             Some("50.00".to_string())
         );
     }
 
     #[test]
-    fn test_statements_response_deserialize() {
+    fn test_fin_summary_response_deserialize() {
+        // V2 API では "fin_summary" フィールド名を使用
         let json_data = json!({
-            "statements": [
+            "fin_summary": [
                 {
                     "DisclosedDate": "2023-11-14",
                     "LocalCode": "72030",
@@ -424,18 +431,18 @@ mod tests {
             ]
         });
 
-        let response: StatementsResponse = serde_json::from_value(json_data).unwrap();
+        let response: FinSummaryResponse = serde_json::from_value(json_data).unwrap();
 
-        assert_eq!(response.statements.len(), 1);
-        assert_eq!(response.statements[0].disclosed_date, "2023-11-14");
-        assert_eq!(response.statements[0].local_code, "72030");
+        assert_eq!(response.fin_summary.len(), 1);
+        assert_eq!(response.fin_summary[0].disclosed_date, "2023-11-14");
+        assert_eq!(response.fin_summary[0].local_code, "72030");
     }
 
     #[test]
-    fn test_statements_response_empty() {
-        let json_data = json!({ "statements": [] });
-        let response: StatementsResponse = serde_json::from_value(json_data).unwrap();
+    fn test_fin_summary_response_empty() {
+        let json_data = json!({ "fin_summary": [] });
+        let response: FinSummaryResponse = serde_json::from_value(json_data).unwrap();
 
-        assert_eq!(response.statements.len(), 0);
+        assert_eq!(response.fin_summary.len(), 0);
     }
 }

--- a/backend/src/models/jquants.rs
+++ b/backend/src/models/jquants.rs
@@ -9,342 +9,447 @@ pub struct FinSummaryQuery {
 }
 
 /// 決算サマリーレスポンス（J-Quants API V2）
-/// V1の fins/statements → V2の fins/summary に対応
+/// V2では fins/summary を使用し、ルートフィールドは "data"
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FinSummaryResponse {
-    /// 決算サマリーデータの配列
-    #[serde(rename = "fin_summary")]
-    pub fin_summary: Vec<FinSummaryData>,
+    /// 決算サマリーデータの配列（V2では "data" フィールド）
+    pub data: Vec<FinSummaryData>,
     /// ページネーションキー（データが大量の場合に設定される）
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pagination_key: Option<String>,
 }
 
 /// 決算サマリーデータ（J-Quants API V2）
+/// V2では省略形フィールド名を使用
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FinSummaryData {
-    #[serde(rename = "DisclosedDate")]
+    /// 開示日（DisclosedDate → DiscDate）
+    #[serde(rename = "DiscDate")]
     pub disclosed_date: String,
 
-    #[serde(rename = "DisclosedTime")]
+    /// 開示時刻
+    #[serde(rename = "DiscTime", default)]
     pub disclosed_time: Option<String>,
 
-    #[serde(rename = "LocalCode")]
+    /// 銘柄コード（LocalCode → Code）
+    #[serde(rename = "Code")]
     pub local_code: String,
 
-    #[serde(rename = "DisclosureNumber")]
+    /// 開示番号
+    #[serde(rename = "DiscNum", default)]
     pub disclosure_number: Option<String>,
 
-    #[serde(rename = "TypeOfDocument")]
+    /// 書類種別
+    #[serde(rename = "DocType")]
     pub type_of_document: String,
 
-    #[serde(rename = "TypeOfCurrentPeriod")]
+    /// 当期種別
+    #[serde(rename = "CurPeriod")]
     pub type_of_current_period: String,
 
-    #[serde(rename = "CurrentPeriodStartDate")]
+    /// 当期開始日
+    #[serde(rename = "CurStartDate")]
     pub current_period_start_date: String,
 
-    #[serde(rename = "CurrentPeriodEndDate")]
+    /// 当期終了日
+    #[serde(rename = "CurEndDate")]
     pub current_period_end_date: String,
 
-    #[serde(rename = "CurrentFiscalYearStartDate")]
+    /// 当会計年度開始日
+    #[serde(rename = "CurFYStartDate")]
     pub current_fiscal_year_start_date: String,
 
-    #[serde(rename = "CurrentFiscalYearEndDate")]
+    /// 当会計年度終了日
+    #[serde(rename = "CurFYEndDate")]
     pub current_fiscal_year_end_date: String,
 
-    #[serde(rename = "NextFiscalYearStartDate")]
+    /// 翌会計年度開始日
+    #[serde(rename = "NxFYStartDate", default)]
     pub next_fiscal_year_start_date: Option<String>,
 
-    #[serde(rename = "NextFiscalYearEndDate")]
+    /// 翌会計年度終了日
+    #[serde(rename = "NxFYEndDate", default)]
     pub next_fiscal_year_end_date: Option<String>,
 
-    #[serde(rename = "NetSales")]
+    /// 売上高
+    #[serde(rename = "Sales", default)]
     pub net_sales: Option<String>,
 
-    #[serde(rename = "OperatingProfit")]
+    /// 営業利益
+    #[serde(rename = "OpProfit", default)]
     pub operating_profit: Option<String>,
 
-    #[serde(rename = "OrdinaryProfit")]
+    /// 経常利益
+    #[serde(rename = "OrdProfit", default)]
     pub ordinary_profit: Option<String>,
 
-    #[serde(rename = "Profit")]
+    /// 当期純利益
+    #[serde(rename = "Profit", default)]
     pub profit: Option<String>,
 
-    #[serde(rename = "EarningsPerShare")]
+    /// 1株当たり当期純利益
+    #[serde(rename = "EPS", default)]
     pub earnings_per_share: Option<String>,
 
-    #[serde(rename = "DilutedEarningsPerShare")]
+    /// 希薄化後1株当たり当期純利益
+    #[serde(rename = "DilutedEPS", default)]
     pub diluted_earnings_per_share: Option<String>,
 
-    #[serde(rename = "TotalAssets")]
+    /// 総資産
+    #[serde(rename = "TotalAssets", default)]
     pub total_assets: Option<String>,
 
-    #[serde(rename = "Equity")]
+    /// 純資産
+    #[serde(rename = "Equity", default)]
     pub equity: Option<String>,
 
-    #[serde(rename = "EquityToAssetRatio")]
+    /// 自己資本比率
+    #[serde(rename = "EquityRatio", default)]
     pub equity_to_asset_ratio: Option<String>,
 
-    #[serde(rename = "BookValuePerShare")]
+    /// 1株当たり純資産
+    #[serde(rename = "BPS", default)]
     pub book_value_per_share: Option<String>,
 
-    #[serde(rename = "CashFlowsFromOperatingActivities")]
+    /// 営業活動によるキャッシュフロー
+    #[serde(rename = "CashFlowOp", default)]
     pub cash_flows_from_operating_activities: Option<String>,
 
-    #[serde(rename = "CashFlowsFromInvestingActivities")]
+    /// 投資活動によるキャッシュフロー
+    #[serde(rename = "CashFlowInv", default)]
     pub cash_flows_from_investing_activities: Option<String>,
 
-    #[serde(rename = "CashFlowsFromFinancingActivities")]
+    /// 財務活動によるキャッシュフロー
+    #[serde(rename = "CashFlowFin", default)]
     pub cash_flows_from_financing_activities: Option<String>,
 
-    #[serde(rename = "CashAndEquivalents")]
+    /// 現金及び現金同等物の期末残高
+    #[serde(rename = "CashEq", default)]
     pub cash_and_equivalents: Option<String>,
 
-    #[serde(rename = "ResultDividendPerShare1stQuarter")]
+    /// 1株当たり配当金（第1四半期末）実績
+    #[serde(rename = "Div1Q", default)]
     pub result_dividend_per_share_1st_quarter: Option<String>,
 
-    #[serde(rename = "ResultDividendPerShare2ndQuarter")]
+    /// 1株当たり配当金（第2四半期末）実績
+    #[serde(rename = "Div2Q", default)]
     pub result_dividend_per_share_2nd_quarter: Option<String>,
 
-    #[serde(rename = "ResultDividendPerShare3rdQuarter")]
+    /// 1株当たり配当金（第3四半期末）実績
+    #[serde(rename = "Div3Q", default)]
     pub result_dividend_per_share_3rd_quarter: Option<String>,
 
-    #[serde(rename = "ResultDividendPerShareFiscalYearEnd")]
+    /// 1株当たり配当金（期末）実績
+    #[serde(rename = "DivYrEnd", default)]
     pub result_dividend_per_share_fiscal_year_end: Option<String>,
 
-    #[serde(rename = "ResultDividendPerShareAnnual")]
+    /// 1株当たり年間配当金実績
+    #[serde(rename = "DivAnn", default)]
     pub result_dividend_per_share_annual: Option<String>,
 
-    #[serde(rename = "DistributionsPerUnit(REIT)")]
+    /// 1口当たり分配金（REIT）
+    #[serde(rename = "DistREIT", default)]
     pub distributions_per_unit_reit: Option<String>,
 
-    #[serde(rename = "ResultTotalDividendPaidAnnual")]
+    /// 年間配当支払総額実績
+    #[serde(rename = "TotalDivPaidAnn", default)]
     pub result_total_dividend_paid_annual: Option<String>,
 
-    #[serde(rename = "ResultPayoutRatioAnnual")]
+    /// 配当性向実績
+    #[serde(rename = "PayoutRatioAnn", default)]
     pub result_payout_ratio_annual: Option<String>,
 
-    #[serde(rename = "ForecastDividendPerShare1stQuarter")]
+    /// 1株当たり配当金（第1四半期末）予想
+    #[serde(rename = "FDiv1Q", default)]
     pub forecast_dividend_per_share_1st_quarter: Option<String>,
 
-    #[serde(rename = "ForecastDividendPerShare2ndQuarter")]
+    /// 1株当たり配当金（第2四半期末）予想
+    #[serde(rename = "FDiv2Q", default)]
     pub forecast_dividend_per_share_2nd_quarter: Option<String>,
 
-    #[serde(rename = "ForecastDividendPerShare3rdQuarter")]
+    /// 1株当たり配当金（第3四半期末）予想
+    #[serde(rename = "FDiv3Q", default)]
     pub forecast_dividend_per_share_3rd_quarter: Option<String>,
 
-    #[serde(rename = "ForecastDividendPerShareFiscalYearEnd")]
+    /// 1株当たり配当金（期末）予想
+    #[serde(rename = "FDivYrEnd", default)]
     pub forecast_dividend_per_share_fiscal_year_end: Option<String>,
 
-    #[serde(rename = "ForecastDividendPerShareAnnual")]
+    /// 1株当たり年間配当金予想（今期）
+    #[serde(rename = "FDivAnn", default)]
     pub forecast_dividend_per_share_annual: Option<String>,
 
-    #[serde(rename = "ForecastDistributionsPerUnit(REIT)")]
+    /// 1口当たり分配金（REIT）予想
+    #[serde(rename = "FDistREIT", default)]
     pub forecast_distributions_per_unit_reit: Option<String>,
 
-    #[serde(rename = "ForecastTotalDividendPaidAnnual")]
+    /// 年間配当支払総額予想
+    #[serde(rename = "FTotalDivPaidAnn", default)]
     pub forecast_total_dividend_paid_annual: Option<String>,
 
-    #[serde(rename = "ForecastPayoutRatioAnnual")]
+    /// 配当性向予想
+    #[serde(rename = "FPayoutRatioAnn", default)]
     pub forecast_payout_ratio_annual: Option<String>,
 
-    #[serde(rename = "NextYearForecastDividendPerShare1stQuarter")]
+    /// 1株当たり配当金（第1四半期末）来期予想
+    #[serde(rename = "NxFDiv1Q", default)]
     pub next_year_forecast_dividend_per_share_1st_quarter: Option<String>,
 
-    #[serde(rename = "NextYearForecastDividendPerShare2ndQuarter")]
+    /// 1株当たり配当金（第2四半期末）来期予想
+    #[serde(rename = "NxFDiv2Q", default)]
     pub next_year_forecast_dividend_per_share_2nd_quarter: Option<String>,
 
-    #[serde(rename = "NextYearForecastDividendPerShare3rdQuarter")]
+    /// 1株当たり配当金（第3四半期末）来期予想
+    #[serde(rename = "NxFDiv3Q", default)]
     pub next_year_forecast_dividend_per_share_3rd_quarter: Option<String>,
 
-    #[serde(rename = "NextYearForecastDividendPerShareFiscalYearEnd")]
+    /// 1株当たり配当金（期末）来期予想
+    #[serde(rename = "NxFDivYrEnd", default)]
     pub next_year_forecast_dividend_per_share_fiscal_year_end: Option<String>,
 
-    #[serde(rename = "NextYearForecastDividendPerShareAnnual")]
+    /// 1株当たり年間配当金来期予想
+    #[serde(rename = "NxFDivAnn", default)]
     pub next_year_forecast_dividend_per_share_annual: Option<String>,
 
-    #[serde(rename = "NextYearForecastDistributionsPerUnit(REIT)")]
+    /// 1口当たり分配金（REIT）来期予想
+    #[serde(rename = "NxFDistREIT", default)]
     pub next_year_forecast_distributions_per_unit_reit: Option<String>,
 
-    #[serde(rename = "NextYearForecastPayoutRatioAnnual")]
+    /// 配当性向来期予想
+    #[serde(rename = "NxFPayoutRatioAnn", default)]
     pub next_year_forecast_payout_ratio_annual: Option<String>,
 
-    #[serde(rename = "ForecastNetSales2ndQuarter")]
+    /// 売上高予想（第2四半期）
+    #[serde(rename = "FSales2Q", default)]
     pub forecast_net_sales_2nd_quarter: Option<String>,
 
-    #[serde(rename = "ForecastOperatingProfit2ndQuarter")]
+    /// 営業利益予想（第2四半期）
+    #[serde(rename = "FOpProfit2Q", default)]
     pub forecast_operating_profit_2nd_quarter: Option<String>,
 
-    #[serde(rename = "ForecastOrdinaryProfit2ndQuarter")]
+    /// 経常利益予想（第2四半期）
+    #[serde(rename = "FOrdProfit2Q", default)]
     pub forecast_ordinary_profit_2nd_quarter: Option<String>,
 
-    #[serde(rename = "ForecastProfit2ndQuarter")]
+    /// 当期純利益予想（第2四半期）
+    #[serde(rename = "FProfit2Q", default)]
     pub forecast_profit_2nd_quarter: Option<String>,
 
-    #[serde(rename = "ForecastEarningsPerShare2ndQuarter")]
+    /// 1株当たり当期純利益予想（第2四半期）
+    #[serde(rename = "FEPS2Q", default)]
     pub forecast_earnings_per_share_2nd_quarter: Option<String>,
 
-    #[serde(rename = "NextYearForecastNetSales2ndQuarter")]
+    /// 売上高来期予想（第2四半期）
+    #[serde(rename = "NxFSales2Q", default)]
     pub next_year_forecast_net_sales_2nd_quarter: Option<String>,
 
-    #[serde(rename = "NextYearForecastOperatingProfit2ndQuarter")]
+    /// 営業利益来期予想（第2四半期）
+    #[serde(rename = "NxFOpProfit2Q", default)]
     pub next_year_forecast_operating_profit_2nd_quarter: Option<String>,
 
-    #[serde(rename = "NextYearForecastOrdinaryProfit2ndQuarter")]
+    /// 経常利益来期予想（第2四半期）
+    #[serde(rename = "NxFOrdProfit2Q", default)]
     pub next_year_forecast_ordinary_profit_2nd_quarter: Option<String>,
 
-    #[serde(rename = "NextYearForecastProfit2ndQuarter")]
+    /// 当期純利益来期予想（第2四半期）
+    #[serde(rename = "NxFProfit2Q", default)]
     pub next_year_forecast_profit_2nd_quarter: Option<String>,
 
-    #[serde(rename = "NextYearForecastEarningsPerShare2ndQuarter")]
+    /// 1株当たり当期純利益来期予想（第2四半期）
+    #[serde(rename = "NxFEPS2Q", default)]
     pub next_year_forecast_earnings_per_share_2nd_quarter: Option<String>,
 
-    #[serde(rename = "ForecastNetSales")]
+    /// 売上高予想（通期）
+    #[serde(rename = "FSales", default)]
     pub forecast_net_sales: Option<String>,
 
-    #[serde(rename = "ForecastOperatingProfit")]
+    /// 営業利益予想（通期）
+    #[serde(rename = "FOpProfit", default)]
     pub forecast_operating_profit: Option<String>,
 
-    #[serde(rename = "ForecastOrdinaryProfit")]
+    /// 経常利益予想（通期）
+    #[serde(rename = "FOrdProfit", default)]
     pub forecast_ordinary_profit: Option<String>,
 
-    #[serde(rename = "ForecastProfit")]
+    /// 当期純利益予想（通期）
+    #[serde(rename = "FProfit", default)]
     pub forecast_profit: Option<String>,
 
-    #[serde(rename = "ForecastEarningsPerShare")]
+    /// 1株当たり当期純利益予想（通期）
+    #[serde(rename = "FEPS", default)]
     pub forecast_earnings_per_share: Option<String>,
 
-    #[serde(rename = "NextYearForecastNetSales")]
+    /// 売上高来期予想（通期）
+    #[serde(rename = "NxFSales", default)]
     pub next_year_forecast_net_sales: Option<String>,
 
-    #[serde(rename = "NextYearForecastOperatingProfit")]
+    /// 営業利益来期予想（通期）
+    #[serde(rename = "NxFOpProfit", default)]
     pub next_year_forecast_operating_profit: Option<String>,
 
-    #[serde(rename = "NextYearForecastOrdinaryProfit")]
+    /// 経常利益来期予想（通期）
+    #[serde(rename = "NxFOrdProfit", default)]
     pub next_year_forecast_ordinary_profit: Option<String>,
 
-    #[serde(rename = "NextYearForecastProfit")]
+    /// 当期純利益来期予想（通期）
+    #[serde(rename = "NxFProfit", default)]
     pub next_year_forecast_profit: Option<String>,
 
-    #[serde(rename = "NextYearForecastEarningsPerShare")]
+    /// 1株当たり当期純利益来期予想（通期）
+    #[serde(rename = "NxFEPS", default)]
     pub next_year_forecast_earnings_per_share: Option<String>,
 
-    #[serde(rename = "MaterialChangesInSubsidiaries")]
+    /// 重要な子会社の異動
+    #[serde(rename = "MatChgSub", default)]
     pub material_changes_in_subsidiaries: Option<String>,
 
-    #[serde(rename = "SignificantChangesInTheScopeOfConsolidation")]
+    /// 連結範囲の重要な変更
+    #[serde(rename = "SigChgScope", default)]
     pub significant_changes_in_the_scope_of_consolidation: Option<String>,
 
-    #[serde(rename = "ChangesBasedOnRevisionsOfAccountingStandard")]
+    /// 会計基準の改正に伴う変更
+    #[serde(rename = "ChgAccStd", default)]
     pub changes_based_on_revisions_of_accounting_standard: Option<String>,
 
-    #[serde(rename = "ChangesOtherThanOnesBasedOnRevisionsOfAccountingStandard")]
+    /// 会計基準の改正以外の変更
+    #[serde(rename = "ChgOther", default)]
     pub changes_other_than_ones_based_on_revisions_of_accounting_standard: Option<String>,
 
-    #[serde(rename = "ChangesInAccountingEstimates")]
+    /// 会計上の見積りの変更
+    #[serde(rename = "ChgEstimate", default)]
     pub changes_in_accounting_estimates: Option<String>,
 
-    #[serde(rename = "RetrospectiveRestatement")]
+    /// 修正再表示
+    #[serde(rename = "Restatement", default)]
     pub retrospective_restatement: Option<String>,
 
-    #[serde(
-        rename = "NumberOfIssuedAndOutstandingSharesAtTheEndOfFiscalYearIncludingTreasuryStock"
-    )]
+    /// 発行済株式数（期末・自己株式を含む）
+    #[serde(rename = "SharesOutstanding", default)]
     pub number_of_issued_and_outstanding_shares_at_the_end_of_fiscal_year_including_treasury_stock:
         Option<String>,
 
-    #[serde(rename = "NumberOfTreasuryStockAtTheEndOfFiscalYear")]
+    /// 自己株式数（期末）
+    #[serde(rename = "TreasuryStock", default)]
     pub number_of_treasury_stock_at_the_end_of_fiscal_year: Option<String>,
 
-    #[serde(rename = "AverageNumberOfShares")]
+    /// 期中平均株式数
+    #[serde(rename = "AvgShares", default)]
     pub average_number_of_shares: Option<String>,
 
-    #[serde(rename = "NonConsolidatedNetSales")]
+    /// 売上高（個別）
+    #[serde(rename = "NonConSales", default)]
     pub non_consolidated_net_sales: Option<String>,
 
-    #[serde(rename = "NonConsolidatedOperatingProfit")]
+    /// 営業利益（個別）
+    #[serde(rename = "NonConOpProfit", default)]
     pub non_consolidated_operating_profit: Option<String>,
 
-    #[serde(rename = "NonConsolidatedOrdinaryProfit")]
+    /// 経常利益（個別）
+    #[serde(rename = "NonConOrdProfit", default)]
     pub non_consolidated_ordinary_profit: Option<String>,
 
-    #[serde(rename = "NonConsolidatedProfit")]
+    /// 当期純利益（個別）
+    #[serde(rename = "NonConProfit", default)]
     pub non_consolidated_profit: Option<String>,
 
-    #[serde(rename = "NonConsolidatedEarningsPerShare")]
+    /// 1株当たり当期純利益（個別）
+    #[serde(rename = "NonConEPS", default)]
     pub non_consolidated_earnings_per_share: Option<String>,
 
-    #[serde(rename = "NonConsolidatedTotalAssets")]
+    /// 総資産（個別）
+    #[serde(rename = "NonConTotalAssets", default)]
     pub non_consolidated_total_assets: Option<String>,
 
-    #[serde(rename = "NonConsolidatedEquity")]
+    /// 純資産（個別）
+    #[serde(rename = "NonConEquity", default)]
     pub non_consolidated_equity: Option<String>,
 
-    #[serde(rename = "NonConsolidatedEquityToAssetRatio")]
+    /// 自己資本比率（個別）
+    #[serde(rename = "NonConEquityRatio", default)]
     pub non_consolidated_equity_to_asset_ratio: Option<String>,
 
-    #[serde(rename = "NonConsolidatedBookValuePerShare")]
+    /// 1株当たり純資産（個別）
+    #[serde(rename = "NonConBPS", default)]
     pub non_consolidated_book_value_per_share: Option<String>,
 
-    #[serde(rename = "ForecastNonConsolidatedNetSales2ndQuarter")]
+    /// 売上高予想（第2四半期・個別）
+    #[serde(rename = "FNonConSales2Q", default)]
     pub forecast_non_consolidated_net_sales_2nd_quarter: Option<String>,
 
-    #[serde(rename = "ForecastNonConsolidatedOperatingProfit2ndQuarter")]
+    /// 営業利益予想（第2四半期・個別）
+    #[serde(rename = "FNonConOpProfit2Q", default)]
     pub forecast_non_consolidated_operating_profit_2nd_quarter: Option<String>,
 
-    #[serde(rename = "ForecastNonConsolidatedOrdinaryProfit2ndQuarter")]
+    /// 経常利益予想（第2四半期・個別）
+    #[serde(rename = "FNonConOrdProfit2Q", default)]
     pub forecast_non_consolidated_ordinary_profit_2nd_quarter: Option<String>,
 
-    #[serde(rename = "ForecastNonConsolidatedProfit2ndQuarter")]
+    /// 当期純利益予想（第2四半期・個別）
+    #[serde(rename = "FNonConProfit2Q", default)]
     pub forecast_non_consolidated_profit_2nd_quarter: Option<String>,
 
-    #[serde(rename = "ForecastNonConsolidatedEarningsPerShare2ndQuarter")]
+    /// 1株当たり当期純利益予想（第2四半期・個別）
+    #[serde(rename = "FNonConEPS2Q", default)]
     pub forecast_non_consolidated_earnings_per_share_2nd_quarter: Option<String>,
 
-    #[serde(rename = "NextYearForecastNonConsolidatedNetSales2ndQuarter")]
+    /// 売上高来期予想（第2四半期・個別）
+    #[serde(rename = "NxFNonConSales2Q", default)]
     pub next_year_forecast_non_consolidated_net_sales_2nd_quarter: Option<String>,
 
-    #[serde(rename = "NextYearForecastNonConsolidatedOperatingProfit2ndQuarter")]
+    /// 営業利益来期予想（第2四半期・個別）
+    #[serde(rename = "NxFNonConOpProfit2Q", default)]
     pub next_year_forecast_non_consolidated_operating_profit_2nd_quarter: Option<String>,
 
-    #[serde(rename = "NextYearForecastNonConsolidatedOrdinaryProfit2ndQuarter")]
+    /// 経常利益来期予想（第2四半期・個別）
+    #[serde(rename = "NxFNonConOrdProfit2Q", default)]
     pub next_year_forecast_non_consolidated_ordinary_profit_2nd_quarter: Option<String>,
 
-    #[serde(rename = "NextYearForecastNonConsolidatedProfit2ndQuarter")]
+    /// 当期純利益来期予想（第2四半期・個別）
+    #[serde(rename = "NxFNonConProfit2Q", default)]
     pub next_year_forecast_non_consolidated_profit_2nd_quarter: Option<String>,
 
-    #[serde(rename = "NextYearForecastNonConsolidatedEarningsPerShare2ndQuarter")]
+    /// 1株当たり当期純利益来期予想（第2四半期・個別）
+    #[serde(rename = "NxFNonConEPS2Q", default)]
     pub next_year_forecast_non_consolidated_earnings_per_share_2nd_quarter: Option<String>,
 
-    #[serde(rename = "ForecastNonConsolidatedNetSales")]
+    /// 売上高予想（通期・個別）
+    #[serde(rename = "FNonConSales", default)]
     pub forecast_non_consolidated_net_sales: Option<String>,
 
-    #[serde(rename = "ForecastNonConsolidatedOperatingProfit")]
+    /// 営業利益予想（通期・個別）
+    #[serde(rename = "FNonConOpProfit", default)]
     pub forecast_non_consolidated_operating_profit: Option<String>,
 
-    #[serde(rename = "ForecastNonConsolidatedOrdinaryProfit")]
+    /// 経常利益予想（通期・個別）
+    #[serde(rename = "FNonConOrdProfit", default)]
     pub forecast_non_consolidated_ordinary_profit: Option<String>,
 
-    #[serde(rename = "ForecastNonConsolidatedProfit")]
+    /// 当期純利益予想（通期・個別）
+    #[serde(rename = "FNonConProfit", default)]
     pub forecast_non_consolidated_profit: Option<String>,
 
-    #[serde(rename = "ForecastNonConsolidatedEarningsPerShare")]
+    /// 1株当たり当期純利益予想（通期・個別）
+    #[serde(rename = "FNonConEPS", default)]
     pub forecast_non_consolidated_earnings_per_share: Option<String>,
 
-    #[serde(rename = "NextYearForecastNonConsolidatedNetSales")]
+    /// 売上高来期予想（通期・個別）
+    #[serde(rename = "NxFNonConSales", default)]
     pub next_year_forecast_non_consolidated_net_sales: Option<String>,
 
-    #[serde(rename = "NextYearForecastNonConsolidatedOperatingProfit")]
+    /// 営業利益来期予想（通期・個別）
+    #[serde(rename = "NxFNonConOpProfit", default)]
     pub next_year_forecast_non_consolidated_operating_profit: Option<String>,
 
-    #[serde(rename = "NextYearForecastNonConsolidatedOrdinaryProfit")]
+    /// 経常利益来期予想（通期・個別）
+    #[serde(rename = "NxFNonConOrdProfit", default)]
     pub next_year_forecast_non_consolidated_ordinary_profit: Option<String>,
 
-    #[serde(rename = "NextYearForecastNonConsolidatedProfit")]
+    /// 当期純利益来期予想（通期・個別）
+    #[serde(rename = "NxFNonConProfit", default)]
     pub next_year_forecast_non_consolidated_profit: Option<String>,
 
-    #[serde(rename = "NextYearForecastNonConsolidatedEarningsPerShare")]
+    /// 1株当たり当期純利益来期予想（通期・個別）
+    #[serde(rename = "NxFNonConEPS", default)]
     pub next_year_forecast_non_consolidated_earnings_per_share: Option<String>,
 }
 
@@ -380,23 +485,26 @@ mod tests {
     }
 
     #[test]
-    fn test_fin_summary_data_deserialize() {
+    fn test_fin_summary_data_deserialize_v2_format() {
+        // V2 API の省略形フィールド名でテスト
         let json_data = json!({
-            "DisclosedDate": "2023-11-14",
-            "DisclosedTime": "15:00:00",
-            "LocalCode": "72030",
-            "DisclosureNumber": "20231114502171",
-            "TypeOfDocument": "決算短信",
-            "TypeOfCurrentPeriod": "2Q",
-            "CurrentPeriodStartDate": "2023-04-01",
-            "CurrentPeriodEndDate": "2023-09-30",
-            "CurrentFiscalYearStartDate": "2023-04-01",
-            "CurrentFiscalYearEndDate": "2024-03-31",
-            "NextFiscalYearStartDate": "2024-04-01",
-            "NextFiscalYearEndDate": "2025-03-31",
-            "NetSales": "18733067000000",
-            "OperatingProfit": "1686297000000",
-            "NextYearForecastDividendPerShareAnnual": "50.00"
+            "DiscDate": "2023-11-14",
+            "DiscTime": "15:00:00",
+            "Code": "72030",
+            "DiscNum": "20231114502171",
+            "DocType": "決算短信",
+            "CurPeriod": "2Q",
+            "CurStartDate": "2023-04-01",
+            "CurEndDate": "2023-09-30",
+            "CurFYStartDate": "2023-04-01",
+            "CurFYEndDate": "2024-03-31",
+            "NxFYStartDate": "2024-04-01",
+            "NxFYEndDate": "2025-03-31",
+            "Sales": "18733067000000",
+            "OpProfit": "1686297000000",
+            "NxFDivAnn": "50.00",
+            "FDivAnn": "45.00",
+            "DivAnn": "40.00"
         });
 
         let fin_summary_data: FinSummaryData = serde_json::from_value(json_data).unwrap();
@@ -411,38 +519,46 @@ mod tests {
             fin_summary_data.next_year_forecast_dividend_per_share_annual,
             Some("50.00".to_string())
         );
+        assert_eq!(
+            fin_summary_data.forecast_dividend_per_share_annual,
+            Some("45.00".to_string())
+        );
+        assert_eq!(
+            fin_summary_data.result_dividend_per_share_annual,
+            Some("40.00".to_string())
+        );
     }
 
     #[test]
-    fn test_fin_summary_response_deserialize() {
-        // V2 API では "fin_summary" フィールド名を使用
+    fn test_fin_summary_response_deserialize_v2_format() {
+        // V2 API では "data" フィールド名を使用
         let json_data = json!({
-            "fin_summary": [
+            "data": [
                 {
-                    "DisclosedDate": "2023-11-14",
-                    "LocalCode": "72030",
-                    "TypeOfDocument": "決算短信",
-                    "TypeOfCurrentPeriod": "2Q",
-                    "CurrentPeriodStartDate": "2023-04-01",
-                    "CurrentPeriodEndDate": "2023-09-30",
-                    "CurrentFiscalYearStartDate": "2023-04-01",
-                    "CurrentFiscalYearEndDate": "2024-03-31"
+                    "DiscDate": "2023-11-14",
+                    "Code": "72030",
+                    "DocType": "決算短信",
+                    "CurPeriod": "2Q",
+                    "CurStartDate": "2023-04-01",
+                    "CurEndDate": "2023-09-30",
+                    "CurFYStartDate": "2023-04-01",
+                    "CurFYEndDate": "2024-03-31"
                 }
             ]
         });
 
         let response: FinSummaryResponse = serde_json::from_value(json_data).unwrap();
 
-        assert_eq!(response.fin_summary.len(), 1);
-        assert_eq!(response.fin_summary[0].disclosed_date, "2023-11-14");
-        assert_eq!(response.fin_summary[0].local_code, "72030");
+        assert_eq!(response.data.len(), 1);
+        assert_eq!(response.data[0].disclosed_date, "2023-11-14");
+        assert_eq!(response.data[0].local_code, "72030");
     }
 
     #[test]
     fn test_fin_summary_response_empty() {
-        let json_data = json!({ "fin_summary": [] });
+        let json_data = json!({ "data": [] });
         let response: FinSummaryResponse = serde_json::from_value(json_data).unwrap();
 
-        assert_eq!(response.fin_summary.len(), 0);
+        assert_eq!(response.data.len(), 0);
     }
 }

--- a/backend/src/services/jquants.rs
+++ b/backend/src/services/jquants.rs
@@ -31,20 +31,45 @@ impl JQuantsService {
             .header("x-api-key", api_key)
             .send()
             .await
-            .map_err(|e| ApiError::NetworkError(format!("財務諸表取得エラー: {}", e)))?;
+            .map_err(|e| {
+                tracing::error!("財務諸表取得ネットワークエラー: {}", e);
+                ApiError::NetworkError(format!("財務諸表取得エラー: {}", e))
+            })?;
 
-        if !response.status().is_success() {
+        let status = response.status();
+        tracing::info!("JQuants API レスポンスステータス: {}", status);
+
+        if !status.is_success() {
             let error_text = response.text().await.unwrap_or_default();
+            tracing::error!(
+                "JQuants API エラー - ステータス: {}, 本文: {}",
+                status,
+                error_text
+            );
             return Err(ApiError::ApiError(format!(
-                "JQuants財務諸表取得エラー: {}",
+                "JQuants財務諸表取得エラー ({}): {}",
+                status,
                 error_text
             )));
         }
 
-        let statements_response = response
-            .json::<StatementsResponse>()
-            .await
-            .map_err(|e| ApiError::NetworkError(format!("財務諸表レスポンス解析エラー: {}", e)))?;
+        // デシリアライズ前にレスポンス本文を取得（デバッグ用）
+        let response_text = response.text().await.map_err(|e| {
+            tracing::error!("レスポンス本文取得エラー: {}", e);
+            ApiError::NetworkError(format!("レスポンス読み取りエラー: {}", e))
+        })?;
+
+        tracing::debug!("JQuants API レスポンス本文: {}", response_text);
+
+        let statements_response: StatementsResponse =
+            serde_json::from_str(&response_text).map_err(|e| {
+                tracing::error!(
+                    "財務諸表レスポンス解析エラー: {} - 本文: {}",
+                    e,
+                    response_text
+                );
+                ApiError::NetworkError(format!("財務諸表レスポンス解析エラー: {}", e))
+            })?;
 
         Ok(statements_response)
     }

--- a/backend/src/services/jquants.rs
+++ b/backend/src/services/jquants.rs
@@ -1,18 +1,19 @@
 use crate::errors::ApiError;
-use crate::models::jquants::{StatementsQuery, StatementsResponse};
+use crate::models::jquants::{FinSummaryQuery, FinSummaryResponse};
 use reqwest::Client;
 
 pub struct JQuantsService;
 
 impl JQuantsService {
-    /// 財務諸表を取得（J-Quants API V2）
-    pub async fn get_statements(
+    /// 決算サマリーを取得（J-Quants API V2）
+    /// V2では fins/statements → fins/summary に変更
+    pub async fn get_fin_summary(
         client: &Client,
-        params: StatementsQuery,
+        params: FinSummaryQuery,
         api_key: &str,
-    ) -> Result<StatementsResponse, ApiError> {
+    ) -> Result<FinSummaryResponse, ApiError> {
         let mut url = format!(
-            "https://api.jquants.com/v2/fins/statements?code={}",
+            "https://api.jquants.com/v2/fins/summary?code={}",
             params.code
         );
 
@@ -32,8 +33,8 @@ impl JQuantsService {
             .send()
             .await
             .map_err(|e| {
-                tracing::error!("財務諸表取得ネットワークエラー: {}", e);
-                ApiError::NetworkError(format!("財務諸表取得エラー: {}", e))
+                tracing::error!("決算サマリー取得ネットワークエラー: {}", e);
+                ApiError::NetworkError(format!("決算サマリー取得エラー: {}", e))
             })?;
 
         let status = response.status();
@@ -47,7 +48,7 @@ impl JQuantsService {
                 error_text
             );
             return Err(ApiError::ApiError(format!(
-                "JQuants財務諸表取得エラー ({}): {}",
+                "JQuants決算サマリー取得エラー ({}): {}",
                 status,
                 error_text
             )));
@@ -61,17 +62,17 @@ impl JQuantsService {
 
         tracing::debug!("JQuants API レスポンス本文: {}", response_text);
 
-        let statements_response: StatementsResponse =
+        let fin_summary_response: FinSummaryResponse =
             serde_json::from_str(&response_text).map_err(|e| {
                 tracing::error!(
-                    "財務諸表レスポンス解析エラー: {} - 本文: {}",
+                    "決算サマリーレスポンス解析エラー: {} - 本文: {}",
                     e,
                     response_text
                 );
-                ApiError::NetworkError(format!("財務諸表レスポンス解析エラー: {}", e))
+                ApiError::NetworkError(format!("決算サマリーレスポンス解析エラー: {}", e))
             })?;
 
-        Ok(statements_response)
+        Ok(fin_summary_response)
     }
 }
 

--- a/frontend/src/features/jquants/api/types.ts
+++ b/frontend/src/features/jquants/api/types.ts
@@ -114,9 +114,14 @@ export interface JQuantsStatementData {
   NextYearForecastNonConsolidatedEarningsPerShare: string;
 }
 
+/**
+ * J-Quants API V2 決算サマリーレスポンス
+ * V2では fins/statements → fins/summary に変更され、
+ * レスポンスフィールド名も statements → fin_summary に変更
+ */
 export interface JQuantsStatementsResponse {
-  statements: JQuantsStatementData[];
-  pagination_key: string;
+  fin_summary: JQuantsStatementData[];
+  pagination_key?: string;
 }
 
 export interface JQuantsDividendResponse {

--- a/frontend/src/features/jquants/api/types.ts
+++ b/frontend/src/features/jquants/api/types.ts
@@ -4,123 +4,151 @@ export interface JQuantsTokenResponse {
   refresh_token: string;
 }
 
+/**
+ * J-Quants API V2 決算サマリーデータ
+ * V2では省略形フィールド名を使用
+ */
 export interface JQuantsStatementData {
-  DisclosedDate: string;
-  DisclosedTime: string;
-  LocalCode: string;
-  DisclosureNumber: string;
-  TypeOfDocument: string;
-  TypeOfCurrentPeriod: string;
-  CurrentPeriodStartDate: string;
-  CurrentPeriodEndDate: string;
-  CurrentFiscalYearStartDate: string;
-  CurrentFiscalYearEndDate: string;
-  NextFiscalYearStartDate: string;
-  NextFiscalYearEndDate: string;
-  NetSales: string;
-  OperatingProfit: string;
-  OrdinaryProfit: string;
-  Profit: string;
-  EarningsPerShare: string;
-  DilutedEarningsPerShare: string;
-  TotalAssets: string;
-  Equity: string;
-  EquityToAssetRatio: string;
-  BookValuePerShare: string;
-  CashFlowsFromOperatingActivities: string;
-  CashFlowsFromInvestingActivities: string;
-  CashFlowsFromFinancingActivities: string;
-  CashAndEquivalents: string;
-  ResultDividendPerShare1stQuarter: string;
-  ResultDividendPerShare2ndQuarter: string;
-  ResultDividendPerShare3rdQuarter: string;
-  ResultDividendPerShareFiscalYearEnd: string;
-  ResultDividendPerShareAnnual: string;
-  DistributionsPerUnit_REIT: string;
-  ResultTotalDividendPaidAnnual: string;
-  ResultPayoutRatioAnnual: string;
-  ForecastDividendPerShare1stQuarter: string;
-  ForecastDividendPerShare2ndQuarter: string;
-  ForecastDividendPerShare3rdQuarter: string;
-  ForecastDividendPerShareFiscalYearEnd: string;
-  ForecastDividendPerShareAnnual: string;
-  ForecastDistributionsPerUnit_REIT: string;
-  ForecastTotalDividendPaidAnnual: string;
-  ForecastPayoutRatioAnnual: string;
-  NextYearForecastDividendPerShare1stQuarter: string;
-  NextYearForecastDividendPerShare2ndQuarter: string;
-  NextYearForecastDividendPerShare3rdQuarter: string;
-  NextYearForecastDividendPerShareFiscalYearEnd: string;
-  NextYearForecastDividendPerShareAnnual: string;
-  NextYearForecastDistributionsPerUnit_REIT: string;
-  NextYearForecastPayoutRatioAnnual: string;
-  ForecastNetSales2ndQuarter: string;
-  ForecastOperatingProfit2ndQuarter: string;
-  ForecastOrdinaryProfit2ndQuarter: string;
-  ForecastProfit2ndQuarter: string;
-  ForecastEarningsPerShare2ndQuarter: string;
-  NextYearForecastNetSales2ndQuarter: string;
-  NextYearForecastOperatingProfit2ndQuarter: string;
-  NextYearForecastOrdinaryProfit2ndQuarter: string;
-  NextYearForecastProfit2ndQuarter: string;
-  NextYearForecastEarningsPerShare2ndQuarter: string;
-  ForecastNetSales: string;
-  ForecastOperatingProfit: string;
-  ForecastOrdinaryProfit: string;
-  ForecastProfit: string;
-  ForecastEarningsPerShare: string;
-  NextYearForecastNetSales: string;
-  NextYearForecastOperatingProfit: string;
-  NextYearForecastOrdinaryProfit: string;
-  NextYearForecastProfit: string;
-  NextYearForecastEarningsPerShare: string;
-  MaterialChangesInSubsidiaries: string;
-  SignificantChangesInTheScopeOfConsolidation: string;
-  ChangesBasedOnRevisionsOfAccountingStandard: string;
-  ChangesOtherThanOnesBasedOnRevisionsOfAccountingStandard: string;
-  ChangesInAccountingEstimates: string;
-  RetrospectiveRestatement: string;
-  NumberOfIssuedAndOutstandingSharesAtTheEndOfFiscalYearIncludingTreasuryStock: string;
-  NumberOfTreasuryStockAtTheEndOfFiscalYear: string;
-  AverageNumberOfShares: string;
-  NonConsolidatedNetSales: string;
-  NonConsolidatedOperatingProfit: string;
-  NonConsolidatedOrdinaryProfit: string;
-  NonConsolidatedProfit: string;
-  NonConsolidatedEarningsPerShare: string;
-  NonConsolidatedTotalAssets: string;
-  NonConsolidatedEquity: string;
-  NonConsolidatedEquityToAssetRatio: string;
-  NonConsolidatedBookValuePerShare: string;
-  ForecastNonConsolidatedNetSales2ndQuarter: string;
-  ForecastNonConsolidatedOperatingProfit2ndQuarter: string;
-  ForecastNonConsolidatedOrdinaryProfit2ndQuarter: string;
-  ForecastNonConsolidatedProfit2ndQuarter: string;
-  ForecastNonConsolidatedEarningsPerShare2ndQuarter: string;
-  NextYearForecastNonConsolidatedNetSales2ndQuarter: string;
-  NextYearForecastNonConsolidatedOperatingProfit2ndQuarter: string;
-  NextYearForecastNonConsolidatedOrdinaryProfit2ndQuarter: string;
-  NextYearForecastNonConsolidatedProfit2ndQuarter: string;
-  NextYearForecastNonConsolidatedEarningsPerShare2ndQuarter: string;
-  ForecastNonConsolidatedNetSales: string;
-  ForecastNonConsolidatedOperatingProfit: string;
-  ForecastNonConsolidatedOrdinaryProfit: string;
-  ForecastNonConsolidatedProfit: string;
-  ForecastNonConsolidatedEarningsPerShare: string;
-  NextYearForecastNonConsolidatedNetSales: string;
-  NextYearForecastNonConsolidatedOperatingProfit: string;
-  NextYearForecastNonConsolidatedOrdinaryProfit: string;
-  NextYearForecastNonConsolidatedProfit: string;
-  NextYearForecastNonConsolidatedEarningsPerShare: string;
+  // 基本情報
+  DiscDate: string; // 開示日
+  DiscTime?: string; // 開示時刻
+  Code: string; // 銘柄コード
+  DiscNum?: string; // 開示番号
+  DocType: string; // 書類種別
+  CurPeriod: string; // 当期種別
+  CurStartDate: string; // 当期開始日
+  CurEndDate: string; // 当期終了日
+  CurFYStartDate: string; // 当会計年度開始日
+  CurFYEndDate: string; // 当会計年度終了日
+  NxFYStartDate?: string; // 翌会計年度開始日
+  NxFYEndDate?: string; // 翌会計年度終了日
+
+  // 業績（連結）
+  Sales?: string; // 売上高
+  OpProfit?: string; // 営業利益
+  OrdProfit?: string; // 経常利益
+  Profit?: string; // 当期純利益
+  EPS?: string; // 1株当たり当期純利益
+  DilutedEPS?: string; // 希薄化後EPS
+  TotalAssets?: string; // 総資産
+  Equity?: string; // 純資産
+  EquityRatio?: string; // 自己資本比率
+  BPS?: string; // 1株当たり純資産
+
+  // キャッシュフロー
+  CashFlowOp?: string; // 営業CF
+  CashFlowInv?: string; // 投資CF
+  CashFlowFin?: string; // 財務CF
+  CashEq?: string; // 現金及び現金同等物
+
+  // 配当実績
+  Div1Q?: string; // 1Q配当実績
+  Div2Q?: string; // 2Q配当実績
+  Div3Q?: string; // 3Q配当実績
+  DivYrEnd?: string; // 期末配当実績
+  DivAnn?: string; // 年間配当実績
+  DistREIT?: string; // REIT分配金
+  TotalDivPaidAnn?: string; // 配当支払総額実績
+  PayoutRatioAnn?: string; // 配当性向実績
+
+  // 配当予想（今期）
+  FDiv1Q?: string; // 1Q配当予想
+  FDiv2Q?: string; // 2Q配当予想
+  FDiv3Q?: string; // 3Q配当予想
+  FDivYrEnd?: string; // 期末配当予想
+  FDivAnn?: string; // 年間配当予想（今期）
+  FDistREIT?: string; // REIT分配金予想
+  FTotalDivPaidAnn?: string; // 配当支払総額予想
+  FPayoutRatioAnn?: string; // 配当性向予想
+
+  // 配当予想（来期）
+  NxFDiv1Q?: string; // 1Q配当来期予想
+  NxFDiv2Q?: string; // 2Q配当来期予想
+  NxFDiv3Q?: string; // 3Q配当来期予想
+  NxFDivYrEnd?: string; // 期末配当来期予想
+  NxFDivAnn?: string; // 年間配当来期予想
+  NxFDistREIT?: string; // REIT分配金来期予想
+  NxFPayoutRatioAnn?: string; // 配当性向来期予想
+
+  // 業績予想（2Q）
+  FSales2Q?: string;
+  FOpProfit2Q?: string;
+  FOrdProfit2Q?: string;
+  FProfit2Q?: string;
+  FEPS2Q?: string;
+
+  // 業績来期予想（2Q）
+  NxFSales2Q?: string;
+  NxFOpProfit2Q?: string;
+  NxFOrdProfit2Q?: string;
+  NxFProfit2Q?: string;
+  NxFEPS2Q?: string;
+
+  // 業績予想（通期）
+  FSales?: string;
+  FOpProfit?: string;
+  FOrdProfit?: string;
+  FProfit?: string;
+  FEPS?: string;
+
+  // 業績来期予想（通期）
+  NxFSales?: string;
+  NxFOpProfit?: string;
+  NxFOrdProfit?: string;
+  NxFProfit?: string;
+  NxFEPS?: string;
+
+  // その他
+  MatChgSub?: string; // 重要な子会社の異動
+  SigChgScope?: string; // 連結範囲の重要な変更
+  ChgAccStd?: string; // 会計基準の改正に伴う変更
+  ChgOther?: string; // 会計基準の改正以外の変更
+  ChgEstimate?: string; // 会計上の見積りの変更
+  Restatement?: string; // 修正再表示
+  SharesOutstanding?: string; // 発行済株式数
+  TreasuryStock?: string; // 自己株式数
+  AvgShares?: string; // 期中平均株式数
+
+  // 個別業績
+  NonConSales?: string;
+  NonConOpProfit?: string;
+  NonConOrdProfit?: string;
+  NonConProfit?: string;
+  NonConEPS?: string;
+  NonConTotalAssets?: string;
+  NonConEquity?: string;
+  NonConEquityRatio?: string;
+  NonConBPS?: string;
+
+  // 個別業績予想
+  FNonConSales2Q?: string;
+  FNonConOpProfit2Q?: string;
+  FNonConOrdProfit2Q?: string;
+  FNonConProfit2Q?: string;
+  FNonConEPS2Q?: string;
+  NxFNonConSales2Q?: string;
+  NxFNonConOpProfit2Q?: string;
+  NxFNonConOrdProfit2Q?: string;
+  NxFNonConProfit2Q?: string;
+  NxFNonConEPS2Q?: string;
+  FNonConSales?: string;
+  FNonConOpProfit?: string;
+  FNonConOrdProfit?: string;
+  FNonConProfit?: string;
+  FNonConEPS?: string;
+  NxFNonConSales?: string;
+  NxFNonConOpProfit?: string;
+  NxFNonConOrdProfit?: string;
+  NxFNonConProfit?: string;
+  NxFNonConEPS?: string;
 }
 
 /**
  * J-Quants API V2 決算サマリーレスポンス
- * V2では fins/statements → fins/summary に変更され、
- * レスポンスフィールド名も statements → fin_summary に変更
+ * V2では fins/summary を使用し、ルートフィールドは "data"
  */
 export interface JQuantsStatementsResponse {
-  fin_summary: JQuantsStatementData[];
+  data: JQuantsStatementData[];
   pagination_key?: string;
 }
 

--- a/frontend/src/features/jquants/hooks/__tests__/useJQuantsDividend.test.ts
+++ b/frontend/src/features/jquants/hooks/__tests__/useJQuantsDividend.test.ts
@@ -39,12 +39,12 @@ describe('useJQuantsDividend', () => {
   });
 
   it('配当情報を正常に取得できる（来期予想）', async () => {
-    // V2 API では fin_summary フィールドを使用
+    // V2 API では data フィールドを使用、省略形フィールド名
     const mockResponse = {
-      fin_summary: [
-        { NextYearForecastDividendPerShareAnnual: '' },
-        { NextYearForecastDividendPerShareAnnual: '50.00' },
-        { NextYearForecastDividendPerShareAnnual: '60.00' },
+      data: [
+        { NxFDivAnn: '' },
+        { NxFDivAnn: '50.00' },
+        { NxFDivAnn: '60.00' },
       ],
     };
 
@@ -67,10 +67,10 @@ describe('useJQuantsDividend', () => {
 
   it('来期予想がない場合、今期予想を使用する', async () => {
     const mockResponse = {
-      fin_summary: [
+      data: [
         {
-          NextYearForecastDividendPerShareAnnual: '',
-          ForecastDividendPerShareAnnual: '45.00',
+          NxFDivAnn: '',
+          FDivAnn: '45.00',
         },
       ],
     };
@@ -90,11 +90,11 @@ describe('useJQuantsDividend', () => {
 
   it('予想がない場合、実績を使用する', async () => {
     const mockResponse = {
-      fin_summary: [
+      data: [
         {
-          NextYearForecastDividendPerShareAnnual: '',
-          ForecastDividendPerShareAnnual: '',
-          ResultDividendPerShareAnnual: '40.00',
+          NxFDivAnn: '',
+          FDivAnn: '',
+          DivAnn: '40.00',
         },
       ],
     };
@@ -114,9 +114,9 @@ describe('useJQuantsDividend', () => {
 
   it('空の配当情報の場合、0を返す', async () => {
     const mockResponse = {
-      fin_summary: [
-        { NextYearForecastDividendPerShareAnnual: '' },
-        { NextYearForecastDividendPerShareAnnual: '' },
+      data: [
+        { NxFDivAnn: '' },
+        { NxFDivAnn: '' },
       ],
     };
 
@@ -163,7 +163,7 @@ describe('useJQuantsDividend', () => {
 
   it('securityCodeが変更された場合、再取得する', async () => {
     const mockResponse = {
-      fin_summary: [{ NextYearForecastDividendPerShareAnnual: '50.00' }],
+      data: [{ NxFDivAnn: '50.00' }],
     };
 
     (jquantsApiClient.getStatements as Mock).mockResolvedValue(mockResponse);

--- a/frontend/src/features/jquants/hooks/__tests__/useJQuantsDividend.test.ts
+++ b/frontend/src/features/jquants/hooks/__tests__/useJQuantsDividend.test.ts
@@ -38,16 +38,17 @@ describe('useJQuantsDividend', () => {
     expect(jquantsApiClient.getStatements).not.toHaveBeenCalled();
   });
 
-  it('配当情報を正常に取得できる', async () => {
-    const mockStatements = {
-      statements: [
+  it('配当情報を正常に取得できる（来期予想）', async () => {
+    // V2 API では fin_summary フィールドを使用
+    const mockResponse = {
+      fin_summary: [
         { NextYearForecastDividendPerShareAnnual: '' },
         { NextYearForecastDividendPerShareAnnual: '50.00' },
         { NextYearForecastDividendPerShareAnnual: '60.00' },
       ],
     };
 
-    (jquantsApiClient.getStatements as Mock).mockResolvedValue(mockStatements);
+    (jquantsApiClient.getStatements as Mock).mockResolvedValue(mockResponse);
     (parseNumber as Mock).mockReturnValue(60);
 
     const { result } = renderHook(() => useJQuantsDividend('1234', true));
@@ -64,15 +65,62 @@ describe('useJQuantsDividend', () => {
     expect(result.current.error).toBeNull();
   });
 
+  it('来期予想がない場合、今期予想を使用する', async () => {
+    const mockResponse = {
+      fin_summary: [
+        {
+          NextYearForecastDividendPerShareAnnual: '',
+          ForecastDividendPerShareAnnual: '45.00',
+        },
+      ],
+    };
+
+    (jquantsApiClient.getStatements as Mock).mockResolvedValue(mockResponse);
+    (parseNumber as Mock).mockReturnValue(45);
+
+    const { result } = renderHook(() => useJQuantsDividend('1234', true));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.dividendPerShare).toBe(45);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('予想がない場合、実績を使用する', async () => {
+    const mockResponse = {
+      fin_summary: [
+        {
+          NextYearForecastDividendPerShareAnnual: '',
+          ForecastDividendPerShareAnnual: '',
+          ResultDividendPerShareAnnual: '40.00',
+        },
+      ],
+    };
+
+    (jquantsApiClient.getStatements as Mock).mockResolvedValue(mockResponse);
+    (parseNumber as Mock).mockReturnValue(40);
+
+    const { result } = renderHook(() => useJQuantsDividend('1234', true));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.dividendPerShare).toBe(40);
+    expect(result.current.error).toBeNull();
+  });
+
   it('空の配当情報の場合、0を返す', async () => {
-    const mockStatements = {
-      statements: [
+    const mockResponse = {
+      fin_summary: [
         { NextYearForecastDividendPerShareAnnual: '' },
         { NextYearForecastDividendPerShareAnnual: '' },
       ],
     };
 
-    (jquantsApiClient.getStatements as Mock).mockResolvedValue(mockStatements);
+    (jquantsApiClient.getStatements as Mock).mockResolvedValue(mockResponse);
     (parseNumber as Mock).mockReturnValue(0);
 
     const { result } = renderHook(() => useJQuantsDividend('1234', true));
@@ -114,11 +162,11 @@ describe('useJQuantsDividend', () => {
   });
 
   it('securityCodeが変更された場合、再取得する', async () => {
-    const mockStatements = {
-      statements: [{ NextYearForecastDividendPerShareAnnual: '50.00' }],
+    const mockResponse = {
+      fin_summary: [{ NextYearForecastDividendPerShareAnnual: '50.00' }],
     };
 
-    (jquantsApiClient.getStatements as Mock).mockResolvedValue(mockStatements);
+    (jquantsApiClient.getStatements as Mock).mockResolvedValue(mockResponse);
     (parseNumber as Mock).mockReturnValue(50);
 
     const { result, rerender } = renderHook(

--- a/frontend/src/features/jquants/hooks/useJQuantsDividend.ts
+++ b/frontend/src/features/jquants/hooks/useJQuantsDividend.ts
@@ -24,23 +24,23 @@ export const useJQuantsDividend = (
       setError(null);
 
       try {
-        // V2 API では fin_summary フィールドを使用
+        // V2 API では data フィールドを使用
         const response = await jquantsApiClient.getStatements(securityCode);
         let dividendValue = '';
 
         // 配当予想を取得（優先順位: 来期予想 > 今期予想 > 実績）
-        for (const summary of response.fin_summary) {
-          // 来期予想年間配当金
-          if (summary.NextYearForecastDividendPerShareAnnual && summary.NextYearForecastDividendPerShareAnnual !== '') {
-            dividendValue = summary.NextYearForecastDividendPerShareAnnual;
+        for (const summary of response.data) {
+          // 来期予想年間配当金 (NxFDivAnn)
+          if (summary.NxFDivAnn && summary.NxFDivAnn !== '') {
+            dividendValue = summary.NxFDivAnn;
           }
-          // 今期予想年間配当金（来期予想がない場合のフォールバック）
-          else if (!dividendValue && summary.ForecastDividendPerShareAnnual && summary.ForecastDividendPerShareAnnual !== '') {
-            dividendValue = summary.ForecastDividendPerShareAnnual;
+          // 今期予想年間配当金 (FDivAnn)（来期予想がない場合のフォールバック）
+          else if (!dividendValue && summary.FDivAnn && summary.FDivAnn !== '') {
+            dividendValue = summary.FDivAnn;
           }
-          // 実績年間配当金（予想がない場合のフォールバック）
-          else if (!dividendValue && summary.ResultDividendPerShareAnnual && summary.ResultDividendPerShareAnnual !== '') {
-            dividendValue = summary.ResultDividendPerShareAnnual;
+          // 実績年間配当金 (DivAnn)（予想がない場合のフォールバック）
+          else if (!dividendValue && summary.DivAnn && summary.DivAnn !== '') {
+            dividendValue = summary.DivAnn;
           }
         }
         setDividendPerShare(parseNumber(dividendValue));

--- a/frontend/src/features/jquants/hooks/useJQuantsDividend.ts
+++ b/frontend/src/features/jquants/hooks/useJQuantsDividend.ts
@@ -24,15 +24,26 @@ export const useJQuantsDividend = (
       setError(null);
 
       try {
-        const statements = await jquantsApiClient.getStatements(securityCode);
-        let nextYearForecastDividendPerShareAnnual = '';
-        for (const statement of statements.statements) {
-          if (statement.NextYearForecastDividendPerShareAnnual === '') {
-            continue;
+        // V2 API では fin_summary フィールドを使用
+        const response = await jquantsApiClient.getStatements(securityCode);
+        let dividendValue = '';
+
+        // 配当予想を取得（優先順位: 来期予想 > 今期予想 > 実績）
+        for (const summary of response.fin_summary) {
+          // 来期予想年間配当金
+          if (summary.NextYearForecastDividendPerShareAnnual && summary.NextYearForecastDividendPerShareAnnual !== '') {
+            dividendValue = summary.NextYearForecastDividendPerShareAnnual;
           }
-          nextYearForecastDividendPerShareAnnual = statement.NextYearForecastDividendPerShareAnnual;
+          // 今期予想年間配当金（来期予想がない場合のフォールバック）
+          else if (!dividendValue && summary.ForecastDividendPerShareAnnual && summary.ForecastDividendPerShareAnnual !== '') {
+            dividendValue = summary.ForecastDividendPerShareAnnual;
+          }
+          // 実績年間配当金（予想がない場合のフォールバック）
+          else if (!dividendValue && summary.ResultDividendPerShareAnnual && summary.ResultDividendPerShareAnnual !== '') {
+            dividendValue = summary.ResultDividendPerShareAnnual;
+          }
         }
-        setDividendPerShare(parseNumber(nextYearForecastDividendPerShareAnnual));
+        setDividendPerShare(parseNumber(dividendValue));
       } catch (err) {
         console.error('配当取得エラー:', err);
         setError(err instanceof Error ? err.message : '配当情報の取得に失敗しました');


### PR DESCRIPTION
## 概要

J-Quants API V2への完全対応と、開発フロードキュメントの整備。

## 変更内容

### J-Quants API V2対応
- エンドポイント変更: `/v1/fins/statements` → `/v2/fins/summary`
- ルートフィールド: `statements` → `data`
- フィールド名を省略形に対応（`NxFDivAnn`, `FDivAnn`, `DivAnn`等）
- エラーログの詳細化

### スキルドキュメント追加
- `local-testing`: ローカルテスト重視の開発フローを記載
- `deploy`: 自動デプロイを強調、手動デプロイは緊急時のみに更新

## 変更種別
- [x] バグ修正
- [x] その他（ドキュメント）

## テスト
- [x] ユニットテスト追加/更新
- [x] 手動テスト実施（fly.ioデプロイ済み）

## チェックリスト
- [x] CIパス確認
- [x] ドキュメント更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)