### PR TITLE
fix: J-Quants API fins/summary の期間フィールドをOption型に変更

### DIFF
--- a/backend/src/models/jquants.rs
+++ b/backend/src/models/jquants.rs
@@ -44,24 +44,24 @@ pub struct FinSummaryData {
     pub type_of_document: String,
 
     /// 当期種別
-    #[serde(rename = "CurPeriod")]
-    pub type_of_current_period: String,
+    #[serde(rename = "CurPeriod", default)]
+    pub type_of_current_period: Option<String>,
 
     /// 当期開始日
-    #[serde(rename = "CurStartDate")]
-    pub current_period_start_date: String,
+    #[serde(rename = "CurStartDate", default)]
+    pub current_period_start_date: Option<String>,
 
     /// 当期終了日
-    #[serde(rename = "CurEndDate")]
-    pub current_period_end_date: String,
+    #[serde(rename = "CurEndDate", default)]
+    pub current_period_end_date: Option<String>,
 
     /// 当会計年度開始日
-    #[serde(rename = "CurFYStartDate")]
-    pub current_fiscal_year_start_date: String,
+    #[serde(rename = "CurFYStartDate", default)]
+    pub current_fiscal_year_start_date: Option<String>,
 
     /// 当会計年度終了日
-    #[serde(rename = "CurFYEndDate")]
-    pub current_fiscal_year_end_date: String,
+    #[serde(rename = "CurFYEndDate", default)]
+    pub current_fiscal_year_end_date: Option<String>,
 
     /// 翌会計年度開始日
     #[serde(rename = "NxFYStartDate", default)]

--- a/backend/src/services/jquants.rs
+++ b/backend/src/services/jquants.rs
@@ -78,9 +78,49 @@ impl JQuantsService {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::models::jquants::FinSummaryQuery;
+
     #[test]
     fn test_module_compilation() {
         // モジュールが正常にコンパイルされることを確認
         assert!(true);
+    }
+
+    /// 実際のJ-Quants APIを呼び出すテスト
+    /// 実行には環境変数 JQUANTS_API_KEY が必要
+    /// cargo test test_get_fin_summary_real_api -- --ignored
+    #[tokio::test]
+    #[ignore]
+    async fn test_get_fin_summary_real_api() {
+        let api_key = std::env::var("JQUANTS_API_KEY")
+            .expect("JQUANTS_API_KEY 環境変数が設定されていません");
+
+        let client = Client::new();
+        let params = FinSummaryQuery {
+            code: "7203".to_string(), // トヨタ自動車
+            from: None,
+            to: None,
+        };
+
+        let result = JQuantsService::get_fin_summary(&client, params, &api_key).await;
+
+        match result {
+            Ok(response) => {
+                println!("取得件数: {}", response.data.len());
+                if let Some(first) = response.data.first() {
+                    println!("銘柄コード: {}", first.local_code);
+                    println!("開示日: {}", first.disclosed_date);
+                    println!("書類種別: {}", first.type_of_document);
+                    println!("当期種別: {:?}", first.type_of_current_period);
+                    println!("当期開始日: {:?}", first.current_period_start_date);
+                    println!("当期終了日: {:?}", first.current_period_end_date);
+                }
+                assert!(!response.data.is_empty(), "データが取得できること");
+            }
+            Err(e) => {
+                panic!("API呼び出しエラー: {:?}", e);
+            }
+        }
     }
 }


### PR DESCRIPTION
## 概要
fly.io 上で稼働しているバックエンドにて、J-Quants API 呼び出し時に `missing field 'CurPeriod'` エラーが発生していた問題を修正。

## 原因
J-Quants API V2 の `fins/summary` エンドポイントでは、すべてのレスポンスフィールドがオプション。開示種別によっては期間関連フィールドが返却されないケースがあり、必須フィールドとして定義していたためデシリアライズエラーが発生していた。

## 変更内容
- `CurPeriod`（当期種別）を `Option<String>` に変更
- `CurStartDate`（当期開始日）を `Option<String>` に変更
- `CurEndDate`（当期終了日）を `Option<String>` に変更
- `CurFYStartDate`（当会計年度開始日）を `Option<String>` に変更
- `CurFYEndDate`（当会計年度終了日）を `Option<String>` に変更
- 実際の API を呼び出す統合テストを追加

## 変更種別
- [x] バグ修正

## テスト
- [x] ユニットテスト（cargo test）パス
- [x] 実際の J-Quants API 呼び出しテストで動作確認済み

## チェックリスト
- [x] CIパス確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)