### PR TITLE
UI改善・Tailwind CSS移行・テスト強化

### DIFF
--- a/.claude/commands/ui-review.md
+++ b/.claude/commands/ui-review.md
@@ -2,7 +2,7 @@
 description: "開発サーバーに対してUIレビューを自動実行し、スクリーンショットとAI分析レポートを生成します。"
 ---
 # UI Review
-Claude Code で完結するUIレビューシステム
+Claude Code で完結するUIレビューシステム（Playwright MCP版）
 
 ## Usage
 ```
@@ -14,26 +14,28 @@ Claude Code で完結するUIレビューシステム
 ## 対象画面
 以下の画面をレビュー対象とする:
 - `/` - ホーム画面
-- `/stocks` - 株式一覧
-- `/dividends` - 配当金一覧
-- `/domestic-stocks` - 国内株式
-- `/mutualfunds` - 投資信託
-- `/asset-balances` - 資産残高
+- `/search` - 銘柄検索
+- `/assetbalance` - 保有銘柄
+- `/receipts` - 受取金
+- `/404` - エラーページ
 
 ## Implementation Steps
 
 ### 1. 環境チェック
 1. 開発サーバー `http://localhost:8080` の起動確認
-   - 起動していない場合: `cd frontend && npm run dev` をバックグラウンド実行
-2. ToolSearch で `chrome-devtools` ツールをロード
+   - 起動していない場合: ユーザーに起動を促す
+2. ToolSearch で `playwright` ツールをロード
+   - `ToolSearch` に `playwright screenshot navigate` でツールを検索
 
 ### 2. スクリーンショット取得
-1. `mcp__chrome-devtools__new_page` で新規ページを開く
+1. `mcp__playwright__browser_navigate` で対象URLに遷移
 2. 各対象画面について:
-   - `mcp__chrome-devtools__navigate_page` でURLに遷移
-   - `mcp__chrome-devtools__take_screenshot` でキャプチャ
-   - スクリーンショットは scratchpad ディレクトリに保存
-3. デスクトップ (1920x1080) とモバイル (375x667) の両方で取得
+   - `mcp__playwright__browser_navigate` でURLに遷移（例: `http://localhost:8080/search`）
+   - `mcp__playwright__browser_take_screenshot` でキャプチャ
+     - `filename`: ページ名.png（例: `home.png`, `search.png`）
+     - `fullPage`: true（全ページキャプチャ）
+     - `type`: png
+   - スクリーンショットは `.playwright-mcp/` ディレクトリに自動保存される
 
 ### 3. UI分析
 Read ツールで各スクリーンショットを読み込み、以下の観点で分析:
@@ -57,16 +59,33 @@ Read ツールで各スクリーンショットを読み込み、以下の観点
 - ...
 
 ### 改善提案
