### PR TITLE
UI改善とCodexレビュー対応

### DIFF
--- a/.claude/commands/ui-review.md
+++ b/.claude/commands/ui-review.md
@@ -11,17 +11,6 @@ Claude Code で完結するUIレビューシステム（Playwright MCP版）
 /ui-review --review-only      # 既存画像の分析のみ
 ```
 
-## 取得するスクリーンショット
-
-受取金ページの各タブと検索結果を取得する（MCP版・E2E版共通）:
-
-| ファイル名 | 内容 |
-|-----------|------|
-| `receipts-dividend.png` | 配当金タブの初期表示 |
-| `receipts-dividend-search.png` | 配当金 - 銘柄検索結果（配当シミュレーション表示） |
-| `receipts-domestic-stock.png` | 国内株式タブの初期表示 |
-| `receipts-mutualfund.png` | 投資信託タブの初期表示 |
-
 ### 保存先
 `.playwright-mcp/` ディレクトリに保存される。
 
@@ -40,10 +29,17 @@ Claude Code で完結するUIレビューシステム（Playwright MCP版）
    ```
 2. `mcp__playwright__browser_navigate` で `http://localhost:8080/receipts` に遷移
 3. 各タブについてスクリーンショットを取得:
-   - 配当金タブ: `receipts-dividend.png`
-   - 配当金タブで銘柄検索: `receipts-dividend-search.png`
-   - 国内株式タブ: `receipts-domestic-stock.png`
-   - 投資信託タブ: `receipts-mutualfund.png`
+| ファイル名 | 内容 |
+|-----------|------|
+| `receipts-dividend-initial.png` | 配当金タブの初期表示 |
+| `receipts-domestic-stock-initial.png` | 国内株式タブの初期表示 |
+| `receipts-mutualfund-initial.png` | 投資信託タブの初期表示 |
+| `receipts-dividend-search-year.png` | 配当金 - 西暦検索結果 |
+| `receipts-dividend-search-security.png` | 配当金 - 銘柄検索結果 |
+| `receipts-domestic-stock-search-year.png` | 国内株式 - 西暦検索結果 |
+| `receipts-domestic-stock-search-account.png` | 国内株式 - 口座検索結果 |
+| `receipts-mutualfund-search-year.png` | 投資信託 - 西暦検索結果 |
+| `receipts-mutualfund-search-fund.png` | 投資信託 - ファンド検索結果 |
 4. スクリーンショット取得時の設定:
    - `fullPage`: true（全ページキャプチャ）
    - `type`: png

--- a/.claude/commands/ui-review.md
+++ b/.claude/commands/ui-review.md
@@ -11,13 +11,19 @@ Claude Code で完結するUIレビューシステム（Playwright MCP版）
 /ui-review --review-only      # 既存画像の分析のみ
 ```
 
-## 対象画面
-以下の画面をレビュー対象とする:
-- `/` - ホーム画面
-- `/search` - 銘柄検索
-- `/assetbalance` - 保有銘柄
-- `/receipts` - 受取金
-- `/404` - エラーページ
+## 取得するスクリーンショット
+
+受取金ページの各タブと検索結果を取得する（MCP版・E2E版共通）:
+
+| ファイル名 | 内容 |
+|-----------|------|
+| `receipts-dividend.png` | 配当金タブの初期表示 |
+| `receipts-dividend-search.png` | 配当金 - 銘柄検索結果（配当シミュレーション表示） |
+| `receipts-domestic-stock.png` | 国内株式タブの初期表示 |
+| `receipts-mutualfund.png` | 投資信託タブの初期表示 |
+
+### 保存先
+`.playwright-mcp/` ディレクトリに保存される。
 
 ## Implementation Steps
 
@@ -28,14 +34,19 @@ Claude Code で完結するUIレビューシステム（Playwright MCP版）
    - `ToolSearch` に `playwright screenshot navigate` でツールを検索
 
 ### 2. スクリーンショット取得
-1. `mcp__playwright__browser_navigate` で対象URLに遷移
-2. 各対象画面について:
-   - `mcp__playwright__browser_navigate` でURLに遷移（例: `http://localhost:8080/search`）
-   - `mcp__playwright__browser_take_screenshot` でキャプチャ
-     - `filename`: ページ名.png（例: `home.png`, `search.png`）
-     - `fullPage`: true（全ページキャプチャ）
-     - `type`: png
-   - スクリーンショットは `.playwright-mcp/` ディレクトリに自動保存される
+1. `.playwright-mcp/` ディレクトリ内の既存画像を削除
+   ```bash
+   rm -f .playwright-mcp/*.png
+   ```
+2. `mcp__playwright__browser_navigate` で `http://localhost:8080/receipts` に遷移
+3. 各タブについてスクリーンショットを取得:
+   - 配当金タブ: `receipts-dividend.png`
+   - 配当金タブで銘柄検索: `receipts-dividend-search.png`
+   - 国内株式タブ: `receipts-domestic-stock.png`
+   - 投資信託タブ: `receipts-mutualfund.png`
+4. スクリーンショット取得時の設定:
+   - `fullPage`: true（全ページキャプチャ）
+   - `type`: png
 
 ### 3. UI分析
 Read ツールで各スクリーンショットを読み込み、以下の観点で分析:
@@ -75,12 +86,12 @@ Read ツールで各スクリーンショットを読み込み、以下の観点
 ToolSearch: query="playwright screenshot navigate"
 
 # ページ遷移
-mcp__playwright__browser_navigate: url="http://localhost:8080"
+mcp__playwright__browser_navigate: url="http://localhost:8080/receipts"
 
 # スクリーンショット取得
 mcp__playwright__browser_take_screenshot:
   type="png"
-  filename="home.png"
+  filename="receipts-dividend.png"
   fullPage=true
 ```
 
@@ -92,32 +103,9 @@ mcp__playwright__browser_take_screenshot:
 
 ---
 
-## 受取金ページ詳細スクリーンショット（npm コマンド版）
+## E2E版（npm コマンド）
 
-上記の `/ui-review` コマンドとは別に、受取金ページの詳細なスクリーンショットを npm コマンドで取得できます。
-
-### 違い
-| 項目 | /ui-review (MCP版) | npm run (E2E版) |
-|------|-------------------|-----------------|
-| 実行方法 | Claude Code から `/ui-review` | ターミナルで `npm run ui:screenshot` |
-| 対象 | 全ページの概要 | 受取金ページの詳細（タブ・検索） |
-| 認証 | 手動ログイン依頼 | storageState で保持可能 |
-
-### 保存先
-`.playwright-mcp/` ディレクトリに保存されます（両方式で共通）。
-
-### 取得するスクリーンショット
-| ファイル名 | 内容 |
-|-----------|------|
-| `receipts-dividend-initial.png` | 配当金タブの初期表示 |
-| `receipts-domestic-stock-initial.png` | 国内株式タブの初期表示 |
-| `receipts-mutualfund-initial.png` | 投資信託タブの初期表示 |
-| `receipts-dividend-search-year.png` | 配当金 - 西暦検索結果 |
-| `receipts-dividend-search-security.png` | 配当金 - 銘柄検索結果 |
-| `receipts-domestic-stock-search-year.png` | 国内株式 - 西暦検索結果 |
-| `receipts-domestic-stock-search-account.png` | 国内株式 - 口座検索結果 |
-| `receipts-mutualfund-search-year.png` | 投資信託 - 西暦検索結果 |
-| `receipts-mutualfund-search-fund.png` | 投資信託 - ファンド検索結果 |
+MCP版と同じスクリーンショットを npm コマンドでも取得できる。
 
 ### 実行コマンド
 

--- a/.claude/commands/ui-review.md
+++ b/.claude/commands/ui-review.md
@@ -3,7 +3,7 @@ description: "開発サーバーに対してUIレビューを自動実行し、�
 ---
 # UI Review
 
-受取金ページのUIレビューを実施し、スクリーンショットと改善提案を作成する。  
+主要ページ（ホーム・銘柄検索・保有銘柄・受取金）のUIレビューを実施し、スクリーンショットと改善提案を作成する。  
 **MCPでもE2Eでも、やることと成果物は同じ。**
 
 ## Usage
@@ -23,6 +23,10 @@ description: "開発サーバーに対してUIレビューを自動実行し、�
 
 | ファイル名 | 内容 |
 |---|---|
+| `home-initial.png` | ホームページの初期表示 |
+| `search-nintendo-result.png` | 銘柄検索で「任天堂」を検索した結果 |
+| `assetbalance-initial.png` | 保有銘柄ページの初期表示 |
+| `assetbalance-search-security.png` | 保有銘柄ページの銘柄検索結果 |
 | `receipts-dividend-initial.png` | 配当金タブの初期表示 |
 | `receipts-domestic-stock-initial.png` | 国内株式タブの初期表示 |
 | `receipts-mutualfund-initial.png` | 投資信託タブの初期表示 |
@@ -53,8 +57,11 @@ rm -f .playwright-mcp/*.png
 
 #### A. MCPで取得する場合
 - 先にログインを完了してから開始する
-- `http://localhost:8080/receipts` に遷移
-- 各タブ/検索状態を操作し、上表と同名で `png` 保存
+- `http://localhost:8080/` に遷移して `home-initial.png` を保存
+- `http://localhost:8080/search` で `任天堂` を検索し、`search-nintendo-result.png` を保存
+- `http://localhost:8080/assetbalance` に遷移し、初期表示を `assetbalance-initial.png` として保存
+- 保有銘柄の検索オプション（銘柄）を1つ選択し、`assetbalance-search-security.png` を保存
+- `http://localhost:8080/receipts` に遷移し、各タブ/検索状態を操作して受取金の9枚を保存
 - 設定は `fullPage: true`
 
 #### B. E2Eで取得する場合

--- a/.claude/commands/ui-review.md
+++ b/.claude/commands/ui-review.md
@@ -100,12 +100,11 @@ mcp__playwright__browser_take_screenshot:
 | 項目 | /ui-review (MCP版) | npm run (E2E版) |
 |------|-------------------|-----------------|
 | 実行方法 | Claude Code から `/ui-review` | ターミナルで `npm run ui:screenshot` |
-| 保存先 | `.playwright-mcp/` | `frontend/screenshots/` |
 | 対象 | 全ページの概要 | 受取金ページの詳細（タブ・検索） |
 | 認証 | 手動ログイン依頼 | storageState で保持可能 |
 
 ### 保存先
-`frontend/screenshots/` ディレクトリに保存されます（コミット可能）。
+`.playwright-mcp/` ディレクトリに保存されます（両方式で共通）。
 
 ### 取得するスクリーンショット
 | ファイル名 | 内容 |
@@ -142,11 +141,12 @@ npm run ui:screenshot:auth
 
 ### ファイル構成
 ```
-frontend/
-├── e2e/
-│   ├── ui-screenshots.spec.ts  # スクショ取得スクリプト
-│   └── save-auth.spec.ts       # ログイン状態保存スクリプト
-├── screenshots/                # スクショ保存先（コミット可能）
-├── .auth/                      # 認証情報（.gitignore対象）
-└── playwright.config.ts        # Playwright設定
+shoken-webapp/
+├── .playwright-mcp/              # スクショ保存先（共通）
+└── frontend/
+    ├── e2e/
+    │   ├── ui-screenshots.spec.ts  # スクショ取得スクリプト
+    │   └── save-auth.spec.ts       # ログイン状態保存スクリプト
+    ├── .auth/                      # 認証情報（.gitignore対象）
+    └── playwright.config.ts        # Playwright設定
 ```

--- a/.claude/commands/ui-review.md
+++ b/.claude/commands/ui-review.md
@@ -2,7 +2,9 @@
 description: "開発サーバーに対してUIレビューを自動実行し、スクリーンショットとAI分析レポートを生成します。"
 ---
 # UI Review
-Claude Code で完結するUIレビューシステム（Playwright MCP版）
+
+受取金ページのUIレビューを実施し、スクリーンショットと改善提案を作成する。  
+**MCPでもE2Eでも、やることと成果物は同じ。**
 
 ## Usage
 ```
@@ -11,26 +13,16 @@ Claude Code で完結するUIレビューシステム（Playwright MCP版）
 /ui-review --review-only      # 既存画像の分析のみ
 ```
 
-### 保存先
-`.playwright-mcp/` ディレクトリに保存される。
+## 完了条件
+1. `.playwright-mcp/` に対象スクリーンショットが揃っている  
+2. UIレビューレポート（日本語）が出ている  
+3. 改善提案に優先度（高/中/低）が付いている
 
-## Implementation Steps
+## 保存先・成果物（共通）
+保存先: `.playwright-mcp/`
 
-### 1. 環境チェック
-1. 開発サーバー `http://localhost:8080` の起動確認
-   - 起動していない場合: ユーザーに起動を促す
-2. ToolSearch で `playwright` ツールをロード
-   - `ToolSearch` に `playwright screenshot navigate` でツールを検索
-
-### 2. スクリーンショット取得
-1. `.playwright-mcp/` ディレクトリ内の既存画像を削除
-   ```bash
-   rm -f .playwright-mcp/*.png
-   ```
-2. `mcp__playwright__browser_navigate` で `http://localhost:8080/receipts` に遷移
-3. 各タブについてスクリーンショットを取得:
 | ファイル名 | 内容 |
-|-----------|------|
+|---|---|
 | `receipts-dividend-initial.png` | 配当金タブの初期表示 |
 | `receipts-domestic-stock-initial.png` | 国内株式タブの初期表示 |
 | `receipts-mutualfund-initial.png` | 投資信託タブの初期表示 |
@@ -40,21 +32,49 @@ Claude Code で完結するUIレビューシステム（Playwright MCP版）
 | `receipts-domestic-stock-search-account.png` | 国内株式 - 口座検索結果 |
 | `receipts-mutualfund-search-year.png` | 投資信託 - 西暦検索結果 |
 | `receipts-mutualfund-search-fund.png` | 投資信託 - ファンド検索結果 |
-4. スクリーンショット取得時の設定:
-   - `fullPage`: true（全ページキャプチャ）
-   - `type`: png
 
-### 3. UI分析
-Read ツールで各スクリーンショットを読み込み、以下の観点で分析:
-- **視認性**: テキストサイズ、コントラスト、情報の階層
-- **操作性**: ボタン配置、クリック領域、ナビゲーション
-- **一貫性**: デザインパターン、カラースキーム、スペーシング
-- **レスポンシブ**: モバイル対応、ブレークポイント
-- **アクセシビリティ**: フォーカス状態、ラベル、セマンティクス
+## 実施手順（共通）
 
-### 4. レポート生成
-分析結果を以下の形式で出力:
+### 1) 事前確認
+- `http://localhost:8080` が利用可能であること（本レビューは **8080固定**）
+- **ログインは必須**。必ず認証状態を準備する
+- このアプリのレビューは **PC表示前提**（モバイル評価は対象外）
 
+### 2) 既存スクショを削除
+```bash
+rm -f .playwright-mcp/*.png
+```
+
+### 3) スクショを取得（MCPかE2Eのどちらか）
+
+#### A. MCPで取得する場合
+- 先にログインを完了してから開始する
+- `http://localhost:8080/receipts` に遷移
+- 各タブ/検索状態を操作し、上表と同名で `png` 保存
+- 設定は `fullPage: true`
+
+#### B. E2Eで取得する場合
+```bash
+cd frontend
+
+# ログイン状態を保存（必須）
+npm run ui:save-auth
+
+# 保存した認証情報を使ってスクショ取得
+npm run ui:screenshot:auth
+```
+
+※ `npm run ui:screenshot` は認証情報を読み込まないため、本レビューでは使用しない。
+
+### 4) UIレビュー（画像分析）
+以下の観点で評価する:
+- 視認性（文字サイズ、コントラスト、情報の階層）
+- 操作性（クリック領域、状態の分かりやすさ、導線）
+- 一貫性（配色、余白、コンポーネント挙動）
+- データ表示の妥当性（ラベル誤り、不自然な空白、誤解を生む表現）
+- アクセシビリティ（フォーカス、ラベル、可読性）
+
+### 5) レポート出力
 ```markdown
 ## UIレビューレポート
 
@@ -67,7 +87,7 @@ Read ツールで各スクリーンショットを読み込み、以下の観点
 
 ### 改善提案
 | 優先度 | 画面 | 問題 | 改善案 |
-|--------|------|------|--------|
+|---|---|---|---|
 | 高 | ... | ... | ... |
 
 ### 推奨アクション
@@ -75,62 +95,7 @@ Read ツールで各スクリーンショットを読み込み、以下の観点
 2. ...
 ```
 
-## Playwright MCP ツール使用例
-
-```
-# ツールのロード
-ToolSearch: query="playwright screenshot navigate"
-
-# ページ遷移
-mcp__playwright__browser_navigate: url="http://localhost:8080/receipts"
-
-# スクリーンショット取得
-mcp__playwright__browser_take_screenshot:
-  type="png"
-  filename="receipts-dividend.png"
-  fullPage=true
-```
-
-## 注意事項
-- 開発サーバーが起動していない場合は起動を促す
-- スクリーンショット取得に失敗した画面はスキップして続行
-- レポートは日本語で出力
-- 認証が必要なページはユーザーにログインを依頼する
-
----
-
-## E2E版（npm コマンド）
-
-MCP版と同じスクリーンショットを npm コマンドでも取得できる。
-
-### 実行コマンド
-
-```bash
-cd frontend
-
-# 1. 開発サーバーを起動（別ターミナル）
-npm run dev
-
-# 2. スクリーンショット取得（ログイン不要の場合）
-npm run ui:screenshot
-
-# 3. ログインが必要な場合
-#    3-1. ログイン状態を保存
-npm run ui:save-auth
-#    ブラウザが開くので手動でログイン後、ターミナルでEnterを押す
-
-#    3-2. 保存した認証情報を使ってスクショ取得
-npm run ui:screenshot:auth
-```
-
-### ファイル構成
-```
-shoken-webapp/
-├── .playwright-mcp/              # スクショ保存先（共通）
-└── frontend/
-    ├── e2e/
-    │   ├── ui-screenshots.spec.ts  # スクショ取得スクリプト
-    │   └── save-auth.spec.ts       # ログイン状態保存スクリプト
-    ├── .auth/                      # 認証情報（.gitignore対象）
-    └── playwright.config.ts        # Playwright設定
-```
+## 運用ルール
+- スクショ取得に一部失敗しても、取得できた分でレビューを継続
+- 失敗ファイルは「未取得」と明記
+- レポートは必ず日本語で出力

--- a/.claude/commands/ui-review.md
+++ b/.claude/commands/ui-review.md
@@ -89,3 +89,64 @@ mcp__playwright__browser_take_screenshot:
 - スクリーンショット取得に失敗した画面はスキップして続行
 - レポートは日本語で出力
 - 認証が必要なページはユーザーにログインを依頼する
