### PR TITLE
refactor: CSS リファクタリング（スタイル統一・共通クラス導入）

### DIFF
--- a/frontend/.claude/rules/00-frontend.md
+++ b/frontend/.claude/rules/00-frontend.md
@@ -5,7 +5,7 @@
 - **React**: 19.x (React Compiler 有効)
 - **TypeScript**: 5.x (strict mode)
 - **Vite**: 7.x
-- **Bootstrap**: 5.x
+- **Tailwind CSS**: 4.x
 - **TanStack Query**: サーバー状態管理
 - **Axios**: HTTPクライアント
 - **Vitest**: テストフレームワーク
@@ -77,9 +77,65 @@ React 19 + React Compiler が有効:
 
 ## スタイリング
 
-- Bootstrap 5 をベースに使用
-- グローバルスタイルは `src/styles/` に配置
-- コンポーネント固有スタイルは CSS Modules を検討
+### 基本方針
+
+- **Tailwind CSS** をベースに使用
+- グローバルスタイルは `src/styles/tailwind.css` に配置
+
+### クラス結合
+
+`cn()` ユーティリティを使用して統一:
+
+```typescript
+import { cn } from '@/lib/utils/classNames';
+
+// 基本パターン
+const classes = cn(baseClasses, conditionalClass && 'active', className);
+```
+
+### 配置ルール
+
+| 種類 | 配置場所 | 例 |
+|------|----------|-----|
+| テーマ変数 | `tailwind.css` の `@theme` | `--color-primary` |
+| 再利用クラス | `tailwind.css` の `@layer components` | `.panel-card`, `.stat-grid` |
+| コンポーネント固有 | 各 `.tsx` ファイル内 | `variantStyles` オブジェクト |
+| 動的スタイル | `style` 属性 | 計算された高さ・幅のみ |
+
+### 共通クラス
+
+| クラス名 | 用途 |
+|---------|------|
+| `.form-input-container` | フォーム入力コンテナ（`w-full max-w-[400px]`） |
+| `.stat-grid` | 統計情報グリッド（3カラム） |
+| `.action-toolbar` | アクションボタン群 |
+| `.status-message` | ローディング・空状態メッセージ |
+| `.panel-card` | パネルカード |
+
+### className の順序
+
+外部からの `className` は最後に配置（オーバーライド可能にするため）:
+
+```typescript
+const classes = cn(
+  baseClasses,      // 1. ベーススタイル
+  variantClass,     // 2. バリアント
+  sizeClass,        // 3. サイズ
+  className         // 4. 外部からの上書き（最後）
+);
+```
+
+### インラインスタイルの使用
+
+動的計算値のみ許可:
+
+```typescript
+// OK: 動的に計算される高さ
+style={{ maxHeight: calculatedHeight }}
+
+// NG: 静的な値は Tailwind クラスを使う
+style={{ padding: '16px' }} // → className="p-4"
+```
 
 ## テスト
 

--- a/frontend/src/components/atoms/Alert.tsx
+++ b/frontend/src/components/atoms/Alert.tsx
@@ -1,4 +1,5 @@
 import { HTMLAttributes, ReactNode } from 'react';
+import { cn } from '../../lib/utils/classNames';
 
 export type AlertVariant = 'info' | 'warning' | 'danger' | 'success';
 
@@ -14,10 +15,10 @@ const variantClasses: Record<AlertVariant, string> = {
   success: 'bg-success/10 text-success border-success/30',
 };
 
