### PR TITLE
feat: 保有銘柄ページに合計取得総額と構成比グラフを追加

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-router-dom": "7.12.0",
+        "recharts": "^3.7.0",
         "tailwindcss": "^4.1.18"
       },
       "devDependencies": {
@@ -1429,6 +1430,42 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.3.tgz",
+      "integrity": "sha512-6jQTc5z0KJFtr1UgFpIL3N9XSC3saRaI9PwWtzM2pSqkNGtiNkYY2OSwkOGDK2XcTRcLb1pi/aNkKZz0nxVH4Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.53",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.53.tgz",
@@ -1772,7 +1809,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
@@ -2211,6 +2253,69 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -2328,7 +2433,7 @@
       "version": "19.2.9",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.9.tgz",
       "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2351,6 +2456,12 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -3283,6 +3394,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3415,8 +3535,129 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-urls": {
       "version": "6.0.1",
@@ -3519,6 +3760,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/deep-is": {
@@ -3839,6 +4086,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
+      "integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/esbuild": {
       "version": "0.27.2",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
@@ -4144,6 +4401,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/expect": {
       "version": "30.2.0",
@@ -4676,6 +4939,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -4726,6 +4999,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -6366,8 +6648,32 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -6417,6 +6723,36 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.7.0.tgz",
+      "integrity": "sha512-l2VCsy3XXeraxIID9fx23eCb6iCBsxUQDnE8tWm6DFdszVAO7WVY/ChAD9wVit01y6B2PMupYiMmQwhgPHc9Ew==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -6429,6 +6765,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -6484,6 +6836,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.5",
@@ -7089,6 +7447,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -7399,6 +7763,37 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-router-dom": "7.12.0",
+    "recharts": "^3.7.0",
     "tailwindcss": "^4.1.18"
   },
   "devDependencies": {

--- a/frontend/src/components/molecules/PortfolioPieChart/PortfolioPieChart.tsx
+++ b/frontend/src/components/molecules/PortfolioPieChart/PortfolioPieChart.tsx
@@ -1,0 +1,117 @@
+import React, { useMemo } from 'react';
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from 'recharts';
+
+// 円グラフ用の配色（視認性を考慮した10色）
+const COLORS = [
+  '#3b82f6', // blue-500
+  '#10b981', // emerald-500
+  '#f59e0b', // amber-500
+  '#ef4444', // red-500
+  '#8b5cf6', // violet-500
+  '#ec4899', // pink-500
+  '#06b6d4', // cyan-500
+  '#f97316', // orange-500
+  '#84cc16', // lime-500
+  '#6366f1', // indigo-500
+];
+
+export interface PortfolioItem {
+  name: string;
+  value: number;
+}
+
+interface PortfolioPieChartProps {
+  data: PortfolioItem[];
+  className?: string;
+}
+
+interface TooltipPayloadItem {
+  name: string;
+  value: number;
+  payload: {
+    name: string;
+    value: number;
+    percentage: number;
+  };
+}
+
+// ツールチップの金額・パーセンテージ表示
+const CustomTooltip = ({
+  active,
+  payload,
+}: {
+  active?: boolean;
+  payload?: TooltipPayloadItem[];
+}) => {
+  if (active && payload && payload.length > 0) {
+    const item = payload[0].payload;
+    return (
+      <div className="rounded border border-border bg-white px-3 py-2 shadow-sm">
+        <p className="text-sm font-medium text-dark">{item.name}</p>
+        <p className="text-sm text-secondary">
+          ¥ {item.value.toLocaleString('ja-JP')}
+        </p>
+        <p className="text-sm text-secondary">{item.percentage.toFixed(1)}%</p>
+      </div>
+    );
+  }
+  return null;
+};
+
+/**
+ * ポートフォリオ構成比を表示する円グラフコンポーネント
+ */
+export const PortfolioPieChart: React.FC<PortfolioPieChartProps> = ({
+  data,
+  className = '',
+}) => {
+  // パーセンテージを計算してデータに追加
+  const chartData = useMemo(() => {
+    const total = data.reduce((sum, item) => sum + item.value, 0);
+    if (total === 0) return [];
+
+    return data.map((item) => ({
+      ...item,
+      percentage: (item.value / total) * 100,
+    }));
+  }, [data]);
+
+  if (chartData.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={className} data-testid="portfolio-pie-chart">
+      <ResponsiveContainer width="100%" height={250}>
+        <PieChart>
+          <Pie
+            data={chartData}
+            cx="50%"
+            cy="50%"
+            innerRadius={50}
+            outerRadius={80}
+            paddingAngle={2}
+            dataKey="value"
+            nameKey="name"
+          >
+            {chartData.map((_, index) => (
+              <Cell
+                key={`cell-${index}`}
+                fill={COLORS[index % COLORS.length]}
+              />
+            ))}
+          </Pie>
+          <Tooltip content={<CustomTooltip />} />
+          <Legend
+            layout="vertical"
+            align="right"
+            verticalAlign="middle"
+            formatter={(value: string) => (
+              <span className="text-sm text-secondary">{value}</span>
+            )}
+          />
+        </PieChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};

--- a/frontend/src/components/molecules/PortfolioPieChart/PortfolioPieChart.tsx
+++ b/frontend/src/components/molecules/PortfolioPieChart/PortfolioPieChart.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from 'recharts';
 
 // 円グラフ用の配色（視認性を考慮した10色）
@@ -20,6 +20,10 @@ export interface PortfolioItem {
   value: number;
 }
 
+interface ChartDataItem extends PortfolioItem {
+  percentage: number;
+}
+
 interface PortfolioPieChartProps {
   data: PortfolioItem[];
   className?: string;
@@ -28,11 +32,7 @@ interface PortfolioPieChartProps {
 interface TooltipPayloadItem {
   name: string;
   value: number;
-  payload: {
-    name: string;
-    value: number;
-    percentage: number;
-  };
+  payload: ChartDataItem;
 }
 
 // ツールチップの金額・パーセンテージ表示
@@ -58,6 +58,20 @@ const CustomTooltip = ({
   return null;
 };
 
+// 画面幅を監視するフック
+const useIsMobile = () => {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const checkMobile = () => setIsMobile(window.innerWidth < 640);
+    checkMobile();
+    window.addEventListener('resize', checkMobile);
+    return () => window.removeEventListener('resize', checkMobile);
+  }, []);
+
+  return isMobile;
+};
+
 /**
  * ポートフォリオ構成比を表示する円グラフコンポーネント
  */
@@ -65,6 +79,8 @@ export const PortfolioPieChart: React.FC<PortfolioPieChartProps> = ({
   data,
   className = '',
 }) => {
+  const isMobile = useIsMobile();
+
   // パーセンテージを計算してデータに追加
   const chartData = useMemo(() => {
     const total = data.reduce((sum, item) => sum + item.value, 0);
@@ -76,20 +92,35 @@ export const PortfolioPieChart: React.FC<PortfolioPieChartProps> = ({
     }));
   }, [data]);
 
+  // 凡例のカスタムフォーマッター（銘柄名 + パーセンテージを表示）
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const legendFormatter = (value: string, entry: any) => {
+    const percentage = entry.payload?.percentage as number | undefined;
+    if (percentage === undefined) {
+      return <span className="text-sm text-secondary">{value}</span>;
+    }
+
+    return (
+      <span className="text-sm text-secondary">
+        {value} ({percentage.toFixed(1)}%)
+      </span>
+    );
+  };
+
   if (chartData.length === 0) {
     return null;
   }
 
   return (
     <div className={className} data-testid="portfolio-pie-chart">
-      <ResponsiveContainer width="100%" height={250}>
+      <ResponsiveContainer width="100%" height={isMobile ? 350 : 250}>
         <PieChart>
           <Pie
             data={chartData}
             cx="50%"
-            cy="50%"
-            innerRadius={50}
-            outerRadius={80}
+            cy={isMobile ? '30%' : '50%'}
+            innerRadius={isMobile ? 40 : 50}
+            outerRadius={isMobile ? 65 : 80}
             paddingAngle={2}
             dataKey="value"
             nameKey="name"
@@ -103,12 +134,11 @@ export const PortfolioPieChart: React.FC<PortfolioPieChartProps> = ({
           </Pie>
           <Tooltip content={<CustomTooltip />} />
           <Legend
-            layout="vertical"
-            align="right"
-            verticalAlign="middle"
-            formatter={(value: string) => (
-              <span className="text-sm text-secondary">{value}</span>
-            )}
+            layout={isMobile ? 'horizontal' : 'vertical'}
+            align={isMobile ? 'center' : 'right'}
+            verticalAlign={isMobile ? 'bottom' : 'middle'}
+            wrapperStyle={isMobile ? { paddingTop: 16 } : undefined}
+            formatter={legendFormatter}
           />
         </PieChart>
       </ResponsiveContainer>

--- a/frontend/src/components/molecules/PortfolioPieChart/__tests__/PortfolioPieChart.test.tsx
+++ b/frontend/src/components/molecules/PortfolioPieChart/__tests__/PortfolioPieChart.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect } from 'vitest';
+import { PortfolioPieChart, PortfolioItem } from '../PortfolioPieChart';
+
+// rechartsのモック（ResponsiveContainerの問題を回避）
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+  PieChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="pie-chart">{children}</div>
+  ),
+  Pie: () => <div data-testid="pie" />,
+  Cell: () => null,
+  Tooltip: () => null,
+  Legend: () => <div data-testid="legend" />,
+}));
+
+describe('PortfolioPieChart', () => {
+  const mockData: PortfolioItem[] = [
+    { name: 'トヨタ自動車', value: 250000 },
+    { name: 'ソニーグループ', value: 600000 },
+    { name: '任天堂', value: 150000 },
+  ];
+
+  it('円グラフが表示される', () => {
+    render(<PortfolioPieChart data={mockData} />);
+
+    expect(screen.getByTestId('portfolio-pie-chart')).toBeInTheDocument();
+    expect(screen.getByTestId('pie-chart')).toBeInTheDocument();
+  });
+
+  it('data-testidが設定される', () => {
+    render(<PortfolioPieChart data={mockData} />);
+
+    expect(screen.getByTestId('portfolio-pie-chart')).toBeInTheDocument();
+  });
+
+  it('空データの場合は何も表示しない', () => {
+    const { container } = render(<PortfolioPieChart data={[]} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('すべての値が0の場合は何も表示しない', () => {
+    const zeroData: PortfolioItem[] = [
+      { name: '銘柄A', value: 0 },
+      { name: '銘柄B', value: 0 },
+    ];
+    const { container } = render(<PortfolioPieChart data={zeroData} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    render(<PortfolioPieChart data={mockData} className="custom-chart" />);
+
+    const chartContainer = screen.getByTestId('portfolio-pie-chart');
+    expect(chartContainer).toHaveClass('custom-chart');
+  });
+
+  it('Legendコンポーネントがレンダリングされる', () => {
+    render(<PortfolioPieChart data={mockData} />);
+
+    expect(screen.getByTestId('legend')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/molecules/PortfolioPieChart/index.ts
+++ b/frontend/src/components/molecules/PortfolioPieChart/index.ts
@@ -1,0 +1,2 @@
+export { PortfolioPieChart } from './PortfolioPieChart';
+export type { PortfolioItem } from './PortfolioPieChart';

--- a/frontend/src/components/molecules/ReceiptHeader/ReceiptHeader.tsx
+++ b/frontend/src/components/molecules/ReceiptHeader/ReceiptHeader.tsx
@@ -21,7 +21,15 @@ export const ReceiptHeader: React.FC<ReceiptHeaderProps> = ({ items }) => {
             <CardBody className="p-4">
                 <div className="stat-grid">
                     {items.map((item, index) => (
-                        <StatItem key={index} title={item.title} value={item.format(item.value)} />
+                        <StatItem
+                            key={index}
+                            title={item.title}
+                            value={
+                                <span data-negative={item.value < 0 ? 'true' : undefined}>
+                                    {item.format(item.value)}
+                                </span>
+                            }
+                        />
                     ))}
                 </div>
             </CardBody>

--- a/frontend/src/components/organisms/AssetPortfolioSummary/AssetPortfolioSummary.tsx
+++ b/frontend/src/components/organisms/AssetPortfolioSummary/AssetPortfolioSummary.tsx
@@ -1,0 +1,92 @@
+import React, { useMemo } from 'react';
+import { Card, CardBody } from '@/components/atoms/Card';
+import { StatItem } from '@/components/atoms/StatItem';
+import { EmptyState } from '@/components/atoms/EmptyState';
+import { PortfolioPieChart, PortfolioItem } from '@/components/molecules/PortfolioPieChart';
+import { AssetBalanceData } from '@/lib/interfaces/assetBalance';
+import { formatCurrency, safeAdd } from '@/lib/utils/formatters';
+
+interface AssetPortfolioSummaryProps {
+  assetBalanceData: AssetBalanceData[];
+}
+
+/**
+ * 保有銘柄のポートフォリオサマリーを表示するコンポーネント
+ * 合計取得総額と構成比の円グラフを表示
+ */
+export const AssetPortfolioSummary: React.FC<AssetPortfolioSummaryProps> = ({
+  assetBalanceData,
+}) => {
+  // 合計取得総額を計算（null/undefinedは0として扱う）
+  const totalPurchaseAmount = useMemo(() => {
+    return assetBalanceData.reduce(
+      (sum, item) => safeAdd(sum, item.total_purchase_amount || 0),
+      0
+    );
+  }, [assetBalanceData]);
+
+  // 円グラフ用データを生成
+  const chartData: PortfolioItem[] = useMemo(() => {
+    return assetBalanceData
+      .filter((item) => (item.total_purchase_amount || 0) > 0)
+      .map((item) => ({
+        name: item.security_name || item.security_code,
+        value: item.total_purchase_amount || 0,
+      }))
+      .sort((a, b) => b.value - a.value);
+  }, [assetBalanceData]);
+
+  // データがない場合
+  if (assetBalanceData.length === 0) {
+    return (
+      <Card className="mb-3">
+        <CardBody>
+          <EmptyState
+            title="保有銘柄がありません"
+            description="CSVファイルをインポートするか、データを登録してください。"
+          />
+        </CardBody>
+      </Card>
+    );
+  }
+
+  // 合計取得総額が0の場合
+  if (totalPurchaseAmount === 0) {
+    return null;
+  }
+
+  return (
+    <Card className="mb-3" data-testid="asset-portfolio-summary">
+      <CardBody className="p-4">
+        <div className="flex flex-col gap-4 md:flex-row md:items-start md:gap-8">
+          {/* 合計取得総額 */}
+          <div className="shrink-0">
+            <StatItem
+              title="合計取得総額"
+              value={
+                <span
+                  dangerouslySetInnerHTML={{
+                    __html: formatCurrency(totalPurchaseAmount),
+                  }}
+                />
+              }
+              variant="default"
+              titleClassName="text-secondary"
+              valueClassName="text-2xl text-primary"
+            />
+          </div>
+
+          {/* 構成比円グラフ */}
+          {chartData.length > 0 && (
+            <div className="min-w-0 flex-1">
+              <h3 className="mb-2 text-sm font-semibold text-secondary">
+                銘柄別構成比
+              </h3>
+              <PortfolioPieChart data={chartData} />
+            </div>
+          )}
+        </div>
+      </CardBody>
+    </Card>
+  );
+};

--- a/frontend/src/components/organisms/AssetPortfolioSummary/AssetPortfolioSummary.tsx
+++ b/frontend/src/components/organisms/AssetPortfolioSummary/AssetPortfolioSummary.tsx
@@ -64,11 +64,9 @@ export const AssetPortfolioSummary: React.FC<AssetPortfolioSummaryProps> = ({
             <StatItem
               title="合計取得総額"
               value={
-                <span
-                  dangerouslySetInnerHTML={{
-                    __html: formatCurrency(totalPurchaseAmount),
-                  }}
-                />
+                <span data-negative={totalPurchaseAmount < 0 ? 'true' : undefined}>
+                  {formatCurrency(totalPurchaseAmount)}
+                </span>
               }
               variant="default"
               titleClassName="text-secondary"

--- a/frontend/src/components/organisms/AssetPortfolioSummary/__tests__/AssetPortfolioSummary.test.tsx
+++ b/frontend/src/components/organisms/AssetPortfolioSummary/__tests__/AssetPortfolioSummary.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect } from 'vitest';
+import { AssetPortfolioSummary } from '../AssetPortfolioSummary';
+import { AssetBalanceData } from '@/lib/interfaces/assetBalance';
+
+// rechartsのモック（ResponsiveContainerの問題を回避）
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+  PieChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="pie-chart">{children}</div>
+  ),
+  Pie: () => <div data-testid="pie" />,
+  Cell: () => null,
+  Tooltip: () => null,
+  Legend: () => <div data-testid="legend" />,
+}));
+
+const createMockData = (overrides: Partial<AssetBalanceData>[] = []): AssetBalanceData[] => {
+  const defaults: AssetBalanceData[] = [
+    {
+      security_code: '7203',
+      security_name: 'トヨタ自動車',
+      shares: 100,
+      executing_shares: 0,
+      average_purchase_price: 2500,
+      total_purchase_amount: 250000,
+      current_price: 2600,
+      daily_change: 50,
+      market_value: 260000,
+      profit_loss_rate: 4.0,
+    },
+    {
+      security_code: '6758',
+      security_name: 'ソニーグループ',
+      shares: 50,
+      executing_shares: 0,
+      average_purchase_price: 12000,
+      total_purchase_amount: 600000,
+      current_price: 13000,
+      daily_change: 200,
+      market_value: 650000,
+      profit_loss_rate: 8.33,
+    },
+  ];
+
+  if (overrides.length > 0) {
+    return overrides.map((override, index) => ({
+      ...defaults[index % defaults.length],
+      ...override,
+    }));
+  }
+  return defaults;
+};
+
+describe('AssetPortfolioSummary', () => {
+  it('合計取得総額が正しく表示される', () => {
+    const mockData = createMockData();
+    render(<AssetPortfolioSummary assetBalanceData={mockData} />);
+
+    // 合計取得総額のラベルが表示される
+    expect(screen.getByText('合計取得総額')).toBeInTheDocument();
+    // 250,000 + 600,000 = 850,000
+    expect(screen.getByText(/850,000/)).toBeInTheDocument();
+  });
+
+  it('円グラフが表示される', () => {
+    const mockData = createMockData();
+    render(<AssetPortfolioSummary assetBalanceData={mockData} />);
+
+    expect(screen.getByTestId('portfolio-pie-chart')).toBeInTheDocument();
+    expect(screen.getByText('銘柄別構成比')).toBeInTheDocument();
+  });
+
+  it('データがない場合は空状態が表示される', () => {
+    render(<AssetPortfolioSummary assetBalanceData={[]} />);
+
+    expect(screen.getByText('保有銘柄がありません')).toBeInTheDocument();
+    expect(screen.getByText('CSVファイルをインポートするか、データを登録してください。')).toBeInTheDocument();
+  });
+
+  it('取得総額がすべて0の場合はサマリーが表示されない', () => {
+    const mockData = createMockData([
+      { total_purchase_amount: 0 },
+      { total_purchase_amount: 0 },
+    ]);
+    const { container } = render(<AssetPortfolioSummary assetBalanceData={mockData} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('取得総額がnull/undefinedの場合は0として扱う', () => {
+    const mockData: AssetBalanceData[] = [
+      {
+        security_code: '7203',
+        security_name: 'トヨタ自動車',
+        shares: 100,
+        executing_shares: 0,
+        average_purchase_price: 2500,
+        total_purchase_amount: undefined as unknown as number,
+        current_price: 2600,
+        daily_change: 50,
+        market_value: 260000,
+        profit_loss_rate: 4.0,
+      },
+      {
+        security_code: '6758',
+        security_name: 'ソニーグループ',
+        shares: 50,
+        executing_shares: 0,
+        average_purchase_price: 12000,
+        total_purchase_amount: 600000,
+        current_price: 13000,
+        daily_change: 200,
+        market_value: 650000,
+        profit_loss_rate: 8.33,
+      },
+    ];
+    render(<AssetPortfolioSummary assetBalanceData={mockData} />);
+
+    // undefinedは0として扱われるので、600,000のみが合計される
+    expect(screen.getByText(/600,000/)).toBeInTheDocument();
+  });
+
+  it('data-testidが設定される', () => {
+    const mockData = createMockData();
+    render(<AssetPortfolioSummary assetBalanceData={mockData} />);
+
+    expect(screen.getByTestId('asset-portfolio-summary')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/organisms/AssetPortfolioSummary/index.ts
+++ b/frontend/src/components/organisms/AssetPortfolioSummary/index.ts
@@ -1,0 +1,1 @@
+export { AssetPortfolioSummary } from './AssetPortfolioSummary';

--- a/frontend/src/components/organisms/ReceiptTable/ReceiptTable.tsx
+++ b/frontend/src/components/organisms/ReceiptTable/ReceiptTable.tsx
@@ -47,6 +47,37 @@ export function ReceiptTable<T extends DataItem, S extends SummaryItem>({
 }: ReceiptTableProps<T, S>) {
     const forceResize = useForceResize();
 
+    const renderTextValue = (value: unknown): string | number => {
+        if (typeof value === 'string' || typeof value === 'number') {
+            return value;
+        }
+        if (value === null || value === undefined) {
+            return '';
+        }
+        return String(value);
+    };
+
+    const isNegativeValue = (value: unknown): boolean => {
+        if (typeof value === 'number') {
+            return Number.isFinite(value) && value < 0;
+        }
+        if (typeof value !== 'string') {
+            return false;
+        }
+
+        const normalized = value
+            .trim()
+            .replace(/[¥￥$€£]/g, '')
+            .replace(/,/g, '')
+            .replace(/\s+/g, '');
+
+        if (!normalized || !/^[-+]?\d+(\.\d+)?$/.test(normalized)) {
+            return false;
+        }
+
+        return Number(normalized) < 0;
+    };
+
     // テーブル内のクリックイベントをハンドル（銘柄コードリンク用）
     const handleTableClick = (e: React.MouseEvent<HTMLTableElement>) => {
         const target = e.target as HTMLElement;
@@ -60,6 +91,7 @@ export function ReceiptTable<T extends DataItem, S extends SummaryItem>({
 
     const renderCell = (value: unknown, column: ColumnConfig, key: string, style?: React.CSSProperties) => {
         const formattedValue = column.format ? column.format(value) : value;
+        const isNegative = !React.isValidElement(formattedValue) && isNegativeValue(value);
 
         const cellStyle: React.CSSProperties = {
             minWidth: 'width' in column ? column.width : undefined,
@@ -77,8 +109,11 @@ export function ReceiptTable<T extends DataItem, S extends SummaryItem>({
             return <TableCell key={key} {...props}>{formattedValue}</TableCell>;
         }
 
-        // 文字列はそのままテキストとして描画（XSS対策）
-        return <TableCell key={key} {...props}>{String(formattedValue ?? '')}</TableCell>;
+        return (
+            <TableCell key={key} {...props} data-negative={isNegative ? 'true' : undefined}>
+                {renderTextValue(formattedValue)}
+            </TableCell>
+        );
     };
 
     const renderDataRows = (items: T[], keyPrefix: string) =>
@@ -95,19 +130,6 @@ export function ReceiptTable<T extends DataItem, S extends SummaryItem>({
         return column.format ? column.format(value) : value;
     };
 
-    // サマリーのラベルを取得
-    const getSummaryLabel = (key: string): string => {
-        const labels: Record<string, string> = {
-            'total_realized_profit_and_loss': '損益',
-            'dividends_before_tax': '配当',
-            'total_taxes': '税額',
-            'taxes': '税額',
-            'total_realized_profit_and_loss_after_tax': '税引後',
-            'net_amount_received': '受取額',
-        };
-        return labels[key] || key;
-    };
-
     const summaryGroupKeys = new Set(data.map(item => getGroupKey(item)));
     const summaryToRender = summary.filter(summaryItem => summaryGroupKeys.has(summaryItem.filter));
 
@@ -120,8 +142,8 @@ export function ReceiptTable<T extends DataItem, S extends SummaryItem>({
             // サマリー値の取得
             const summaryValues = summaryColumns.map(column => ({
                 key: column.key,
-                label: getSummaryLabel(column.key),
-                value: formatSummaryValue(summaryItem[column.key], column)
+                value: formatSummaryValue(summaryItem[column.key], column),
+                rawValue: summaryItem[column.key]
             }));
 
             const summaryBorderClass = summaryIndex > 0 && 'border-t border-slate-200';
@@ -144,12 +166,13 @@ export function ReceiptTable<T extends DataItem, S extends SummaryItem>({
                                     {itemCount}件
                                 </span>
                             </TableCell>
-                            {summaryValues.map((sv, idx) => (
+                            {summaryValues.map((sv) => (
                                 <TableCell
-                                    key={idx}
+                                    key={sv.key}
                                     className={summaryValueClass}
+                                    data-negative={!React.isValidElement(sv.value) && isNegativeValue(sv.rawValue) ? 'true' : undefined}
                                 >
-                                    {String(sv.value)}
+                                    {React.isValidElement(sv.value) ? sv.value : renderTextValue(sv.value)}
                                 </TableCell>
                             ))}
                         </TableRow>

--- a/frontend/src/components/organisms/ReceiptTable/__tests__/ReceiptTable.test.tsx
+++ b/frontend/src/components/organisms/ReceiptTable/__tests__/ReceiptTable.test.tsx
@@ -100,6 +100,31 @@ describe('ReceiptTable', () => {
     expect(screen.getAllByText('<a href="https://example.com">リンク</a>')).toHaveLength(3);
   });
 
+  it('負の値のセルにはdata-negative属性が付与される', () => {
+    const dataWithNegative = [
+      { date: '2024-01-01', name: '銘柄A', amount: -1200, group: 'A' },
+    ];
+    const summaryWithNegative = [
+      { filter: 'A', amount: -1200, name: 'グループA' },
+    ];
+
+    render(
+      <ReceiptTable
+        data={dataWithNegative}
+        summary={summaryWithNegative}
+        columns={mockColumns}
+        summaryColumns={mockSummaryColumns}
+        getGroupKey={getGroupKey}
+      />
+    );
+
+    const negativeCells = screen.getAllByText('¥-1,200').map((element) => element.closest('td'));
+    expect(negativeCells).toHaveLength(2); // 明細行 + サマリー行
+    negativeCells.forEach((cell) => {
+      expect(cell).toHaveAttribute('data-negative', 'true');
+    });
+  });
+
   it('空のデータでも正しくレンダリングされる', () => {
     render(
       <ReceiptTable

--- a/frontend/src/lib/utils/__tests__/formatters.test.ts
+++ b/frontend/src/lib/utils/__tests__/formatters.test.ts
@@ -149,11 +149,7 @@ describe('数値関連のフォーマット関数', () => {
     });
 
     it('負の数値をフォーマットする', () => {
-      expect(formatNumber(-12345)).toBe('<span data-negative="true">-12,345</span>');
-    });
-
-    it('負の数値をスパンなしでフォーマットする', () => {
-      expect(formatNumber(-12345, { showNegativeSpan: false })).toBe('-12,345');
+      expect(formatNumber(-12345)).toBe('-12,345');
     });
 
     it('小数点オプションが動作する', () => {
@@ -177,7 +173,7 @@ describe('数値関連のフォーマット関数', () => {
     });
 
     it('負の金額をフォーマットする', () => {
-      expect(formatCurrency(-12345)).toBe('<span data-negative="true">¥ -12,345</span>');
+      expect(formatCurrency(-12345)).toBe('¥ -12,345');
     });
 
     it('カスタム通貨記号が動作する', () => {

--- a/frontend/src/lib/utils/formatters.ts
+++ b/frontend/src/lib/utils/formatters.ts
@@ -186,14 +186,12 @@ export function formatNumber(
     minimumFractionDigits?: number;
     maximumFractionDigits?: number;
     useGrouping?: boolean;
-    showNegativeSpan?: boolean;
   } = {}
 ): string {
   const {
     minimumFractionDigits = 0,
     maximumFractionDigits = 2,
-    useGrouping = true,
-    showNegativeSpan = true
+    useGrouping = true
   } = options;
 
   try {
@@ -221,9 +219,7 @@ export function formatNumber(
       maximumFractionDigits
     }).format(absNum);
 
-    if (isNegative && showNegativeSpan) {
-      return `<span data-negative="true">-${formattedNumber}</span>`;
-    } else if (isNegative) {
+    if (isNegative) {
       return `-${formattedNumber}`;
     } else {
       return formattedNumber;
@@ -246,14 +242,12 @@ export function formatCurrency(
     currency?: string;
     minimumFractionDigits?: number;
     maximumFractionDigits?: number;
-    showNegativeSpan?: boolean;
   } = {}
 ): string {
   const {
     currency = '¥',
     minimumFractionDigits = 0,
-    maximumFractionDigits = 15,
-    showNegativeSpan = true
+    maximumFractionDigits = 15
   } = options;
 
   try {
@@ -281,9 +275,7 @@ export function formatCurrency(
       maximumFractionDigits
     }).format(absNum);
 
-    if (isNegative && showNegativeSpan) {
-      return `<span data-negative="true">${currency} -${formattedNumber}</span>`;
-    } else if (isNegative) {
+    if (isNegative) {
       return `${currency} -${formattedNumber}`;
     } else {
       return `${currency} ${formattedNumber}`;

--- a/frontend/src/pages/AssetBalance.tsx
+++ b/frontend/src/pages/AssetBalance.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useMemo } from 'react';
+import React, { useEffect, useState, useMemo, Suspense, lazy } from 'react';
 import { Layout } from '../components/templates/Layout';
 import { PageHeader } from '../components/atoms/PageHeader';
 import { CSVFileInput } from '../components/molecules/CSVFileInput';
@@ -23,7 +23,13 @@ import {
 import { renderSecurityCode } from '@/components/atoms/SecurityCodeLink';
 import { assetBalanceApi } from '@/features/receipt/api/receiptApi';
 import { useReceiptDataSource } from '@/hooks/common/useReceiptDataSource';
-import { AssetPortfolioSummary } from '@/components/organisms/AssetPortfolioSummary';
+
+// rechartsを含むコンポーネントを遅延読み込み（バンドルサイズ最適化）
+const AssetPortfolioSummary = lazy(() =>
+  import('@/components/organisms/AssetPortfolioSummary').then(module => ({
+    default: module.AssetPortfolioSummary
+  }))
+);
 
 
 // CSVアイテムをAssetBalanceDataに変換
@@ -88,7 +94,11 @@ export const AssetBalanceInfo: React.FC<AssetBalanceProps> = ({ assetBalanceData
       title="保有銘柄"
       onSearch={(query: string) => setSearchQuery(query)}
       searchCategories={searchCategories}
-      header={<AssetPortfolioSummary assetBalanceData={assetBalanceData} />}
+      header={
+        <Suspense fallback={<div className="h-64 flex items-center justify-center"><Spinner size="md" /></div>}>
+          <AssetPortfolioSummary assetBalanceData={assetBalanceData} />
+        </Suspense>
+      }
     >
       <ReceiptTable
         data={filteredData}

--- a/frontend/src/pages/AssetBalance.tsx
+++ b/frontend/src/pages/AssetBalance.tsx
@@ -23,6 +23,7 @@ import {
 import { renderSecurityCode } from '@/components/atoms/SecurityCodeLink';
 import { assetBalanceApi } from '@/features/receipt/api/receiptApi';
 import { useReceiptDataSource } from '@/hooks/common/useReceiptDataSource';
+import { AssetPortfolioSummary } from '@/components/organisms/AssetPortfolioSummary';
 
 
 // CSVアイテムをAssetBalanceDataに変換
@@ -87,6 +88,7 @@ export const AssetBalanceInfo: React.FC<AssetBalanceProps> = ({ assetBalanceData
       title="保有銘柄"
       onSearch={(query: string) => setSearchQuery(query)}
       searchCategories={searchCategories}
+      header={<AssetPortfolioSummary assetBalanceData={assetBalanceData} />}
     >
       <ReceiptTable
         data={filteredData}

--- a/frontend/src/pages/__tests__/AssetBalance.test.tsx
+++ b/frontend/src/pages/__tests__/AssetBalance.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { AssetBalanceData } from '@/lib/interfaces/assetBalance';
 import { AssetBalanceInfo } from '../AssetBalance';
@@ -9,16 +9,19 @@ vi.mock('@/components/templates/ReceiptTemplate', () => ({
   ReceiptTemplate: ({
     children,
     title,
+    header,
     onSearch,
     searchCategories
   }: {
     children: React.ReactNode;
     title: string;
+    header?: React.ReactNode;
     onSearch?: (query: string) => void;
     searchCategories?: Record<string, Array<{ value: string; label: string }>>;
   }) => (
     <div data-testid="receipt-template">
       <h1>{title}</h1>
+      {header && <div data-testid="receipt-header">{header}</div>}
       {onSearch && searchCategories && (
         <div data-testid="search-area">
           <input
@@ -32,6 +35,16 @@ vi.mock('@/components/templates/ReceiptTemplate', () => ({
         </div>
       )}
       {children}
+    </div>
+  ),
+}));
+
+// AssetPortfolioSummaryのモック（遅延読み込み対応）
+vi.mock('@/components/organisms/AssetPortfolioSummary', () => ({
+  AssetPortfolioSummary: ({ assetBalanceData }: { assetBalanceData: AssetBalanceData[] }) => (
+    <div data-testid="asset-portfolio-summary">
+      <div data-testid="total-amount">合計取得総額: {assetBalanceData.reduce((sum, item) => sum + (item.total_purchase_amount || 0), 0)}</div>
+      <div data-testid="chart-items">銘柄数: {assetBalanceData.length}</div>
     </div>
   ),
 }));
@@ -189,5 +202,34 @@ describe('AssetBalance', () => {
     // 空のデータの場合でもサマリーが表示される
     const tableProps = screen.getByTestId('table-props');
     expect(tableProps).toHaveTextContent('summary: 0');
+  });
+
+  it('ポートフォリオサマリーがヘッダーとして表示される', async () => {
+    render(<AssetBalanceInfo assetBalanceData={mockAssetBalanceData} />);
+
+    // ヘッダー部分が表示されていることを確認
+    expect(screen.getByTestId('receipt-header')).toBeInTheDocument();
+    // 遅延読み込みコンポーネントの表示を待機
+    await waitFor(() => {
+      expect(screen.getByTestId('asset-portfolio-summary')).toBeInTheDocument();
+    });
+  });
+
+  it('ポートフォリオサマリーに正しいデータが渡される', async () => {
+    render(<AssetBalanceInfo assetBalanceData={mockAssetBalanceData} />);
+
+    // 遅延読み込みコンポーネントの表示を待機
+    await waitFor(() => {
+      // 合計取得総額が正しく計算されていることを確認（250000 + 600000 = 850000）
+      expect(screen.getByTestId('total-amount')).toHaveTextContent('850000');
+      expect(screen.getByTestId('chart-items')).toHaveTextContent('銘柄数: 2');
+    });
+  });
+
+  it('空データの場合でもヘッダー領域が存在する', () => {
+    render(<AssetBalanceInfo assetBalanceData={[]} />);
+
+    // ヘッダー領域自体は存在する（中身はSuspenseのfallbackか空状態）
+    expect(screen.getByTestId('receipt-header')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## 概要
保有銘柄ページで「持ち株分析」をしやすくするため、合計取得総額の表示と銘柄別構成比の円グラフを追加しました。

## 変更種別
- [x] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] その他

## 変更内容
### 新機能
- 合計取得総額をページ上部に表示
- 銘柄別構成比を円グラフで可視化（recharts使用）
- 凡例にパーセンテージを常時表示（ホバー非依存）
- モバイル対応（凡例を下部に横並び配置）

### パフォーマンス最適化
- AssetPortfolioSummaryをReact.lazyで遅延読み込み
- バンドルサイズ: 694KB → 321KB + 遅延376KB

### その他
- null/undefinedの取得総額は0として安全に処理
- 空データ時は簡潔な空状態を表示

## テスト
- [x] ユニットテスト追加/更新
- [x] 手動テスト実施

## チェックリスト
- [x] コードレビュー依頼済み
- [x] CIパス確認
- [x] ドキュメント更新（必要な場合）

## コミット一覧
- chore: rechartsライブラリを追加
- feat: ポートフォリオ構成比表示コンポーネントを追加
- feat: 保有銘柄ページに合計取得総額と構成比グラフを追加
- fix: 負数表示のHTML文字列混入を解消
- fix: ポートフォリオ表示の改善とバンドル最適化

🤖 Generated with [Claude Code](https://claude.ai/code)