### PR TITLE
fix: 1株当たり配当金の計算ロジックを修正

### DIFF
--- a/frontend/src/features/jquants/hooks/__tests__/useJQuantsDividend.test.ts
+++ b/frontend/src/features/jquants/hooks/__tests__/useJQuantsDividend.test.ts
@@ -38,18 +38,18 @@ describe('useJQuantsDividend', () => {
     expect(jquantsApiClient.getStatements).not.toHaveBeenCalled();
   });
 
-  it('配当情報を正常に取得できる（来期予想）', async () => {
-    // V2 API では data フィールドを使用、省略形フィールド名
+  it('最新の決算データから配当情報を取得する（開示日でソート）', async () => {
+    // 開示日が異なる複数のデータ（古い順）
     const mockResponse = {
       data: [
-        { NxFDivAnn: '' },
-        { NxFDivAnn: '50.00' },
-        { NxFDivAnn: '60.00' },
+        { DiscDate: '2024-01-15', NxFDivAnn: '50.00' },
+        { DiscDate: '2024-04-15', NxFDivAnn: '60.00' },
+        { DiscDate: '2024-07-15', NxFDivAnn: '70.00' },
       ],
     };
 
     (jquantsApiClient.getStatements as Mock).mockResolvedValue(mockResponse);
-    (parseNumber as Mock).mockReturnValue(60);
+    (parseNumber as Mock).mockReturnValue(70);
 
     const { result } = renderHook(() => useJQuantsDividend('1234', true));
 
@@ -61,7 +61,9 @@ describe('useJQuantsDividend', () => {
     });
 
     expect(jquantsApiClient.getStatements).toHaveBeenCalledWith('1234');
-    expect(result.current.dividendPerShare).toBe(60);
+    // 最新データ（2024-07-15）の70.00が取得されること
+    expect(parseNumber).toHaveBeenCalledWith('70.00');
+    expect(result.current.dividendPerShare).toBe(70);
     expect(result.current.error).toBeNull();
   });
 
@@ -69,6 +71,7 @@ describe('useJQuantsDividend', () => {
     const mockResponse = {
       data: [
         {
+          DiscDate: '2024-04-15',
           NxFDivAnn: '',
           FDivAnn: '45.00',
         },
@@ -92,6 +95,7 @@ describe('useJQuantsDividend', () => {
     const mockResponse = {
       data: [
         {
+          DiscDate: '2024-04-15',
           NxFDivAnn: '',
           FDivAnn: '',
           DivAnn: '40.00',
@@ -112,11 +116,34 @@ describe('useJQuantsDividend', () => {
     expect(result.current.error).toBeNull();
   });
 
+  it('最新データに配当情報がない場合、次のデータから取得する', async () => {
+    const mockResponse = {
+      data: [
+        { DiscDate: '2024-01-15', NxFDivAnn: '50.00' },
+        { DiscDate: '2024-04-15', NxFDivAnn: '' }, // 最新だが配当情報なし
+      ],
+    };
+
+    (jquantsApiClient.getStatements as Mock).mockResolvedValue(mockResponse);
+    (parseNumber as Mock).mockReturnValue(50);
+
+    const { result } = renderHook(() => useJQuantsDividend('1234', true));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    // 2番目に新しいデータ（2024-01-15）の50.00が取得されること
+    expect(parseNumber).toHaveBeenCalledWith('50.00');
+    expect(result.current.dividendPerShare).toBe(50);
+    expect(result.current.error).toBeNull();
+  });
+
   it('空の配当情報の場合、0を返す', async () => {
     const mockResponse = {
       data: [
-        { NxFDivAnn: '' },
-        { NxFDivAnn: '' },
+        { DiscDate: '2024-01-15', NxFDivAnn: '' },
+        { DiscDate: '2024-04-15', NxFDivAnn: '' },
       ],
     };
 

--- a/frontend/src/features/jquants/hooks/useJQuantsDividend.ts
+++ b/frontend/src/features/jquants/hooks/useJQuantsDividend.ts
@@ -1,9 +1,28 @@
 import { useState, useEffect } from 'react';
 import { jquantsApiClient } from '../api/client';
+import { JQuantsStatementData } from '../api/types';
 import { parseNumber } from '@/lib/utils/formatters';
 
 /**
+ * 決算データから配当情報を抽出する
+ * 優先順位: 来期予想 > 今期予想 > 実績
+ */
+const extractDividendFromSummary = (summary: JQuantsStatementData): string | null => {
+  if (summary.NxFDivAnn && summary.NxFDivAnn !== '') {
+    return summary.NxFDivAnn;
+  }
+  if (summary.FDivAnn && summary.FDivAnn !== '') {
+    return summary.FDivAnn;
+  }
+  if (summary.DivAnn && summary.DivAnn !== '') {
+    return summary.DivAnn;
+  }
+  return null;
+};
+
+/**
  * J-Quants APIを使用して配当情報を取得するフック
+ * 最新の決算データから配当情報を優先的に取得する
  */
 export const useJQuantsDividend = (
   securityCode: string,
@@ -26,7 +45,6 @@ export const useJQuantsDividend = (
       try {
         // V2 API では data フィールドを使用
         const response = await jquantsApiClient.getStatements(securityCode);
-        let dividendValue = '';
 
         // レスポンスの data フィールドが配列でない場合はスキップ
         if (!response?.data || !Array.isArray(response.data)) {
@@ -34,22 +52,23 @@ export const useJQuantsDividend = (
           return;
         }
 
-        // 配当予想を取得（優先順位: 来期予想 > 今期予想 > 実績）
-        for (const summary of response.data) {
-          // 来期予想年間配当金 (NxFDivAnn)
-          if (summary.NxFDivAnn && summary.NxFDivAnn !== '') {
-            dividendValue = summary.NxFDivAnn;
-          }
-          // 今期予想年間配当金 (FDivAnn)（来期予想がない場合のフォールバック）
-          else if (!dividendValue && summary.FDivAnn && summary.FDivAnn !== '') {
-            dividendValue = summary.FDivAnn;
-          }
-          // 実績年間配当金 (DivAnn)（予想がない場合のフォールバック）
-          else if (!dividendValue && summary.DivAnn && summary.DivAnn !== '') {
-            dividendValue = summary.DivAnn;
+        // 開示日で降順ソート（最新データを優先）
+        const sortedData = [...response.data].sort((a, b) => {
+          const dateA = a.DiscDate || '';
+          const dateB = b.DiscDate || '';
+          return dateB.localeCompare(dateA);
+        });
+
+        // 最新の決算データから順に配当情報を検索
+        let dividendValue: string | null = null;
+        for (const summary of sortedData) {
+          dividendValue = extractDividendFromSummary(summary);
+          if (dividendValue) {
+            break;
           }
         }
-        setDividendPerShare(parseNumber(dividendValue));
+
+        setDividendPerShare(parseNumber(dividendValue || ''));
       } catch (err) {
         console.error('配当取得エラー:', err);
         setError(err instanceof Error ? err.message : '配当情報の取得に失敗しました');


### PR DESCRIPTION
## 概要
1株当たり配当金の計算が正しく行われていない問題を修正しました。

## 変更種別
- [x] バグ修正

## 問題の原因
- ループ内で `NxFDivAnn` は毎回上書きし、`FDivAnn`/`DivAnn` は最初のみ取得する矛盾したロジック
- 開示日を考慮せず最新の決算データを特定できていなかった

## 修正内容
- 開示日で降順ソートし最新データを優先的に取得
- 配当抽出ロジックを `extractDividendFromSummary` 関数に分離
- 最新データに配当情報がない場合は次データから取得

## 変更ファイル
- `frontend/src/features/jquants/hooks/useJQuantsDividend.ts`
- `frontend/src/features/jquants/hooks/__tests__/useJQuantsDividend.test.ts`

## テスト
- [x] ユニットテスト追加/更新（12件パス）
- [ ] 手動テスト実施（本番デプロイ後に複数銘柄で確認）

## チェックリスト
- [x] CIパス確認
- [x] 既存仕様を壊さないこと確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)