-| 優先度 | 画面 | 問題 | 改善案 | 実装例 |
-|--------|------|------|--------|--------|
-| 高 | ... | ... | ... | `className="..."` |
+| 優先度 | 画面 | 問題 | 改善案 |
+|--------|------|------|--------|
+| 高 | ... | ... | ... |
 
 ### 推奨アクション
 1. ...
 2. ...
 ```
 
+## Playwright MCP ツール使用例
+
+```
+# ツールのロード
+ToolSearch: query="playwright screenshot navigate"
+
+# ページ遷移
+mcp__playwright__browser_navigate: url="http://localhost:8080"
+
+# スクリーンショット取得
+mcp__playwright__browser_take_screenshot:
+  type="png"
+  filename="home.png"
+  fullPage=true
+```
+
 ## 注意事項
 - 開発サーバーが起動していない場合は起動を促す
 - スクリーンショット取得に失敗した画面はスキップして続行
 - レポートは日本語で出力
+- 認証が必要なページはユーザーにログインを依頼する

--- a/frontend/src/components/atoms/Card.tsx
+++ b/frontend/src/components/atoms/Card.tsx
@@ -36,7 +36,7 @@ export function Card({ children, className, ...rest }: CardProps) {
 
 export function CardHeader({ children, variant = 'default', className, ...rest }: CardHeaderProps) {
   const variantClass = variant === 'primary'
-    ? 'bg-primary text-white'
+    ? 'bg-slate-700 text-white'
     : 'border-b border-border bg-white text-dark';
 
   return (

--- a/frontend/src/components/atoms/EmptyState.tsx
+++ b/frontend/src/components/atoms/EmptyState.tsx
@@ -1,0 +1,42 @@
+import { ReactNode } from 'react';
+import { cn } from '../../lib/utils/classNames';
+
+interface EmptyStateProps {
+  icon?: ReactNode;
+  title: string;
+  description?: string;
+  action?: ReactNode;
+  className?: string;
+}
+
+/**
+ * 空状態を表示するコンポーネント
+ * データがない場合やエラー時に使用
+ */
+export function EmptyState({
+  icon,
+  title,
+  description,
+  action,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col items-center justify-center py-12 px-4 text-center',
+        className
+      )}
+    >
+      {icon && (
+        <div className="mb-4 text-slate-400" aria-hidden="true">
+          {icon}
+        </div>
+      )}
+      <h3 className="text-lg font-medium text-slate-900">{title}</h3>
+      {description && (
+        <p className="mt-2 max-w-md text-base text-slate-600">{description}</p>
+      )}
+      {action && <div className="mt-6">{action}</div>}
+    </div>
+  );
+}

--- a/frontend/src/components/atoms/EmptyState.tsx
+++ b/frontend/src/components/atoms/EmptyState.tsx
@@ -1,13 +1,23 @@
 import { ReactNode } from 'react';
 import { cn } from '../../lib/utils/classNames';
 
+type HeadingLevel = 'h1' | 'h2' | 'h3';
+
 interface EmptyStateProps {
   icon?: ReactNode;
   title: string;
   description?: string;
   action?: ReactNode;
   className?: string;
+  /** 見出しレベル（デフォルト: h3） */
+  headingLevel?: HeadingLevel;
 }
+
+const headingStyles: Record<HeadingLevel, string> = {
+  h1: 'text-2xl font-bold text-slate-900',
+  h2: 'text-xl font-bold text-slate-900',
+  h3: 'text-base font-semibold text-slate-900',
+};
 
 /**
  * 空状態を表示するコンポーネント
@@ -19,7 +29,10 @@ export function EmptyState({
   description,
   action,
   className,
+  headingLevel = 'h3',
 }: EmptyStateProps) {
+  const Heading = headingLevel;
+
   return (
     <div
       className={cn(
@@ -32,7 +45,7 @@ export function EmptyState({
           {icon}
         </div>
       )}
-      <h3 className="text-base font-semibold text-slate-900">{title}</h3>
+      <Heading className={headingStyles[headingLevel]}>{title}</Heading>
       {description && (
         <p className="mt-1.5 max-w-md text-sm text-slate-600">{description}</p>
       )}

--- a/frontend/src/components/atoms/EmptyState.tsx
+++ b/frontend/src/components/atoms/EmptyState.tsx
@@ -23,20 +23,20 @@ export function EmptyState({
   return (
     <div
       className={cn(
-        'flex flex-col items-center justify-center py-12 px-4 text-center',
+        'flex flex-col items-center justify-center py-8 px-4 text-center',
         className
       )}
     >
       {icon && (
-        <div className="mb-4 text-slate-400" aria-hidden="true">
+        <div className="mb-3 text-slate-400" aria-hidden="true">
           {icon}
         </div>
       )}
-      <h3 className="text-lg font-medium text-slate-900">{title}</h3>
+      <h3 className="text-base font-semibold text-slate-900">{title}</h3>
       {description && (
-        <p className="mt-2 max-w-md text-base text-slate-600">{description}</p>
+        <p className="mt-1.5 max-w-md text-sm text-slate-600">{description}</p>
       )}
-      {action && <div className="mt-6">{action}</div>}
+      {action && <div className="mt-4">{action}</div>}
     </div>
   );
 }

--- a/frontend/src/components/atoms/PageHeader.tsx
+++ b/frontend/src/components/atoms/PageHeader.tsx
@@ -1,0 +1,29 @@
+import { ReactNode } from 'react';
+import { cn } from '../../lib/utils/classNames';
+
+interface PageHeaderProps {
+  title: string;
+  description?: string;
+  actions?: ReactNode;
+  className?: string;
+}
+
+/**
+ * ページタイトル用の見出しコンポーネント
+ * H1レベルの見出しとして使用
+ */
+export function PageHeader({ title, description, actions, className }: PageHeaderProps) {
+  return (
+    <div className={cn('mb-6', className)}>
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900">{title}</h1>
+          {description && (
+            <p className="mt-1 text-base text-slate-600">{description}</p>
+          )}
+        </div>
+        {actions && <div className="flex items-center gap-2">{actions}</div>}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/atoms/PageHeader.tsx
+++ b/frontend/src/components/atoms/PageHeader.tsx
@@ -14,12 +14,12 @@ interface PageHeaderProps {
  */
 export function PageHeader({ title, description, actions, className }: PageHeaderProps) {
   return (
-    <div className={cn('mb-6', className)}>
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+    <div className={cn('mb-4', className)}>
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-slate-900">{title}</h1>
+          <h1 className="text-xl font-bold text-slate-900">{title}</h1>
           {description && (
-            <p className="mt-1 text-base text-slate-600">{description}</p>
+            <p className="mt-0.5 text-sm text-slate-600">{description}</p>
           )}
         </div>
         {actions && <div className="flex items-center gap-2">{actions}</div>}

--- a/frontend/src/components/atoms/SectionHeader.tsx
+++ b/frontend/src/components/atoms/SectionHeader.tsx
@@ -1,0 +1,41 @@
+import { ReactNode } from 'react';
+import { cn } from '../../lib/utils/classNames';
+
+interface SectionHeaderProps {
+  title: string;
+  description?: string;
+  actions?: ReactNode;
+  className?: string;
+  level?: 2 | 3;
+}
+
+/**
+ * セクション見出しコンポーネント
+ * H2/H3レベルの見出しとして使用
+ */
+export function SectionHeader({
+  title,
+  description,
+  actions,
+  className,
+  level = 2,
+}: SectionHeaderProps) {
+  const Tag = `h${level}` as const;
+  const titleClasses = level === 2
+    ? 'text-xl font-semibold text-slate-900'
+    : 'text-lg font-medium text-slate-900';
+
+  return (
+    <div className={cn('mb-4', className)}>
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <Tag className={titleClasses}>{title}</Tag>
+          {description && (
+            <p className="mt-1 text-sm text-slate-600">{description}</p>
+          )}
+        </div>
+        {actions && <div className="flex items-center gap-2">{actions}</div>}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/atoms/Table.tsx
+++ b/frontend/src/components/atoms/Table.tsx
@@ -80,14 +80,14 @@ const Table = forwardRef<HTMLTableElement, TableProps>(
 
     // CSSクラスの構築
     const tableClasses = cn(
-      'w-full text-left border-collapse',
-      bordered && '[&_th]:border [&_th]:border-gray-200 [&_td]:border [&_td]:border-gray-200 print:[&_th]:border-black print:[&_td]:border-black',
+      'w-full text-left border-collapse text-sm',
+      bordered && '[&_th]:border [&_th]:border-slate-200 [&_td]:border [&_td]:border-slate-200 print:[&_th]:border-black print:[&_td]:border-black',
       small
-        ? 'text-sm [&_th]:py-1 [&_th]:px-2 [&_td]:py-1 [&_td]:px-2'
-        : '[&_th]:py-2 [&_th]:px-3 [&_td]:py-2 [&_td]:px-3',
+        ? '[&_th]:py-2 [&_th]:px-3 [&_td]:py-2 [&_td]:px-3'
+        : '[&_th]:py-3 [&_th]:px-4 [&_td]:py-3 [&_td]:px-4',
       variant && variantBgColors[variant],
-      striped && '[&_tbody_tr:nth-child(even)]:bg-gray-50',
-      hover && '[&_tbody_tr:hover]:bg-gray-100',
+      striped && '[&_tbody_tr:nth-child(even)]:bg-slate-50',
+      hover && '[&_tbody_tr:hover]:bg-slate-100',
       className
     );
 
@@ -127,9 +127,10 @@ Table.displayName = 'Table';
 const TableHeader = forwardRef<HTMLTableSectionElement, TableHeaderProps>(
   ({ children, variant, stickyTop = true, className, ...rest }, ref) => {
     const headerClasses = cn(
-      variant === 'light' && 'bg-gray-100',
-      variant === 'dark' && 'bg-gray-800 text-white',
-      stickyTop && 'sticky top-0 z-10 bg-white',
+      'bg-slate-50',
+      variant === 'light' && 'bg-slate-100',
+      variant === 'dark' && 'bg-slate-800 text-white',
+      stickyTop && 'sticky top-0 z-10',
       className
     );
 
@@ -189,7 +190,7 @@ const TableCell = forwardRef<HTMLTableCellElement, TableCellProps>(
   ) => {
     const Cell = as;
     const scopeAttr = as === 'th' ? { scope } : {};
-    const cellClasses = cn(as === 'th' && 'font-semibold text-gray-700', className);
+    const cellClasses = cn(as === 'th' && 'font-semibold text-slate-700', className);
 
     if (dangerouslySetInnerHTML) {
       return (

--- a/frontend/src/components/atoms/Table.tsx
+++ b/frontend/src/components/atoms/Table.tsx
@@ -80,10 +80,11 @@ const Table = forwardRef<HTMLTableElement, TableProps>(
 
     // CSSクラスの構築
     const tableClasses = cn(
-      'w-full text-left border-collapse text-sm',
+      'w-full text-left border-collapse',
+      small ? 'text-sm' : 'text-base',
       bordered && '[&_th]:border [&_th]:border-slate-200 [&_td]:border [&_td]:border-slate-200 print:[&_th]:border-black print:[&_td]:border-black',
       small
-        ? '[&_th]:py-2 [&_th]:px-3 [&_td]:py-2 [&_td]:px-3'
+        ? '[&_th]:py-2.5 [&_th]:px-3 [&_td]:py-2.5 [&_td]:px-3'
         : '[&_th]:py-3 [&_th]:px-4 [&_td]:py-3 [&_td]:px-4',
       variant && variantBgColors[variant],
       striped && '[&_tbody_tr:nth-child(even)]:bg-slate-50',

--- a/frontend/src/components/atoms/__tests__/Table.test.tsx
+++ b/frontend/src/components/atoms/__tests__/Table.test.tsx
@@ -66,7 +66,7 @@ describe('Table', () => {
     );
 
     const table = screen.getByRole('table');
-    expect(table).toHaveClass('[&_tbody_tr:nth-child(even)]:bg-gray-50');
+    expect(table).toHaveClass('[&_tbody_tr:nth-child(even)]:bg-slate-50');
   });
 
   test('borderedプロパティが正しく適用される', () => {
@@ -96,7 +96,7 @@ describe('Table', () => {
     );
 
     const table = screen.getByRole('table');
-    expect(table).toHaveClass('[&_tbody_tr:hover]:bg-gray-100');
+    expect(table).toHaveClass('[&_tbody_tr:hover]:bg-slate-100');
   });
 
   test('smallプロパティが正しく適用される', () => {
@@ -288,7 +288,7 @@ describe('Table', () => {
     );
 
     const thead = screen.getByRole('rowgroup');
-    expect(thead).toHaveClass('bg-gray-800', 'text-white');
+    expect(thead).toHaveClass('bg-slate-800', 'text-white');
   });
 
   test('TableCellのscopeプロパティがthの場合に正しく適用される', () => {

--- a/frontend/src/components/molecules/DividendInfo/DividendInfo.tsx
+++ b/frontend/src/components/molecules/DividendInfo/DividendInfo.tsx
@@ -91,7 +91,7 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({ searchQuery, securit
 
   return (
     <div className="bg-white rounded-lg shadow-sm border border-border mt-1">
-      <div className="bg-primary text-white px-4 py-2 rounded-t-lg flex justify-between items-center">
+      <div className="bg-slate-700 text-white px-4 py-2 rounded-t-lg flex justify-between items-center">
         <h5 className="font-semibold">配当情報</h5>
         {assetBalanceData && (
           <small className="text-white/80">

--- a/frontend/src/components/organisms/Header.tsx
+++ b/frontend/src/components/organisms/Header.tsx
@@ -68,13 +68,13 @@ export function Header() {
   return (
     <>
       <header className="bg-slate-800 text-white no-print">
-        <div className="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8 py-4">
-          <div className="flex flex-col gap-3 md:flex-row md:items-center">
+        <div className="mx-auto w-full max-w-[1440px] px-4 sm:px-5 lg:px-6 py-3">
+          <div className="flex flex-col gap-2 md:flex-row md:items-center">
             <div className="flex items-center justify-between">
-              <Link className="text-xl font-bold tracking-wide text-white hover:text-slate-200 transition-colors" to="/">証券Web</Link>
+              <Link className="text-2xl font-bold tracking-wide text-white hover:text-slate-200 transition-colors" to="/">証券Web</Link>
             </div>
 
-            <nav className="flex flex-wrap items-center gap-1 md:gap-2" aria-label="主要ナビゲーション">
+            <nav className="flex flex-wrap items-center gap-1" aria-label="主要ナビゲーション">
               {NAV_LINKS.map(({ to, label }) => {
                 const isActive = location.pathname === to || location.pathname.startsWith(to + '/');
                 return (
@@ -82,10 +82,10 @@ export function Header() {
                     key={to}
                     to={to}
                     className={cn(
-                      'px-3 py-2 rounded-md text-base font-medium transition-colors',
+                      'px-4 py-2 text-base font-medium transition-colors border-b-2',
                       isActive
-                        ? 'bg-slate-700 text-white'
-                        : 'text-slate-300 hover:bg-slate-700 hover:text-white'
+                        ? 'border-white text-white font-semibold'
+                        : 'border-transparent text-slate-300 hover:text-white hover:border-slate-500'
                     )}
                     aria-current={isActive ? 'page' : undefined}
                   >

--- a/frontend/src/components/organisms/Header.tsx
+++ b/frontend/src/components/organisms/Header.tsx
@@ -1,13 +1,22 @@
 import { useState, useEffect, useRef } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { Button } from '../atoms/Button';
 import { useAuth } from '../../features/auth/hooks/useAuth';
+import { cn } from '../../lib/utils/classNames';
+
+// ナビゲーションリンクの設定
+const NAV_LINKS = [
+  { to: '/search', label: '銘柄検索' },
+  { to: '/assetbalance', label: '保有銘柄' },
+  { to: '/receipts', label: '受取金' },
+] as const;
 
 export function Header() {
   const { user, login, logout, deleteAccount, isAuthenticated, isLoading } = useAuth();
   const [showDropdown, setShowDropdown] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const location = useLocation();
 
   // ドロップダウン外クリックで閉じる
   useEffect(() => {
@@ -58,17 +67,32 @@ export function Header() {
 
   return (
     <>
-      <header className="bg-primary text-white no-print">
-        <div className="mx-auto w-full max-w-[1600px] px-4 py-3">
+      <header className="bg-slate-800 text-white no-print">
+        <div className="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8 py-4">
           <div className="flex flex-col gap-3 md:flex-row md:items-center">
             <div className="flex items-center justify-between">
-              <Link className="text-lg font-semibold tracking-wide text-white" to="/">証券Web</Link>
+              <Link className="text-xl font-bold tracking-wide text-white hover:text-slate-200 transition-colors" to="/">証券Web</Link>
             </div>
 
-            <nav className="flex flex-wrap items-center gap-4 text-base md:text-lg" aria-label="主要ナビゲーション">
-              <Link className="text-white/90 hover:text-white transition-colors" to="/search">銘柄検索</Link>
-              <Link className="text-white/90 hover:text-white transition-colors" to="/assetbalance">保有銘柄</Link>
-              <Link className="text-white/90 hover:text-white transition-colors" to="/receipts">受取金</Link>
+            <nav className="flex flex-wrap items-center gap-1 md:gap-2" aria-label="主要ナビゲーション">
+              {NAV_LINKS.map(({ to, label }) => {
+                const isActive = location.pathname === to || location.pathname.startsWith(to + '/');
+                return (
+                  <Link
+                    key={to}
+                    to={to}
+                    className={cn(
+                      'px-3 py-2 rounded-md text-base font-medium transition-colors',
+                      isActive
+                        ? 'bg-slate-700 text-white'
+                        : 'text-slate-300 hover:bg-slate-700 hover:text-white'
+                    )}
+                    aria-current={isActive ? 'page' : undefined}
+                  >
+                    {label}
+                  </Link>
+                );
+              })}
             </nav>
 
             <div className="flex items-center gap-3 md:ml-auto">

--- a/frontend/src/components/organisms/ReceiptTable/ReceiptTable.tsx
+++ b/frontend/src/components/organisms/ReceiptTable/ReceiptTable.tsx
@@ -77,14 +77,7 @@ export function ReceiptTable<T extends DataItem, S extends SummaryItem>({
             return <TableCell key={key} {...props}>{formattedValue}</TableCell>;
         }
 
-        // 文字列でHTMLを含む場合（後方互換性のため残す）
-        const isHtml = typeof formattedValue === 'string' && /<[^>]*>/.test(formattedValue);
-        if (isHtml) {
-            return (
-                <TableCell key={key} {...props} dangerouslySetInnerHTML={{ __html: formattedValue as string }} />
-            );
-        }
-
+        // 文字列はそのままテキストとして描画（XSS対策）
         return <TableCell key={key} {...props}>{String(formattedValue ?? '')}</TableCell>;
     };
 

--- a/frontend/src/components/organisms/ReceiptTable/ReceiptTable.tsx
+++ b/frontend/src/components/organisms/ReceiptTable/ReceiptTable.tsx
@@ -131,9 +131,9 @@ export function ReceiptTable<T extends DataItem, S extends SummaryItem>({
                 value: formatSummaryValue(summaryItem[column.key], column)
             }));
 
-            const summaryBorderClass = summaryIndex > 0 && 'border-t-2 border-primary-hover';
-            const summaryLeftClass = cn('bg-primary text-white font-semibold border-l-4 border-primary-dark', summaryBorderClass);
-            const summaryValueClass = cn('bg-primary text-white text-right font-bold', summaryBorderClass);
+            const summaryBorderClass = summaryIndex > 0 && 'border-t-2 border-slate-300';
+            const summaryLeftClass = cn('bg-slate-700 text-white font-semibold border-l-4 border-slate-900', summaryBorderClass);
+            const summaryValueClass = cn('bg-slate-700 text-white text-right font-bold', summaryBorderClass);
 
             return (
                 <React.Fragment key={`group-${summaryIndex}`}>

--- a/frontend/src/components/organisms/ReceiptTable/ReceiptTable.tsx
+++ b/frontend/src/components/organisms/ReceiptTable/ReceiptTable.tsx
@@ -124,9 +124,9 @@ export function ReceiptTable<T extends DataItem, S extends SummaryItem>({
                 value: formatSummaryValue(summaryItem[column.key], column)
             }));
 
-            const summaryBorderClass = summaryIndex > 0 && 'border-t-2 border-slate-300';
-            const summaryLeftClass = cn('bg-slate-700 text-white font-semibold border-l-4 border-slate-900', summaryBorderClass);
-            const summaryValueClass = cn('bg-slate-700 text-white text-right font-bold', summaryBorderClass);
+            const summaryBorderClass = summaryIndex > 0 && 'border-t border-slate-200';
+            const summaryLeftClass = cn('bg-slate-100 text-slate-800 font-semibold border-l-4 border-slate-600', summaryBorderClass);
+            const summaryValueClass = cn('bg-slate-100 text-slate-800 text-right font-semibold', summaryBorderClass);
 
             return (
                 <React.Fragment key={`group-${summaryIndex}`}>
@@ -140,7 +140,7 @@ export function ReceiptTable<T extends DataItem, S extends SummaryItem>({
                                 <span className="text-base font-bold">
                                     {headerText}
                                 </span>
-                                <span className="ml-3 inline-flex items-center rounded bg-white/20 px-2.5 py-0.5 text-xs font-semibold text-white">
+                                <span className="ml-3 inline-flex items-center rounded bg-slate-600 px-2.5 py-0.5 text-xs font-semibold text-white">
                                     {itemCount}件
                                 </span>
                             </TableCell>
@@ -164,7 +164,7 @@ export function ReceiptTable<T extends DataItem, S extends SummaryItem>({
                                 <span className="text-base font-bold">
                                     {headerText}
                                 </span>
-                                <span className="ml-3 inline-flex items-center rounded bg-white/20 px-2.5 py-0.5 text-xs font-semibold text-white">
+                                <span className="ml-3 inline-flex items-center rounded bg-slate-600 px-2.5 py-0.5 text-xs font-semibold text-white">
                                     {itemCount}件
                                 </span>
                             </TableCell>
@@ -192,7 +192,7 @@ export function ReceiptTable<T extends DataItem, S extends SummaryItem>({
             onClick={handleTableClick}
         >
             <TableHeader>
-                <TableRow className="bg-warning/20 text-center">
+                <TableRow className="bg-slate-50 text-center">
                     {columns.map((column, index) => (
                         <TableCell
                             as="th"

--- a/frontend/src/components/organisms/ReceiptTable/__tests__/ReceiptTable.test.tsx
+++ b/frontend/src/components/organisms/ReceiptTable/__tests__/ReceiptTable.test.tsx
@@ -66,13 +66,13 @@ describe('ReceiptTable', () => {
     expect(screen.getAllByText('合計:')).toHaveLength(2);
   });
 
-  it('HTMLタグが含まれる値が正しくレンダリングされる', () => {
+  it('HTMLタグが含まれる文字列はエスケープされてテキストとして表示される（XSS対策）', () => {
     const columnsWithHtml: TableColumnConfig[] = [
       ...mockColumns,
-      { 
-        header: 'リンク', 
-        key: 'link', 
-        width: '100px', 
+      {
+        header: 'リンク',
+        key: 'link',
+        width: '100px',
         textAlign: 'center',
         format: (value) => `<a href="${value}">リンク</a>`
       },
@@ -90,16 +90,14 @@ describe('ReceiptTable', () => {
       />
     );
 
-    // ヘッダーの「リンク」を確認
-    expect(screen.getAllByText('リンク')).toHaveLength(4); // ヘッダー1つ + データ3つ
+    // ヘッダーの「リンク」のみ表示
+    expect(screen.getByText('リンク')).toBeInTheDocument();
 
-    // リンク要素だけを取得
-    const links = screen.getAllByRole('link');
-    expect(links).toHaveLength(3);
-    links.forEach(link => {
-      expect(link).toHaveAttribute('href', 'https://example.com');
-      expect(link).toHaveTextContent('リンク');
-    });
+    // HTML文字列はリンクとしてレンダリングされず、テキストとして表示される
+    expect(screen.queryAllByRole('link')).toHaveLength(0);
+
+    // エスケープされたHTML文字列がテキストとして表示される
+    expect(screen.getAllByText('<a href="https://example.com">リンク</a>')).toHaveLength(3);
   });
 
   it('空のデータでも正しくレンダリングされる', () => {

--- a/frontend/src/components/organisms/SearchCard/SearchCard.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchCard.tsx
@@ -44,6 +44,14 @@ export const SearchCard: React.FC<SearchCardProps> = ({
         onExpandToggle?.(newExpandedState);
     };
 
+    // キーボードイベントハンドラ
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleToggleExpanded();
+        }
+    };
+
     const handleQuickSearch = (value: string) => {
         setSearchQuery(value);
         onSearch(value);
@@ -92,7 +100,9 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                 variant="primary"
                 className="flex cursor-pointer items-center justify-between"
                 onClick={handleToggleExpanded}
+                onKeyDown={handleKeyDown}
                 role="button"
+                tabIndex={0}
                 aria-expanded={isExpanded}
                 aria-controls="search-options-body"
                 data-testid="search-card-header"

--- a/frontend/src/components/organisms/SearchCard/SearchCard.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchCard.tsx
@@ -19,7 +19,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
     onExpandToggle
 }) => {
 
-    const [isExpanded, setIsExpanded] = useState(false);
+    const [isExpanded, setIsExpanded] = useState(true);
     const [searchQuery, setSearchQuery] = useState('');
 
     // データが存在するかチェックするヘルパー関数

--- a/frontend/src/components/organisms/SearchCard/__tests__/SearchCard.test.tsx
+++ b/frontend/src/components/organisms/SearchCard/__tests__/SearchCard.test.tsx
@@ -35,7 +35,7 @@ describe('SearchCard', () => {
     expect(screen.getByText('検索オプション')).toBeInTheDocument();
   });
 
-  test('初期状態では検索オプションが折りたたまれている', () => {
+  test('初期状態では検索オプションが展開されている', () => {
     render(
       <SearchCard
         onSearch={mockOnSearch}
@@ -43,12 +43,13 @@ describe('SearchCard', () => {
       />
     );
 
-    expect(screen.queryByText('銘柄')).not.toBeInTheDocument();
-    expect(screen.queryByText('西暦')).not.toBeInTheDocument();
-    expect(screen.queryByText('商品')).not.toBeInTheDocument();
+    expect(screen.getByText('銘柄')).toBeInTheDocument();
+    expect(screen.getByText('西暦')).toBeInTheDocument();
+    expect(screen.getByText('商品')).toBeInTheDocument();
+    expect(screen.getByText('口座')).toBeInTheDocument();
   });
 
-  test('ヘッダーをクリックすると検索オプションが展開される', () => {
+  test('ヘッダーをクリックすると検索オプションが折りたたまれる', () => {
     render(
       <SearchCard
         onSearch={mockOnSearch}
@@ -59,10 +60,9 @@ describe('SearchCard', () => {
     const header = screen.getByTestId('search-card-header');
     fireEvent.click(header!);
 
-    expect(screen.getByText('銘柄')).toBeInTheDocument();
-    expect(screen.getByText('西暦')).toBeInTheDocument();
-    expect(screen.getByText('商品')).toBeInTheDocument();
-    expect(screen.getByText('口座')).toBeInTheDocument();
+    expect(screen.queryByText('銘柄')).not.toBeInTheDocument();
+    expect(screen.queryByText('西暦')).not.toBeInTheDocument();
+    expect(screen.queryByText('商品')).not.toBeInTheDocument();
   });
 
   test('onExpandToggleコールバックが呼ばれる', () => {
@@ -77,10 +77,10 @@ describe('SearchCard', () => {
     const header = screen.getByTestId('search-card-header');
     fireEvent.click(header!);
 
-    expect(mockOnExpandToggle).toHaveBeenCalledWith(true);
+    expect(mockOnExpandToggle).toHaveBeenCalledWith(false);
 
     fireEvent.click(header!);
-    expect(mockOnExpandToggle).toHaveBeenCalledWith(false);
+    expect(mockOnExpandToggle).toHaveBeenCalledWith(true);
   });
 
   test('銘柄ドロップダウンから選択すると検索が実行される', () => {
@@ -91,11 +91,7 @@ describe('SearchCard', () => {
       />
     );
 
-    // 展開
-    const header = screen.getByTestId('search-card-header');
-    fireEvent.click(header!);
-
-    // 銘柄選択（IDで指定）
+    // 初期状態で展開済み - 銘柄選択（IDで指定）
     const select = container.querySelector('#securities-search') as HTMLSelectElement;
     fireEvent.change(select, { target: { value: 'AAPL' } });
 
@@ -110,11 +106,7 @@ describe('SearchCard', () => {
       />
     );
 
-    // 展開
-    const header = screen.getByTestId('search-card-header');
-    fireEvent.click(header!);
-
-    // 商品ボタンクリック
+    // 初期状態で展開済み - 商品ボタンクリック
     const productButton = screen.getByText('株式');
     fireEvent.click(productButton);
 
@@ -129,11 +121,7 @@ describe('SearchCard', () => {
       />
     );
 
-    // 展開
-    const header = screen.getByTestId('search-card-header');
-    fireEvent.click(header!);
-
-    // 口座ボタンクリック
+    // 初期状態で展開済み - 口座ボタンクリック
     const accountButton = screen.getByText('一般口座');
     fireEvent.click(accountButton);
 
@@ -183,9 +171,7 @@ describe('SearchCard', () => {
       />
     );
 
-    const header = screen.getByTestId('search-card-header');
-    fireEvent.click(header!);
-
+    // 初期状態で展開済み
     expect(screen.getByText('西暦')).toBeInTheDocument();
     expect(screen.queryByText('銘柄')).not.toBeInTheDocument();
     expect(screen.queryByText('商品')).not.toBeInTheDocument();
@@ -223,10 +209,7 @@ describe('SearchCard', () => {
       />
     );
 
-    const header = screen.getByTestId('search-card-header');
-    fireEvent.click(header!);
-
-    // 11番目、21番目の商品ボタンの後に改行要素があることを確認
+    // 初期状態で展開済み - 11番目、21番目の商品ボタンの後に改行要素があることを確認
     expect(screen.getByText('商品11')).toBeInTheDocument();
     expect(screen.getByText('商品21')).toBeInTheDocument();
   });
@@ -239,10 +222,7 @@ describe('SearchCard', () => {
       />
     );
 
-    const header = screen.getByTestId('search-card-header');
-    fireEvent.click(header!);
-
-    // IDで指定して選択
+    // 初期状態で展開済み - IDで指定して選択
     const select = container.querySelector('#securities-search') as HTMLSelectElement;
     fireEvent.change(select, { target: { value: '' } });
 

--- a/frontend/src/components/templates/ErrorPage.tsx
+++ b/frontend/src/components/templates/ErrorPage.tsx
@@ -6,29 +6,52 @@ interface ErrorPageProps {
   title?: string;
   message?: string;
   showHomeButton?: boolean;
+  showRelatedLinks?: boolean;
 }
+
+const RELATED_LINKS = [
+  { to: '/', label: 'ホーム' },
+  { to: '/search', label: '銘柄検索' },
+  { to: '/receipts', label: '受取金' },
+] as const;
 
 export function ErrorPage({
   title = 'エラーが発生しました',
   message = 'アプリケーションで問題が発生しました。もう一度お試しください。',
-  showHomeButton = true
+  showHomeButton = true,
+  showRelatedLinks = false
 }: ErrorPageProps) {
   return (
-    <div className="min-h-[60vh] flex items-center justify-center">
+    <div className="min-h-[50vh] flex items-center justify-center">
       <EmptyState
         icon={
-          <svg className="h-16 w-16" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <svg className="h-12 w-12" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
           </svg>
         }
         title={title}
         description={message}
         action={
-          showHomeButton && (
-            <Link to="/">
-              <Button variant="primary">ホームに戻る</Button>
-            </Link>
-          )
+          <div className="flex flex-col items-center gap-3">
+            {showHomeButton && (
+              <Link to="/">
+                <Button variant="primary" size="sm">ホームに戻る</Button>
+              </Link>
+            )}
+            {showRelatedLinks && (
+              <div className="flex flex-wrap justify-center gap-2">
+                {RELATED_LINKS.map(({ to, label }) => (
+                  <Link
+                    key={to}
+                    to={to}
+                    className="text-sm text-primary hover:underline"
+                  >
+                    {label}
+                  </Link>
+                ))}
+              </div>
+            )}
+          </div>
         }
       />
     </div>

--- a/frontend/src/components/templates/ErrorPage.tsx
+++ b/frontend/src/components/templates/ErrorPage.tsx
@@ -25,26 +25,27 @@ export function ErrorPage({
     <div className="min-h-[50vh] flex items-center justify-center">
       <EmptyState
         icon={
-          <svg className="h-12 w-12" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <svg className="h-16 w-16" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
           </svg>
         }
         title={title}
         description={message}
+        headingLevel="h1"
         action={
-          <div className="flex flex-col items-center gap-3">
+          <div className="flex flex-col items-center gap-4">
             {showHomeButton && (
               <Link to="/">
-                <Button variant="primary" size="sm">ホームに戻る</Button>
+                <Button variant="primary" size="md">ホームに戻る</Button>
               </Link>
             )}
             {showRelatedLinks && (
-              <div className="flex flex-wrap justify-center gap-2">
+              <div className="flex flex-wrap justify-center gap-3">
                 {RELATED_LINKS.map(({ to, label }) => (
                   <Link
                     key={to}
                     to={to}
-                    className="text-sm text-primary hover:underline"
+                    className="text-base text-primary hover:underline"
                   >
                     {label}
                   </Link>

--- a/frontend/src/components/templates/ErrorPage.tsx
+++ b/frontend/src/components/templates/ErrorPage.tsx
@@ -1,5 +1,6 @@
-import { Button } from '../atoms/Button';
 import { Link } from 'react-router-dom';
+import { Button } from '../atoms/Button';
+import { EmptyState } from '../atoms/EmptyState';
 
 interface ErrorPageProps {
   title?: string;
@@ -13,15 +14,23 @@ export function ErrorPage({
   showHomeButton = true
 }: ErrorPageProps) {
   return (
-    <div className="mx-auto flex min-h-[60vh] max-w-xl flex-col items-center justify-center px-4 py-12 text-center">
-      <div className="text-6xl font-bold text-danger">⚠️</div>
-      <h2 className="mt-4 text-2xl font-semibold">{title}</h2>
-      <p className="mt-4 text-base text-secondary">{message}</p>
-        {showHomeButton && (
-        <Link to="/" className="mt-6">
-          <Button variant="primary">ホームに戻る</Button>
-        </Link>
-        )}
+    <div className="min-h-[60vh] flex items-center justify-center">
+      <EmptyState
+        icon={
+          <svg className="h-16 w-16" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+          </svg>
+        }
+        title={title}
+        description={message}
+        action={
+          showHomeButton && (
+            <Link to="/">
+              <Button variant="primary">ホームに戻る</Button>
+            </Link>
+          )
+        }
+      />
     </div>
   );
 }

--- a/frontend/src/components/templates/Layout.tsx
+++ b/frontend/src/components/templates/Layout.tsx
@@ -10,7 +10,7 @@ export function Layout({ children }: LayoutProps) {
     <div className="min-h-screen flex flex-col bg-slate-50">
       <Header />
 
-      <main className="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8 py-6 flex-1">
+      <main className="mx-auto w-full max-w-[1440px] px-4 sm:px-5 lg:px-6 py-4 flex-1">
         {children}
       </main>
 

--- a/frontend/src/components/templates/Layout.tsx
+++ b/frontend/src/components/templates/Layout.tsx
@@ -7,10 +7,10 @@ interface LayoutProps {
 
 export function Layout({ children }: LayoutProps) {
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="min-h-screen flex flex-col bg-slate-50">
       <Header />
 
-      <main className="mx-auto w-full max-w-[1600px] px-4 py-4 flex-1">
+      <main className="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8 py-6 flex-1">
         {children}
       </main>
 

--- a/frontend/src/components/templates/__tests__/ReceiptTemplate.integration.test.tsx
+++ b/frontend/src/components/templates/__tests__/ReceiptTemplate.integration.test.tsx
@@ -109,19 +109,19 @@ describe('ReceiptTemplate Context API統合テスト', () => {
       </ReceiptTemplate>
     );
 
-    // 初期状態の確認
+    // 初期状態の確認（SearchCardは展開済み）
     expect(screen.getByText('検索オプション')).toBeInTheDocument();
     expect(screen.getByRole('table')).toBeInTheDocument();
 
-    // SearchCardを展開
+    // SearchCardを折りたたむ
     const header = screen.getByTestId('search-card-header');
     fireEvent.click(header!);
 
     // タイマーを進める
     vi.advanceTimersByTime(100);
 
-    // コールバックが呼ばれることを確認
-    expect(mockOnSearchExpandToggle).toHaveBeenCalledWith(true);
+    // コールバックが呼ばれることを確認（折りたたみ）
+    expect(mockOnSearchExpandToggle).toHaveBeenCalledWith(false);
 
     // テーブルが正常に表示されることを確認
     expect(screen.getByText('商品A')).toBeInTheDocument();
@@ -145,11 +145,7 @@ describe('ReceiptTemplate Context API統合テスト', () => {
       </ReceiptTemplate>
     );
 
-    // SearchCardを展開
-    const header = screen.getByTestId('search-card-header');
-    fireEvent.click(header!);
-
-    // 商品ボタンをクリック
+    // 初期状態で展開済み - 商品ボタンをクリック
     const productButton = screen.getByText('株式');
     fireEvent.click(productButton);
 
@@ -176,17 +172,17 @@ describe('ReceiptTemplate Context API統合テスト', () => {
 
     const header = screen.getByTestId('search-card-header');
 
-    // 複数回展開・折りたたみを実行
+    // 初期状態は展開済み - 複数回折りたたみ・展開を実行
     for (let i = 0; i < 3; i++) {
-      // 展開
-      fireEvent.click(header!);
-      vi.advanceTimersByTime(100);
-      expect(mockOnSearchExpandToggle).toHaveBeenCalledWith(true);
-
       // 折りたたみ
       fireEvent.click(header!);
       vi.advanceTimersByTime(100);
       expect(mockOnSearchExpandToggle).toHaveBeenCalledWith(false);
+
+      // 展開
+      fireEvent.click(header!);
+      vi.advanceTimersByTime(100);
+      expect(mockOnSearchExpandToggle).toHaveBeenCalledWith(true);
     }
 
     // 各操作で適切にコールバックが呼ばれることを確認
@@ -245,11 +241,7 @@ describe('ReceiptTemplate Context API統合テスト', () => {
       </ReceiptTemplate>
     );
 
-    // SearchCardを展開
-    const header = screen.getByTestId('search-card-header');
-    fireEvent.click(header!);
-
-    // 銘柄ドロップダウンを操作（IDで指定）
+    // 初期状態で展開済み - 銘柄ドロップダウンを操作（IDで指定）
     const select = container.querySelector('#securities-search') as HTMLSelectElement;
     fireEvent.change(select, { target: { value: 'AAPL' } });
 

--- a/frontend/src/pages/AssetBalance.tsx
+++ b/frontend/src/pages/AssetBalance.tsx
@@ -180,7 +180,7 @@ export function AssetBalancePage() {
                   disabled={loading || saving || deleting}
                 />
               </div>
-              <div className="action-toolbar" role="group" aria-label="データ操作">
+              <div className="action-button-group" role="group" aria-label="データ操作">
                 {hasCsvData && (
                   <Button
                     variant="primary"

--- a/frontend/src/pages/AssetBalance.tsx
+++ b/frontend/src/pages/AssetBalance.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import { Layout } from '../components/templates/Layout';
+import { PageHeader } from '../components/atoms/PageHeader';
 import { CSVFileInput } from '../components/molecules/CSVFileInput';
 import { Alert } from '@/components/atoms/Alert';
 import { Button } from '@/components/atoms/Button';
@@ -145,6 +146,10 @@ export function AssetBalancePage() {
 
   return (
     <Layout>
+      <PageHeader
+        title="保有銘柄"
+        description="保有している銘柄の一覧と評価額を確認できます。"
+      />
       <div className="mt-2" aria-busy={isProcessing}>
         {/* 認証確認中 */}
         {authLoading && (

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,36 +1,66 @@
+import { Link } from 'react-router-dom';
 import { Layout } from '../components/templates/Layout';
 import { Card, CardBody } from '../components/atoms/Card';
+import { PageHeader } from '../components/atoms/PageHeader';
+
+const FEATURES = [
+  {
+    title: '銘柄検索',
+    description: '日本の株式銘柄情報を検索できます。コードや銘柄名から簡単に検索できます。',
+    to: '/search',
+    icon: (
+      <svg className="h-8 w-8 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+      </svg>
+    ),
+  },
+  {
+    title: '保有銘柄',
+    description: '保有している銘柄の一覧と評価額を確認できます。',
+    to: '/assetbalance',
+    icon: (
+      <svg className="h-8 w-8 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+      </svg>
+    ),
+  },
+  {
+    title: '受取金',
+    description: '配当金や分配金の記録を管理できます。CSVファイルのインポートにも対応しています。',
+    to: '/receipts',
+    icon: (
+      <svg className="h-8 w-8 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+    ),
+  },
+] as const;
 
 export function HomePage() {
   return (
     <Layout>
-      <div className="rounded-lg border border-border bg-white p-6 shadow-sm">
-        <h1 className="text-3xl font-bold">証券Webへようこそ</h1>
-        <p className="mt-2 text-sm text-secondary">このプラットフォームでは、銘柄検索や受取金の管理ができます。</p>
-        <hr className="my-4 border-border" />
-        <p className="text-sm text-dark">さまざまな機能を使って、投資をより効率的に管理しましょう。</p>
+      <div className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <PageHeader
+          title="証券Webへようこそ"
+          description="銘柄検索や受取金の管理ができます。さまざまな機能を使って、投資をより効率的に管理しましょう。"
+        />
 
-        <div className="mt-6 grid gap-4 md:grid-cols-3">
-          <Card className="h-full">
-            <CardBody className="space-y-2">
-              <h5 className="text-base font-semibold">銘柄検索</h5>
-              <p className="text-sm text-secondary">日本の株式銘柄情報を検索できます。コードや銘柄名から簡単に検索できます。</p>
-            </CardBody>
-          </Card>
-
-          <Card className="h-full">
-            <CardBody className="space-y-2">
-              <h5 className="text-base font-semibold">受取金</h5>
-              <p className="text-sm text-secondary">配当金や分配金の記録を管理できます。CSVファイルのインポートにも対応しています。</p>
-            </CardBody>
-          </Card>
-
-          <Card className="h-full">
-            <CardBody className="space-y-2">
-              <h5 className="text-base font-semibold">投資情報</h5>
-              <p className="text-sm text-secondary">株式や投資信託に関する情報にアクセスできます。効率的な投資判断をサポートします。</p>
-            </CardBody>
-          </Card>
+        <div className="grid gap-6 md:grid-cols-3">
+          {FEATURES.map(({ title, description, to, icon }) => (
+            <Link key={to} to={to} className="block group">
+              <Card className="h-full transition-shadow hover:shadow-md">
+                <CardBody className="space-y-3">
+                  <div className="flex items-center gap-3">
+                    {icon}
+                    <h3 className="text-lg font-semibold text-slate-900 group-hover:text-primary transition-colors">
+                      {title}
+                    </h3>
+                  </div>
+                  <p className="text-sm text-slate-600">{description}</p>
+                </CardBody>
+              </Card>
+            </Link>
+          ))}
         </div>
       </div>
     </Layout>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -6,10 +6,10 @@ import { PageHeader } from '../components/atoms/PageHeader';
 const FEATURES = [
   {
     title: '銘柄検索',
-    description: '日本の株式銘柄情報を検索できます。コードや銘柄名から簡単に検索できます。',
+    description: '日本の株式銘柄情報を検索できます。',
     to: '/search',
     icon: (
-      <svg className="h-8 w-8 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <svg className="h-6 w-6 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
       </svg>
     ),
@@ -19,17 +19,17 @@ const FEATURES = [
     description: '保有している銘柄の一覧と評価額を確認できます。',
     to: '/assetbalance',
     icon: (
-      <svg className="h-8 w-8 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <svg className="h-6 w-6 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
       </svg>
     ),
   },
   {
     title: '受取金',
-    description: '配当金や分配金の記録を管理できます。CSVファイルのインポートにも対応しています。',
+    description: '配当金や分配金の記録を管理できます。',
     to: '/receipts',
     icon: (
-      <svg className="h-8 w-8 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <svg className="h-6 w-6 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
       </svg>
     ),
@@ -39,20 +39,20 @@ const FEATURES = [
 export function HomePage() {
   return (
     <Layout>
-      <div className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+      <div className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
         <PageHeader
           title="証券Webへようこそ"
-          description="銘柄検索や受取金の管理ができます。さまざまな機能を使って、投資をより効率的に管理しましょう。"
+          description="銘柄検索や受取金の管理ができます。"
         />
 
-        <div className="grid gap-6 md:grid-cols-3">
+        <div className="grid gap-4 md:grid-cols-3">
           {FEATURES.map(({ title, description, to, icon }) => (
             <Link key={to} to={to} className="block group">
               <Card className="h-full transition-shadow hover:shadow-md">
-                <CardBody className="space-y-3">
-                  <div className="flex items-center gap-3">
+                <CardBody className="space-y-2 p-3">
+                  <div className="flex items-center gap-2">
                     {icon}
-                    <h3 className="text-lg font-semibold text-slate-900 group-hover:text-primary transition-colors">
+                    <h3 className="text-base font-semibold text-slate-900 group-hover:text-primary transition-colors">
                       {title}
                     </h3>
                   </div>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -9,7 +9,7 @@ const FEATURES = [
     description: '日本の株式銘柄情報を検索できます。',
     to: '/search',
     icon: (
-      <svg className="h-6 w-6 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <svg className="h-6 w-6 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true" focusable="false">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
       </svg>
     ),
@@ -19,7 +19,7 @@ const FEATURES = [
     description: '保有している銘柄の一覧と評価額を確認できます。',
     to: '/assetbalance',
     icon: (
-      <svg className="h-6 w-6 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <svg className="h-6 w-6 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true" focusable="false">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
       </svg>
     ),
@@ -29,7 +29,7 @@ const FEATURES = [
     description: '配当金や分配金の記録を管理できます。',
     to: '/receipts',
     icon: (
-      <svg className="h-6 w-6 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <svg className="h-6 w-6 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true" focusable="false">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
       </svg>
     ),

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -1,12 +1,15 @@
 import { ErrorPage } from '../components/templates/ErrorPage';
+import { Layout } from '../components/templates/Layout';
 
 export function NotFoundPage() {
   return (
-    <ErrorPage
-      title="404 - ページが見つかりません"
-      message="お探しのページは存在しないか、移動した可能性があります。"
-      showHomeButton={true}
-      showRelatedLinks={true}
-    />
+    <Layout>
+      <ErrorPage
+        title="404 - ページが見つかりません"
+        message="お探しのページは存在しないか、移動した可能性があります。"
+        showHomeButton={true}
+        showRelatedLinks={true}
+      />
+    </Layout>
   );
 }

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -6,6 +6,7 @@ export function NotFoundPage() {
       title="404 - ページが見つかりません"
       message="お探しのページは存在しないか、移動した可能性があります。"
       showHomeButton={true}
+      showRelatedLinks={true}
     />
   );
 }

--- a/frontend/src/pages/Receipt/__tests__/Dividend.test.tsx
+++ b/frontend/src/pages/Receipt/__tests__/Dividend.test.tsx
@@ -82,9 +82,10 @@ describe('Dividend', () => {
         render(<Dividend csvData={mockCsvData} />);
 
         // テーブルヘッダーの確認（実際のカラム定義に合わせる）
+        // 「商品」「口座」は検索オプション内にも表示されるためgetAllByTextを使用
         expect(screen.getByText('入金日')).toBeInTheDocument();
-        expect(screen.getByText('商品')).toBeInTheDocument();
-        expect(screen.getByText('口座')).toBeInTheDocument();
+        expect(screen.getAllByText('商品').length).toBeGreaterThan(0);
+        expect(screen.getAllByText('口座').length).toBeGreaterThan(0);
         expect(screen.getByText('銘柄コード')).toBeInTheDocument();
         expect(screen.getByText('銘柄名')).toBeInTheDocument();
         expect(screen.getByText('単価')).toBeInTheDocument();
@@ -107,13 +108,11 @@ describe('Dividend', () => {
     });
 
     it('検索オプションが正しく生成される', async () => {
-        const user = userEvent.setup();
         const { container } = render(<Dividend csvData={mockCsvData} />);
 
-        // 検索オプションのヘッダーをクリックして展開
+        // 検索オプションは初期状態で展開済み
         const searchOptionsHeader = screen.getByText('検索オプション');
         expect(searchOptionsHeader).toBeInTheDocument();
-        await user.click(searchOptionsHeader);
 
         // 銘柄検索セレクトボックスの確認（IDで指定）
         await waitFor(() => {
@@ -131,11 +130,7 @@ describe('Dividend', () => {
         const user = userEvent.setup();
         const { container } = render(<Dividend csvData={mockCsvData} />);
 
-        // 検索オプションのヘッダーをクリックして展開
-        const searchOptionsHeader = screen.getByText('検索オプション');
-        await user.click(searchOptionsHeader);
-
-        // 銘柄検索セレクトボックスで銘柄を選択（IDで指定）
+        // 検索オプションは初期状態で展開済み - 銘柄検索セレクトボックスで銘柄を選択（IDで指定）
         await waitFor(() => {
             expect(container.querySelector('#securities-search')).toBeInTheDocument();
         });
@@ -160,11 +155,7 @@ describe('Dividend', () => {
         const user = userEvent.setup();
         const { container } = render(<Dividend csvData={mockCsvData} />);
 
-        // 検索オプションのヘッダーをクリックして展開
-        const searchOptionsHeader = screen.getByText('検索オプション');
-        await user.click(searchOptionsHeader);
-
-        // 最初に銘柄を選択（IDで指定）
+        // 検索オプションは初期状態で展開済み - 最初に銘柄を選択（IDで指定）
         await waitFor(() => {
             expect(container.querySelector('#securities-search')).toBeInTheDocument();
         });
@@ -224,11 +215,7 @@ describe('Dividend', () => {
         const user = userEvent.setup();
         const { container } = render(<Dividend csvData={mockCsvData} />);
 
-        // 検索オプションのヘッダーをクリックして展開
-        const searchOptionsHeader = screen.getByText('検索オプション');
-        await user.click(searchOptionsHeader);
-
-        // 銘柄を選択して配当情報フォームを表示（IDで指定）
+        // 検索オプションは初期状態で展開済み - 銘柄を選択して配当情報フォームを表示（IDで指定）
         await waitFor(() => {
             expect(container.querySelector('#securities-search')).toBeInTheDocument();
         });

--- a/frontend/src/pages/Receipt/__tests__/DomesticStock.test.tsx
+++ b/frontend/src/pages/Receipt/__tests__/DomesticStock.test.tsx
@@ -69,10 +69,11 @@ describe('DomesticStock', () => {
         render(<DomesticStock csvData={mockCsvData} />);
 
         // テーブルヘッダーの確認（実際のカラム定義に合わせる）
+        // 「口座」は検索オプション内にも表示されるためgetAllByTextを使用
         expect(screen.getByText('約定日')).toBeInTheDocument();
         expect(screen.getByText('銘柄コード')).toBeInTheDocument();
         expect(screen.getByText('銘柄名')).toBeInTheDocument();
-        expect(screen.getByText('口座')).toBeInTheDocument();
+        expect(screen.getAllByText('口座').length).toBeGreaterThan(0);
         expect(screen.getByText('数量')).toBeInTheDocument();
         expect(screen.getByText('売却単価')).toBeInTheDocument();
         expect(screen.getByText('売却額')).toBeInTheDocument();
@@ -93,13 +94,11 @@ describe('DomesticStock', () => {
     });
 
     it('検索オプションが正しく生成される', async () => {
-        const user = userEvent.setup();
         const { container } = render(<DomesticStock csvData={mockCsvData} />);
 
-        // 検索オプションのヘッダーをクリックして展開
+        // 検索オプションは初期状態で展開済み
         const searchOptionsHeader = screen.getByText('検索オプション');
         expect(searchOptionsHeader).toBeInTheDocument();
-        await user.click(searchOptionsHeader);
 
         // 銘柄検索セレクトボックスの確認（IDで指定）
         await waitFor(() => {
@@ -117,11 +116,11 @@ describe('DomesticStock', () => {
         const user = userEvent.setup();
         const { container } = render(<DomesticStock csvData={mockCsvData} />);
 
-        const searchOptionsHeader = screen.getByText('検索オプション');
-        await user.click(searchOptionsHeader);
-
+        // 検索オプションは初期状態で展開済み
+        await waitFor(() => {
+            expect(container.querySelector('#securities-search')).toBeInTheDocument();
+        });
         const securitiesSelect = container.querySelector('#securities-search') as HTMLSelectElement;
-        expect(securitiesSelect).toBeInTheDocument();
 
         await user.selectOptions(securitiesSelect, '1234');
 

--- a/frontend/src/pages/Receipts.tsx
+++ b/frontend/src/pages/Receipts.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { Layout } from '../components/templates/Layout';
+import { PageHeader } from '../components/atoms/PageHeader';
 import { CSVFileInput } from '../components/molecules/CSVFileInput';
 import { Alert } from '@/components/atoms/Alert';
 import { Button } from '@/components/atoms/Button';
@@ -273,6 +274,10 @@ export function ReceiptsPage() {
 
   return (
     <Layout>
+      <PageHeader
+        title="受取金"
+        description="配当金・国内株式・投資信託の受取金を管理します。"
+      />
       <nav className="border-b border-slate-200 no-print">
         <div className="flex flex-wrap gap-1">
           {(['dividend', 'domesticstock', 'mutualfund'] as const).map((tab) => {

--- a/frontend/src/pages/Receipts.tsx
+++ b/frontend/src/pages/Receipts.tsx
@@ -273,15 +273,19 @@ export function ReceiptsPage() {
 
   return (
     <Layout>
-      <nav className="border-b border-border no-print">
-        <div className="flex flex-wrap gap-2">
+      <nav className="border-b border-slate-200 no-print">
+        <div className="flex flex-wrap gap-1">
           {(['dividend', 'domesticstock', 'mutualfund'] as const).map((tab) => {
             const isActive = receiptsType === tab;
             const label = tab === 'dividend' ? '配当金' : tab === 'domesticstock' ? '国内株式' : '投資信託';
             return (
               <button
                 key={tab}
-                className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 ${isActive ? 'border-primary text-primary' : 'border-transparent text-secondary hover:text-primary'}`}
+                className={`px-4 py-3 text-sm font-medium transition-colors border-b-2 -mb-px ${
+                  isActive
+                    ? 'border-primary text-primary bg-white'
+                    : 'border-transparent text-slate-600 hover:text-slate-900 hover:border-slate-300'
+                }`}
                 onClick={() => setReceiptsType(tab)}
                 type="button"
                 role="tab"