+
+---
+
+## 受取金ページ詳細スクリーンショット（npm コマンド版）
+
+上記の `/ui-review` コマンドとは別に、受取金ページの詳細なスクリーンショットを npm コマンドで取得できます。
+
+### 違い
+| 項目 | /ui-review (MCP版) | npm run (E2E版) |
+|------|-------------------|-----------------|
+| 実行方法 | Claude Code から `/ui-review` | ターミナルで `npm run ui:screenshot` |
+| 保存先 | `.playwright-mcp/` | `frontend/screenshots/` |
+| 対象 | 全ページの概要 | 受取金ページの詳細（タブ・検索） |
+| 認証 | 手動ログイン依頼 | storageState で保持可能 |
+
+### 保存先
+`frontend/screenshots/` ディレクトリに保存されます（コミット可能）。
+
+### 取得するスクリーンショット
+| ファイル名 | 内容 |
+|-----------|------|
+| `receipts-dividend-initial.png` | 配当金タブの初期表示 |
+| `receipts-domestic-stock-initial.png` | 国内株式タブの初期表示 |
+| `receipts-mutualfund-initial.png` | 投資信託タブの初期表示 |
+| `receipts-dividend-search-year.png` | 配当金 - 西暦検索結果 |
+| `receipts-dividend-search-security.png` | 配当金 - 銘柄検索結果 |
+| `receipts-domestic-stock-search-year.png` | 国内株式 - 西暦検索結果 |
+| `receipts-domestic-stock-search-account.png` | 国内株式 - 口座検索結果 |
+| `receipts-mutualfund-search-year.png` | 投資信託 - 西暦検索結果 |
+| `receipts-mutualfund-search-fund.png` | 投資信託 - ファンド検索結果 |
+
+### 実行コマンド
+
+```bash
+cd frontend
+
+# 1. 開発サーバーを起動（別ターミナル）
+npm run dev
+
+# 2. スクリーンショット取得（ログイン不要の場合）
+npm run ui:screenshot
+
+# 3. ログインが必要な場合
+#    3-1. ログイン状態を保存
+npm run ui:save-auth
+#    ブラウザが開くので手動でログイン後、ターミナルでEnterを押す
+
+#    3-2. 保存した認証情報を使ってスクショ取得
+npm run ui:screenshot:auth
+```
+
+### ファイル構成
+```
+frontend/
+├── e2e/
+│   ├── ui-screenshots.spec.ts  # スクショ取得スクリプト
+│   └── save-auth.spec.ts       # ログイン状態保存スクリプト
+├── screenshots/                # スクショ保存先（コミット可能）
+├── .auth/                      # 認証情報（.gitignore対象）
+└── playwright.config.ts        # Playwright設定
+```

--- a/.claude/commands/ui-review.md
+++ b/.claude/commands/ui-review.md
@@ -36,9 +36,13 @@ description: "開発サーバーに対してUIレビューを自動実行し、�
 ## 実施手順（共通）
 
 ### 1) 事前確認
-- `http://localhost:8080` が利用可能であること（本レビューは **8080固定**）
+- 本レビューは **8080固定**（`http://127.0.0.1:8080` を使用）
 - **ログインは必須**。必ず認証状態を準備する
 - このアプリのレビューは **PC表示前提**（モバイル評価は対象外）
+- 開発サーバー運用は以下を厳守する
+  - 8080が既に起動中なら **再利用**（新規起動しない）
+  - 新規起動時は `--strictPort` を必須化（8081/8082への自動フォールバック禁止）
+  - 新規起動したプロセスは `trap` で必ず停止する（残留防止）
 
 ### 2) 既存スクショを削除
 ```bash
@@ -55,16 +59,34 @@ rm -f .playwright-mcp/*.png
 
 #### B. E2Eで取得する場合
 ```bash
+set -euo pipefail
 cd frontend
 