-export function Alert({ children, variant = 'info', className = '', ...rest }: AlertProps) {
+export function Alert({ children, variant = 'info', className, ...rest }: AlertProps) {
   return (
     <div
-      className={`rounded-md border px-4 py-3 text-sm ${variantClasses[variant]} ${className}`.trim()}
+      className={cn('rounded-md border px-4 py-3 text-sm', variantClasses[variant], className)}
       role="alert"
       {...rest}
     >

--- a/frontend/src/components/atoms/Badge.tsx
+++ b/frontend/src/components/atoms/Badge.tsx
@@ -1,4 +1,5 @@
 import { HTMLAttributes, ReactNode } from 'react';
+import { cn } from '../../lib/utils/classNames';
 
 export type BadgeVariant = 'primary' | 'secondary' | 'success' | 'warning' | 'danger' | 'info' | 'light' | 'dark';
 export type BadgeTone = 'solid' | 'soft' | 'outline';
@@ -42,7 +43,7 @@ const outlineStyles: Record<BadgeVariant, string> = {
   dark: 'border border-dark text-dark',
 };
 
-export function Badge({ children, variant = 'primary', tone = 'soft', className = '', ...rest }: BadgeProps) {
+export function Badge({ children, variant = 'primary', tone = 'soft', className, ...rest }: BadgeProps) {
   const toneClass = tone === 'solid'
     ? solidStyles[variant]
     : tone === 'outline'
@@ -51,7 +52,7 @@ export function Badge({ children, variant = 'primary', tone = 'soft', className 
 
   return (
     <span
-      className={`inline-flex items-center rounded-md px-2.5 py-0.5 text-xs font-semibold ${toneClass} ${className}`.trim()}
+      className={cn('inline-flex items-center rounded-md px-2.5 py-0.5 text-xs font-semibold', toneClass, className)}
       {...rest}
     >
       {children}

--- a/frontend/src/components/atoms/Card.tsx
+++ b/frontend/src/components/atoms/Card.tsx
@@ -1,4 +1,5 @@
 import { HTMLAttributes, ReactNode } from 'react';
+import { cn } from '../../lib/utils/classNames';
 
 export type CardVariant = 'default' | 'primary';
 
@@ -19,10 +20,13 @@ export interface CardFooterProps extends HTMLAttributes<HTMLDivElement> {
   children: ReactNode;
 }
 
-export function Card({ children, className = '', ...rest }: CardProps) {
+export function Card({ children, className, ...rest }: CardProps) {
   return (
     <div
-      className={`rounded-lg border border-border bg-white shadow-sm print:border-black print:shadow-none ${className}`.trim()}
+      className={cn(
+        'rounded-lg border border-border bg-white shadow-sm print:border-black print:shadow-none',
+        className
+      )}
       {...rest}
     >
       {children}
@@ -30,14 +34,14 @@ export function Card({ children, className = '', ...rest }: CardProps) {
   );
 }
 
-export function CardHeader({ children, variant = 'default', className = '', ...rest }: CardHeaderProps) {
+export function CardHeader({ children, variant = 'default', className, ...rest }: CardHeaderProps) {
   const variantClass = variant === 'primary'
     ? 'bg-primary text-white'
     : 'border-b border-border bg-white text-dark';
 
   return (
     <div
-      className={`px-4 py-2 ${variantClass} ${className}`.trim()}
+      className={cn('px-4 py-2', variantClass, className)}
       {...rest}
     >
       {children}
@@ -45,18 +49,18 @@ export function CardHeader({ children, variant = 'default', className = '', ...r
   );
 }
 
-export function CardBody({ children, className = '', ...rest }: CardBodyProps) {
+export function CardBody({ children, className, ...rest }: CardBodyProps) {
   return (
-    <div className={`${className}`.trim()} {...rest}>
+    <div className={cn(className)} {...rest}>
       {children}
     </div>
   );
 }
 
-export function CardFooter({ children, className = '', ...rest }: CardFooterProps) {
+export function CardFooter({ children, className, ...rest }: CardFooterProps) {
   return (
     <div
-      className={`border-t border-border px-4 py-3 ${className}`.trim()}
+      className={cn('border-t border-border px-4 py-3', className)}
       {...rest}
     >
       {children}

--- a/frontend/src/components/atoms/Spinner.tsx
+++ b/frontend/src/components/atoms/Spinner.tsx
@@ -1,4 +1,5 @@
 import { HTMLAttributes } from 'react';
+import { cn } from '../../lib/utils/classNames';
 
 export type SpinnerSize = 'sm' | 'md' | 'lg';
 
@@ -13,11 +14,11 @@ const sizeClasses: Record<SpinnerSize, string> = {
   lg: 'h-8 w-8',
 };
 
-export function Spinner({ size = 'md', label = '読み込み中...', className = '', ...rest }: SpinnerProps) {
+export function Spinner({ size = 'md', label = '読み込み中...', className, ...rest }: SpinnerProps) {
   return (
-    <span className={`inline-flex items-center ${className}`.trim()} {...rest}>
+    <span className={cn('inline-flex items-center', className)} {...rest}>
       <svg
-        className={`animate-spin ${sizeClasses[size]}`}
+        className={cn('animate-spin', sizeClasses[size])}
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"

--- a/frontend/src/components/atoms/StatItem.tsx
+++ b/frontend/src/components/atoms/StatItem.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { cn } from '../../lib/utils/classNames';
 
 export interface StatItemProps {
   title: string;
@@ -16,9 +17,9 @@ export interface StatItemProps {
 export const StatItem: React.FC<StatItemProps> = ({
   title,
   value,
-  className = '',
-  titleClassName = '',
-  valueClassName = '',
+  className,
+  titleClassName,
+  valueClassName,
   variant = 'default'
 }) => {
   const getVariantClasses = () => {
@@ -47,11 +48,11 @@ export const StatItem: React.FC<StatItemProps> = ({
   const variantClasses = getVariantClasses();
 
   return (
-    <div className={`${variantClasses.container} ${className}`.trim()}>
-      <div className={`${variantClasses.title} ${titleClassName}`.trim()}>
+    <div className={cn(variantClasses.container, className)}>
+      <div className={cn(variantClasses.title, titleClassName)}>
         {title}
       </div>
-      <div className={`${variantClasses.value} ${valueClassName}`.trim()}>
+      <div className={cn(variantClasses.value, valueClassName)}>
         {value}
       </div>
     </div>

--- a/frontend/src/components/atoms/Table.tsx
+++ b/frontend/src/components/atoms/Table.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, HTMLAttributes, TableHTMLAttributes, forwardRef } from 'react';
 import { useTableAutoResize } from '../../hooks/common/useTableAutoResize';
+import { cn } from '../../lib/utils/classNames';
 
 export interface TableProps extends TableHTMLAttributes<HTMLTableElement> {
   children: ReactNode;
@@ -64,7 +65,7 @@ const Table = forwardRef<HTMLTableElement, TableProps>(
       maxHeight,
       bottomMargin = 20,
       forceResize,
-      className = '',
+      className,
       ...rest
     },
     ref
@@ -78,24 +79,20 @@ const Table = forwardRef<HTMLTableElement, TableProps>(
     });
 
     // CSSクラスの構築
-    const buildTableClasses = () => {
-      const classes = ['w-full text-left border-collapse'];
-
-      if (bordered) classes.push('[&_th]:border [&_th]:border-gray-200 [&_td]:border [&_td]:border-gray-200 print:[&_th]:border-black print:[&_td]:border-black');
-      if (small) classes.push('text-sm [&_th]:py-1 [&_th]:px-2 [&_td]:py-1 [&_td]:px-2');
-      else classes.push('[&_th]:py-2 [&_th]:px-3 [&_td]:py-2 [&_td]:px-3');
-      if (variant) classes.push(variantBgColors[variant] || '');
-      if (className) classes.push(className);
-
-      return classes.join(' ');
-    };
-
-    // striped と hover は tbody に適用
-    const stripedClass = striped ? '[&_tbody_tr:nth-child(even)]:bg-gray-50' : '';
-    const hoverClass = hover ? '[&_tbody_tr:hover]:bg-gray-100' : '';
+    const tableClasses = cn(
+      'w-full text-left border-collapse',
+      bordered && '[&_th]:border [&_th]:border-gray-200 [&_td]:border [&_td]:border-gray-200 print:[&_th]:border-black print:[&_td]:border-black',
+      small
+        ? 'text-sm [&_th]:py-1 [&_th]:px-2 [&_td]:py-1 [&_td]:px-2'
+        : '[&_th]:py-2 [&_th]:px-3 [&_td]:py-2 [&_td]:px-3',
+      variant && variantBgColors[variant],
+      striped && '[&_tbody_tr:nth-child(even)]:bg-gray-50',
+      hover && '[&_tbody_tr:hover]:bg-gray-100',
+      className
+    );
 
     const table = (
-      <table ref={ref} className={`${buildTableClasses()} ${stripedClass} ${hoverClass}`} {...rest}>
+      <table ref={ref} className={tableClasses} {...rest}>
         {children}
       </table>
     );
@@ -128,20 +125,16 @@ const Table = forwardRef<HTMLTableElement, TableProps>(
 Table.displayName = 'Table';
 
 const TableHeader = forwardRef<HTMLTableSectionElement, TableHeaderProps>(
-  ({ children, variant, stickyTop = true, className = '', ...rest }, ref) => {
-    const buildHeaderClasses = () => {
-      const classes = [];
-
-      if (variant === 'light') classes.push('bg-gray-100');
-      if (variant === 'dark') classes.push('bg-gray-800 text-white');
-      if (stickyTop) classes.push('sticky top-0 z-10 bg-white');
-      if (className) classes.push(className);
-
-      return classes.join(' ');
-    };
+  ({ children, variant, stickyTop = true, className, ...rest }, ref) => {
+    const headerClasses = cn(
+      variant === 'light' && 'bg-gray-100',
+      variant === 'dark' && 'bg-gray-800 text-white',
+      stickyTop && 'sticky top-0 z-10 bg-white',
+      className
+    );
 
     return (
-      <thead ref={ref} className={buildHeaderClasses()} {...rest}>
+      <thead ref={ref} className={headerClasses} {...rest}>
         {children}
       </thead>
     );
@@ -151,9 +144,9 @@ const TableHeader = forwardRef<HTMLTableSectionElement, TableHeaderProps>(
 TableHeader.displayName = 'TableHeader';
 
 const TableBody = forwardRef<HTMLTableSectionElement, HTMLAttributes<HTMLTableSectionElement>>(
-  ({ children, className = '', ...rest }, ref) => {
+  ({ children, className, ...rest }, ref) => {
     return (
-      <tbody ref={ref} className={className} {...rest}>
+      <tbody ref={ref} className={cn(className)} {...rest}>
         {children}
       </tbody>
     );
@@ -163,19 +156,16 @@ const TableBody = forwardRef<HTMLTableSectionElement, HTMLAttributes<HTMLTableSe
 TableBody.displayName = 'TableBody';
 
 const TableRow = forwardRef<HTMLTableRowElement, TableRowProps>(
-  ({ children, active = false, variant, className = '', ...rest }, ref) => {
-    const buildRowClasses = () => {
-      const classes = ['[&_th]:align-middle [&_td]:align-middle'];
-
-      if (active) classes.push('bg-primary/10');
-      if (variant) classes.push(variantBgColors[variant] || '');
-      if (className) classes.push(className);
-
-      return classes.join(' ');
-    };
+  ({ children, active = false, variant, className, ...rest }, ref) => {
+    const rowClasses = cn(
+      '[&_th]:align-middle [&_td]:align-middle',
+      active && 'bg-primary/10',
+      variant && variantBgColors[variant],
+      className
+    );
 
     return (
-      <tr ref={ref} className={buildRowClasses()} {...rest}>
+      <tr ref={ref} className={rowClasses} {...rest}>
         {children}
       </tr>
     );
@@ -191,7 +181,7 @@ const TableCell = forwardRef<HTMLTableCellElement, TableCellProps>(
       as = 'td',
       scope = 'col',
       colSpan = 1,
-      className = '',
+      className,
       dangerouslySetInnerHTML,
       ...rest
     },
@@ -199,13 +189,13 @@ const TableCell = forwardRef<HTMLTableCellElement, TableCellProps>(
   ) => {
     const Cell = as;
     const scopeAttr = as === 'th' ? { scope } : {};
-    const thClasses = as === 'th' ? 'font-semibold text-gray-700' : '';
+    const cellClasses = cn(as === 'th' && 'font-semibold text-gray-700', className);
 
     if (dangerouslySetInnerHTML) {
       return (
         <Cell
           ref={ref}
-          className={`${thClasses} ${className}`}
+          className={cellClasses}
           {...scopeAttr}
           {...rest}
           colSpan={colSpan}
@@ -215,7 +205,7 @@ const TableCell = forwardRef<HTMLTableCellElement, TableCellProps>(
     }
 
     return (
-      <Cell ref={ref} className={`${thClasses} ${className}`} {...scopeAttr} {...rest} colSpan={colSpan}>
+      <Cell ref={ref} className={cellClasses} {...scopeAttr} {...rest} colSpan={colSpan}>
         {children}
       </Cell>
     );

--- a/frontend/src/components/molecules/DividendInfo/DividendInfo.tsx
+++ b/frontend/src/components/molecules/DividendInfo/DividendInfo.tsx
@@ -100,7 +100,7 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({ searchQuery, securit
         )}
       </div>
       <div className="p-4">
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="stat-grid">
           <div>
             <NumberInputField label="平均取得価格" value={averageUnitPrice} onChange={setAverageUnitPrice} />
           </div>
@@ -118,7 +118,7 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({ searchQuery, securit
           </div>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-4">
+        <div className="stat-grid mt-4">
           <StatItem title="取得総額" value={formatCurrency(totalInvestment)} />
           <StatItemWithRate title="合計受取金額 (累積利回り)" value={summary[0]?.net_amount_received || 0} rate={dividendReturnRate} format={formatCurrency} />
           <StatItemWithRate title="年間配当金額 (配当利回り)" value={annualDividendAmount} rate={dividendYield} format={formatCurrency} />

--- a/frontend/src/components/molecules/ReceiptHeader/ReceiptHeader.tsx
+++ b/frontend/src/components/molecules/ReceiptHeader/ReceiptHeader.tsx
@@ -19,7 +19,7 @@ export const ReceiptHeader: React.FC<ReceiptHeaderProps> = ({ items }) => {
                 <h5>集計情報</h5>
             </CardHeader>
             <CardBody className="p-4">
-                <div className="grid grid-cols-1 md:grid-cols-3">
+                <div className="stat-grid">
                     {items.map((item, index) => (
                         <StatItem key={index} title={item.title} value={item.format(item.value)} />
                     ))}

--- a/frontend/src/components/organisms/ReceiptTable/ReceiptTable.tsx
+++ b/frontend/src/components/organisms/ReceiptTable/ReceiptTable.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Table, TableBody, TableCell, TableHeader, TableRow } from '@/components/atoms/Table';
 import { TableColumnConfig, SummaryColumnConfig } from '@/lib/interfaces/receipt';
 import { useForceResize } from '@/hooks/common/useResize';
+import { cn } from '@/lib/utils/classNames';
 
 type DataItem = Record<string, unknown>;
 type SummaryItem = Record<string, unknown> & { filter: string };
@@ -130,9 +131,9 @@ export function ReceiptTable<T extends DataItem, S extends SummaryItem>({
                 value: formatSummaryValue(summaryItem[column.key], column)
             }));
 
-            const summaryBorderClass = summaryIndex > 0 ? 'border-t-2 border-primary-hover' : '';
-            const summaryLeftClass = `bg-primary text-white font-semibold ${summaryBorderClass} border-l-4 border-primary-dark`.trim();
-            const summaryValueClass = `bg-primary text-white text-right font-bold ${summaryBorderClass}`.trim();
+            const summaryBorderClass = summaryIndex > 0 && 'border-t-2 border-primary-hover';
+            const summaryLeftClass = cn('bg-primary text-white font-semibold border-l-4 border-primary-dark', summaryBorderClass);
+            const summaryValueClass = cn('bg-primary text-white text-right font-bold', summaryBorderClass);
 
             return (
                 <React.Fragment key={`group-${summaryIndex}`}>

--- a/frontend/src/components/organisms/StockInfo.tsx
+++ b/frontend/src/components/organisms/StockInfo.tsx
@@ -46,7 +46,7 @@ export function StockInfo({ stockData }: StockInfoProps) {
               ))}
             </tbody>
           </table>
-          <div className="mt-3">
+          <div className="mt-3 p-3">
             <StockInfoLinks code={code} />
           </div>
         </CardBody>

--- a/frontend/src/lib/utils/classNames.ts
+++ b/frontend/src/lib/utils/classNames.ts
@@ -1,0 +1,14 @@
+/**
+ * クラス名結合ユーティリティ
+ * - falsy な値（false, null, undefined, ''）を除外
+ * - 複数のクラス名を空白で結合
+ *
+ * @example
+ * cn('base', isActive && 'active', className)
+ * // isActive=true, className='custom' => 'base active custom'
+ */
+export function cn(
+  ...classes: (string | boolean | undefined | null)[]
+): string {
+  return classes.filter(Boolean).join(' ');
+}

--- a/frontend/src/pages/AssetBalance.tsx
+++ b/frontend/src/pages/AssetBalance.tsx
@@ -148,7 +148,7 @@ export function AssetBalancePage() {
       <div className="mt-2" aria-busy={isProcessing}>
         {/* 認証確認中 */}
         {authLoading && (
-          <div className="my-4 flex flex-col items-center gap-2" role="status" aria-live="polite">
+          <div className="status-message" role="status" aria-live="polite">
             <Spinner size="md" className="text-primary" />
             <p className="text-sm text-secondary">認証状態を確認しています...</p>
           </div>
@@ -172,15 +172,15 @@ export function AssetBalancePage() {
         {/* ログイン済みの場合のメインコンテンツ */}
         {!authLoading && isAuthenticated && (
           <>
-            <div className="flex flex-wrap items-center gap-2">
-              <div className="w-full max-w-[400px]">
+            <div className="action-toolbar">
+              <div className="form-input-container">
                 <CSVFileInput
                   onFileSelect={handleFileSelect}
                   selectedFileName={csvReader.fileName || ''}
                   disabled={loading || saving || deleting}
                 />
               </div>
-              <div className="flex items-center gap-2" role="group" aria-label="データ操作">
+              <div className="action-toolbar" role="group" aria-label="データ操作">
                 {hasCsvData && (
                   <Button
                     variant="primary"
@@ -214,7 +214,7 @@ export function AssetBalancePage() {
 
             <div aria-live="polite" aria-atomic="true">
               {(loading || saving || deleting || csvReader.isLoading) && (
-                <div className="my-4 flex flex-col items-center gap-2" role="status">
+                <div className="status-message" role="status">
                   <Spinner size="md" className="text-primary" />
                   <p className="text-sm text-secondary">
                     {loading && 'データを読み込んでいます...'}

--- a/frontend/src/pages/Receipts.tsx
+++ b/frontend/src/pages/Receipts.tsx
@@ -293,8 +293,8 @@ export function ReceiptsPage() {
         </div>
       </nav>
       <div className="mt-2" aria-busy={isLoading || dbLoading || authLoading || saving || deleting}>
-        <div className="flex flex-wrap items-center gap-2">
-          <div className="w-full max-w-[400px]">
+        <div className="action-toolbar">
+          <div className="form-input-container">
             <CSVFileInput
               onFileSelect={handleFileSelect}
               selectedFileName={fileName}
@@ -302,7 +302,7 @@ export function ReceiptsPage() {
             />
           </div>
           {isAuthenticated && (
-            <div className="flex items-center gap-2" role="group" aria-label="データ操作">
+            <div className="action-toolbar" role="group" aria-label="データ操作">
               {hasCsvData && (
                 <Button
                   variant="primary"
@@ -337,7 +337,7 @@ export function ReceiptsPage() {
 
         <div aria-live="polite" aria-atomic="true">
           {(isLoading || dbLoading || authLoading) && (
-            <div className="my-4 flex flex-col items-center gap-2" role="status">
+            <div className="status-message" role="status">
               <Spinner size="md" className="text-primary" />
               <p className="text-sm text-secondary">
                 {authLoading && '認証状態を確認しています...'}

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -131,6 +131,26 @@
   .button-set > *:not(:last-child) {
     @apply mr-2;
   }
+
+  /* フォーム入力コンテナ（CSV入力等） */
+  .form-input-container {
+    @apply w-full max-w-[400px];
+  }
+
+  /* 統計情報グリッド（3カラム） */
+  .stat-grid {
+    @apply grid grid-cols-1 gap-4 md:grid-cols-3;
+  }
+
+  /* アクションツールバー */
+  .action-toolbar {
+    @apply flex flex-wrap items-center gap-2;
+  }
+
+  /* ステータスメッセージ（ローディング・空状態） */
+  .status-message {
+    @apply my-4 flex flex-col items-center gap-2;
+  }
 }
 
 /* 印刷対応 */


### PR DESCRIPTION
## 概要
- フロントエンドのスタイル設計を見直し、統一ルールで整理
- クラス結合を `cn()` ユーティリティに統一
- 重複パターンを共通クラスに集約

## 変更種別
- [x] リファクタリング

## 主な変更内容
- `cn()` ユーティリティ関数を追加（`lib/utils/classNames.ts`）
- 共通クラスを `tailwind.css` に追加（`.form-input-container`, `.stat-grid`, `.action-toolbar`, `.status-message`）
- atoms/molecules/organisms/pages の `.trim()` パターンを `cn()` に置換
- スタイル運用ルールをドキュメント化

## テスト
- [x] ビルド確認
- [ ] 各ページの表示確認（Login / Home / Search / Receipts / AssetBalance）

🤖 Generated with [Claude Code](https://claude.com/claude-code)