--- a/frontend/src/pages/Receipts.tsx
+++ b/frontend/src/pages/Receipts.tsx
@@ -312,7 +312,7 @@ export function ReceiptsPage() {
             />
           </div>
           {isAuthenticated && (
-            <div className="action-toolbar" role="group" aria-label="データ操作">
+            <div className="action-button-group" role="group" aria-label="データ操作">
               {hasCsvData && (
                 <Button
                   variant="primary"

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -4,6 +4,7 @@ import { Layout } from '../components/templates/Layout';
 import { SearchForm } from '../components/organisms/SearchForm';
 import { StockInfo } from '../components/organisms/StockInfo';
 import { Alert } from '../components/atoms/Alert';
+import { EmptyState } from '../components/atoms/EmptyState';
 import { useStockSearch } from '../features/stock/hooks/useStockSearch';
 import { SECURITY_CODE_REGEX } from '@/lib/utils/formatters';
 
@@ -62,9 +63,16 @@ export function SearchPage() {
         )}
 
         {!stockData && !isError && !isLoading && (
-          <div className="py-10 text-center">
-            <p className="text-sm text-secondary">銘柄コードを入力して検索してください。</p>
-          </div>
+          <EmptyState
+            icon={
+              <svg className="h-12 w-12" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+              </svg>
+            }
+            title="銘柄を検索"
+            description="銘柄コード（例：7203）を入力して検索してください。日本株の情報を表示します。"
+            className="py-16"
+          />
         )}
       </div>
     </Layout>

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -5,6 +5,7 @@ import { SearchForm } from '../components/organisms/SearchForm';
 import { StockInfo } from '../components/organisms/StockInfo';
 import { Alert } from '../components/atoms/Alert';
 import { EmptyState } from '../components/atoms/EmptyState';
+import { PageHeader } from '../components/atoms/PageHeader';
 import { useStockSearch } from '../features/stock/hooks/useStockSearch';
 import { SECURITY_CODE_REGEX } from '@/lib/utils/formatters';
 
@@ -39,6 +40,10 @@ export function SearchPage() {
   return (
     <Layout>
       <div>
+        <PageHeader
+          title="銘柄検索"
+          description="銘柄コードを入力して株式情報を検索できます。"
+        />
         <SearchForm
           stockCode={stockCode}
           onStockCodeChange={setStockCode}

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -65,13 +65,13 @@ export function SearchPage() {
         {!stockData && !isError && !isLoading && (
           <EmptyState
             icon={
-              <svg className="h-12 w-12" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <svg className="h-10 w-10" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
               </svg>
             }
             title="銘柄を検索"
-            description="銘柄コード（例：7203）を入力して検索してください。日本株の情報を表示します。"
-            className="py-16"
+            description="銘柄コード（例：7203）を入力して検索してください。"
+            className="py-10"
           />
         )}
       </div>

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -147,6 +147,11 @@
     @apply flex flex-wrap items-center gap-3 rounded-lg border border-slate-200 bg-white p-3 shadow-sm;
   }
 
+  /* ネストされたaction-toolbarはカード装飾を解除 */
+  .action-toolbar .action-toolbar {
+    @apply border-0 bg-transparent p-0 shadow-none rounded-none;
+  }
+
   /* ステータスメッセージ（ローディング・空状態） */
   .status-message {
     @apply my-4 flex flex-col items-center gap-2;

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -144,7 +144,7 @@
 
   /* アクションツールバー */
   .action-toolbar {
-    @apply flex flex-wrap items-center gap-2;
+    @apply flex flex-wrap items-center gap-3 rounded-lg border border-slate-200 bg-white p-3 shadow-sm;
   }
 
   /* ステータスメッセージ（ローディング・空状態） */

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -121,7 +121,7 @@
   }
 
   .table-heading {
-    @apply bg-warning/20 text-center text-xs font-semibold uppercase tracking-wide text-dark;
+    @apply bg-slate-100 text-center text-xs font-semibold uppercase tracking-wide text-slate-700 border-b border-slate-200;
   }
 
   .table-chip {

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -147,9 +147,9 @@
     @apply flex flex-wrap items-center gap-3 rounded-lg border border-slate-200 bg-white p-3 shadow-sm;
   }
 
-  /* ネストされたaction-toolbarはカード装飾を解除 */
-  .action-toolbar .action-toolbar {
-    @apply border-0 bg-transparent p-0 shadow-none rounded-none;
+  /* ボタングループ（カード装飾なし、横並びのみ） */
+  .action-button-group {
+    @apply flex flex-wrap items-center gap-3;
   }
 
   /* ステータスメッセージ（ローディング・空状態） */

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -101,7 +101,7 @@
   }
 
   .panel-card-header {
-    @apply bg-primary text-white px-4 py-2 text-sm font-semibold;
+    @apply bg-slate-100 text-slate-800 px-4 py-3 text-base font-semibold border-b border-slate-200;
   }
 
   .panel-card-body {


### PR DESCRIPTION
## Summary
- Tailwind CSS への完全移行（Bootstrap 削除）
- UI/UX 改善（見出し階層、余白、情報密度、アクセシビリティ）
- XSS 対策（ReceiptTable の dangerouslySetInnerHTML 削除）
- バックエンドのモジュール構成整理とテスト追加
- SearchCard を初期展開状態に変更
- AssetBalance ページに PageHeader を追加

## 変更種別
- [x] 新機能
- [x] リファクタリング
- [x] バグ修正

## Test plan
- [ ] `npm run lint` が通ること
- [ ] `npm test -- --run` が通ること
- [ ] `npm run build` が通ること
- [ ] 受取金ページ・保有銘柄ページの表示確認
- [ ] 検索オプションの展開・折りたたみ動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)