-# ログイン状態を保存（必須）
-npm run ui:save-auth
+# ログイン状態を保存（初回のみ/期限切れ時）
+# npm run ui:save-auth
+
+STARTED=0
+if curl -sSf http://127.0.0.1:8080/ >/dev/null 2>&1; then
+  echo "reuse existing server on :8080"
+else
+  npm run dev -- --host 127.0.0.1 --port 8080 --strictPort >/tmp/shoken-dev.log 2>&1 &
+  DEV_PID=$!
+  STARTED=1
+fi
+
+cleanup() {
+  if [ "$STARTED" -eq 1 ]; then
+    kill "$DEV_PID" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT INT TERM
 
 # 保存した認証情報を使ってスクショ取得
 npm run ui:screenshot:auth
 ```
 
 ※ `npm run ui:screenshot` は認証情報を読み込まないため、本レビューでは使用しない。
+※ `npm run dev` を単独でバックグラウンド起動して放置しないこと（プロセス残留の原因）。
 
 ### 4) UIレビュー（画像分析）
 以下の観点で評価する:
@@ -99,3 +121,4 @@ npm run ui:screenshot:auth
 - スクショ取得に一部失敗しても、取得できた分でレビューを継続
 - 失敗ファイルは「未取得」と明記
 - レポートは必ず日本語で出力
+- 作業終了時に `8080/8081/8082` の不要プロセスが残っていないことを確認する

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -45,3 +45,9 @@ coverage
 # TypeScript
 *.tsbuildinfo
 .vercel
+
+# Playwright
+.auth/
+playwright-report/
+test-results/
+screenshots/

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -50,4 +50,3 @@ coverage
 .auth/
 playwright-report/
 test-results/
-screenshots/

--- a/frontend/e2e/save-auth.spec.ts
+++ b/frontend/e2e/save-auth.spec.ts
@@ -32,7 +32,7 @@ async function main() {
   });
 
   const page = context.pages()[0] || await context.newPage();
-  await page.goto('http://localhost:8081/');
+  await page.goto('http://localhost:8080/');
 
   console.log('ブラウザでログインしてください。');
   console.log('ログイン完了後、このターミナルでEnterを押してください。');

--- a/frontend/e2e/save-auth.spec.ts
+++ b/frontend/e2e/save-auth.spec.ts
@@ -1,0 +1,53 @@
+import { chromium } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const AUTH_DIR = path.join(__dirname, '../.auth');
+const AUTH_FILE = path.join(AUTH_DIR, 'storage-state.json');
+const USER_DATA_DIR = path.join(AUTH_DIR, 'user-data');
+
+/**
+ * ログイン状態を保存するためのスクリプト
+ *
+ * 永続的なユーザーデータディレクトリを使用してGoogleログイン制限を回避
+ */
+async function main() {
+  // ディレクトリ作成
+  if (!fs.existsSync(AUTH_DIR)) {
+    fs.mkdirSync(AUTH_DIR, { recursive: true });
+  }
+
+  console.log('\n====================================');
+  console.log('永続ブラウザを起動します...');
+  console.log('====================================\n');
+
+  // 永続的なコンテキストでブラウザを起動
+  const context = await chromium.launchPersistentContext(USER_DATA_DIR, {
+    headless: false,
+    channel: 'chrome',
+    args: ['--disable-blink-features=AutomationControlled'],
+  });
+
+  const page = context.pages()[0] || await context.newPage();
+  await page.goto('http://localhost:8080/');
+
+  console.log('ブラウザでログインしてください。');
+  console.log('ログイン完了後、このターミナルでEnterを押してください。');
+  console.log('====================================\n');
+
+  // stdinからの入力を待機
+  await new Promise<void>((resolve) => {
+    process.stdin.once('data', () => resolve());
+  });
+
+  // ログイン状態を保存
+  await context.storageState({ path: AUTH_FILE });
+  console.log(`\nログイン状態を保存しました: ${AUTH_FILE}`);
+
+  await context.close();
+}
+
+main().catch(console.error);

--- a/frontend/e2e/save-auth.spec.ts
+++ b/frontend/e2e/save-auth.spec.ts
@@ -32,7 +32,7 @@ async function main() {
   });
 
   const page = context.pages()[0] || await context.newPage();
-  await page.goto('http://localhost:8080/');
+  await page.goto('http://localhost:8081/');
 
   console.log('ブラウザでログインしてください。');
   console.log('ログイン完了後、このターミナルでEnterを押してください。');

--- a/frontend/e2e/ui-screenshots.spec.ts
+++ b/frontend/e2e/ui-screenshots.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test } from '@playwright/test';
 import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';

--- a/frontend/e2e/ui-screenshots.spec.ts
+++ b/frontend/e2e/ui-screenshots.spec.ts
@@ -11,79 +11,47 @@ import { fileURLToPath } from 'url';
  * 2. スクショ取得: npm run ui:screenshot
  *
  * ログインが必要な場合:
- * 1. 手動でブラウザを開きログイン
- * 2. npm run ui:save-auth でログイン状態を保存
- * 3. npm run ui:screenshot で実行
+ * 1. npm run ui:save-auth でログイン状態を保存
+ * 2. npm run ui:screenshot:auth で実行
+ *
+ * 取得するスクリーンショット:
+ * - receipts-dividend.png: 配当金タブの初期表示
+ * - receipts-dividend-search.png: 配当金 - 銘柄検索結果（配当シミュレーション表示）
+ * - receipts-domestic-stock.png: 国内株式タブの初期表示
+ * - receipts-mutualfund.png: 投資信託タブの初期表示
  */
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const SCREENSHOT_DIR = path.join(__dirname, '../../.playwright-mcp');
-const TABS = [
-  { name: 'dividend', label: '配当金', index: 0 },
-  { name: 'domestic-stock', label: '国内株式', index: 1 },
-  { name: 'mutualfund', label: '投資信託', index: 2 },
-] as const;
 
-// スクショ保存ディレクトリを作成
+// スクショ保存ディレクトリを作成し、既存画像を削除
 test.beforeAll(async () => {
   if (!fs.existsSync(SCREENSHOT_DIR)) {
     fs.mkdirSync(SCREENSHOT_DIR, { recursive: true });
   }
-});
-
-// 各タブの初期表示をスクショ
-test.describe('受取金ページ - タブ初期表示', () => {
-  for (const tab of TABS) {
-    test(`${tab.label}タブの初期表示`, async ({ page }) => {
-      await page.goto('/receipts');
-      await page.waitForLoadState('networkidle');
-
-      // タブをクリック
-      if (tab.index > 0) {
-        const tabButton = page.getByRole('tab', { name: tab.label });
-        await tabButton.click();
-        await page.waitForLoadState('networkidle');
-      }
-
-      // データ読み込み待機（最大5秒）
-      await page.waitForTimeout(2000);
-
-      // スクショ取得
-      await page.screenshot({
-        path: path.join(SCREENSHOT_DIR, `receipts-${tab.name}-initial.png`),
-        fullPage: true,
-      });
-    });
+  // 既存のスクリーンショットを削除
+  const files = fs.readdirSync(SCREENSHOT_DIR);
+  for (const file of files) {
+    if (file.endsWith('.png')) {
+      fs.unlinkSync(path.join(SCREENSHOT_DIR, file));
+    }
   }
 });
 
-// 各タブの検索結果をスクショ
-test.describe('受取金ページ - 検索結果', () => {
-  test('配当金 - 西暦検索', async ({ page }) => {
+test.describe('受取金ページ - スクリーンショット', () => {
+  test('配当金タブの初期表示', async ({ page }) => {
     await page.goto('/receipts');
     await page.waitForLoadState('networkidle');
-    await page.waitForTimeout(1000);
-
-    // 検索オプションが表示されるまで待機
-    const yearSelect = page.locator('#years-search');
-    if (await yearSelect.isVisible()) {
-      // 最初の年度オプションを選択（全て表示以外）
-      const options = await yearSelect.locator('option').allTextContents();
-      const yearOption = options.find(opt => /^\d{4}年$/.test(opt));
-      if (yearOption) {
-        await yearSelect.selectOption({ label: yearOption });
-        await page.waitForTimeout(1500);
-      }
-    }
+    await page.waitForTimeout(2000);
 
     await page.screenshot({
-      path: path.join(SCREENSHOT_DIR, 'receipts-dividend-search-year.png'),
+      path: path.join(SCREENSHOT_DIR, 'receipts-dividend.png'),
       fullPage: true,
     });
   });
 
-  test('配当金 - 銘柄検索', async ({ page }) => {
+  test('配当金 - 銘柄検索（配当シミュレーション表示）', async ({ page }) => {
     await page.goto('/receipts');
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(1000);
@@ -101,107 +69,37 @@ test.describe('受取金ページ - 検索結果', () => {
     }
 
     await page.screenshot({
-      path: path.join(SCREENSHOT_DIR, 'receipts-dividend-search-security.png'),
+      path: path.join(SCREENSHOT_DIR, 'receipts-dividend-search.png'),
       fullPage: true,
     });
   });
 
-  test('国内株式 - 西暦検索', async ({ page }) => {
+  test('国内株式タブの初期表示', async ({ page }) => {
     await page.goto('/receipts');
     await page.waitForLoadState('networkidle');
 
     // 国内株式タブをクリック
     await page.getByRole('tab', { name: '国内株式' }).click();
     await page.waitForLoadState('networkidle');
-    await page.waitForTimeout(1000);
-
-    // 西暦検索
-    const yearSelect = page.locator('#years-search');
-    if (await yearSelect.isVisible()) {
-      const options = await yearSelect.locator('option').allTextContents();
-      const yearOption = options.find(opt => /^\d{4}年$/.test(opt));
-      if (yearOption) {
-        await yearSelect.selectOption({ label: yearOption });
-        await page.waitForTimeout(1500);
-      }
-    }
+    await page.waitForTimeout(2000);
 
     await page.screenshot({
-      path: path.join(SCREENSHOT_DIR, 'receipts-domestic-stock-search-year.png'),
+      path: path.join(SCREENSHOT_DIR, 'receipts-domestic-stock.png'),
       fullPage: true,
     });
   });
 
-  test('国内株式 - 口座検索', async ({ page }) => {
-    await page.goto('/receipts');
-    await page.waitForLoadState('networkidle');
-
-    // 国内株式タブをクリック
-    await page.getByRole('tab', { name: '国内株式' }).click();
-    await page.waitForLoadState('networkidle');
-    await page.waitForTimeout(1000);
-
-    // 口座ボタンが表示されていればクリック
-    const accountButtons = page.locator('button:has-text("特定")');
-    if (await accountButtons.first().isVisible()) {
-      await accountButtons.first().click();
-      await page.waitForTimeout(1500);
-    }
-
-    await page.screenshot({
-      path: path.join(SCREENSHOT_DIR, 'receipts-domestic-stock-search-account.png'),
-      fullPage: true,
-    });
-  });
-
-  test('投資信託 - 西暦検索', async ({ page }) => {
+  test('投資信託タブの初期表示', async ({ page }) => {
     await page.goto('/receipts');
     await page.waitForLoadState('networkidle');
 
     // 投資信託タブをクリック
     await page.getByRole('tab', { name: '投資信託' }).click();
     await page.waitForLoadState('networkidle');
-    await page.waitForTimeout(1000);
-
-    // 西暦検索
-    const yearSelect = page.locator('#years-search');
-    if (await yearSelect.isVisible()) {
-      const options = await yearSelect.locator('option').allTextContents();
-      const yearOption = options.find(opt => /^\d{4}年$/.test(opt));
-      if (yearOption) {
-        await yearSelect.selectOption({ label: yearOption });
-        await page.waitForTimeout(1500);
-      }
-    }
+    await page.waitForTimeout(2000);
 
     await page.screenshot({
-      path: path.join(SCREENSHOT_DIR, 'receipts-mutualfund-search-year.png'),
-      fullPage: true,
-    });
-  });
-
-  test('投資信託 - ファンド検索', async ({ page }) => {
-    await page.goto('/receipts');
-    await page.waitForLoadState('networkidle');
-
-    // 投資信託タブをクリック
-    await page.getByRole('tab', { name: '投資信託' }).click();
-    await page.waitForLoadState('networkidle');
-    await page.waitForTimeout(1000);
-
-    // ファンドセレクトが表示されていれば選択
-    const securitySelect = page.locator('#securities-search');
-    if (await securitySelect.isVisible()) {
-      const options = await securitySelect.locator('option').allTextContents();
-      const fundOption = options.find(opt => opt !== '全て表示' && opt !== '');
-      if (fundOption) {
-        await securitySelect.selectOption({ label: fundOption });
-        await page.waitForTimeout(1500);
-      }
-    }
-
-    await page.screenshot({
-      path: path.join(SCREENSHOT_DIR, 'receipts-mutualfund-search-fund.png'),
+      path: path.join(SCREENSHOT_DIR, 'receipts-mutualfund.png'),
       fullPage: true,
     });
   });

--- a/frontend/e2e/ui-screenshots.spec.ts
+++ b/frontend/e2e/ui-screenshots.spec.ts
@@ -18,7 +18,7 @@ import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const SCREENSHOT_DIR = path.join(__dirname, '../screenshots');
+const SCREENSHOT_DIR = path.join(__dirname, '../../.playwright-mcp');
 const TABS = [
   { name: 'dividend', label: '配当金', index: 0 },
   { name: 'domestic-stock', label: '国内株式', index: 1 },

--- a/frontend/e2e/ui-screenshots.spec.ts
+++ b/frontend/e2e/ui-screenshots.spec.ts
@@ -11,47 +11,79 @@ import { fileURLToPath } from 'url';
  * 2. スクショ取得: npm run ui:screenshot
  *
  * ログインが必要な場合:
- * 1. npm run ui:save-auth でログイン状態を保存
- * 2. npm run ui:screenshot:auth で実行
- *
- * 取得するスクリーンショット:
- * - receipts-dividend.png: 配当金タブの初期表示
- * - receipts-dividend-search.png: 配当金 - 銘柄検索結果（配当シミュレーション表示）
- * - receipts-domestic-stock.png: 国内株式タブの初期表示
- * - receipts-mutualfund.png: 投資信託タブの初期表示
+ * 1. 手動でブラウザを開きログイン
+ * 2. npm run ui:save-auth でログイン状態を保存
+ * 3. npm run ui:screenshot で実行
  */
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const SCREENSHOT_DIR = path.join(__dirname, '../../.playwright-mcp');
+const TABS = [
+  { name: 'dividend', label: '配当金', index: 0 },
+  { name: 'domestic-stock', label: '国内株式', index: 1 },
+  { name: 'mutualfund', label: '投資信託', index: 2 },
+] as const;
 
-// スクショ保存ディレクトリを作成し、既存画像を削除
+// スクショ保存ディレクトリを作成
 test.beforeAll(async () => {
   if (!fs.existsSync(SCREENSHOT_DIR)) {
     fs.mkdirSync(SCREENSHOT_DIR, { recursive: true });
   }
-  // 既存のスクリーンショットを削除
-  const files = fs.readdirSync(SCREENSHOT_DIR);
-  for (const file of files) {
-    if (file.endsWith('.png')) {
-      fs.unlinkSync(path.join(SCREENSHOT_DIR, file));
-    }
+});
+
+// 各タブの初期表示をスクショ
+test.describe('受取金ページ - タブ初期表示', () => {
+  for (const tab of TABS) {
+    test(`${tab.label}タブの初期表示`, async ({ page }) => {
+      await page.goto('/receipts');
+      await page.waitForLoadState('networkidle');
+
+      // タブをクリック
+      if (tab.index > 0) {
+        const tabButton = page.getByRole('tab', { name: tab.label });
+        await tabButton.click();
+        await page.waitForLoadState('networkidle');
+      }
+
+      // データ読み込み待機（最大5秒）
+      await page.waitForTimeout(2000);
+
+      // スクショ取得
+      await page.screenshot({
+        path: path.join(SCREENSHOT_DIR, `receipts-${tab.name}-initial.png`),
+        fullPage: true,
+      });
+    });
   }
 });
 
-test.describe('受取金ページ - スクリーンショット', () => {
-  test('配当金タブの初期表示', async ({ page }) => {
+// 各タブの検索結果をスクショ
+test.describe('受取金ページ - 検索結果', () => {
+  test('配当金 - 西暦検索', async ({ page }) => {
     await page.goto('/receipts');
     await page.waitForLoadState('networkidle');
-    await page.waitForTimeout(2000);
+    await page.waitForTimeout(1000);
+
+    // 検索オプションが表示されるまで待機
+    const yearSelect = page.locator('#years-search');
+    if (await yearSelect.isVisible()) {
+      // 最初の年度オプションを選択（全て表示以外）
+      const options = await yearSelect.locator('option').allTextContents();
+      const yearOption = options.find(opt => /^\d{4}年$/.test(opt));
+      if (yearOption) {
+        await yearSelect.selectOption({ label: yearOption });
+        await page.waitForTimeout(1500);
+      }
+    }
 
     await page.screenshot({
-      path: path.join(SCREENSHOT_DIR, 'receipts-dividend.png'),
+      path: path.join(SCREENSHOT_DIR, 'receipts-dividend-search-year.png'),
       fullPage: true,
     });
   });
 
-  test('配当金 - 銘柄検索（配当シミュレーション表示）', async ({ page }) => {
+  test('配当金 - 銘柄検索', async ({ page }) => {
     await page.goto('/receipts');
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(1000);
@@ -69,37 +101,107 @@ test.describe('受取金ページ - スクリーンショット', () => {
     }
 
     await page.screenshot({
-      path: path.join(SCREENSHOT_DIR, 'receipts-dividend-search.png'),
+      path: path.join(SCREENSHOT_DIR, 'receipts-dividend-search-security.png'),
       fullPage: true,
     });
   });
 
-  test('国内株式タブの初期表示', async ({ page }) => {
+  test('国内株式 - 西暦検索', async ({ page }) => {
     await page.goto('/receipts');
     await page.waitForLoadState('networkidle');
 
     // 国内株式タブをクリック
     await page.getByRole('tab', { name: '国内株式' }).click();
     await page.waitForLoadState('networkidle');
-    await page.waitForTimeout(2000);
+    await page.waitForTimeout(1000);
+
+    // 西暦検索
+    const yearSelect = page.locator('#years-search');
+    if (await yearSelect.isVisible()) {
+      const options = await yearSelect.locator('option').allTextContents();
+      const yearOption = options.find(opt => /^\d{4}年$/.test(opt));
+      if (yearOption) {
+        await yearSelect.selectOption({ label: yearOption });
+        await page.waitForTimeout(1500);
+      }
+    }
 
     await page.screenshot({
-      path: path.join(SCREENSHOT_DIR, 'receipts-domestic-stock.png'),
+      path: path.join(SCREENSHOT_DIR, 'receipts-domestic-stock-search-year.png'),
       fullPage: true,
     });
   });
 
-  test('投資信託タブの初期表示', async ({ page }) => {
+  test('国内株式 - 口座検索', async ({ page }) => {
+    await page.goto('/receipts');
+    await page.waitForLoadState('networkidle');
+
+    // 国内株式タブをクリック
+    await page.getByRole('tab', { name: '国内株式' }).click();
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(1000);
+
+    // 口座ボタンが表示されていればクリック
+    const accountButtons = page.locator('button:has-text("特定")');
+    if (await accountButtons.first().isVisible()) {
+      await accountButtons.first().click();
+      await page.waitForTimeout(1500);
+    }
+
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, 'receipts-domestic-stock-search-account.png'),
+      fullPage: true,
+    });
+  });
+
+  test('投資信託 - 西暦検索', async ({ page }) => {
     await page.goto('/receipts');
     await page.waitForLoadState('networkidle');
 
     // 投資信託タブをクリック
     await page.getByRole('tab', { name: '投資信託' }).click();
     await page.waitForLoadState('networkidle');
-    await page.waitForTimeout(2000);
+    await page.waitForTimeout(1000);
+
+    // 西暦検索
+    const yearSelect = page.locator('#years-search');
+    if (await yearSelect.isVisible()) {
+      const options = await yearSelect.locator('option').allTextContents();
+      const yearOption = options.find(opt => /^\d{4}年$/.test(opt));
+      if (yearOption) {
+        await yearSelect.selectOption({ label: yearOption });
+        await page.waitForTimeout(1500);
+      }
+    }
 
     await page.screenshot({
-      path: path.join(SCREENSHOT_DIR, 'receipts-mutualfund.png'),
+      path: path.join(SCREENSHOT_DIR, 'receipts-mutualfund-search-year.png'),
+      fullPage: true,
+    });
+  });
+
+  test('投資信託 - ファンド検索', async ({ page }) => {
+    await page.goto('/receipts');
+    await page.waitForLoadState('networkidle');
+
+    // 投資信託タブをクリック
+    await page.getByRole('tab', { name: '投資信託' }).click();
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(1000);
+
+    // ファンドセレクトが表示されていれば選択
+    const securitySelect = page.locator('#securities-search');
+    if (await securitySelect.isVisible()) {
+      const options = await securitySelect.locator('option').allTextContents();
+      const fundOption = options.find(opt => opt !== '全て表示' && opt !== '');
+      if (fundOption) {
+        await securitySelect.selectOption({ label: fundOption });
+        await page.waitForTimeout(1500);
+      }
+    }
+
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, 'receipts-mutualfund-search-fund.png'),
       fullPage: true,
     });
   });

--- a/frontend/e2e/ui-screenshots.spec.ts
+++ b/frontend/e2e/ui-screenshots.spec.ts
@@ -1,10 +1,10 @@
-import { test } from '@playwright/test';
+import { test, type Page } from '@playwright/test';
 import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 
 /**
- * 受取金ページのUIレビュー用スクリーンショット取得
+ * UIレビュー用スクリーンショット取得
  *
  * 使用方法:
  * 1. 開発サーバーを起動: npm run dev
@@ -25,6 +25,30 @@ const TABS = [
   { name: 'mutualfund', label: '投資信託', index: 2 },
 ] as const;
 
+async function waitForPageReady(page: Page) {
+  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(1000);
+}
+
+async function selectFirstNonDefaultOption(
+  page: Page,
+  selector: string
+) {
+  const select = page.locator(selector);
+  if (!(await select.isVisible())) {
+    return;
+  }
+
+  const options = await select.locator('option').allTextContents();
+  const option = options.find(opt => opt !== '全て表示' && opt !== '');
+  if (!option) {
+    return;
+  }
+
+  await select.selectOption({ label: option });
+  await page.waitForTimeout(1500);
+}
+
 // スクショ保存ディレクトリを作成
 test.beforeAll(async () => {
   if (!fs.existsSync(SCREENSHOT_DIR)) {
@@ -32,22 +56,87 @@ test.beforeAll(async () => {
   }
 });
 
+test.describe('主要ページ', () => {
+  test('ホームページ - 初期表示', async ({ page }) => {
+    await page.goto('/');
+    await waitForPageReady(page);
+
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, 'home-initial.png'),
+      fullPage: true,
+    });
+  });
+
+  test('銘柄検索 - 任天堂検索', async ({ page }) => {
+    await page.goto('/search');
+    await waitForPageReady(page);
+
+    const codeInput = page.getByLabel('銘柄コード');
+    await codeInput.fill('任天堂');
+    await page.getByRole('button', { name: '検索' }).click();
+    await waitForPageReady(page);
+
+    const hasNintendoResult = await page
+      .locator('text=任天堂')
+      .first()
+      .isVisible({ timeout: 2000 })
+      .catch(() => false);
+
+    // API側が銘柄名検索に対応していない環境でも、任天堂の検索結果を取得するために銘柄コードで再検索
+    if (!hasNintendoResult) {
+      await codeInput.fill('7974');
+      await page.getByRole('button', { name: '検索' }).click();
+      await waitForPageReady(page);
+      await page.waitForTimeout(1000);
+    }
+
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, 'search-nintendo-result.png'),
+      fullPage: true,
+    });
+  });
+
+  test('保有銘柄 - 初期表示', async ({ page }) => {
+    await page.goto('/assetbalance');
+    await waitForPageReady(page);
+    await page.waitForTimeout(2000);
+
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, 'assetbalance-initial.png'),
+      fullPage: true,
+    });
+  });
+
+  test('保有銘柄 - 銘柄検索', async ({ page }) => {
+    await page.goto('/assetbalance');
+    await waitForPageReady(page);
+    await page.waitForTimeout(2000);
+
+    await selectFirstNonDefaultOption(page, '#securities-search');
+
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, 'assetbalance-search-security.png'),
+      fullPage: true,
+    });
+  });
+});
+
 // 各タブの初期表示をスクショ
 test.describe('受取金ページ - タブ初期表示', () => {
   for (const tab of TABS) {
     test(`${tab.label}タブの初期表示`, async ({ page }) => {
       await page.goto('/receipts');
-      await page.waitForLoadState('networkidle');
+      await waitForPageReady(page);
 
       // タブをクリック
       if (tab.index > 0) {
         const tabButton = page.getByRole('tab', { name: tab.label });
         await tabButton.click();
-        await page.waitForLoadState('networkidle');
+        await waitForPageReady(page);
       }
 
       // データ読み込み待機（最大5秒）
-      await page.waitForTimeout(2000);
+      await page.waitForTimeout(1000);
 
       // スクショ取得
       await page.screenshot({
@@ -62,8 +151,7 @@ test.describe('受取金ページ - タブ初期表示', () => {
 test.describe('受取金ページ - 検索結果', () => {
   test('配当金 - 西暦検索', async ({ page }) => {
     await page.goto('/receipts');
-    await page.waitForLoadState('networkidle');
-    await page.waitForTimeout(1000);
+    await waitForPageReady(page);
 
     // 検索オプションが表示されるまで待機
     const yearSelect = page.locator('#years-search');
@@ -85,20 +173,10 @@ test.describe('受取金ページ - 検索結果', () => {
 
   test('配当金 - 銘柄検索', async ({ page }) => {
     await page.goto('/receipts');
-    await page.waitForLoadState('networkidle');
-    await page.waitForTimeout(1000);
+    await waitForPageReady(page);
 
     // 銘柄セレクトが表示されていれば選択
-    const securitySelect = page.locator('#securities-search');
-    if (await securitySelect.isVisible()) {
-      const options = await securitySelect.locator('option').allTextContents();
-      // 「全て表示」以外の最初のオプションを選択
-      const securityOption = options.find(opt => opt !== '全て表示' && opt !== '');
-      if (securityOption) {
-        await securitySelect.selectOption({ label: securityOption });
-        await page.waitForTimeout(1500);
-      }
-    }
+    await selectFirstNonDefaultOption(page, '#securities-search');
 
     await page.screenshot({
       path: path.join(SCREENSHOT_DIR, 'receipts-dividend-search-security.png'),
@@ -108,12 +186,11 @@ test.describe('受取金ページ - 検索結果', () => {
 
   test('国内株式 - 西暦検索', async ({ page }) => {
     await page.goto('/receipts');
-    await page.waitForLoadState('networkidle');
+    await waitForPageReady(page);
 
     // 国内株式タブをクリック
     await page.getByRole('tab', { name: '国内株式' }).click();
-    await page.waitForLoadState('networkidle');
-    await page.waitForTimeout(1000);
+    await waitForPageReady(page);
 
     // 西暦検索
     const yearSelect = page.locator('#years-search');
@@ -134,12 +211,11 @@ test.describe('受取金ページ - 検索結果', () => {
 
   test('国内株式 - 口座検索', async ({ page }) => {
     await page.goto('/receipts');
-    await page.waitForLoadState('networkidle');
+    await waitForPageReady(page);
 
     // 国内株式タブをクリック
     await page.getByRole('tab', { name: '国内株式' }).click();
-    await page.waitForLoadState('networkidle');
-    await page.waitForTimeout(1000);
+    await waitForPageReady(page);
 
     // 口座ボタンが表示されていればクリック
     const accountButtons = page.locator('button:has-text("特定")');
@@ -156,12 +232,11 @@ test.describe('受取金ページ - 検索結果', () => {
 
   test('投資信託 - 西暦検索', async ({ page }) => {
     await page.goto('/receipts');
-    await page.waitForLoadState('networkidle');
+    await waitForPageReady(page);
 
     // 投資信託タブをクリック
     await page.getByRole('tab', { name: '投資信託' }).click();
-    await page.waitForLoadState('networkidle');
-    await page.waitForTimeout(1000);
+    await waitForPageReady(page);
 
     // 西暦検索
     const yearSelect = page.locator('#years-search');
@@ -182,23 +257,14 @@ test.describe('受取金ページ - 検索結果', () => {
 
   test('投資信託 - ファンド検索', async ({ page }) => {
     await page.goto('/receipts');
-    await page.waitForLoadState('networkidle');
+    await waitForPageReady(page);
 
     // 投資信託タブをクリック
     await page.getByRole('tab', { name: '投資信託' }).click();
-    await page.waitForLoadState('networkidle');
-    await page.waitForTimeout(1000);
+    await waitForPageReady(page);
 
     // ファンドセレクトが表示されていれば選択
-    const securitySelect = page.locator('#securities-search');
-    if (await securitySelect.isVisible()) {
-      const options = await securitySelect.locator('option').allTextContents();
-      const fundOption = options.find(opt => opt !== '全て表示' && opt !== '');
-      if (fundOption) {
-        await securitySelect.selectOption({ label: fundOption });
-        await page.waitForTimeout(1500);
-      }
-    }
+    await selectFirstNonDefaultOption(page, '#securities-search');
 
     await page.screenshot({
       path: path.join(SCREENSHOT_DIR, 'receipts-mutualfund-search-fund.png'),

--- a/frontend/e2e/ui-screenshots.spec.ts
+++ b/frontend/e2e/ui-screenshots.spec.ts
@@ -13,7 +13,7 @@ import { fileURLToPath } from 'url';
  * ログインが必要な場合:
  * 1. 手動でブラウザを開きログイン
  * 2. npm run ui:save-auth でログイン状態を保存
- * 3. npm run ui:screenshot で実行
+ * 3. npm run ui:screenshot:auth で実行
  */
 
 const __filename = fileURLToPath(import.meta.url);

--- a/frontend/e2e/ui-screenshots.spec.ts
+++ b/frontend/e2e/ui-screenshots.spec.ts
@@ -1,0 +1,208 @@
+import { test, expect } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+/**
+ * 受取金ページのUIレビュー用スクリーンショット取得
+ *
+ * 使用方法:
+ * 1. 開発サーバーを起動: npm run dev
+ * 2. スクショ取得: npm run ui:screenshot
+ *
+ * ログインが必要な場合:
+ * 1. 手動でブラウザを開きログイン
+ * 2. npm run ui:save-auth でログイン状態を保存
+ * 3. npm run ui:screenshot で実行
+ */
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const SCREENSHOT_DIR = path.join(__dirname, '../screenshots');
+const TABS = [
+  { name: 'dividend', label: '配当金', index: 0 },
+  { name: 'domestic-stock', label: '国内株式', index: 1 },
+  { name: 'mutualfund', label: '投資信託', index: 2 },
+] as const;
+
+// スクショ保存ディレクトリを作成
+test.beforeAll(async () => {
+  if (!fs.existsSync(SCREENSHOT_DIR)) {
+    fs.mkdirSync(SCREENSHOT_DIR, { recursive: true });
+  }
+});
+
+// 各タブの初期表示をスクショ
+test.describe('受取金ページ - タブ初期表示', () => {
+  for (const tab of TABS) {
+    test(`${tab.label}タブの初期表示`, async ({ page }) => {
+      await page.goto('/receipts');
+      await page.waitForLoadState('networkidle');
+
+      // タブをクリック
+      if (tab.index > 0) {
+        const tabButton = page.getByRole('tab', { name: tab.label });
+        await tabButton.click();
+        await page.waitForLoadState('networkidle');
+      }
+
+      // データ読み込み待機（最大5秒）
+      await page.waitForTimeout(2000);
+
+      // スクショ取得
+      await page.screenshot({
+        path: path.join(SCREENSHOT_DIR, `receipts-${tab.name}-initial.png`),
+        fullPage: true,
+      });
+    });
+  }
+});
+
+// 各タブの検索結果をスクショ
+test.describe('受取金ページ - 検索結果', () => {
+  test('配当金 - 西暦検索', async ({ page }) => {
+    await page.goto('/receipts');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(1000);
+
+    // 検索オプションが表示されるまで待機
+    const yearSelect = page.locator('#years-search');
+    if (await yearSelect.isVisible()) {
+      // 最初の年度オプションを選択（全て表示以外）
+      const options = await yearSelect.locator('option').allTextContents();
+      const yearOption = options.find(opt => /^\d{4}年$/.test(opt));
+      if (yearOption) {
+        await yearSelect.selectOption({ label: yearOption });
+        await page.waitForTimeout(1500);
+      }
+    }
+
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, 'receipts-dividend-search-year.png'),
+      fullPage: true,
+    });
+  });
+
+  test('配当金 - 銘柄検索', async ({ page }) => {
+    await page.goto('/receipts');
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(1000);
+
+    // 銘柄セレクトが表示されていれば選択
+    const securitySelect = page.locator('#securities-search');
+    if (await securitySelect.isVisible()) {
+      const options = await securitySelect.locator('option').allTextContents();
+      // 「全て表示」以外の最初のオプションを選択
+      const securityOption = options.find(opt => opt !== '全て表示' && opt !== '');
+      if (securityOption) {
+        await securitySelect.selectOption({ label: securityOption });
+        await page.waitForTimeout(1500);
+      }
+    }
+
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, 'receipts-dividend-search-security.png'),
+      fullPage: true,
+    });
+  });
+
+  test('国内株式 - 西暦検索', async ({ page }) => {
+    await page.goto('/receipts');
+    await page.waitForLoadState('networkidle');
+
+    // 国内株式タブをクリック
+    await page.getByRole('tab', { name: '国内株式' }).click();
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(1000);
+
+    // 西暦検索
+    const yearSelect = page.locator('#years-search');
+    if (await yearSelect.isVisible()) {
+      const options = await yearSelect.locator('option').allTextContents();
+      const yearOption = options.find(opt => /^\d{4}年$/.test(opt));
+      if (yearOption) {
+        await yearSelect.selectOption({ label: yearOption });
+        await page.waitForTimeout(1500);
+      }
+    }
+
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, 'receipts-domestic-stock-search-year.png'),
+      fullPage: true,
+    });
+  });
+
+  test('国内株式 - 口座検索', async ({ page }) => {
+    await page.goto('/receipts');
+    await page.waitForLoadState('networkidle');
+
+    // 国内株式タブをクリック
+    await page.getByRole('tab', { name: '国内株式' }).click();
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(1000);
+
+    // 口座ボタンが表示されていればクリック
+    const accountButtons = page.locator('button:has-text("特定")');
+    if (await accountButtons.first().isVisible()) {
+      await accountButtons.first().click();
+      await page.waitForTimeout(1500);
+    }
+
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, 'receipts-domestic-stock-search-account.png'),
+      fullPage: true,
+    });
+  });
+
+  test('投資信託 - 西暦検索', async ({ page }) => {
+    await page.goto('/receipts');
+    await page.waitForLoadState('networkidle');
+
+    // 投資信託タブをクリック
+    await page.getByRole('tab', { name: '投資信託' }).click();
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(1000);
+
+    // 西暦検索
+    const yearSelect = page.locator('#years-search');
+    if (await yearSelect.isVisible()) {
+      const options = await yearSelect.locator('option').allTextContents();
+      const yearOption = options.find(opt => /^\d{4}年$/.test(opt));
+      if (yearOption) {
+        await yearSelect.selectOption({ label: yearOption });
+        await page.waitForTimeout(1500);
+      }
+    }
+
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, 'receipts-mutualfund-search-year.png'),
+      fullPage: true,
+    });
+  });
+
+  test('投資信託 - ファンド検索', async ({ page }) => {
+    await page.goto('/receipts');
+    await page.waitForLoadState('networkidle');
+
+    // 投資信託タブをクリック
+    await page.getByRole('tab', { name: '投資信託' }).click();
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(1000);
+
+    // ファンドセレクトが表示されていれば選択
+    const securitySelect = page.locator('#securities-search');
+    if (await securitySelect.isVisible()) {
+      const options = await securitySelect.locator('option').allTextContents();
+      const fundOption = options.find(opt => opt !== '全て表示' && opt !== '');
+      if (fundOption) {
+        await securitySelect.selectOption({ label: fundOption });
+        await page.waitForTimeout(1500);
+      }
+    }
+
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, 'receipts-mutualfund-search-fund.png'),
+      fullPage: true,
+    });
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@eslint/js": "9.39.2",
+        "@playwright/test": "^1.58.1",
         "@testing-library/jest-dom": "6.9.1",
         "@testing-library/react": "16.3.2",
         "@testing-library/user-event": "14.6.1",
@@ -38,6 +39,7 @@
         "globals": "17.0.0",
         "jsdom": "27.4.0",
         "terser": "5.46.0",
+        "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "typescript-eslint": "8.53.1",
         "vite": "7.3.1",
@@ -1428,6 +1430,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.1.tgz",
+      "integrity": "sha512-6LdVIUERWxQMmUSSQi0I53GgCBYgM2RpGngCPY7hSeju+VrKjq3lvs7HpJoPbDiY5QM5EYRtRX5fvrinnMAz3w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -4719,6 +4737,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.1.tgz",
+      "integrity": "sha512-EoY1N2xCn44xU6750Sx7OjOIT59FkmstNc3X6y5xpz7D5cBtZRe/3pSlTkDJgqsOk3WwZPkWfonhhUJfttQo3w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -6510,6 +6541,53 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.1.tgz",
+      "integrity": "sha512-+2uTZHxSCcxjvGc5C891LrS1/NlxglGxzrC4seZiVjcYVQfUa87wBL6rTDqzGjuoWNjnBzRqKmF6zRYGMvQUaQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.1.tgz",
+      "integrity": "sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -6869,6 +6947,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "devOptional": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/rollup": {
@@ -7566,6 +7654,27 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/type-check": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,10 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "test": "NODE_OPTIONS='--max-old-space-size=8192' vitest",
-    "test:watch": "NODE_OPTIONS='--max-old-space-size=8192' vitest --watch"
+    "test:watch": "NODE_OPTIONS='--max-old-space-size=8192' vitest --watch",
+    "ui:screenshot": "npx playwright test e2e/ui-screenshots.spec.ts",
+    "ui:screenshot:auth": "STORAGE_STATE=.auth/storage-state.json npx playwright test e2e/ui-screenshots.spec.ts",
+    "ui:save-auth": "npx tsx e2e/save-auth.spec.ts"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.18",
@@ -24,6 +27,7 @@
   },
   "devDependencies": {
     "@eslint/js": "9.39.2",
+    "@playwright/test": "^1.58.1",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",
     "@testing-library/user-event": "14.6.1",
@@ -42,6 +46,7 @@
     "globals": "17.0.0",
     "jsdom": "27.4.0",
     "terser": "5.46.0",
+    "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "typescript-eslint": "8.53.1",
     "vite": "7.3.1",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   workers: 1,
   reporter: 'list',
   use: {
-    baseURL: process.env.BASE_URL || 'http://localhost:8080',
+    baseURL: process.env.BASE_URL || 'http://localhost:8081',
     trace: 'off',
     screenshot: 'off',
     // ログイン状態を保持するためのstorageState

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   workers: 1,
   reporter: 'list',
   use: {
-    baseURL: process.env.BASE_URL || 'http://localhost:8081',
+    baseURL: process.env.BASE_URL || 'http://localhost:8080',
     trace: 'off',
     screenshot: 'off',
     // ログイン状態を保持するためのstorageState

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * UIレビュー用スクリーンショット取得のためのPlaywright設定
+ */
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  workers: 1,
+  reporter: 'list',
+  use: {
+    baseURL: process.env.BASE_URL || 'http://localhost:8080',
+    trace: 'off',
+    screenshot: 'off',
+    // ログイン状態を保持するためのstorageState
+    storageState: process.env.STORAGE_STATE || undefined,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  // 開発サーバーは手動で起動する前提
+  webServer: undefined,
+});

--- a/frontend/src/components/atoms/Button.tsx
+++ b/frontend/src/components/atoms/Button.tsx
@@ -32,7 +32,7 @@ const variantStyles: Record<ButtonVariant, string> = {
   'outline-secondary': 'border border-secondary text-secondary hover:bg-secondary hover:text-white',
   'outline-success': 'border border-success text-success hover:bg-success hover:text-white',
   'outline-danger': 'border border-danger text-danger hover:bg-danger hover:text-white',
-  'outline-warning': 'border border-warning text-warning hover:bg-warning hover:text-dark',
+  'outline-warning': 'border border-amber-600 text-amber-700 hover:bg-warning hover:text-dark',
   'outline-info': 'border border-info text-info hover:bg-info hover:text-dark',
   'outline-light': 'border border-light text-light hover:bg-light hover:text-dark',
   'outline-dark': 'border border-dark text-dark hover:bg-dark hover:text-white',

--- a/frontend/src/components/atoms/Card.tsx
+++ b/frontend/src/components/atoms/Card.tsx
@@ -1,7 +1,7 @@
 import { HTMLAttributes, ReactNode } from 'react';
 import { cn } from '../../lib/utils/classNames';
 
-export type CardVariant = 'default' | 'primary';
+export type CardVariant = 'default' | 'primary' | 'secondary';
 
 export interface CardProps extends HTMLAttributes<HTMLDivElement> {
   children: ReactNode;
@@ -35,13 +35,15 @@ export function Card({ children, className, ...rest }: CardProps) {
 }
 
 export function CardHeader({ children, variant = 'default', className, ...rest }: CardHeaderProps) {
-  const variantClass = variant === 'primary'
-    ? 'bg-slate-700 text-white'
-    : 'border-b border-border bg-white text-dark';
+  const variantClasses: Record<CardVariant, string> = {
+    primary: 'bg-slate-700 text-white',
+    secondary: 'bg-slate-500 text-white',
+    default: 'border-b border-border bg-white text-dark',
+  };
 
   return (
     <div
-      className={cn('px-4 py-2', variantClass, className)}
+      className={cn('px-4 py-2', variantClasses[variant], className)}
       {...rest}
     >
       {children}

--- a/frontend/src/components/atoms/InputField.tsx
+++ b/frontend/src/components/atoms/InputField.tsx
@@ -1,7 +1,7 @@
 import { InputHTMLAttributes, ReactNode, forwardRef, useId } from 'react';
 
 export interface InputFieldProps extends InputHTMLAttributes<HTMLInputElement> {
-  label?: string;
+  label?: ReactNode;
   error?: string;
   fullWidth?: boolean;
   helpText?: ReactNode;

--- a/frontend/src/components/atoms/Table.tsx
+++ b/frontend/src/components/atoms/Table.tsx
@@ -113,9 +113,9 @@ const Table = forwardRef<HTMLTableElement, TableProps>(
           ref={containerRef}
           className={cn(
             'w-full overflow-x-auto rounded-md',
-            // モバイル時のスクロールヒント（右端に影）
-            'sm:shadow-none',
-            '[&::-webkit-scrollbar]:h-2 [&::-webkit-scrollbar-track]:bg-slate-100 [&::-webkit-scrollbar-thumb]:bg-slate-300 [&::-webkit-scrollbar-thumb]:rounded'
+            // スクロールヒント（右端にフェード効果）
+            'relative',
+            '[&::-webkit-scrollbar]:h-2.5 [&::-webkit-scrollbar-track]:bg-slate-100 [&::-webkit-scrollbar-thumb]:bg-slate-400 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:hover:bg-slate-500'
           )}
           style={containerStyle}
         >

--- a/frontend/src/components/atoms/Table.tsx
+++ b/frontend/src/components/atoms/Table.tsx
@@ -78,14 +78,14 @@ const Table = forwardRef<HTMLTableElement, TableProps>(
       forceResize,
     });
 
-    // CSSクラスの構築
+    // CSSクラスの構築（モバイル対応: パディング縮小、フォント調整）
     const tableClasses = cn(
       'w-full text-left border-collapse',
-      small ? 'text-sm' : 'text-base',
+      small ? 'text-xs sm:text-sm' : 'text-sm sm:text-base',
       bordered && '[&_th]:border [&_th]:border-slate-200 [&_td]:border [&_td]:border-slate-200 print:[&_th]:border-black print:[&_td]:border-black',
       small
-        ? '[&_th]:py-2.5 [&_th]:px-3 [&_td]:py-2.5 [&_td]:px-3'
-        : '[&_th]:py-3 [&_th]:px-4 [&_td]:py-3 [&_td]:px-4',
+        ? '[&_th]:py-1.5 [&_th]:px-2 [&_td]:py-1.5 [&_td]:px-2 sm:[&_th]:py-2.5 sm:[&_th]:px-3 sm:[&_td]:py-2.5 sm:[&_td]:px-3'
+        : '[&_th]:py-2 [&_th]:px-2 [&_td]:py-2 [&_td]:px-2 sm:[&_th]:py-3 sm:[&_th]:px-4 sm:[&_td]:py-3 sm:[&_td]:px-4',
       variant && variantBgColors[variant],
       striped && '[&_tbody_tr:nth-child(even)]:bg-slate-50',
       hover && '[&_tbody_tr:hover]:bg-slate-100',
@@ -111,7 +111,12 @@ const Table = forwardRef<HTMLTableElement, TableProps>(
       return (
         <div
           ref={containerRef}
-          className="w-full overflow-x-auto rounded-md"
+          className={cn(
+            'w-full overflow-x-auto rounded-md',
+            // モバイル時のスクロールヒント（右端に影）
+            'sm:shadow-none',
+            '[&::-webkit-scrollbar]:h-2 [&::-webkit-scrollbar-track]:bg-slate-100 [&::-webkit-scrollbar-thumb]:bg-slate-300 [&::-webkit-scrollbar-thumb]:rounded'
+          )}
           style={containerStyle}
         >
           {table}

--- a/frontend/src/components/molecules/DividendInfo/DividendInfo.tsx
+++ b/frontend/src/components/molecules/DividendInfo/DividendInfo.tsx
@@ -74,9 +74,14 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({ searchQuery, securit
 
   const totalInvestment = parseNumber(averageUnitPrice) * parseNumber(holdingQuantity);
 
+  // 全グループの合計受取金額を計算
+  const totalNetAmountReceived = React.useMemo(() => {
+    return summary.reduce((sum, item) => sum + (item.net_amount_received || 0), 0);
+  }, [summary]);
+
   const dividendReturnRate = (() => {
-    if (totalInvestment > 0 && summary[0]) {
-      return (summary[0].net_amount_received / totalInvestment) * 100;
+    if (totalInvestment > 0 && totalNetAmountReceived > 0) {
+      return (totalNetAmountReceived / totalInvestment) * 100;
     }
     return 0;
   })();
@@ -120,7 +125,7 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({ searchQuery, securit
 
         <div className="stat-grid mt-4">
           <StatItem title="取得総額" value={formatCurrency(totalInvestment)} />
-          <StatItemWithRate title="合計受取金額 (累積利回り)" value={summary[0]?.net_amount_received || 0} rate={dividendReturnRate} format={formatCurrency} />
+          <StatItemWithRate title="合計受取金額 (累積利回り)" value={totalNetAmountReceived} rate={dividendReturnRate} format={formatCurrency} />
           <StatItemWithRate title="年間配当金額 (配当利回り)" value={annualDividendAmount} rate={dividendYield} format={formatCurrency} />
         </div>
       </div>

--- a/frontend/src/components/molecules/DividendInfo/DividendInfo.tsx
+++ b/frontend/src/components/molecules/DividendInfo/DividendInfo.tsx
@@ -117,14 +117,29 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({
     ? getAssetBalanceByCode(effectiveSecurityCode)
     : undefined;
 
+  // 自動入力バッジ
+  const AutoBadge = () => (
+    <span className="ml-1 inline-flex items-center rounded bg-blue-100 px-1.5 py-0.5 text-xs font-medium text-blue-700">
+      自動
+    </span>
+  );
+
   const content = (
     <>
       <div className="stat-grid">
         <div>
-          <NumberInputField label="平均取得価格" value={averageUnitPrice} onChange={setAverageUnitPrice} />
+          <NumberInputField
+            label={<>平均取得価格{assetBalanceData && <AutoBadge />}</>}
+            value={averageUnitPrice}
+            onChange={setAverageUnitPrice}
+          />
         </div>
         <div>
-          <NumberInputField label="保有数量(株)" value={holdingQuantity} onChange={setHoldingQuantity} />
+          <NumberInputField
+            label={<>保有数量(株){assetBalanceData && <AutoBadge />}</>}
+            value={holdingQuantity}
+            onChange={setHoldingQuantity}
+          />
         </div>
         <div>
           <NumberInputField
@@ -159,7 +174,7 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({
         {assetBalanceData && (
           <div className="mb-3 flex justify-end">
             <small className="text-gray-500">
-              保有銘柄データから自動入力
+              平均取得価格・保有数量を自動入力
             </small>
           </div>
         )}
@@ -174,7 +189,7 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({
         <h5 className="text-sm font-medium">配当シミュレーション</h5>
         {assetBalanceData && (
           <small className="text-xs text-white/70">
-            自動入力
+            取得価格・数量を自動入力
           </small>
         )}
       </div>

--- a/frontend/src/components/molecules/DividendInfo/DividendInfo.tsx
+++ b/frontend/src/components/molecules/DividendInfo/DividendInfo.tsx
@@ -170,15 +170,15 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({
 
   return (
     <div className="bg-white rounded-lg shadow-sm border border-border mt-1">
-      <div className="bg-slate-700 text-white px-4 py-2 rounded-t-lg flex justify-between items-center">
-        <h5 className="font-semibold">配当シミュレーション</h5>
+      <div className="bg-slate-600 text-white px-3 py-1.5 rounded-t-lg flex justify-between items-center">
+        <h5 className="text-sm font-medium">配当シミュレーション</h5>
         {assetBalanceData && (
-          <small className="text-white/80">
-            保有銘柄データから自動入力
+          <small className="text-xs text-white/70">
+            自動入力
           </small>
         )}
       </div>
-      <div className="p-4">
+      <div className="p-3">
         {content}
       </div>
     </div>

--- a/frontend/src/components/molecules/DividendInfo/DividendInfo.tsx
+++ b/frontend/src/components/molecules/DividendInfo/DividendInfo.tsx
@@ -155,7 +155,7 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({
 
   if (embedded) {
     return (
-      <div className="mt-4 border-t border-border pt-4">
+      <div className="mt-4 pt-4">
         {assetBalanceData && (
           <div className="mb-4 flex justify-end">
             <small className="text-gray-500">

--- a/frontend/src/components/molecules/DividendInfo/DividendInfo.tsx
+++ b/frontend/src/components/molecules/DividendInfo/DividendInfo.tsx
@@ -11,9 +11,15 @@ interface DividendInfoProps {
   searchQuery: string;
   securityCode?: string;
   summary: SummaryResult<keyof Pick<DividendData, 'dividends_before_tax' | 'taxes' | 'net_amount_received'>>[];
+  embedded?: boolean;
 }
 
-export const DividendInfo: React.FC<DividendInfoProps> = ({ searchQuery, securityCode, summary }) => {
+export const DividendInfo: React.FC<DividendInfoProps> = ({
+  searchQuery,
+  securityCode,
+  summary,
+  embedded = false
+}) => {
   const [averageUnitPrice, setAverageUnitPrice] = useState<number | undefined>(undefined);
   const [holdingQuantity, setHoldingQuantity] = useState<number | undefined>(undefined);
   const [dividendPerShare, setDividendPerShare] = useState<number | undefined>(undefined);
@@ -79,6 +85,23 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({ searchQuery, securit
     return summary.reduce((sum, item) => sum + (item.net_amount_received || 0), 0);
   }, [summary]);
 
+  // 全グループの合計配当金（税引前）を計算
+  const totalDividendsBeforeTax = React.useMemo(() => {
+    return summary.reduce((sum, item) => sum + (item.dividends_before_tax || 0), 0);
+  }, [summary]);
+
+  // 全グループの合計税額を計算
+  const totalTaxes = React.useMemo(() => {
+    return summary.reduce((sum, item) => sum + (item.taxes || 0), 0);
+  }, [summary]);
+
+  const grossDividendReturnRate = (() => {
+    if (totalInvestment > 0 && totalDividendsBeforeTax > 0) {
+      return (totalDividendsBeforeTax / totalInvestment) * 100;
+    }
+    return 0;
+  })();
+
   const dividendReturnRate = (() => {
     if (totalInvestment > 0 && totalNetAmountReceived > 0) {
       return (totalNetAmountReceived / totalInvestment) * 100;
@@ -94,6 +117,57 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({ searchQuery, securit
     ? getAssetBalanceByCode(effectiveSecurityCode)
     : undefined;
 
+  const content = (
+    <>
+      <div className="stat-grid">
+        <div>
+          <NumberInputField label="平均取得価格" value={averageUnitPrice} onChange={setAverageUnitPrice} />
+        </div>
+        <div>
+          <NumberInputField label="保有数量(株)" value={holdingQuantity} onChange={setHoldingQuantity} />
+        </div>
+        <div>
+          <NumberInputField
+            label="一株配当"
+            value={dividendPerShare}
+            onChange={setDividendPerShare}
+            disabled={apiLoading}
+            placeholder={apiLoading ? "データ取得中..." : ""}
+          />
+        </div>
+      </div>
+
+      {embedded ? (
+        <div className="stat-grid mt-4">
+          <StatItemWithRate title="配当金額 (配当利回り)" value={totalDividendsBeforeTax} rate={grossDividendReturnRate} format={formatCurrency} />
+          <StatItem title="税額" value={formatCurrency(totalTaxes)} />
+          <StatItemWithRate title="受取金額 (累積利回り)" value={totalNetAmountReceived} rate={dividendReturnRate} format={formatCurrency} />
+        </div>
+      ) : (
+        <div className="stat-grid mt-4">
+          <StatItem title="取得総額" value={formatCurrency(totalInvestment)} />
+          <StatItemWithRate title="合計受取金額 (累積利回り)" value={totalNetAmountReceived} rate={dividendReturnRate} format={formatCurrency} />
+          <StatItemWithRate title="年間配当金額 (配当利回り)" value={annualDividendAmount} rate={dividendYield} format={formatCurrency} />
+        </div>
+      )}
+    </>
+  );
+
+  if (embedded) {
+    return (
+      <div className="mt-4 border-t border-border pt-4">
+        {assetBalanceData && (
+          <div className="mb-4 flex justify-end">
+            <small className="text-gray-500">
+              保有銘柄データから自動入力
+            </small>
+          </div>
+        )}
+        {content}
+      </div>
+    );
+  }
+
   return (
     <div className="bg-white rounded-lg shadow-sm border border-border mt-1">
       <div className="bg-slate-700 text-white px-4 py-2 rounded-t-lg flex justify-between items-center">
@@ -105,29 +179,7 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({ searchQuery, securit
         )}
       </div>
       <div className="p-4">
-        <div className="stat-grid">
-          <div>
-            <NumberInputField label="平均取得価格" value={averageUnitPrice} onChange={setAverageUnitPrice} />
-          </div>
-          <div>
-            <NumberInputField label="保有数量(株)" value={holdingQuantity} onChange={setHoldingQuantity} />
-          </div>
-          <div>
-            <NumberInputField
-              label="一株配当"
-              value={dividendPerShare}
-              onChange={setDividendPerShare}
-              disabled={apiLoading}
-              placeholder={apiLoading ? "データ取得中..." : ""}
-            />
-          </div>
-        </div>
-
-        <div className="stat-grid mt-4">
-          <StatItem title="取得総額" value={formatCurrency(totalInvestment)} />
-          <StatItemWithRate title="合計受取金額 (累積利回り)" value={totalNetAmountReceived} rate={dividendReturnRate} format={formatCurrency} />
-          <StatItemWithRate title="年間配当金額 (配当利回り)" value={annualDividendAmount} rate={dividendYield} format={formatCurrency} />
-        </div>
+        {content}
       </div>
     </div>
   );

--- a/frontend/src/components/molecules/DividendInfo/DividendInfo.tsx
+++ b/frontend/src/components/molecules/DividendInfo/DividendInfo.tsx
@@ -117,10 +117,15 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({
     ? getAssetBalanceByCode(effectiveSecurityCode)
     : undefined;
 
-  // 自動入力バッジ
-  const AutoBadge = () => (
+  // 自動入力バッジ（データ元を明示）
+  const AssetBadge = () => (
+    <span className="ml-1 inline-flex items-center rounded bg-emerald-100 px-1.5 py-0.5 text-xs font-medium text-emerald-700">
+      保有銘柄
+    </span>
+  );
+  const JQuantsBadge = () => (
     <span className="ml-1 inline-flex items-center rounded bg-blue-100 px-1.5 py-0.5 text-xs font-medium text-blue-700">
-      自動
+      J-Quants
     </span>
   );
 
@@ -129,21 +134,21 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({
       <div className="stat-grid">
         <div>
           <NumberInputField
-            label={<>平均取得価格{assetBalanceData && <AutoBadge />}</>}
+            label={<>平均取得価格{assetBalanceData && <AssetBadge />}</>}
             value={averageUnitPrice}
             onChange={setAverageUnitPrice}
           />
         </div>
         <div>
           <NumberInputField
-            label={<>保有数量(株){assetBalanceData && <AutoBadge />}</>}
+            label={<>保有数量(株){assetBalanceData && <AssetBadge />}</>}
             value={holdingQuantity}
             onChange={setHoldingQuantity}
           />
         </div>
         <div>
           <NumberInputField
-            label="一株配当"
+            label={<>一株配当{dividendPerShare !== undefined && <JQuantsBadge />}</>}
             value={dividendPerShare}
             onChange={setDividendPerShare}
             disabled={apiLoading}
@@ -169,29 +174,13 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({
   );
 
   if (embedded) {
-    return (
-      <div>
-        {assetBalanceData && (
-          <div className="mb-3 flex justify-end">
-            <small className="text-gray-500">
-              平均取得価格・保有数量を自動入力
-            </small>
-          </div>
-        )}
-        {content}
-      </div>
-    );
+    return <div>{content}</div>;
   }
 
   return (
     <div className="bg-white rounded-lg shadow-sm border border-border mt-1">
-      <div className="bg-slate-600 text-white px-3 py-1.5 rounded-t-lg flex justify-between items-center">
+      <div className="bg-slate-600 text-white px-3 py-1.5 rounded-t-lg">
         <h5 className="text-sm font-medium">配当シミュレーション</h5>
-        {assetBalanceData && (
-          <small className="text-xs text-white/70">
-            取得価格・数量を自動入力
-          </small>
-        )}
       </div>
       <div className="p-3">
         {content}

--- a/frontend/src/components/molecules/DividendInfo/DividendInfo.tsx
+++ b/frontend/src/components/molecules/DividendInfo/DividendInfo.tsx
@@ -155,9 +155,9 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({
 
   if (embedded) {
     return (
-      <div className="mt-4 pt-4">
+      <div>
         {assetBalanceData && (
-          <div className="mb-4 flex justify-end">
+          <div className="mb-3 flex justify-end">
             <small className="text-gray-500">
               保有銘柄データから自動入力
             </small>

--- a/frontend/src/components/molecules/DividendInfo/DividendInfo.tsx
+++ b/frontend/src/components/molecules/DividendInfo/DividendInfo.tsx
@@ -171,7 +171,7 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({
   return (
     <div className="bg-white rounded-lg shadow-sm border border-border mt-1">
       <div className="bg-slate-700 text-white px-4 py-2 rounded-t-lg flex justify-between items-center">
-        <h5 className="font-semibold">配当情報</h5>
+        <h5 className="font-semibold">配当シミュレーション</h5>
         {assetBalanceData && (
           <small className="text-white/80">
             保有銘柄データから自動入力

--- a/frontend/src/components/molecules/PortfolioPieChart/PortfolioPieChart.tsx
+++ b/frontend/src/components/molecules/PortfolioPieChart/PortfolioPieChart.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState, useEffect } from 'react';
-import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from 'recharts';
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from 'recharts';
 
 // 円グラフ用の配色（視認性を考慮した10色）
 const COLORS = [
@@ -92,56 +92,79 @@ export const PortfolioPieChart: React.FC<PortfolioPieChartProps> = ({
     }));
   }, [data]);
 
-  // 凡例のカスタムフォーマッター（銘柄名 + パーセンテージを表示）
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const legendFormatter = (value: string, entry: any) => {
-    const percentage = entry.payload?.percentage as number | undefined;
-    if (percentage === undefined) {
-      return <span className="text-sm text-secondary">{value}</span>;
-    }
-
-    return (
-      <span className="text-sm text-secondary">
-        {value} ({percentage.toFixed(1)}%)
-      </span>
-    );
-  };
-
   if (chartData.length === 0) {
     return null;
   }
 
+  // カスタム凡例コンポーネント（パーセンテージバー付き）
+  const CustomLegend = () => (
+    <div className="space-y-2">
+      {chartData.map((item, index) => (
+        <div key={item.name} className="flex items-center gap-3 text-sm">
+          {/* 色マーカー */}
+          <span
+            className="h-3 w-3 shrink-0 rounded-sm"
+            style={{ backgroundColor: COLORS[index % COLORS.length] }}
+          />
+          {/* 銘柄名とパーセンテージ */}
+          <div className="min-w-0 flex-1">
+            <div className="flex items-baseline justify-between gap-2">
+              <span className="truncate text-slate-700" title={item.name}>
+                {item.name}
+              </span>
+              <span className="shrink-0 text-xs font-medium text-slate-500">
+                {item.percentage.toFixed(1)}%
+              </span>
+            </div>
+            {/* パーセンテージバー */}
+            <div className="mt-1 h-1.5 w-full rounded-full bg-slate-100">
+              <div
+                className="h-full rounded-full transition-all"
+                style={{
+                  width: `${Math.min(item.percentage, 100)}%`,
+                  backgroundColor: COLORS[index % COLORS.length],
+                }}
+              />
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+
   return (
     <div className={className} data-testid="portfolio-pie-chart">
-      <ResponsiveContainer width="100%" height={isMobile ? 350 : 250}>
-        <PieChart>
-          <Pie
-            data={chartData}
-            cx="50%"
-            cy={isMobile ? '30%' : '50%'}
-            innerRadius={isMobile ? 40 : 50}
-            outerRadius={isMobile ? 65 : 80}
-            paddingAngle={2}
-            dataKey="value"
-            nameKey="name"
-          >
-            {chartData.map((_, index) => (
-              <Cell
-                key={`cell-${index}`}
-                fill={COLORS[index % COLORS.length]}
-              />
-            ))}
-          </Pie>
-          <Tooltip content={<CustomTooltip />} />
-          <Legend
-            layout={isMobile ? 'horizontal' : 'vertical'}
-            align={isMobile ? 'center' : 'right'}
-            verticalAlign={isMobile ? 'bottom' : 'middle'}
-            wrapperStyle={isMobile ? { paddingTop: 16 } : undefined}
-            formatter={legendFormatter}
-          />
-        </PieChart>
-      </ResponsiveContainer>
+      <div className={isMobile ? 'flex flex-col gap-4' : 'flex items-start gap-6'}>
+        {/* 円グラフ */}
+        <div className={isMobile ? 'mx-auto w-48' : 'w-44 shrink-0'}>
+          <ResponsiveContainer width="100%" height={isMobile ? 160 : 180}>
+            <PieChart>
+              <Pie
+                data={chartData}
+                cx="50%"
+                cy="50%"
+                innerRadius={isMobile ? 35 : 45}
+                outerRadius={isMobile ? 60 : 75}
+                paddingAngle={2}
+                dataKey="value"
+                nameKey="name"
+              >
+                {chartData.map((_, index) => (
+                  <Cell
+                    key={`cell-${index}`}
+                    fill={COLORS[index % COLORS.length]}
+                  />
+                ))}
+              </Pie>
+              <Tooltip content={<CustomTooltip />} />
+            </PieChart>
+          </ResponsiveContainer>
+        </div>
+        {/* 凡例リスト */}
+        <div className="min-w-0 flex-1">
+          <CustomLegend />
+        </div>
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/molecules/ReceiptHeader/ReceiptHeader.tsx
+++ b/frontend/src/components/molecules/ReceiptHeader/ReceiptHeader.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode, useEffect, useId, useState } from 'react';
 import { StatItem } from '@/components/atoms/StatItem';
 import { Card, CardBody, CardHeader } from '@/components/atoms/Card';
 
@@ -10,29 +10,78 @@ interface HeaderItem {
 
 interface ReceiptHeaderProps {
     items: HeaderItem[];
+    title?: string;
+    children?: ReactNode;
+    collapsible?: boolean;
 }
 
-export const ReceiptHeader: React.FC<ReceiptHeaderProps> = ({ items }) => {
+export const ReceiptHeader: React.FC<ReceiptHeaderProps> = ({
+    items,
+    title = '集計情報',
+    children,
+    collapsible = false
+}) => {
+    const [isExpanded, setIsExpanded] = useState(true);
+    const bodyId = useId();
+
+    // 折りたたみを無効化したら展開状態に戻す
+    useEffect(() => {
+        if (!collapsible) {
+            setIsExpanded(true);
+        }
+    }, [collapsible]);
+
+    const handleToggleExpanded = () => {
+        if (!collapsible) return;
+        setIsExpanded(prev => !prev);
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+        if (!collapsible) return;
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleToggleExpanded();
+        }
+    };
+
     return (
         <Card>
-            <CardHeader variant="primary">
-                <h5>集計情報</h5>
+            <CardHeader
+                variant="primary"
+                className={collapsible ? 'flex cursor-pointer items-center justify-between' : undefined}
+                onClick={collapsible ? handleToggleExpanded : undefined}
+                onKeyDown={collapsible ? handleKeyDown : undefined}
+                role={collapsible ? 'button' : undefined}
+                tabIndex={collapsible ? 0 : undefined}
+                aria-expanded={collapsible ? isExpanded : undefined}
+                aria-controls={collapsible ? bodyId : undefined}
+                data-testid="receipt-header"
+            >
+                <h5>{title}</h5>
+                {collapsible && (
+                    <div
+                        className={`h-0 w-0 border-l-[6px] border-r-[6px] border-t-[8px] border-l-transparent border-r-transparent border-t-white transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+                    />
+                )}
             </CardHeader>
