### PR TITLE
fix: 任天堂など一部銘柄での配当取得エラーを修正

### DIFF
--- a/.claude/skills/backend-api/SKILL.md
+++ b/.claude/skills/backend-api/SKILL.md
@@ -102,3 +102,50 @@ pub async fn bulk_create(
     }))
 }
 ```
+
+## J-Quants API V2 連携
+
+### フィールド名の注意点
+
+J-Quants API V2 は省略形フィールド名を使用。`serde(rename)` で正確に指定する必要がある。
+
+| 項目 | API V2 フィールド名 |
+|------|-------------------|
+| 営業利益 | `OP` |
+| 経常利益 | `OdP` |
+| 当期純利益 | `NP` |
+| 当期種別 | `CurPerType` |
+| 当期開始日 | `CurPerSt` |
+| 期末配当 | `DivFY` |
+| 年間配当実績 | `DivAnn` |
+| 年間配当予想 | `FDivAnn` |
+| 年間配当来期予想 | `NxFDivAnn` |
+
+### 型定義例
+
+```rust
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FinSummaryData {
+    #[serde(rename = "DiscDate")]
+    pub disclosed_date: String,
+
+    #[serde(rename = "OP", default)]
+    pub operating_profit: Option<String>,
+
+    #[serde(rename = "NxFDivAnn", default)]
+    pub next_year_forecast_dividend_per_share_annual: Option<String>,
+}
+```
+
+### フロントエンドでの防御的コーディング
+
+APIレスポンスの `data` フィールドが配列でない場合に備える：
+
+```typescript
+if (!response?.data || !Array.isArray(response.data)) {
+  return;
+}
+for (const item of response.data) {
+  // 処理
+}
+```

--- a/backend/src/models/jquants.rs
+++ b/backend/src/models/jquants.rs
@@ -36,7 +36,7 @@ pub struct FinSummaryData {
     pub local_code: String,
 
     /// 開示番号
-    #[serde(rename = "DiscNum", default)]
+    #[serde(rename = "DiscNo", default)]
     pub disclosure_number: Option<String>,
 
     /// 書類種別
@@ -44,31 +44,31 @@ pub struct FinSummaryData {
     pub type_of_document: String,
 
     /// 当期種別
-    #[serde(rename = "CurPeriod", default)]
+    #[serde(rename = "CurPerType", default)]
     pub type_of_current_period: Option<String>,
 
     /// 当期開始日
-    #[serde(rename = "CurStartDate", default)]
+    #[serde(rename = "CurPerSt", default)]
     pub current_period_start_date: Option<String>,
 
     /// 当期終了日
-    #[serde(rename = "CurEndDate", default)]
+    #[serde(rename = "CurPerEn", default)]
     pub current_period_end_date: Option<String>,
 
     /// 当会計年度開始日
-    #[serde(rename = "CurFYStartDate", default)]
+    #[serde(rename = "CurFYSt", default)]
     pub current_fiscal_year_start_date: Option<String>,
 
     /// 当会計年度終了日
-    #[serde(rename = "CurFYEndDate", default)]
+    #[serde(rename = "CurFYEn", default)]
     pub current_fiscal_year_end_date: Option<String>,
 
     /// 翌会計年度開始日
-    #[serde(rename = "NxFYStartDate", default)]
+    #[serde(rename = "NxtFYSt", default)]
     pub next_fiscal_year_start_date: Option<String>,
 
     /// 翌会計年度終了日
-    #[serde(rename = "NxFYEndDate", default)]
+    #[serde(rename = "NxtFYEn", default)]
     pub next_fiscal_year_end_date: Option<String>,
 
     /// 売上高
@@ -76,15 +76,15 @@ pub struct FinSummaryData {
     pub net_sales: Option<String>,
 
     /// 営業利益
-    #[serde(rename = "OpProfit", default)]
+    #[serde(rename = "OP", default)]
     pub operating_profit: Option<String>,
 
     /// 経常利益
-    #[serde(rename = "OrdProfit", default)]
+    #[serde(rename = "OdP", default)]
     pub ordinary_profit: Option<String>,
 
     /// 当期純利益
-    #[serde(rename = "Profit", default)]
+    #[serde(rename = "NP", default)]
     pub profit: Option<String>,
 
     /// 1株当たり当期純利益
@@ -92,19 +92,19 @@ pub struct FinSummaryData {
     pub earnings_per_share: Option<String>,
 
     /// 希薄化後1株当たり当期純利益
-    #[serde(rename = "DilutedEPS", default)]
+    #[serde(rename = "DEPS", default)]
     pub diluted_earnings_per_share: Option<String>,
 
     /// 総資産
-    #[serde(rename = "TotalAssets", default)]
+    #[serde(rename = "TA", default)]
     pub total_assets: Option<String>,
 
     /// 純資産
-    #[serde(rename = "Equity", default)]
+    #[serde(rename = "Eq", default)]
     pub equity: Option<String>,
 
     /// 自己資本比率
-    #[serde(rename = "EquityRatio", default)]
+    #[serde(rename = "EqAR", default)]
     pub equity_to_asset_ratio: Option<String>,
 
     /// 1株当たり純資産
@@ -112,15 +112,15 @@ pub struct FinSummaryData {
     pub book_value_per_share: Option<String>,
 
     /// 営業活動によるキャッシュフロー
-    #[serde(rename = "CashFlowOp", default)]
+    #[serde(rename = "CFO", default)]
     pub cash_flows_from_operating_activities: Option<String>,
 
     /// 投資活動によるキャッシュフロー
-    #[serde(rename = "CashFlowInv", default)]
+    #[serde(rename = "CFI", default)]
     pub cash_flows_from_investing_activities: Option<String>,
 
     /// 財務活動によるキャッシュフロー
-    #[serde(rename = "CashFlowFin", default)]
+    #[serde(rename = "CFF", default)]
     pub cash_flows_from_financing_activities: Option<String>,
 
     /// 現金及び現金同等物の期末残高
@@ -140,7 +140,7 @@ pub struct FinSummaryData {
     pub result_dividend_per_share_3rd_quarter: Option<String>,
 
     /// 1株当たり配当金（期末）実績
-    #[serde(rename = "DivYrEnd", default)]
+    #[serde(rename = "DivFY", default)]
     pub result_dividend_per_share_fiscal_year_end: Option<String>,
 
     /// 1株当たり年間配当金実績
@@ -148,11 +148,11 @@ pub struct FinSummaryData {
     pub result_dividend_per_share_annual: Option<String>,
 
     /// 1口当たり分配金（REIT）
-    #[serde(rename = "DistREIT", default)]
+    #[serde(rename = "DivUnit", default)]
     pub distributions_per_unit_reit: Option<String>,
 
     /// 年間配当支払総額実績
-    #[serde(rename = "TotalDivPaidAnn", default)]
+    #[serde(rename = "DivTotalAnn", default)]
     pub result_total_dividend_paid_annual: Option<String>,
 
     /// 配当性向実績
@@ -172,7 +172,7 @@ pub struct FinSummaryData {
     pub forecast_dividend_per_share_3rd_quarter: Option<String>,
 
     /// 1株当たり配当金（期末）予想
-    #[serde(rename = "FDivYrEnd", default)]
+    #[serde(rename = "FDivFY", default)]
     pub forecast_dividend_per_share_fiscal_year_end: Option<String>,
 
     /// 1株当たり年間配当金予想（今期）
@@ -180,11 +180,11 @@ pub struct FinSummaryData {
     pub forecast_dividend_per_share_annual: Option<String>,
 
     /// 1口当たり分配金（REIT）予想
-    #[serde(rename = "FDistREIT", default)]
+    #[serde(rename = "FDivUnit", default)]
     pub forecast_distributions_per_unit_reit: Option<String>,
 
     /// 年間配当支払総額予想
-    #[serde(rename = "FTotalDivPaidAnn", default)]
+    #[serde(rename = "FDivTotalAnn", default)]
     pub forecast_total_dividend_paid_annual: Option<String>,
 
     /// 配当性向予想
@@ -204,7 +204,7 @@ pub struct FinSummaryData {
     pub next_year_forecast_dividend_per_share_3rd_quarter: Option<String>,
 
     /// 1株当たり配当金（期末）来期予想
-    #[serde(rename = "NxFDivYrEnd", default)]
+    #[serde(rename = "NxFDivFY", default)]
     pub next_year_forecast_dividend_per_share_fiscal_year_end: Option<String>,
 
     /// 1株当たり年間配当金来期予想
@@ -212,7 +212,7 @@ pub struct FinSummaryData {
     pub next_year_forecast_dividend_per_share_annual: Option<String>,
 
     /// 1口当たり分配金（REIT）来期予想
-    #[serde(rename = "NxFDistREIT", default)]
+    #[serde(rename = "NxFDivUnit", default)]
     pub next_year_forecast_distributions_per_unit_reit: Option<String>,
 
     /// 配当性向来期予想
@@ -224,15 +224,15 @@ pub struct FinSummaryData {
     pub forecast_net_sales_2nd_quarter: Option<String>,
 
     /// 営業利益予想（第2四半期）
-    #[serde(rename = "FOpProfit2Q", default)]
+    #[serde(rename = "FOP2Q", default)]
     pub forecast_operating_profit_2nd_quarter: Option<String>,
 
     /// 経常利益予想（第2四半期）
-    #[serde(rename = "FOrdProfit2Q", default)]
+    #[serde(rename = "FOdP2Q", default)]
     pub forecast_ordinary_profit_2nd_quarter: Option<String>,
 
     /// 当期純利益予想（第2四半期）
-    #[serde(rename = "FProfit2Q", default)]
+    #[serde(rename = "FNP2Q", default)]
     pub forecast_profit_2nd_quarter: Option<String>,
 
     /// 1株当たり当期純利益予想（第2四半期）
@@ -244,15 +244,15 @@ pub struct FinSummaryData {
     pub next_year_forecast_net_sales_2nd_quarter: Option<String>,
 
     /// 営業利益来期予想（第2四半期）
-    #[serde(rename = "NxFOpProfit2Q", default)]
+    #[serde(rename = "NxFOP2Q", default)]
     pub next_year_forecast_operating_profit_2nd_quarter: Option<String>,
 
     /// 経常利益来期予想（第2四半期）
-    #[serde(rename = "NxFOrdProfit2Q", default)]
+    #[serde(rename = "NxFOdP2Q", default)]
     pub next_year_forecast_ordinary_profit_2nd_quarter: Option<String>,
 
     /// 当期純利益来期予想（第2四半期）
-    #[serde(rename = "NxFProfit2Q", default)]
+    #[serde(rename = "NxFNp2Q", default)]
     pub next_year_forecast_profit_2nd_quarter: Option<String>,
 
     /// 1株当たり当期純利益来期予想（第2四半期）
@@ -264,15 +264,15 @@ pub struct FinSummaryData {
     pub forecast_net_sales: Option<String>,
 
     /// 営業利益予想（通期）
-    #[serde(rename = "FOpProfit", default)]
+    #[serde(rename = "FOP", default)]
     pub forecast_operating_profit: Option<String>,
 
     /// 経常利益予想（通期）
-    #[serde(rename = "FOrdProfit", default)]
+    #[serde(rename = "FOdP", default)]
     pub forecast_ordinary_profit: Option<String>,
 
     /// 当期純利益予想（通期）
-    #[serde(rename = "FProfit", default)]
+    #[serde(rename = "FNP", default)]
     pub forecast_profit: Option<String>,
 
     /// 1株当たり当期純利益予想（通期）
@@ -284,15 +284,15 @@ pub struct FinSummaryData {
     pub next_year_forecast_net_sales: Option<String>,
 
     /// 営業利益来期予想（通期）
-    #[serde(rename = "NxFOpProfit", default)]
+    #[serde(rename = "NxFOP", default)]
     pub next_year_forecast_operating_profit: Option<String>,
 
     /// 経常利益来期予想（通期）
-    #[serde(rename = "NxFOrdProfit", default)]
+    #[serde(rename = "NxFOdP", default)]
     pub next_year_forecast_ordinary_profit: Option<String>,
 
     /// 当期純利益来期予想（通期）
-    #[serde(rename = "NxFProfit", default)]
+    #[serde(rename = "NxFNp", default)]
     pub next_year_forecast_profit: Option<String>,
 
     /// 1株当たり当期純利益来期予想（通期）
@@ -304,7 +304,7 @@ pub struct FinSummaryData {
     pub material_changes_in_subsidiaries: Option<String>,
 
     /// 連結範囲の重要な変更
-    #[serde(rename = "SigChgScope", default)]
+    #[serde(rename = "SigChgInC", default)]
     pub significant_changes_in_the_scope_of_consolidation: Option<String>,
 
     /// 会計基準の改正に伴う変更
@@ -324,132 +324,132 @@ pub struct FinSummaryData {
     pub retrospective_restatement: Option<String>,
 
     /// 発行済株式数（期末・自己株式を含む）
-    #[serde(rename = "SharesOutstanding", default)]
+    #[serde(rename = "ShOutFY", default)]
     pub number_of_issued_and_outstanding_shares_at_the_end_of_fiscal_year_including_treasury_stock:
         Option<String>,
 
     /// 自己株式数（期末）
-    #[serde(rename = "TreasuryStock", default)]
+    #[serde(rename = "TrShFY", default)]
     pub number_of_treasury_stock_at_the_end_of_fiscal_year: Option<String>,
 
     /// 期中平均株式数
-    #[serde(rename = "AvgShares", default)]
+    #[serde(rename = "AvgSh", default)]
     pub average_number_of_shares: Option<String>,
 
     /// 売上高（個別）
-    #[serde(rename = "NonConSales", default)]
+    #[serde(rename = "NCSales", default)]
     pub non_consolidated_net_sales: Option<String>,
 
     /// 営業利益（個別）
-    #[serde(rename = "NonConOpProfit", default)]
+    #[serde(rename = "NCOP", default)]
     pub non_consolidated_operating_profit: Option<String>,
 
     /// 経常利益（個別）
-    #[serde(rename = "NonConOrdProfit", default)]
+    #[serde(rename = "NCOdP", default)]
     pub non_consolidated_ordinary_profit: Option<String>,
 
     /// 当期純利益（個別）
-    #[serde(rename = "NonConProfit", default)]
+    #[serde(rename = "NCNP", default)]
     pub non_consolidated_profit: Option<String>,
 
     /// 1株当たり当期純利益（個別）
-    #[serde(rename = "NonConEPS", default)]
+    #[serde(rename = "NCEPS", default)]
     pub non_consolidated_earnings_per_share: Option<String>,
 
     /// 総資産（個別）
-    #[serde(rename = "NonConTotalAssets", default)]
+    #[serde(rename = "NCTA", default)]
     pub non_consolidated_total_assets: Option<String>,
 
     /// 純資産（個別）
-    #[serde(rename = "NonConEquity", default)]
+    #[serde(rename = "NCEq", default)]
     pub non_consolidated_equity: Option<String>,
 
     /// 自己資本比率（個別）
-    #[serde(rename = "NonConEquityRatio", default)]
+    #[serde(rename = "NCEqAR", default)]
     pub non_consolidated_equity_to_asset_ratio: Option<String>,
 
     /// 1株当たり純資産（個別）
-    #[serde(rename = "NonConBPS", default)]
+    #[serde(rename = "NCBPS", default)]
     pub non_consolidated_book_value_per_share: Option<String>,
 
     /// 売上高予想（第2四半期・個別）
-    #[serde(rename = "FNonConSales2Q", default)]
+    #[serde(rename = "FNCSales2Q", default)]
     pub forecast_non_consolidated_net_sales_2nd_quarter: Option<String>,
 
     /// 営業利益予想（第2四半期・個別）
-    #[serde(rename = "FNonConOpProfit2Q", default)]
+    #[serde(rename = "FNCOP2Q", default)]
     pub forecast_non_consolidated_operating_profit_2nd_quarter: Option<String>,
 
     /// 経常利益予想（第2四半期・個別）
-    #[serde(rename = "FNonConOrdProfit2Q", default)]
+    #[serde(rename = "FNCOdP2Q", default)]
     pub forecast_non_consolidated_ordinary_profit_2nd_quarter: Option<String>,
 
     /// 当期純利益予想（第2四半期・個別）
-    #[serde(rename = "FNonConProfit2Q", default)]
+    #[serde(rename = "FNCNP2Q", default)]
     pub forecast_non_consolidated_profit_2nd_quarter: Option<String>,
 
     /// 1株当たり当期純利益予想（第2四半期・個別）
-    #[serde(rename = "FNonConEPS2Q", default)]
+    #[serde(rename = "FNCEPS2Q", default)]
     pub forecast_non_consolidated_earnings_per_share_2nd_quarter: Option<String>,
 
     /// 売上高来期予想（第2四半期・個別）
-    #[serde(rename = "NxFNonConSales2Q", default)]
+    #[serde(rename = "NxFNCSales2Q", default)]
     pub next_year_forecast_non_consolidated_net_sales_2nd_quarter: Option<String>,
 
     /// 営業利益来期予想（第2四半期・個別）
-    #[serde(rename = "NxFNonConOpProfit2Q", default)]
+    #[serde(rename = "NxFNCOP2Q", default)]
     pub next_year_forecast_non_consolidated_operating_profit_2nd_quarter: Option<String>,
 
     /// 経常利益来期予想（第2四半期・個別）
-    #[serde(rename = "NxFNonConOrdProfit2Q", default)]
+    #[serde(rename = "NxFNCOdP2Q", default)]
     pub next_year_forecast_non_consolidated_ordinary_profit_2nd_quarter: Option<String>,
 
     /// 当期純利益来期予想（第2四半期・個別）
-    #[serde(rename = "NxFNonConProfit2Q", default)]
+    #[serde(rename = "NxFNCNP2Q", default)]
     pub next_year_forecast_non_consolidated_profit_2nd_quarter: Option<String>,
 
     /// 1株当たり当期純利益来期予想（第2四半期・個別）
-    #[serde(rename = "NxFNonConEPS2Q", default)]
+    #[serde(rename = "NxFNCEPS2Q", default)]
     pub next_year_forecast_non_consolidated_earnings_per_share_2nd_quarter: Option<String>,
 
     /// 売上高予想（通期・個別）
-    #[serde(rename = "FNonConSales", default)]
+    #[serde(rename = "FNCSales", default)]
     pub forecast_non_consolidated_net_sales: Option<String>,
 
     /// 営業利益予想（通期・個別）
-    #[serde(rename = "FNonConOpProfit", default)]
+    #[serde(rename = "FNCOP", default)]
     pub forecast_non_consolidated_operating_profit: Option<String>,
 
     /// 経常利益予想（通期・個別）
-    #[serde(rename = "FNonConOrdProfit", default)]
+    #[serde(rename = "FNCOdP", default)]
     pub forecast_non_consolidated_ordinary_profit: Option<String>,
 
     /// 当期純利益予想（通期・個別）
-    #[serde(rename = "FNonConProfit", default)]
+    #[serde(rename = "FNCNP", default)]
     pub forecast_non_consolidated_profit: Option<String>,
 
     /// 1株当たり当期純利益予想（通期・個別）
-    #[serde(rename = "FNonConEPS", default)]
+    #[serde(rename = "FNCEPS", default)]
     pub forecast_non_consolidated_earnings_per_share: Option<String>,
 
     /// 売上高来期予想（通期・個別）
-    #[serde(rename = "NxFNonConSales", default)]
+    #[serde(rename = "NxFNCSales", default)]
     pub next_year_forecast_non_consolidated_net_sales: Option<String>,
 
     /// 営業利益来期予想（通期・個別）
-    #[serde(rename = "NxFNonConOpProfit", default)]
+    #[serde(rename = "NxFNCOP", default)]
     pub next_year_forecast_non_consolidated_operating_profit: Option<String>,
 
     /// 経常利益来期予想（通期・個別）
-    #[serde(rename = "NxFNonConOrdProfit", default)]
+    #[serde(rename = "NxFNCOdP", default)]
     pub next_year_forecast_non_consolidated_ordinary_profit: Option<String>,
 
     /// 当期純利益来期予想（通期・個別）
-    #[serde(rename = "NxFNonConProfit", default)]
+    #[serde(rename = "NxFNCNP", default)]
     pub next_year_forecast_non_consolidated_profit: Option<String>,
 
     /// 1株当たり当期純利益来期予想（通期・個別）
-    #[serde(rename = "NxFNonConEPS", default)]
+    #[serde(rename = "NxFNCEPS", default)]
     pub next_year_forecast_non_consolidated_earnings_per_share: Option<String>,
 }
 
@@ -491,17 +491,17 @@ mod tests {
             "DiscDate": "2023-11-14",
             "DiscTime": "15:00:00",
             "Code": "72030",
-            "DiscNum": "20231114502171",
+            "DiscNo": "20231114502171",
             "DocType": "決算短信",
-            "CurPeriod": "2Q",
-            "CurStartDate": "2023-04-01",
-            "CurEndDate": "2023-09-30",
-            "CurFYStartDate": "2023-04-01",
-            "CurFYEndDate": "2024-03-31",
-            "NxFYStartDate": "2024-04-01",
-            "NxFYEndDate": "2025-03-31",
+            "CurPerType": "2Q",
+            "CurPerSt": "2023-04-01",
+            "CurPerEn": "2023-09-30",
+            "CurFYSt": "2023-04-01",
+            "CurFYEn": "2024-03-31",
+            "NxtFYSt": "2024-04-01",
+            "NxtFYEn": "2025-03-31",
             "Sales": "18733067000000",
-            "OpProfit": "1686297000000",
+            "OP": "1686297000000",
             "NxFDivAnn": "50.00",
             "FDivAnn": "45.00",
             "DivAnn": "40.00"
@@ -538,11 +538,11 @@ mod tests {
                     "DiscDate": "2023-11-14",
                     "Code": "72030",
                     "DocType": "決算短信",
-                    "CurPeriod": "2Q",
-                    "CurStartDate": "2023-04-01",
-                    "CurEndDate": "2023-09-30",
-                    "CurFYStartDate": "2023-04-01",
-                    "CurFYEndDate": "2024-03-31"
+                    "CurPerType": "2Q",
+                    "CurPerSt": "2023-04-01",
+                    "CurPerEn": "2023-09-30",
+                    "CurFYSt": "2023-04-01",
+                    "CurFYEn": "2024-03-31"
                 }
             ]
         });

--- a/backend/src/services/jquants.rs
+++ b/backend/src/services/jquants.rs
@@ -123,4 +123,47 @@ mod tests {
             }
         }
     }
+
+    /// 任天堂（7974）の配当情報取得テスト
+    /// 実行には環境変数 JQUANTS_API_KEY が必要
+    /// cargo test test_get_nintendo_dividend -- --ignored --nocapture
+    #[tokio::test]
+    #[ignore]
+    async fn test_get_nintendo_dividend() {
+        let api_key = std::env::var("JQUANTS_API_KEY")
+            .expect("JQUANTS_API_KEY 環境変数が設定されていません");
+
+        let client = Client::new();
+        let params = FinSummaryQuery {
+            code: "7974".to_string(), // 任天堂
+            from: None,
+            to: None,
+        };
+
+        let result = JQuantsService::get_fin_summary(&client, params, &api_key).await;
+
+        match result {
+            Ok(response) => {
+                println!("取得件数: {}", response.data.len());
+                for summary in &response.data {
+                    println!("---");
+                    println!("開示日: {}", summary.disclosed_date);
+                    println!("書類種別: {}", summary.type_of_document);
+                    println!("年間配当実績(DivAnn): {:?}", summary.result_dividend_per_share_annual);
+                    println!(
+                        "年間配当予想(FDivAnn): {:?}",
+                        summary.forecast_dividend_per_share_annual
+                    );
+                    println!(
+                        "年間配当来期予想(NxFDivAnn): {:?}",
+                        summary.next_year_forecast_dividend_per_share_annual
+                    );
+                }
+                assert!(!response.data.is_empty(), "データが取得できること");
+            }
+            Err(e) => {
+                panic!("API呼び出しエラー: {:?}", e);
+            }
+        }
+    }
 }

--- a/frontend/src/features/jquants/api/__tests__/client.test.ts
+++ b/frontend/src/features/jquants/api/__tests__/client.test.ts
@@ -23,8 +23,8 @@ describe('JQuantsApiClient', () => {
   describe('getStatements', () => {
     it('財務諸表を正常に取得できる', async () => {
       const mockResponse = {
-        statements: [
-          { NextYearForecastDividendPerShareAnnual: '100' },
+        data: [
+          { NxFDivAnn: '100' },
         ],
       };
       (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue(mockResponse);
@@ -38,7 +38,7 @@ describe('JQuantsApiClient', () => {
     });
 
     it('オプションパラメータを含めて取得できる', async () => {
-      const mockResponse = { statements: [] };
+      const mockResponse = { data: [] };
       (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue(mockResponse);
 
       await client.getStatements('1234', '2024-01-01', '2024-12-31');

--- a/frontend/src/features/jquants/api/types.ts
+++ b/frontend/src/features/jquants/api/types.ts
@@ -13,134 +13,134 @@ export interface JQuantsStatementData {
   DiscDate: string; // 開示日
   DiscTime?: string; // 開示時刻
   Code: string; // 銘柄コード
-  DiscNum?: string; // 開示番号
+  DiscNo?: string; // 開示番号
   DocType: string; // 書類種別
-  CurPeriod: string; // 当期種別
-  CurStartDate: string; // 当期開始日
-  CurEndDate: string; // 当期終了日
-  CurFYStartDate: string; // 当会計年度開始日
-  CurFYEndDate: string; // 当会計年度終了日
-  NxFYStartDate?: string; // 翌会計年度開始日
-  NxFYEndDate?: string; // 翌会計年度終了日
+  CurPerType?: string; // 当期種別
+  CurPerSt?: string; // 当期開始日
+  CurPerEn?: string; // 当期終了日
+  CurFYSt?: string; // 当会計年度開始日
+  CurFYEn?: string; // 当会計年度終了日
+  NxtFYSt?: string; // 翌会計年度開始日
+  NxtFYEn?: string; // 翌会計年度終了日
 
   // 業績（連結）
   Sales?: string; // 売上高
-  OpProfit?: string; // 営業利益
-  OrdProfit?: string; // 経常利益
-  Profit?: string; // 当期純利益
+  OP?: string; // 営業利益
+  OdP?: string; // 経常利益
+  NP?: string; // 当期純利益
   EPS?: string; // 1株当たり当期純利益
-  DilutedEPS?: string; // 希薄化後EPS
-  TotalAssets?: string; // 総資産
-  Equity?: string; // 純資産
-  EquityRatio?: string; // 自己資本比率
+  DEPS?: string; // 希薄化後EPS
+  TA?: string; // 総資産
+  Eq?: string; // 純資産
+  EqAR?: string; // 自己資本比率
   BPS?: string; // 1株当たり純資産
 
   // キャッシュフロー
-  CashFlowOp?: string; // 営業CF
-  CashFlowInv?: string; // 投資CF
-  CashFlowFin?: string; // 財務CF
+  CFO?: string; // 営業CF
+  CFI?: string; // 投資CF
+  CFF?: string; // 財務CF
   CashEq?: string; // 現金及び現金同等物
 
   // 配当実績
   Div1Q?: string; // 1Q配当実績
   Div2Q?: string; // 2Q配当実績
   Div3Q?: string; // 3Q配当実績
-  DivYrEnd?: string; // 期末配当実績
+  DivFY?: string; // 期末配当実績
   DivAnn?: string; // 年間配当実績
-  DistREIT?: string; // REIT分配金
-  TotalDivPaidAnn?: string; // 配当支払総額実績
+  DivUnit?: string; // REIT分配金
+  DivTotalAnn?: string; // 配当支払総額実績
   PayoutRatioAnn?: string; // 配当性向実績
 
   // 配当予想（今期）
   FDiv1Q?: string; // 1Q配当予想
   FDiv2Q?: string; // 2Q配当予想
   FDiv3Q?: string; // 3Q配当予想
-  FDivYrEnd?: string; // 期末配当予想
+  FDivFY?: string; // 期末配当予想
   FDivAnn?: string; // 年間配当予想（今期）
-  FDistREIT?: string; // REIT分配金予想
-  FTotalDivPaidAnn?: string; // 配当支払総額予想
+  FDivUnit?: string; // REIT分配金予想
+  FDivTotalAnn?: string; // 配当支払総額予想
   FPayoutRatioAnn?: string; // 配当性向予想
 
   // 配当予想（来期）
   NxFDiv1Q?: string; // 1Q配当来期予想
   NxFDiv2Q?: string; // 2Q配当来期予想
   NxFDiv3Q?: string; // 3Q配当来期予想
-  NxFDivYrEnd?: string; // 期末配当来期予想
+  NxFDivFY?: string; // 期末配当来期予想
   NxFDivAnn?: string; // 年間配当来期予想
-  NxFDistREIT?: string; // REIT分配金来期予想
+  NxFDivUnit?: string; // REIT分配金来期予想
   NxFPayoutRatioAnn?: string; // 配当性向来期予想
 
   // 業績予想（2Q）
   FSales2Q?: string;
-  FOpProfit2Q?: string;
-  FOrdProfit2Q?: string;
-  FProfit2Q?: string;
+  FOP2Q?: string;
+  FOdP2Q?: string;
+  FNP2Q?: string;
   FEPS2Q?: string;
 
   // 業績来期予想（2Q）
   NxFSales2Q?: string;
-  NxFOpProfit2Q?: string;
-  NxFOrdProfit2Q?: string;
-  NxFProfit2Q?: string;
+  NxFOP2Q?: string;
+  NxFOdP2Q?: string;
+  NxFNp2Q?: string;
   NxFEPS2Q?: string;
 
   // 業績予想（通期）
   FSales?: string;
-  FOpProfit?: string;
-  FOrdProfit?: string;
-  FProfit?: string;
+  FOP?: string;
+  FOdP?: string;
+  FNP?: string;
   FEPS?: string;
 
   // 業績来期予想（通期）
   NxFSales?: string;
-  NxFOpProfit?: string;
-  NxFOrdProfit?: string;
-  NxFProfit?: string;
+  NxFOP?: string;
+  NxFOdP?: string;
+  NxFNp?: string;
   NxFEPS?: string;
 
   // その他
   MatChgSub?: string; // 重要な子会社の異動
-  SigChgScope?: string; // 連結範囲の重要な変更
-  ChgAccStd?: string; // 会計基準の改正に伴う変更
-  ChgOther?: string; // 会計基準の改正以外の変更
-  ChgEstimate?: string; // 会計上の見積りの変更
-  Restatement?: string; // 修正再表示
-  SharesOutstanding?: string; // 発行済株式数
-  TreasuryStock?: string; // 自己株式数
-  AvgShares?: string; // 期中平均株式数
+  SigChgInC?: string; // 連結範囲の重要な変更
+  ChgByASRev?: string; // 会計基準の改正に伴う変更
+  ChgNoASRev?: string; // 会計基準の改正以外の変更
+  ChgAcEst?: string; // 会計上の見積りの変更
+  RetroRst?: string; // 修正再表示
+  ShOutFY?: string; // 発行済株式数
+  TrShFY?: string; // 自己株式数
+  AvgSh?: string; // 期中平均株式数
 
   // 個別業績
-  NonConSales?: string;
-  NonConOpProfit?: string;
-  NonConOrdProfit?: string;
-  NonConProfit?: string;
-  NonConEPS?: string;
-  NonConTotalAssets?: string;
-  NonConEquity?: string;
-  NonConEquityRatio?: string;
-  NonConBPS?: string;
+  NCSales?: string;
+  NCOP?: string;
+  NCOdP?: string;
+  NCNP?: string;
+  NCEPS?: string;
+  NCTA?: string;
+  NCEq?: string;
+  NCEqAR?: string;
+  NCBPS?: string;
 
   // 個別業績予想
-  FNonConSales2Q?: string;
-  FNonConOpProfit2Q?: string;
-  FNonConOrdProfit2Q?: string;
-  FNonConProfit2Q?: string;
-  FNonConEPS2Q?: string;
-  NxFNonConSales2Q?: string;
-  NxFNonConOpProfit2Q?: string;
-  NxFNonConOrdProfit2Q?: string;
-  NxFNonConProfit2Q?: string;
-  NxFNonConEPS2Q?: string;
-  FNonConSales?: string;
-  FNonConOpProfit?: string;
-  FNonConOrdProfit?: string;
-  FNonConProfit?: string;
-  FNonConEPS?: string;
-  NxFNonConSales?: string;
-  NxFNonConOpProfit?: string;
-  NxFNonConOrdProfit?: string;
-  NxFNonConProfit?: string;
-  NxFNonConEPS?: string;
+  FNCSales2Q?: string;
+  FNCOP2Q?: string;
+  FNCOdP2Q?: string;
+  FNCNP2Q?: string;
+  FNCEPS2Q?: string;
+  NxFNCSales2Q?: string;
+  NxFNCOP2Q?: string;
+  NxFNCOdP2Q?: string;
+  NxFNCNP2Q?: string;
+  NxFNCEPS2Q?: string;
+  FNCSales?: string;
+  FNCOP?: string;
+  FNCOdP?: string;
+  FNCNP?: string;
+  FNCEPS?: string;
+  NxFNCSales?: string;
+  NxFNCOP?: string;
+  NxFNCOdP?: string;
+  NxFNCNP?: string;
+  NxFNCEPS?: string;
 }
 
 /**

--- a/frontend/src/features/jquants/hooks/__tests__/useJQuantsDividend.test.ts
+++ b/frontend/src/features/jquants/hooks/__tests__/useJQuantsDividend.test.ts
@@ -161,6 +161,36 @@ describe('useJQuantsDividend', () => {
     expect(result.current.error).toBe('配当情報の取得に失敗しました');
   });
 
+  it('response.dataがundefinedの場合、undefinedを返す', async () => {
+    const mockResponse = { data: undefined };
+
+    (jquantsApiClient.getStatements as Mock).mockResolvedValue(mockResponse);
+
+    const { result } = renderHook(() => useJQuantsDividend('1234', true));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.dividendPerShare).toBeUndefined();
+    expect(result.current.error).toBeNull();
+  });
+
+  it('response.dataが配列でない場合、undefinedを返す', async () => {
+    const mockResponse = { data: { some: 'object' } };
+
+    (jquantsApiClient.getStatements as Mock).mockResolvedValue(mockResponse);
+
+    const { result } = renderHook(() => useJQuantsDividend('1234', true));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.dividendPerShare).toBeUndefined();
+    expect(result.current.error).toBeNull();
+  });
+
   it('securityCodeが変更された場合、再取得する', async () => {
     const mockResponse = {
       data: [{ NxFDivAnn: '50.00' }],

--- a/frontend/src/features/jquants/hooks/useJQuantsDividend.ts
+++ b/frontend/src/features/jquants/hooks/useJQuantsDividend.ts
@@ -28,6 +28,12 @@ export const useJQuantsDividend = (
         const response = await jquantsApiClient.getStatements(securityCode);
         let dividendValue = '';
 
+        // レスポンスの data フィールドが配列でない場合はスキップ
+        if (!response?.data || !Array.isArray(response.data)) {
+          setDividendPerShare(undefined);
+          return;
+        }
+
         // 配当予想を取得（優先順位: 来期予想 > 今期予想 > 実績）
         for (const summary of response.data) {
           // 来期予想年間配当金 (NxFDivAnn)


### PR DESCRIPTION
## 概要
任天堂（7974）など一部銘柄で配当金額を検索すると発生していたエラー `t.statements is not iterable` を修正

## 原因
1. **バックエンドの型定義**: `serde(rename)` が J-Quants API V2 の実際のフィールド名と不一致
   - 例: `OpProfit` → 実際は `OP`、`CurPeriod` → 実際は `CurPerType`
2. **フロントエンドの防御不足**: `response.data` が配列でない場合のハンドリングがなかった

## 変更種別
- [x] バグ修正

## 変更内容
- バックエンド: J-Quants API V2 の実際のフィールド名に `serde(rename)` を修正
- フロントエンド: 型定義をバックエンドと同じフィールド名に更新
- フロントエンド: `Array.isArray()` による防御的チェックを追加

## テスト
- [x] ユニットテスト追加/更新
- [x] 任天堂（7974）の配当情報取得テストを追加
- [x] `response.data` が配列でない場合のテストを追加

## チェックリスト
- [x] CIパス確認
- [x] 既存仕様を壊さないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)