-            <CardBody className="p-4">
-                <div className="stat-grid">
-                    {items.map((item, index) => (
-                        <StatItem
-                            key={index}
-                            title={item.title}
-                            value={
-                                <span data-negative={item.value < 0 ? 'true' : undefined}>
-                                    {item.format(item.value)}
-                                </span>
-                            }
-                        />
-                    ))}
-                </div>
-            </CardBody>
+            {(!collapsible || isExpanded) && (
+                <CardBody id={bodyId} className="p-4">
+                    <div className="stat-grid">
+                        {items.map((item, index) => (
+                            <StatItem
+                                key={index}
+                                title={item.title}
+                                value={
+                                    <span data-negative={item.value < 0 ? 'true' : undefined}>
+                                        {item.format(item.value)}
+                                    </span>
+                                }
+                            />
+                        ))}
+                    </div>
+                    {children}
+                </CardBody>
+            )}
         </Card >
     );
 };

--- a/frontend/src/components/molecules/ReceiptHeader/ReceiptHeader.tsx
+++ b/frontend/src/components/molecules/ReceiptHeader/ReceiptHeader.tsx
@@ -66,20 +66,28 @@ export const ReceiptHeader: React.FC<ReceiptHeaderProps> = ({
             </CardHeader>
             {(!collapsible || isExpanded) && (
                 <CardBody id={bodyId} className="p-4">
-                    <div className="stat-grid">
-                        {items.map((item, index) => (
-                            <StatItem
-                                key={index}
-                                title={item.title}
-                                value={
-                                    <span data-negative={item.value < 0 ? 'true' : undefined}>
-                                        {item.format(item.value)}
-                                    </span>
-                                }
-                            />
-                        ))}
-                    </div>
-                    {children}
+                    {/* stat-gridはitemsがある場合のみ表示 */}
+                    {items.length > 0 && (
+                        <div className="stat-grid">
+                            {items.map((item, index) => (
+                                <StatItem
+                                    key={index}
+                                    title={item.title}
+                                    value={
+                                        <span data-negative={item.value < 0 ? 'true' : undefined}>
+                                            {item.format(item.value)}
+                                        </span>
+                                    }
+                                />
+                            ))}
+                        </div>
+                    )}
+                    {/* childrenはitemsがある場合のみ上余白を設ける */}
+                    {children && (
+                        <div className={items.length > 0 ? 'mt-4 pt-4 border-t border-slate-200' : ''}>
+                            {children}
+                        </div>
+                    )}
                 </CardBody>
             )}
         </Card >

--- a/frontend/src/components/molecules/ReceiptHeader/ReceiptHeader.tsx
+++ b/frontend/src/components/molecules/ReceiptHeader/ReceiptHeader.tsx
@@ -59,9 +59,9 @@ export const ReceiptHeader: React.FC<ReceiptHeaderProps> = ({
             >
                 <h5>{title}</h5>
                 {collapsible && (
-                    <div
-                        className={`h-0 w-0 border-l-[6px] border-r-[6px] border-t-[8px] border-l-transparent border-r-transparent border-t-white transition-transform ${isExpanded ? 'rotate-180' : ''}`}
-                    />
+                    <span className="flex items-center gap-1 text-xs font-medium bg-white/20 px-2 py-1 rounded">
+                        {isExpanded ? '▲ 閉じる' : '▼ 開く'}
+                    </span>
                 )}
             </CardHeader>
             {(!collapsible || isExpanded) && (

--- a/frontend/src/components/molecules/ReceiptHeader/__tests__/ReceiptHeader.test.tsx
+++ b/frontend/src/components/molecules/ReceiptHeader/__tests__/ReceiptHeader.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { ReceiptHeader } from '../ReceiptHeader';
 
 describe('ReceiptHeader', () => {
@@ -67,9 +67,33 @@ describe('ReceiptHeader', () => {
     ];
 
     render(<ReceiptHeader items={items} />);
-    
+
     expect(screen.getByText('¥1500')).toBeInTheDocument();
     expect(screen.getByText('75%')).toBeInTheDocument();
     expect(screen.getByText('10個')).toBeInTheDocument();
+  });
+
+  it('タイトルと追加コンテンツを表示できる', () => {
+    render(
+      <ReceiptHeader items={defaultItems} title="集計・配当情報">
+        <div>配当情報</div>
+      </ReceiptHeader>
+    );
+
+    expect(screen.getByText('集計・配当情報')).toBeInTheDocument();
+    expect(screen.getByText('配当情報')).toBeInTheDocument();
+  });
+
+  it('collapsibleがtrueのときヘッダークリックで開閉できる', () => {
+    render(<ReceiptHeader items={defaultItems} title="配当情報" collapsible />);
+
+    const header = screen.getByTestId('receipt-header');
+    expect(screen.getByText('テスト項目1')).toBeInTheDocument();
+
+    fireEvent.click(header);
+    expect(screen.queryByText('テスト項目1')).not.toBeInTheDocument();
+
+    fireEvent.click(header);
+    expect(screen.getByText('テスト項目1')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/organisms/AssetPortfolioSummary/AssetPortfolioSummary.tsx
+++ b/frontend/src/components/organisms/AssetPortfolioSummary/AssetPortfolioSummary.tsx
@@ -56,35 +56,38 @@ export const AssetPortfolioSummary: React.FC<AssetPortfolioSummaryProps> = ({
   }
 
   return (
-    <Card className="mb-3" data-testid="asset-portfolio-summary">
-      <CardBody className="p-4">
-        <div className="flex flex-col gap-4 md:flex-row md:items-start md:gap-8">
-          {/* 合計取得総額 */}
-          <div className="shrink-0">
-            <StatItem
-              title="合計取得総額"
-              value={
-                <span data-negative={totalPurchaseAmount < 0 ? 'true' : undefined}>
-                  {formatCurrency(totalPurchaseAmount)}
-                </span>
-              }
-              variant="default"
-              titleClassName="text-secondary"
-              valueClassName="text-2xl text-primary"
-            />
-          </div>
+    <div className="mb-3 space-y-3" data-testid="asset-portfolio-summary">
+      {/* KPI: 合計取得総額（独立カード） */}
+      <Card>
+        <CardBody className="p-4">
+          <StatItem
+            title="合計取得総額"
+            value={
+              <span data-negative={totalPurchaseAmount < 0 ? 'true' : undefined}>
+                {formatCurrency(totalPurchaseAmount)}
+              </span>
+            }
+            variant="default"
+            titleClassName="text-secondary"
+            valueClassName="text-3xl font-bold text-primary"
+          />
+          <p className="mt-1 text-xs text-slate-500">
+            {assetBalanceData.length}銘柄を保有
+          </p>
+        </CardBody>
+      </Card>
 
-          {/* 構成比円グラフ */}
-          {chartData.length > 0 && (
-            <div className="min-w-0 flex-1">
-              <h3 className="mb-2 text-sm font-semibold text-secondary">
-                銘柄別構成比
-              </h3>
-              <PortfolioPieChart data={chartData} />
-            </div>
-          )}
-        </div>
-      </CardBody>
-    </Card>
+      {/* 構成比エリア */}
+      {chartData.length > 0 && (
+        <Card>
+          <CardBody className="p-4">
+            <h3 className="mb-3 text-sm font-semibold text-slate-700">
+              銘柄別構成比
+            </h3>
+            <PortfolioPieChart data={chartData} />
+          </CardBody>
+        </Card>
+      )}
+    </div>
   );
 };

--- a/frontend/src/components/organisms/Header.tsx
+++ b/frontend/src/components/organisms/Header.tsx
@@ -11,10 +11,26 @@ const NAV_LINKS = [
   { to: '/receipts', label: '受取金' },
 ] as const;
 
+// ユーザー名からイニシャルを取得
+const getInitials = (name: string | null | undefined, email: string | null | undefined): string => {
+  if (name) {
+    const parts = name.trim().split(/\s+/);
+    if (parts.length >= 2) {
+      return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+    }
+    return name.slice(0, 2).toUpperCase();
+  }
+  if (email) {
+    return email.slice(0, 2).toUpperCase();
+  }
+  return 'U';
+};
+
 export function Header() {
   const { user, login, logout, deleteAccount, isAuthenticated, isLoading } = useAuth();
   const [showDropdown, setShowDropdown] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [imageError, setImageError] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const location = useLocation();
 
@@ -100,12 +116,21 @@ export function Header() {
                 <span className="text-white/80 text-base">読み込み中...</span>
               ) : isAuthenticated && user ? (
                 <div className="flex items-center gap-3">
-                  {user.picture_url && (
+                  {/* ユーザーアバター（フォールバック付き） */}
+                  {user.picture_url && !imageError ? (
                     <img
                       src={user.picture_url}
                       alt={user.name || 'ユーザー'}
-                      className="h-8 w-8 rounded-full object-cover"
+                      className="h-8 w-8 rounded-full object-cover bg-slate-600"
+                      onError={() => setImageError(true)}
                     />
+                  ) : (
+                    <div
+                      className="h-8 w-8 rounded-full bg-slate-600 flex items-center justify-center text-white text-sm font-medium"
+                      aria-label={user.name || 'ユーザー'}
+                    >
+                      {getInitials(user.name, user.email)}
+                    </div>
                   )}
                   <span className="text-base text-white/90">{user.name || user.email}</span>
                   <div className="relative" ref={dropdownRef}>

--- a/frontend/src/components/organisms/ReceiptTable/ReceiptTable.tsx
+++ b/frontend/src/components/organisms/ReceiptTable/ReceiptTable.tsx
@@ -162,7 +162,7 @@ export function ReceiptTable<T extends DataItem, S extends SummaryItem>({
                                 <span className="text-sm font-medium">
                                     {headerText}
                                 </span>
-                                <span className="ml-2 inline-flex items-center rounded bg-slate-400 px-2 py-0.5 text-xs font-medium text-white">
+                                <span className="ml-2 inline-flex items-center rounded bg-slate-600 px-2 py-0.5 text-xs font-medium text-white">
                                     {itemCount}件
                                 </span>
                             </TableCell>
@@ -187,7 +187,7 @@ export function ReceiptTable<T extends DataItem, S extends SummaryItem>({
                                 <span className="text-sm font-medium">
                                     {headerText}
                                 </span>
-                                <span className="ml-2 inline-flex items-center rounded bg-slate-400 px-2 py-0.5 text-xs font-medium text-white">
+                                <span className="ml-2 inline-flex items-center rounded bg-slate-600 px-2 py-0.5 text-xs font-medium text-white">
                                     {itemCount}件
                                 </span>
                             </TableCell>

--- a/frontend/src/components/organisms/ReceiptTable/ReceiptTable.tsx
+++ b/frontend/src/components/organisms/ReceiptTable/ReceiptTable.tsx
@@ -219,7 +219,7 @@ export function ReceiptTable<T extends DataItem, S extends SummaryItem>({
                     {columns.map((column, index) => (
                         <TableCell
                             as="th"
-                            className="text-center"
+                            className="text-center whitespace-nowrap"
                             style={{ minWidth: column.width }}
                             key={index}
                         >

--- a/frontend/src/components/organisms/ReceiptTable/ReceiptTable.tsx
+++ b/frontend/src/components/organisms/ReceiptTable/ReceiptTable.tsx
@@ -147,8 +147,8 @@ export function ReceiptTable<T extends DataItem, S extends SummaryItem>({
             }));
 
             const summaryBorderClass = summaryIndex > 0 && 'border-t border-slate-200';
-            const summaryLeftClass = cn('bg-slate-100 text-slate-800 font-semibold border-l-4 border-slate-600', summaryBorderClass);
-            const summaryValueClass = cn('bg-slate-100 text-slate-800 text-right font-semibold', summaryBorderClass);
+            const summaryLeftClass = cn('bg-slate-50 text-slate-700 font-medium border-l-2 border-slate-400', summaryBorderClass);
+            const summaryValueClass = cn('bg-slate-50 text-slate-700 text-right font-medium', summaryBorderClass);
 
             return (
                 <React.Fragment key={`group-${summaryIndex}`}>
@@ -159,10 +159,10 @@ export function ReceiptTable<T extends DataItem, S extends SummaryItem>({
                                 colSpan={columns.length - summaryColumns.length}
                                 className={summaryLeftClass}
                             >
-                                <span className="text-base font-bold">
+                                <span className="text-sm font-medium">
                                     {headerText}
                                 </span>
-                                <span className="ml-3 inline-flex items-center rounded bg-slate-600 px-2.5 py-0.5 text-xs font-semibold text-white">
+                                <span className="ml-2 inline-flex items-center rounded bg-slate-400 px-2 py-0.5 text-xs font-medium text-white">
                                     {itemCount}件
                                 </span>
                             </TableCell>
@@ -184,10 +184,10 @@ export function ReceiptTable<T extends DataItem, S extends SummaryItem>({
                                 colSpan={columns.length}
                                 className={summaryLeftClass}
                             >
-                                <span className="text-base font-bold">
+                                <span className="text-sm font-medium">
                                     {headerText}
                                 </span>
-                                <span className="ml-3 inline-flex items-center rounded bg-slate-600 px-2.5 py-0.5 text-xs font-semibold text-white">
+                                <span className="ml-2 inline-flex items-center rounded bg-slate-400 px-2 py-0.5 text-xs font-medium text-white">
                                     {itemCount}件
                                 </span>
                             </TableCell>

--- a/frontend/src/components/organisms/SearchCard/SearchCard.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchCard.tsx
@@ -68,23 +68,42 @@ export const SearchCard: React.FC<SearchCardProps> = ({
     const renderQuickSearchButtons = (items: string[], variant: string, searchType: 'products' | 'accounts') => {
         if (!items || items.length === 0) return null;
 
-        return items.map((item, index) => (
-            <React.Fragment key={index}>
-                <Button type="button" variant={variant as ButtonVariant} size="sm" onClick={() => handleQuickSearch(item, searchType)}>
-                    {item}
-                </Button>
-                {index % 10 === 9 && <div className="mt-1" />}
-            </React.Fragment>
-        ));
+        return items.map((item, index) => {
+            // 選択中のボタンを判定
+            const isSelected = activeSearchType === searchType && searchQuery === item;
+            // 選択中はprimaryバリアント、そうでなければ元のvariant
+            const buttonVariant = isSelected ? 'primary' : variant;
+
+            return (
+                <React.Fragment key={index}>
+                    <Button
+                        type="button"
+                        variant={buttonVariant as ButtonVariant}
+                        size="sm"
+                        onClick={() => handleQuickSearch(item, searchType)}
+                        className={isSelected ? 'ring-2 ring-primary ring-offset-1' : ''}
+                    >
+                        {item}
+                    </Button>
+                    {index % 10 === 9 && <div className="mt-1" />}
+                </React.Fragment>
+            );
+        });
     };
 
     const renderQuickSearchDropdown = (items: { value: string, label: string }[], id: string, searchType: 'securities' | 'years') => {
         // このドロップダウンがアクティブな検索タイプの場合のみ値を表示
         const displayValue = activeSearchType === searchType ? searchQuery : '';
+        const isSelected = activeSearchType === searchType && displayValue !== '';
+
         return (
             <select
                 id={id}
-                className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-dark focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/25"
+                className={`w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 ${
+                    isSelected
+                        ? 'border-primary bg-primary/5 text-primary font-medium ring-2 ring-primary/25'
+                        : 'border-gray-300 bg-white text-dark focus:border-primary focus:ring-primary/25'
+                }`}
                 value={displayValue}
                 onChange={(e) => handleQuickSearch(e.target.value, searchType)}
                 aria-label="検索フィルター"
@@ -103,7 +122,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
         <Card className="mt-1">
             <CardHeader
                 variant="primary"
-                className="flex cursor-pointer items-center justify-between"
+                className="flex cursor-pointer items-center justify-between select-none hover:bg-primary/90 transition-colors"
                 onClick={handleToggleExpanded}
                 onKeyDown={handleKeyDown}
                 role="button"
@@ -112,10 +131,27 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                 aria-controls="search-options-body"
                 data-testid="search-card-header"
             >
-                <h5>検索オプション</h5>
-                <div
-                    className={`h-0 w-0 border-l-[6px] border-r-[6px] border-t-[8px] border-l-transparent border-r-transparent border-t-white transition-transform ${isExpanded ? 'rotate-180' : ''}`}
-                />
+                <div className="flex items-center gap-2">
+                    <h5 className="text-sm font-medium">検索オプション</h5>
+                    {!isExpanded && activeSearchType && (
+                        <span className="text-xs bg-white/20 px-2 py-0.5 rounded">
+                            フィルタ適用中
+                        </span>
+                    )}
+                </div>
+                <div className="flex items-center gap-1">
+                    <span className="text-xs opacity-75 hidden sm:inline">
+                        {isExpanded ? '閉じる' : '開く'}
+                    </span>
+                    <svg
+                        className={`w-4 h-4 transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`}
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                    >
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                    </svg>
+                </div>
             </CardHeader>
             {isExpanded && categories && (
                 <CardBody id="search-options-body" className="p-3">

--- a/frontend/src/components/organisms/SearchCard/SearchCard.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchCard.tsx
@@ -71,7 +71,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
         return items.map((item, index) => {
             // 選択中のボタンを判定
             const isSelected = activeSearchType === searchType && searchQuery === item;
-            // 選択中はprimaryバリアント、そうでなければ元のvariant
+            // 選択中はprimaryバリアント（塗りつぶし）、未選択はアウトライン
             const buttonVariant = isSelected ? 'primary' : variant;
 
             return (
@@ -82,14 +82,15 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                         size="sm"
                         onClick={() => handleQuickSearch(item, searchType)}
                         className={isSelected
-                            ? 'ring-2 ring-primary ring-offset-1 font-bold'
-                            : 'hover:ring-1 hover:ring-slate-300 focus:ring-2 focus:ring-primary/50 focus:outline-none'
+                            ? 'ring-2 ring-primary ring-offset-1 font-bold shadow-sm'
+                            : 'opacity-80 hover:opacity-100 hover:ring-1 hover:ring-slate-300 focus:ring-2 focus:ring-primary/50 focus:outline-none'
                         }
                         aria-pressed={isSelected}
+                        aria-label={isSelected ? `${item}（選択中）` : item}
                     >
                         {/* 選択時はチェックアイコンを表示 */}
                         {isSelected && (
-                            <svg className="w-3.5 h-3.5 mr-1 inline-block" fill="currentColor" viewBox="0 0 20 20">
+                            <svg className="w-3.5 h-3.5 mr-1 inline-block" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
                                 <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
                             </svg>
                         )}

--- a/frontend/src/components/organisms/SearchCard/SearchCard.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchCard.tsx
@@ -142,13 +142,14 @@ export const SearchCard: React.FC<SearchCardProps> = ({
         <Card className="mt-1">
             <CardHeader
                 variant="primary"
-                className="flex cursor-pointer items-center justify-between select-none hover:bg-primary/90 transition-colors"
+                className="flex cursor-pointer items-center justify-between select-none hover:bg-primary/90 transition-colors focus-within:ring-2 focus-within:ring-white/50 focus-within:ring-inset"
                 onClick={handleToggleExpanded}
                 onKeyDown={handleKeyDown}
                 role="button"
                 tabIndex={0}
                 aria-expanded={isExpanded}
                 aria-controls="search-options-body"
+                aria-label={`検索オプション ${isExpanded ? '閉じる' : '開く'}`}
                 data-testid="search-card-header"
             >
                 <div className="flex items-center gap-2">
@@ -159,8 +160,12 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                         </span>
                     )}
                 </div>
-                <div className="flex items-center gap-1">
-                    <span className="text-xs opacity-75 hidden sm:inline">
+                {/* 開閉ボタン: ヒットエリア拡大、視覚的に押しやすく */}
+                <span
+                    className="flex items-center gap-1.5 px-3 py-1.5 -mr-2 rounded-md bg-white/10 hover:bg-white/20 transition-colors"
+                    aria-hidden="true"
+                >
+                    <span className="text-xs font-medium hidden sm:inline">
                         {isExpanded ? '閉じる' : '開く'}
                     </span>
                     <svg
@@ -171,7 +176,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                     >
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
                     </svg>
-                </div>
+                </span>
             </CardHeader>
             {isExpanded && categories && (
                 <CardBody id="search-options-body" className="p-3">

--- a/frontend/src/components/organisms/SearchCard/SearchCard.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchCard.tsx
@@ -141,8 +141,8 @@ export const SearchCard: React.FC<SearchCardProps> = ({
     return (
         <Card className="mt-1">
             <CardHeader
-                variant="primary"
-                className="flex cursor-pointer items-center justify-between select-none hover:bg-primary/90 transition-colors focus-within:ring-2 focus-within:ring-white/50 focus-within:ring-inset"
+                variant="secondary"
+                className="flex cursor-pointer items-center justify-between select-none hover:bg-slate-600 transition-colors focus-within:ring-2 focus-within:ring-white/50 focus-within:ring-inset"
                 onClick={handleToggleExpanded}
                 onKeyDown={handleKeyDown}
                 role="button"

--- a/frontend/src/components/organisms/SearchCard/SearchCard.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchCard.tsx
@@ -81,8 +81,18 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                         variant={buttonVariant as ButtonVariant}
                         size="sm"
                         onClick={() => handleQuickSearch(item, searchType)}
-                        className={isSelected ? 'ring-2 ring-primary ring-offset-1' : ''}
+                        className={isSelected
+                            ? 'ring-2 ring-primary ring-offset-1 font-bold'
+                            : 'hover:ring-1 hover:ring-slate-300 focus:ring-2 focus:ring-primary/50 focus:outline-none'
+                        }
+                        aria-pressed={isSelected}
                     >
+                        {/* 選択時はチェックアイコンを表示 */}
+                        {isSelected && (
+                            <svg className="w-3.5 h-3.5 mr-1 inline-block" fill="currentColor" viewBox="0 0 20 20">
+                                <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                            </svg>
+                        )}
                         {item}
                     </Button>
                     {index % 10 === 9 && <div className="mt-1" />}
@@ -97,24 +107,34 @@ export const SearchCard: React.FC<SearchCardProps> = ({
         const isSelected = activeSearchType === searchType && displayValue !== '';
 
         return (
-            <select
-                id={id}
-                className={`w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 ${
-                    isSelected
-                        ? 'border-primary bg-primary/5 text-primary font-medium ring-2 ring-primary/25'
-                        : 'border-gray-300 bg-white text-dark focus:border-primary focus:ring-primary/25'
-                }`}
-                value={displayValue}
-                onChange={(e) => handleQuickSearch(e.target.value, searchType)}
-                aria-label="検索フィルター"
-            >
-                <option value="">全て表示</option>
-                {items.map((option, index) => (
-                    <option key={`search-option-${option.value}-${index}`} value={option.value}>
-                        {option.label}
-                    </option>
-                ))}
-            </select>
+            <div className="relative">
+                <select
+                    id={id}
+                    className={`w-full rounded-md border px-3 py-2 text-sm transition-colors focus:outline-none focus:ring-2 ${
+                        isSelected
+                            ? 'border-primary bg-primary/10 text-primary font-bold ring-2 ring-primary/40'
+                            : 'border-gray-300 bg-white text-dark hover:border-slate-400 focus:border-primary focus:ring-primary/25'
+                    }`}
+                    value={displayValue}
+                    onChange={(e) => handleQuickSearch(e.target.value, searchType)}
+                    aria-label="検索フィルター"
+                >
+                    <option value="">全て表示</option>
+                    {items.map((option, index) => (
+                        <option key={`search-option-${option.value}-${index}`} value={option.value}>
+                            {option.label}
+                        </option>
+                    ))}
+                </select>
+                {/* 選択時はチェックアイコンを表示 */}
+                {isSelected && (
+                    <span className="absolute right-8 top-1/2 -translate-y-1/2 text-primary pointer-events-none">
+                        <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                            <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                        </svg>
+                    </span>
+                )}
+            </div>
         );
     };
 

--- a/frontend/src/components/organisms/SearchCard/SearchCard.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchCard.tsx
@@ -112,7 +112,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                     id={id}
                     className={`w-full rounded-md border px-3 py-2 text-sm transition-colors focus:outline-none focus:ring-2 ${
                         isSelected
-                            ? 'border-primary bg-primary/10 text-primary font-bold ring-2 ring-primary/40'
+                            ? 'border-primary bg-primary/20 text-blue-800 font-bold ring-2 ring-primary/50'
                             : 'border-gray-300 bg-white text-dark hover:border-slate-400 focus:border-primary focus:ring-primary/25'
                     }`}
                     value={displayValue}
@@ -128,7 +128,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                 </select>
                 {/* 選択時はチェックアイコンを表示 */}
                 {isSelected && (
-                    <span className="absolute right-8 top-1/2 -translate-y-1/2 text-primary pointer-events-none">
+                    <span className="absolute right-8 top-1/2 -translate-y-1/2 text-blue-700 pointer-events-none">
                         <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
                             <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
                         </svg>

--- a/frontend/src/components/organisms/SearchCard/SearchCard.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchCard.tsx
@@ -21,6 +21,8 @@ export const SearchCard: React.FC<SearchCardProps> = ({
 
     const [isExpanded, setIsExpanded] = useState(true);
     const [searchQuery, setSearchQuery] = useState('');
+    // アクティブな検索タイプを追跡（ドロップダウンの表示制御用）
+    const [activeSearchType, setActiveSearchType] = useState<'securities' | 'years' | 'products' | 'accounts' | null>(null);
 
     // データが存在するかチェックするヘルパー関数
     const hasData = (data: unknown[] | undefined): boolean => {
@@ -52,8 +54,9 @@ export const SearchCard: React.FC<SearchCardProps> = ({
         }
     };
 
-    const handleQuickSearch = (value: string) => {
+    const handleQuickSearch = (value: string, searchType: 'securities' | 'years' | 'products' | 'accounts') => {
         setSearchQuery(value);
+        setActiveSearchType(value ? searchType : null);
         onSearch(value);
     };
 
@@ -62,12 +65,12 @@ export const SearchCard: React.FC<SearchCardProps> = ({
         return null;
     }
 
-    const renderQuickSearchButtons = (items: string[], variant: string) => {
+    const renderQuickSearchButtons = (items: string[], variant: string, searchType: 'products' | 'accounts') => {
         if (!items || items.length === 0) return null;
 
         return items.map((item, index) => (
             <React.Fragment key={index}>
-                <Button type="button" variant={variant as ButtonVariant} size="sm" onClick={() => handleQuickSearch(item)}>
+                <Button type="button" variant={variant as ButtonVariant} size="sm" onClick={() => handleQuickSearch(item, searchType)}>
                     {item}
                 </Button>
                 {index % 10 === 9 && <div className="mt-1" />}
@@ -75,13 +78,15 @@ export const SearchCard: React.FC<SearchCardProps> = ({
         ));
     };
 
-    const renderQuickSearchDropdown = (items: { value: string, label: string }[], id: string = 'search-dropdown') => {
+    const renderQuickSearchDropdown = (items: { value: string, label: string }[], id: string, searchType: 'securities' | 'years') => {
+        // このドロップダウンがアクティブな検索タイプの場合のみ値を表示
+        const displayValue = activeSearchType === searchType ? searchQuery : '';
         return (
             <select
                 id={id}
                 className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-dark focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/25"
-                value={searchQuery}
-                onChange={(e) => handleQuickSearch(e.target.value)}
+                value={displayValue}
+                onChange={(e) => handleQuickSearch(e.target.value, searchType)}
                 aria-label="検索フィルター"
             >
                 <option value="">全て表示</option>
@@ -120,7 +125,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                         {hasData(categories.securities) && (
                             <div className="space-y-1">
                                 <label htmlFor="securities-search" className="text-sm font-medium text-dark">銘柄</label>
-                                {renderQuickSearchDropdown(categories.securities!, 'securities-search')}
+                                {renderQuickSearchDropdown(categories.securities!, 'securities-search', 'securities')}
                             </div>
                         )}
 
@@ -128,7 +133,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                         {hasData(categories.years) && (
                             <div className="space-y-1">
                                 <label htmlFor="years-search" className="text-sm font-medium text-dark">西暦</label>
-                                {renderQuickSearchDropdown(categories.years!, 'years-search')}
+                                {renderQuickSearchDropdown(categories.years!, 'years-search', 'years')}
                             </div>
                         )}
 
@@ -136,7 +141,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                         {hasData(categories.products) && (
                             <div className="space-y-1">
                                 <div className="text-sm font-medium text-dark">商品</div>
-                                <div className="flex flex-wrap gap-1">{renderQuickSearchButtons(categories.products!, "outline-success")}</div>
+                                <div className="flex flex-wrap gap-1">{renderQuickSearchButtons(categories.products!, "outline-success", 'products')}</div>
                             </div>
                         )}
 
@@ -144,7 +149,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                         {hasData(categories.accounts) && (
                             <div className="space-y-1">
                                 <div className="text-sm font-medium text-dark">口座</div>
-                                <div className="flex flex-wrap gap-1">{renderQuickSearchButtons(categories.accounts!, "outline-warning")}</div>
+                                <div className="flex flex-wrap gap-1">{renderQuickSearchButtons(categories.accounts!, "outline-warning", 'accounts')}</div>
                             </div>
                         )}
                     </div>

--- a/frontend/src/components/organisms/SearchCard/SearchCard.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchCard.tsx
@@ -143,7 +143,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
         <Card className="mt-1">
             <CardHeader
                 variant="secondary"
-                className="flex cursor-pointer items-center justify-between select-none hover:bg-slate-600 transition-colors focus-within:ring-2 focus-within:ring-white/50 focus-within:ring-inset"
+                className="flex cursor-pointer items-center justify-between select-none hover:bg-slate-600 transition-colors focus-within:ring-2 focus-within:ring-white/50 focus-within:ring-inset border-b-2 border-slate-600"
                 onClick={handleToggleExpanded}
                 onKeyDown={handleKeyDown}
                 role="button"
@@ -154,29 +154,28 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                 data-testid="search-card-header"
             >
                 <div className="flex items-center gap-2">
-                    <h5 className="text-sm font-medium">検索オプション</h5>
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
+                    </svg>
+                    <h5 className="text-sm font-semibold">検索オプション</h5>
                     {!isExpanded && activeSearchType && (
                         <span className="text-xs bg-white/20 px-2 py-0.5 rounded">
                             フィルタ適用中
                         </span>
                     )}
                 </div>
-                {/* 開閉ボタン: ヒットエリア拡大、視覚的に押しやすく */}
+                {/* 開閉ボタン: 状態に応じた視覚的フィードバック */}
                 <span
-                    className="flex items-center gap-1.5 px-3 py-1.5 -mr-2 rounded-md bg-white/10 hover:bg-white/20 transition-colors"
+                    className={`flex items-center gap-1.5 px-3 py-1.5 -mr-2 rounded-md transition-colors ${
+                        isExpanded
+                            ? 'bg-white/25 hover:bg-white/30'
+                            : 'bg-white/10 hover:bg-white/20'
+                    }`}
                     aria-hidden="true"
                 >
-                    <span className="text-xs font-medium hidden sm:inline">
-                        {isExpanded ? '閉じる' : '開く'}
+                    <span className="text-xs font-semibold">
+                        {isExpanded ? '▲ 閉じる' : '▼ 開く'}
                     </span>
-                    <svg
-                        className={`w-4 h-4 transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`}
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                    >
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                    </svg>
                 </span>
             </CardHeader>
             {isExpanded && categories && (

--- a/frontend/src/components/organisms/SearchCard/SearchCard.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchCard.tsx
@@ -113,40 +113,38 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                 />
             </CardHeader>
             {isExpanded && categories && (
-                <CardBody id="search-options-body" className="space-y-4 p-3">
-                    {/* 銘柄検索 */}
-                    {hasData(categories.securities) && (
-                        <div className="w-full max-w-[500px] space-y-2">
-                            <div className="text-sm font-medium text-dark">銘柄</div>
-                            <div>{renderQuickSearchDropdown(categories.securities!, 'securities-search')}</div>
-                        </div>
-                    )}
+                <CardBody id="search-options-body" className="p-3">
+                    {/* グリッドレイアウト: モバイル1列、sm2列、lg4列 */}
+                    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                        {/* 銘柄検索 */}
+                        {hasData(categories.securities) && (
+                            <div className="space-y-1">
+                                <label htmlFor="securities-search" className="text-sm font-medium text-dark">銘柄</label>
+                                {renderQuickSearchDropdown(categories.securities!, 'securities-search')}
+                            </div>
+                        )}
 
-                    <div className="flex flex-wrap gap-6">
                         {/* 年度検索 */}
                         {hasData(categories.years) && (
-                            <div>
-                                <div className="mb-2 w-[200px] text-sm font-medium text-dark">西暦</div>
-                                <div>{renderQuickSearchDropdown(categories.years!, 'years-search')}</div>
+                            <div className="space-y-1">
+                                <label htmlFor="years-search" className="text-sm font-medium text-dark">西暦</label>
+                                {renderQuickSearchDropdown(categories.years!, 'years-search')}
                             </div>
                         )}
-                        {/* 年月検索 */}
-                        {/* 年月検索は現状非表示 */}
-                    </div>
 
-                    <div className="flex flex-wrap gap-6">
                         {/* 商品検索 */}
                         {hasData(categories.products) && (
-                            <div className="space-y-2">
+                            <div className="space-y-1">
                                 <div className="text-sm font-medium text-dark">商品</div>
-                                <div className="flex flex-wrap gap-2">{renderQuickSearchButtons(categories.products!, "outline-success")}</div>
+                                <div className="flex flex-wrap gap-1">{renderQuickSearchButtons(categories.products!, "outline-success")}</div>
                             </div>
                         )}
+
                         {/* 口座検索 */}
                         {hasData(categories.accounts) && (
-                            <div className="space-y-2">
+                            <div className="space-y-1">
                                 <div className="text-sm font-medium text-dark">口座</div>
-                                <div className="flex flex-wrap gap-2">{renderQuickSearchButtons(categories.accounts!, "outline-warning")}</div>
+                                <div className="flex flex-wrap gap-1">{renderQuickSearchButtons(categories.accounts!, "outline-warning")}</div>
                             </div>
                         )}
                     </div>

--- a/frontend/src/components/organisms/SearchForm.tsx
+++ b/frontend/src/components/organisms/SearchForm.tsx
@@ -33,10 +33,10 @@ export const SearchForm: React.FC<SearchFormProps> = ({
           <InputField
             type="text"
             className="rounded-r-none border-r-0"
-            placeholder="銘柄コードを入力"
+            placeholder="銘柄コードまたは銘柄名"
             value={stockCode}
             onChange={handleInputChange}
-            aria-label="銘柄コード"
+            aria-label="銘柄コードまたは銘柄名"
             autoComplete="off"
             disabled={isLoading}
             fullWidth

--- a/frontend/src/components/templates/ReceiptTemplate.tsx
+++ b/frontend/src/components/templates/ReceiptTemplate.tsx
@@ -35,7 +35,7 @@ const ReceiptTemplateContent: React.FC<ReceiptTemplateProps> = ({
   };
 
   return (
-    <div className="space-y-3" data-testid="receipt-container">
+    <div className="space-y-2" data-testid="receipt-container">
       {/* 検索カード */}
       {onSearch && (
         <SearchCard
@@ -46,7 +46,7 @@ const ReceiptTemplateContent: React.FC<ReceiptTemplateProps> = ({
       )}
 
       {/* ヘッダー情報 */}
-      {header && <div>{header}</div>}
+      {header && <div className="mt-1">{header}</div>}
 
       {/* メインコンテンツ */}
       <Card className="mt-1" data-testid="receipt-card">

--- a/frontend/src/pages/AssetBalance.tsx
+++ b/frontend/src/pages/AssetBalance.tsx
@@ -214,10 +214,10 @@ export function AssetBalancePage() {
                     variant="outline-danger"
                     size="sm"
                     onClick={handleDeleteAll}
-                    disabled={saving || deleting}
-                    aria-disabled={saving || deleting}
+                    disabled={saving || deleting || loading}
+                    aria-disabled={saving || deleting || loading}
                   >
-                    {deleting ? '削除中...' : '削除'}
+                    {deleting ? '削除中...' : `全件削除 (${dbData.length}件)`}
                   </Button>
                 )}
               </div>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -3,6 +3,13 @@ import { Layout } from '../components/templates/Layout';
 import { Card, CardBody } from '../components/atoms/Card';
 import { PageHeader } from '../components/atoms/PageHeader';
 
+// クイックアクション（ショートカット）
+const QUICK_ACTIONS = [
+  { label: '配当金を確認', to: '/receipts', icon: '💰' },
+  { label: '保有銘柄を確認', to: '/assetbalance', icon: '📊' },
+  { label: '銘柄を検索', to: '/search', icon: '🔍' },
+] as const;
+
 const FEATURES = [
   {
     title: '銘柄検索',
@@ -61,6 +68,23 @@ export function HomePage() {
               </Card>
             </Link>
           ))}
+        </div>
+
+        {/* クイックアクション */}
+        <div className="mt-6 pt-4 border-t border-slate-200">
+          <h2 className="text-sm font-medium text-slate-500 mb-3">クイックアクション</h2>
+          <div className="flex flex-wrap gap-2">
+            {QUICK_ACTIONS.map(({ label, to, icon }) => (
+              <Link
+                key={to}
+                to={to}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-slate-100 hover:bg-slate-200 text-slate-700 rounded-full transition-colors"
+              >
+                <span aria-hidden="true">{icon}</span>
+                {label}
+              </Link>
+            ))}
+          </div>
         </div>
       </div>
     </Layout>

--- a/frontend/src/pages/Receipt/Dividend.tsx
+++ b/frontend/src/pages/Receipt/Dividend.tsx
@@ -219,7 +219,7 @@ export const Dividend: React.FC<DividendProps> = ({ csvData }) => {
             header={
                 <ReceiptHeader
                     items={headerItems}
-                    title="集計情報"
+                    title={isSecurityCodeSearch ? "銘柄詳細" : "集計情報"}
                 >
                     {isSecurityCodeSearch && (
                         <DividendInfo

--- a/frontend/src/pages/Receipt/Dividend.tsx
+++ b/frontend/src/pages/Receipt/Dividend.tsx
@@ -142,7 +142,7 @@ export const Dividend: React.FC<DividendProps> = ({ csvData }) => {
     }, [filteredData, searchQuery]);
 
     // ヘッダー項目の定義
-    const headerItems = [
+    const allHeaderItems = [
         {
             title: '合計配当金',
             value: calculations.total_dividends_before_tax,
@@ -159,6 +159,9 @@ export const Dividend: React.FC<DividendProps> = ({ csvData }) => {
             format: formatCurrency
         }
     ];
+
+    // 配当情報表示時は配当情報内に3指標を表示するため、上段の集計は非表示
+    const headerItems = searchQuery ? [] : allHeaderItems;
 
     // テーブルカラムの定義（検索タイプに応じて表示順序を調整）
     const baseColumns: TableColumnConfig[] = useMemo(() => ([
@@ -208,16 +211,20 @@ export const Dividend: React.FC<DividendProps> = ({ csvData }) => {
         <ReceiptTemplate
             title="配当金"
             header={
-                <>
-                    <ReceiptHeader items={headerItems} />
+                <ReceiptHeader
+                    items={headerItems}
+                    title={searchQuery ? '配当情報' : '集計情報'}
+                    collapsible={!!searchQuery}
+                >
                     {searchQuery && (
                         <DividendInfo
                             searchQuery={searchQuery}
                             securityCode={searchSecurityCode}
                             summary={summary}
+                            embedded
                         />
                     )}
-                </>
+                </ReceiptHeader>
             }
             onSearch={(query: string) => setSearchQuery(query)}
             searchCategories={searchCategories}

--- a/frontend/src/pages/Receipt/Dividend.tsx
+++ b/frontend/src/pages/Receipt/Dividend.tsx
@@ -90,10 +90,10 @@ export const Dividend: React.FC<DividendProps> = ({ csvData }) => {
 
         const query = searchQuery.toLowerCase();
 
-        // 銘柄での検索の場合
+        // 銘柄での検索の場合（銘柄名でグループ化、年と誤判定を防ぐ）
         if (item.security_code.toLowerCase() === query ||
             item.security_name.toLowerCase() === query) {
-            return item.security_code;
+            return item.security_name;
         }
 
         // 商品での検索の場合

--- a/frontend/src/pages/Receipt/Dividend.tsx
+++ b/frontend/src/pages/Receipt/Dividend.tsx
@@ -105,14 +105,14 @@ export const Dividend: React.FC<DividendProps> = ({ csvData }) => {
             return item.account;
         }
 
-        // 年度での検索の場合
+        // 年度での検索の場合も月単位でグループ化（検索なし時と同一ルール）
         if (matchesYear(item.settlement_date, query)) {
-            return item.settlement_date.getFullYear().toString();
+            return createYearMonthKey(item.settlement_date);
         }
 
-        // 年月での検索の場合
+        // 年月での検索の場合も月単位でグループ化（検索なし時と同一ルール）
         if (matchesYearMonth(item.settlement_date, query)) {
-            return query;
+            return createYearMonthKey(item.settlement_date);
         }
 
         // デフォルトは年月でグループ化

--- a/frontend/src/pages/Receipt/Dividend.tsx
+++ b/frontend/src/pages/Receipt/Dividend.tsx
@@ -42,9 +42,6 @@ export const Dividend: React.FC<DividendProps> = ({ csvData }) => {
     // CSVデータを配当データ形式に変換
     const dividendData = useReceiptData(csvData, parseDividendCsvItem, sortDividendBySettlementDate);
 
-    // 全体の集計
-    const calculations = useReceiptCalculations(dividendData, calculateDividends);
-
     // 検索カテゴリーの生成
     const searchCategories = useMemo(() => ({
         securities: createSearchOptions(dividendData, 'security_code', 'security_name', true),
@@ -80,6 +77,9 @@ export const Dividend: React.FC<DividendProps> = ({ csvData }) => {
         () => filterByConfig(dividendData, searchQuery, filterConfig),
         [dividendData, searchQuery, filterConfig]
     );
+
+    // 表示用の集計（検索前後で同一ロジック: フィルタ後データから計算）
+    const calculations = useReceiptCalculations(filteredData, calculateDividends);
 
     // グループキーの取得（検索タイプに応じて動的に変更）
     const getGroupKey = useCallback((item: DividendData): string => {
@@ -207,15 +207,18 @@ export const Dividend: React.FC<DividendProps> = ({ csvData }) => {
     return (
         <ReceiptTemplate
             title="配当金"
-            header={searchQuery ? (
-                <DividendInfo
-                    searchQuery={searchQuery}
-                    securityCode={searchSecurityCode}
-                    summary={summary}
-                />
-            ) : (
-                <ReceiptHeader items={headerItems} />
-            )}
+            header={
+                <>
+                    <ReceiptHeader items={headerItems} />
+                    {searchQuery && (
+                        <DividendInfo
+                            searchQuery={searchQuery}
+                            securityCode={searchSecurityCode}
+                            summary={summary}
+                        />
+                    )}
+                </>
+            }
             onSearch={(query: string) => setSearchQuery(query)}
             searchCategories={searchCategories}
         >

--- a/frontend/src/pages/Receipt/Dividend.tsx
+++ b/frontend/src/pages/Receipt/Dividend.tsx
@@ -12,7 +12,8 @@ import {
     formatJPDate,
     createYearMonthKey,
     formatCurrency,
-    formatNumber
+    formatNumber,
+    SECURITY_CODE_REGEX
 } from '@/lib/utils/formatters';
 import { renderSecurityCode } from '@/components/atoms/SecurityCodeLink';
 import { useReceiptData, useReceiptCalculations } from '@/hooks/receipt/useReceiptData';
@@ -141,6 +142,11 @@ export const Dividend: React.FC<DividendProps> = ({ csvData }) => {
         return matchedItem?.security_code || '';
     }, [filteredData, searchQuery]);
 
+    // 銘柄コード検索かどうかを判定（配当シミュレーション表示の条件）
+    const isSecurityCodeSearch = useMemo(() => {
+        return !!searchSecurityCode && SECURITY_CODE_REGEX.test(searchSecurityCode);
+    }, [searchSecurityCode]);
+
     // ヘッダー項目の定義
     const allHeaderItems = [
         {
@@ -160,8 +166,8 @@ export const Dividend: React.FC<DividendProps> = ({ csvData }) => {
         }
     ];
 
-    // 配当情報表示時は配当情報内に3指標を表示するため、上段の集計は非表示
-    const headerItems = searchQuery ? [] : allHeaderItems;
+    // 配当シミュレーション表示時は内部に3指標を表示するため、上段の集計は非表示
+    const headerItems = isSecurityCodeSearch ? [] : allHeaderItems;
 
     // テーブルカラムの定義（検索タイプに応じて表示順序を調整）
     const baseColumns: TableColumnConfig[] = useMemo(() => ([
@@ -213,10 +219,9 @@ export const Dividend: React.FC<DividendProps> = ({ csvData }) => {
             header={
                 <ReceiptHeader
                     items={headerItems}
-                    title={searchQuery ? '配当情報' : '集計情報'}
-                    collapsible={!!searchQuery}
+                    title="集計情報"
                 >
-                    {searchQuery && (
+                    {isSecurityCodeSearch && (
                         <DividendInfo
                             searchQuery={searchQuery}
                             securityCode={searchSecurityCode}

--- a/frontend/src/pages/Receipt/DomesticStock.tsx
+++ b/frontend/src/pages/Receipt/DomesticStock.tsx
@@ -36,11 +36,8 @@ export const DomesticStock: React.FC<DomesticStockProps> = ({ csvData }) => {
     // CSVデータを国内株式データ形式に変換
     const domesticStockData = useReceiptData(csvData, parseDomesticStockCsvItem, sortDomesticStockByTradeDate);
 
-    // 日次データの集計
+    // 日次データの集計（全データ）
     const dailyData = useMemo(() => calculateDailyData(domesticStockData), [domesticStockData]);
-
-    // 全体の集計
-    const calculations = useReceiptCalculations(dailyData, calculateDomesticStock);
 
     // 検索カテゴリーの生成
     const searchCategories = useMemo(() => ({
@@ -74,11 +71,14 @@ export const DomesticStock: React.FC<DomesticStockProps> = ({ csvData }) => {
         [domesticStockData, searchQuery, filterConfig]
     );
 
-    // フィルタ後の日次集計（サマリーの0件表示を防止）
+    // フィルタ後の日次集計
     const filteredDailyData = useMemo(
         () => (searchQuery ? calculateDailyData(filteredData) : dailyData),
         [dailyData, filteredData, searchQuery]
     );
+
+    // 表示用の集計（検索前後で同一ロジック: フィルタ後データから計算）
+    const calculations = useReceiptCalculations(filteredDailyData, calculateDomesticStock);
 
     // グループキーの取得
     const getGroupKey = useCallback((item: DomesticStockData): string => {
@@ -154,7 +154,7 @@ export const DomesticStock: React.FC<DomesticStockProps> = ({ csvData }) => {
                 data={filteredData}
                 summary={filteredDailyData}
                 columns={columns}
-                summaryColumns={searchQuery ? [] : summaryColumns}
+                summaryColumns={summaryColumns}
                 getGroupKey={getGroupKey}
             />
         </ReceiptTemplate>

--- a/frontend/src/pages/Receipt/Mutualfund.tsx
+++ b/frontend/src/pages/Receipt/Mutualfund.tsx
@@ -119,21 +119,21 @@ export const Mutualfund: React.FC<MutualfundProps> = ({ csvData }) => {
     ];
 
     /**
-     * テーブルカラムの定義
+     * テーブルカラムの定義（列幅を明示的に設定して右端切れを防止）
      */
     const columns: TableColumnConfig[] = useMemo(() => ([
-        { key: 'trade_date', header: '約定日', format: formatJPDate },
-        { key: 'settlement_date', header: '受渡日', format: formatJPDate },
-        { key: 'fund_name', header: 'ファンド名', width: '250px' },
-        { key: 'account', header: '口座', width: '80px' },
-        { key: 'shares', header: '数量[株]', textAlign: 'right', format: formatNumber },
-        { key: 'exchange_rate', header: '為替レート', textAlign: 'right', format: formatCurrency },
-        { key: 'cancellation_unit_price_yen', header: '解約単価', textAlign: 'right', format: formatCurrency },
-        { key: 'cancellation_amount_yen', header: '解約額', textAlign: 'right', format: formatCurrency },
-        { key: 'average_acquisition_price_yen', header: '平均取得価額', textAlign: 'right', format: formatCurrency },
-        { key: 'realized_profit_and_loss', header: '実現損益', textAlign: 'right', format: formatCurrency },
-        { key: 'taxes', header: '税額', textAlign: 'right', format: formatCurrency },
-        { key: 'realized_profit_and_loss_after_tax', header: '実現損益(税引)', textAlign: 'right', format: formatCurrency },
+        { key: 'trade_date', header: '約定日', width: '90px', format: formatJPDate },
+        { key: 'settlement_date', header: '受渡日', width: '90px', format: formatJPDate },
+        { key: 'fund_name', header: 'ファンド名', width: '200px' },
+        { key: 'account', header: '口座', width: '70px' },
+        { key: 'shares', header: '数量', width: '70px', textAlign: 'right', format: formatNumber },
+        { key: 'exchange_rate', header: '為替', width: '70px', textAlign: 'right', format: formatCurrency },
+        { key: 'cancellation_unit_price_yen', header: '解約単価', width: '90px', textAlign: 'right', format: formatCurrency },
+        { key: 'cancellation_amount_yen', header: '解約額', width: '90px', textAlign: 'right', format: formatCurrency },
+        { key: 'average_acquisition_price_yen', header: '取得価額', width: '90px', textAlign: 'right', format: formatCurrency },
+        { key: 'realized_profit_and_loss', header: '実現損益', width: '90px', textAlign: 'right', format: formatCurrency },
+        { key: 'taxes', header: '税額', width: '70px', textAlign: 'right', format: formatCurrency },
+        { key: 'realized_profit_and_loss_after_tax', header: '税引損益', width: '90px', textAlign: 'right', format: formatCurrency },
     ]), []);
 
     /**

--- a/frontend/src/pages/Receipt/Mutualfund.tsx
+++ b/frontend/src/pages/Receipt/Mutualfund.tsx
@@ -6,7 +6,7 @@ import {
     MutualfundData,
     MutualfundCalculations
 } from '@/lib/interfaces/mutualfund';
-import { TableColumnConfig } from '@/lib/interfaces/receipt';
+import { TableColumnConfig, SummaryColumnConfig } from '@/lib/interfaces/receipt';
 import { createSearchOptions, groupAndSummarizeData } from '@/lib/utils/dataTransformer';
 import {
     formatJPDate,
@@ -129,6 +129,15 @@ export const Mutualfund: React.FC<MutualfundProps> = ({ csvData }) => {
         { key: 'realized_profit_and_loss_after_tax', header: '実現損益(税引)', textAlign: 'right', format: formatCurrency },
     ]), []);
 
+    /**
+     * サマリーカラムの定義（ヘッダーと同じ項目: 実現損益、税額、税引後）
+     */
+    const summaryColumns: SummaryColumnConfig[] = [
+        { key: 'realized_profit_and_loss', textAlign: 'right', format: formatCurrency },
+        { key: 'taxes', textAlign: 'right', format: formatCurrency },
+        { key: 'realized_profit_and_loss_after_tax', textAlign: 'right', format: formatCurrency },
+    ];
+
     return (
         <ReceiptTemplate
             title="投資信託"
@@ -140,7 +149,7 @@ export const Mutualfund: React.FC<MutualfundProps> = ({ csvData }) => {
                 data={filteredData}
                 summary={summary}
                 columns={columns}
-                summaryColumns={[]}
+                summaryColumns={summaryColumns}
                 getGroupKey={getGroupKey}
             />
         </ReceiptTemplate>

--- a/frontend/src/pages/Receipt/Mutualfund.tsx
+++ b/frontend/src/pages/Receipt/Mutualfund.tsx
@@ -35,19 +35,6 @@ export const Mutualfund: React.FC<MutualfundProps> = ({ csvData }) => {
     ), [csvData]);
 
     /**
-     * 全体の集計
-     */
-    const calculations: MutualfundCalculations = useMemo(() => mutualfundData.reduce((acc, item) => ({
-        total_realized_profit_and_loss: acc.total_realized_profit_and_loss + item.realized_profit_and_loss,
-        total_taxes: acc.total_taxes + item.taxes,
-        total_realized_profit_and_loss_after_tax: acc.total_realized_profit_and_loss_after_tax + item.realized_profit_and_loss_after_tax,
-    }), {
-        total_realized_profit_and_loss: 0,
-        total_taxes: 0,
-        total_realized_profit_and_loss_after_tax: 0,
-    }), [mutualfundData]);
-
-    /**
      * 検索オプションの生成
      */
     const searchCategories = useMemo(() => ({
@@ -70,6 +57,19 @@ export const Mutualfund: React.FC<MutualfundProps> = ({ csvData }) => {
         () => filterByConfig(mutualfundData, searchQuery, filterConfig),
         [mutualfundData, searchQuery, filterConfig]
     );
+
+    /**
+     * 表示用の集計（検索前後で同一ロジック: フィルタ後データから計算）
+     */
+    const calculations: MutualfundCalculations = useMemo(() => filteredData.reduce((acc, item) => ({
+        total_realized_profit_and_loss: acc.total_realized_profit_and_loss + item.realized_profit_and_loss,
+        total_taxes: acc.total_taxes + item.taxes,
+        total_realized_profit_and_loss_after_tax: acc.total_realized_profit_and_loss_after_tax + item.realized_profit_and_loss_after_tax,
+    }), {
+        total_realized_profit_and_loss: 0,
+        total_taxes: 0,
+        total_realized_profit_and_loss_after_tax: 0,
+    }), [filteredData]);
 
     /**
      * グループキーの取得（日付文字列：年月）

--- a/frontend/src/pages/Receipt/Mutualfund.tsx
+++ b/frontend/src/pages/Receipt/Mutualfund.tsx
@@ -73,10 +73,17 @@ export const Mutualfund: React.FC<MutualfundProps> = ({ csvData }) => {
 
     /**
      * グループキーの取得（日付文字列：年月）
+     * ファンド名検索時は元データの正式表記を使用
      */
     const getGroupKey = useCallback((item: MutualfundData): string => {
         if (searchQuery) {
-            return searchQuery.toLowerCase();
+            // ファンド名検索の場合は元データの表記を使用（小文字化しない）
+            const query = searchQuery.toLowerCase();
+            if (item.fund_name.toLowerCase().includes(query)) {
+                return item.fund_name;
+            }
+            // 年検索など他の場合は年月でグループ化
+            return createYearMonthKey(item.trade_date);
         }
         return createYearMonthKey(item.trade_date);
     }, [searchQuery]);

--- a/frontend/src/pages/Receipt/__tests__/Dividend.test.tsx
+++ b/frontend/src/pages/Receipt/__tests__/Dividend.test.tsx
@@ -145,10 +145,36 @@ describe('Dividend', () => {
             expect(screen.getByText('一株配当')).toBeInTheDocument();
         });
 
-        // 統計項目が表示されることを確認
-        expect(screen.getByText('取得総額')).toBeInTheDocument();
-        expect(screen.getByText('合計受取金額 (累積利回り)')).toBeInTheDocument();
-        expect(screen.getByText('年間配当金額 (配当利回り)')).toBeInTheDocument();
+        // 統計項目が重複せず表示されることを確認
+        expect(screen.queryByText('取得総額')).not.toBeInTheDocument();
+        expect(screen.queryByText('合計配当金')).not.toBeInTheDocument();
+        expect(screen.queryByText('合計税額')).not.toBeInTheDocument();
+        expect(screen.queryByText('合計受取金額')).not.toBeInTheDocument();
+        expect(screen.getByText('配当金額 (配当利回り)')).toBeInTheDocument();
+        expect(screen.getAllByText('税額').length).toBeGreaterThanOrEqual(2);
+        expect(screen.getByText('受取金額 (累積利回り)')).toBeInTheDocument();
+    });
+
+    it('配当情報ヘッダーをクリックすると開閉できる', async () => {
+        const user = userEvent.setup();
+        const { container } = render(<Dividend csvData={mockCsvData} />);
+
+        await waitFor(() => {
+            expect(container.querySelector('#securities-search')).toBeInTheDocument();
+        });
+        const selectElement = container.querySelector('#securities-search') as HTMLSelectElement;
+        await user.selectOptions(selectElement, '1234');
+
+        await waitFor(() => {
+            expect(screen.getByText('平均取得価格')).toBeInTheDocument();
+        });
+
+        const header = screen.getByTestId('receipt-header');
+        await user.click(header);
+        expect(screen.queryByText('平均取得価格')).not.toBeInTheDocument();
+
+        await user.click(header);
+        expect(screen.getByText('平均取得価格')).toBeInTheDocument();
     });
 
     it('検索をクリアすると通常のヘッダーに戻る', async () => {

--- a/frontend/src/pages/Receipts.tsx
+++ b/frontend/src/pages/Receipts.tsx
@@ -219,7 +219,9 @@ export function ReceiptsPage() {
    */
   const handleDeleteAll = async () => {
     if (!isAuthenticated) return;
-    if (!window.confirm('現在のタブのデータをすべて削除しますか？')) return;
+    const count = runtimeDataMap[receiptsType].dbData.length;
+    const tabName = receiptsType === 'dividend' ? '配当金' : receiptsType === 'domesticstock' ? '国内株式' : '投資信託';
+    if (!window.confirm(`【${tabName}】${count}件のデータをすべて削除しますか？\n\nこの操作は取り消せません。`)) return;
 
     setDeleting(true);
     setDbError(null);
@@ -253,10 +255,13 @@ export function ReceiptsPage() {
   const { isLoading, error, fileName, csvData } = currentCSVState;
   const hasCsvData = csvData.length > 0;
 
-  // 現在のタブのDBデータがあるか判定
-  const hasDbData = useMemo(() => {
-    return runtimeDataMap[receiptsType].dbData.length > 0;
+  // 現在のタブのDBデータ件数を取得
+  const dbDataCount = useMemo(() => {
+    return runtimeDataMap[receiptsType].dbData.length;
   }, [runtimeDataMap, receiptsType]);
+
+  // 現在のタブのDBデータがあるか判定
+  const hasDbData = dbDataCount > 0;
 
   // 表示用データを決定（ログイン時はDB優先、未ログイン時はCSV）
   const dividendData = useMemo(
@@ -332,7 +337,7 @@ export function ReceiptsPage() {
                   disabled={saving || deleting || dbLoading}
                   aria-disabled={saving || deleting || dbLoading}
                 >
-                  {deleting ? '削除中...' : '全件削除'}
+                  {deleting ? '削除中...' : `全件削除 (${dbDataCount}件)`}
                 </Button>
               )}
             </div>

--- a/frontend/src/pages/Receipts.tsx
+++ b/frontend/src/pages/Receipts.tsx
@@ -329,10 +329,10 @@ export function ReceiptsPage() {
                   variant="outline-danger"
                   size="sm"
                   onClick={handleDeleteAll}
-                  disabled={saving || deleting}
-                  aria-disabled={saving || deleting}
+                  disabled={saving || deleting || dbLoading}
+                  aria-disabled={saving || deleting || dbLoading}
                 >
-                  {deleting ? '削除中...' : '削除'}
+                  {deleting ? '削除中...' : '全件削除'}
                 </Button>
               )}
             </div>

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -42,7 +42,7 @@ export function SearchPage() {
       <div>
         <PageHeader
           title="銘柄検索"
-          description="銘柄コードを入力して株式情報を検索できます。"
+          description="銘柄コードまたは銘柄名を入力して株式情報を検索できます。"
         />
         <SearchForm
           stockCode={stockCode}
@@ -75,7 +75,7 @@ export function SearchPage() {
               </svg>
             }
             title="銘柄を検索"
-            description="銘柄コード（例：7203）を入力して検索してください。"
+            description="銘柄コード（例：7203）または銘柄名を入力して検索してください。"
             className="py-10"
           />
         )}


### PR DESCRIPTION
## 概要
受取金ページ（配当金/国内株式/投資信託）のUI改善とCodexレビュー指摘への対応

## 変更種別
- [x] 新機能
- [x] バグ修正
- [x] リファクタリング

## 主な変更内容

### UI改善（Codexレビュー対応）
- **UI-01**: headerItems空時のstat-grid非表示対応
- **UI-02**: 検索チップの選択状態改善（チェックアイコン・太字）
- **UI-04**: 検索オプション開閉のヒットエリア拡大
- **UI-05**: 濃色ヘッダー帯のトーン調整

### UIレビュー第2弾
- 検索チップのコントラスト改善（WCAG 4.5:1準拠）
- 自動入力バッジのデータ元明示（保有銘柄/J-Quants）
- 選択状態カラーの視認性強化
- 投資信託のグループ見出し表記修正
- 件数バッジの可読性改善

### 検索オプションUI
- グリッドレイアウト（モバイル1列、sm2列、lg4列）
- サマリー表示ルールを検索前後で統一
- 投資信託にテーブルサマリー行を追加
- 配当金の西暦検索時も月単位でグループ化

### その他
- ポートフォリオ構成比グラフの追加
- テーブルのモバイル対応改善
- アクセシビリティ改善

## テスト
- [x] 3タブ（配当金/国内株式/投資信託）で表示確認
- [x] 検索前/検索後でUIが正常に動作
- [x] モバイル表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)