### PR TITLE
フロントエンドリファクタリングとUI改善

### DIFF
--- a/.claude/skills/ui-review/SKILL.md
+++ b/.claude/skills/ui-review/SKILL.md
@@ -37,12 +37,25 @@ description: "開発サーバーに対してUIレビューを自動実行し、�
 | `receipts-mutualfund-search-year.png` | 投資信託 - 西暦検索結果 |
 | `receipts-mutualfund-search-fund.png` | 投資信託 - ファンド検索結果 |
 
+## 追加であると安心なスクショ（任意）
+| ファイル名 | 内容 |
+|---|---|
+| `login-initial.png` | ログインページの初期表示（**未ログイン時**） |
+| `notfound-404.png` | 404ページ（関連リンク表示） |
+| `header-user-menu.png` | ヘッダーのユーザーメニュー展開（**ログイン時**） |
+| `header-delete-account-modal.png` | アカウント削除の確認モーダル（**ログイン時**） |
+| `search-empty.png` | 銘柄検索の初期状態（EmptyState表示） |
+| `search-invalid-code-param.png` | `?code=` が不正な場合の警告表示 |
+| `assetbalance-empty.png` | 保有銘柄が0件のEmptyState（**ログイン時**） |
+| `assetbalance-filter-empty.png` | 絞り込み0件のEmptyState（解除リンク表示） |
+
 ## 実施手順（共通）
 
 ### 1) 事前確認
 - 本レビューは **8080固定**（`http://127.0.0.1:8080` を使用）
 - **ログインは必須**。必ず認証状態を準備する
 - このアプリのレビューは **PC表示前提**（モバイル評価は対象外）
+- スクショは **FHD（1920x1080）** を基準に取得する
 - 開発サーバー運用は以下を厳守する
   - 8080が既に起動中なら **再利用**（新規起動しない）
   - 新規起動時は `--strictPort` を必須化（8081/8082への自動フォールバック禁止）

--- a/frontend/src/components/molecules/ReceiptHeader/ReceiptHeader.tsx
+++ b/frontend/src/components/molecules/ReceiptHeader/ReceiptHeader.tsx
@@ -1,12 +1,7 @@
 import React, { ReactNode, useEffect, useId, useState } from 'react';
 import { StatItem } from '@/components/atoms/StatItem';
 import { Card, CardBody, CardHeader } from '@/components/atoms/Card';
-
-interface HeaderItem {
-    title: string;
-    value: number;
-    format: (value: number) => string;
-}
+import { HeaderItem } from '@/types/common';
 
 interface ReceiptHeaderProps {
     items: HeaderItem[];

--- a/frontend/src/hooks/receipt/useReceiptPageState.ts
+++ b/frontend/src/hooks/receipt/useReceiptPageState.ts
@@ -1,0 +1,19 @@
+import { useState, useMemo } from 'react';
+import { filterByConfig, FilterConfig } from '@/lib/utils/searchUtils';
+
+/**
+ * 受取金ページ共通のフィルタ状態管理フック
+ * @param data フィルタ対象のデータ配列
+ * @param filterConfig フィルタ設定
+ */
+export function useReceiptPageState<T>(
+    data: T[],
+    filterConfig: FilterConfig<T>
+) {
+    const [searchQuery, setSearchQuery] = useState('');
+    const filteredData = useMemo(
+        () => filterByConfig(data, searchQuery, filterConfig),
+        [data, searchQuery, filterConfig]
+    );
+    return { searchQuery, setSearchQuery, filteredData } as const;
+}

--- a/frontend/src/lib/utils/__tests__/columnUtils.test.ts
+++ b/frontend/src/lib/utils/__tests__/columnUtils.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { reorderColumnsBySearch, ColumnReorderRule } from '../columnUtils';
+import { TableColumnConfig } from '@/lib/interfaces/receipt';
+
+interface TestItem {
+    id: number;
+    name: string;
+    category: string;
+    account: string;
+}
+
+const baseColumns: TableColumnConfig[] = [
+    { key: 'date', header: '日付' },
+    { key: 'code', header: 'コード' },
+    { key: 'name', header: '名前' },
+    { key: 'category', header: 'カテゴリ' },
+    { key: 'account', header: '口座' },
+    { key: 'amount', header: '金額' },
+];
+
+const testData: TestItem[] = [
+    { id: 1, name: 'テスト1', category: '商品A', account: '特定口座' },
+    { id: 2, name: 'テスト2', category: '商品B', account: 'NISA' },
+];
+
+describe('columnUtils', () => {
+    describe('reorderColumnsBySearch', () => {
+        it('検索クエリがない場合はbaseColumnsをそのまま返す', () => {
+            const rules: ColumnReorderRule<TestItem>[] = [
+                { columnKey: 'account', match: (item, q) => item.account.toLowerCase().includes(q) },
+            ];
+
+            const result = reorderColumnsBySearch(baseColumns, testData, '', rules, 1);
+            expect(result).toEqual(baseColumns);
+        });
+
+        it('マッチするルールがある場合は該当列を前面に配置する', () => {
+            const rules: ColumnReorderRule<TestItem>[] = [
+                { columnKey: 'account', match: (item, q) => item.account.toLowerCase().includes(q) },
+            ];
+
+            const result = reorderColumnsBySearch(baseColumns, testData, '特定', rules, 1);
+
+            // date(固定) + account(移動) + code, name, category, amount
+            expect(result[0].key).toBe('date');
+            expect(result[1].key).toBe('account');
+            expect(result[2].key).toBe('code');
+        });
+
+        it('fixedColumnCountに応じて固定列数を変更できる', () => {
+            const rules: ColumnReorderRule<TestItem>[] = [
+                { columnKey: 'account', match: (item, q) => item.account.toLowerCase().includes(q) },
+            ];
+
+            const result = reorderColumnsBySearch(baseColumns, testData, '特定', rules, 2);
+
+            // date, code(固定2列) + account(移動) + name, category, amount
+            expect(result[0].key).toBe('date');
+            expect(result[1].key).toBe('code');
+            expect(result[2].key).toBe('account');
+            expect(result[3].key).toBe('name');
+        });
+
+        it('複数ルールがある場合は優先度順に評価される', () => {
+            const rules: ColumnReorderRule<TestItem>[] = [
+                { columnKey: 'category', match: (item, q) => item.category.toLowerCase().includes(q) },
+                { columnKey: 'account', match: (item, q) => item.account.toLowerCase().includes(q) },
+            ];
+
+            // 商品Aにマッチ → categoryが前面に
+            const result = reorderColumnsBySearch(baseColumns, testData, '商品a', rules, 1);
+            expect(result[1].key).toBe('category');
+        });
+
+        it('マッチするデータがない場合はbaseColumnsを返す', () => {
+            const rules: ColumnReorderRule<TestItem>[] = [
+                { columnKey: 'account', match: (item, q) => item.account.toLowerCase().includes(q) },
+            ];
+
+            const result = reorderColumnsBySearch(baseColumns, testData, '存在しない', rules, 1);
+            expect(result).toEqual(baseColumns);
+        });
+
+        it('存在しないcolumnKeyの場合はスキップして次のルールを評価', () => {
+            const rules: ColumnReorderRule<TestItem>[] = [
+                { columnKey: 'nonexistent', match: () => true },
+                { columnKey: 'account', match: (item, q) => item.account.toLowerCase().includes(q) },
+            ];
+
+            const result = reorderColumnsBySearch(baseColumns, testData, '特定', rules, 1);
+            expect(result[1].key).toBe('account');
+        });
+    });
+});

--- a/frontend/src/lib/utils/__tests__/dataTransformer.test.ts
+++ b/frontend/src/lib/utils/__tests__/dataTransformer.test.ts
@@ -1,4 +1,4 @@
-import { createSearchOptions, filterDataBySearchQuery, groupAndSummarizeData } from '../dataTransformer';
+import { createSearchOptions, groupAndSummarizeData } from '../dataTransformer';
 
 interface TestItemWithCode {
     code: string;
@@ -57,34 +57,6 @@ describe('createSearchOptions', () => {
             { value: '1234', label: '1234: テスト1' },
             { value: '5678', label: '5678: テスト2' }
         ]);
-    });
-});
-
-describe('filterDataBySearchQuery', () => {
-    const testData: TestItemWithCode[] = [
-        { code: '1234', name: 'テスト1', value: 100 },
-        { code: '5678', name: 'サンプル', value: 200 },
-        { code: '9012', name: 'テスト2', value: 300 }
-    ];
-
-    it('検索クエリが空の場合はすべてのデータを返す', () => {
-        const result = filterDataBySearchQuery(testData, '', ['code', 'name']);
-        expect(result).toEqual(testData);
-    });
-
-    it('codeフィールドでフィルタリングする', () => {
-        const result = filterDataBySearchQuery(testData, '123', ['code', 'name']);
-        expect(result).toEqual([testData[0]]);
-    });
-
-    it('nameフィールドでフィルタリングする', () => {
-        const result = filterDataBySearchQuery(testData, 'テスト', ['code', 'name']);
-        expect(result).toEqual([testData[0], testData[2]]);
-    });
-
-    it('検索クエリに一致するデータがない場合は空の配列を返す', () => {
-        const result = filterDataBySearchQuery(testData, 'ないデータ', ['code', 'name']);
-        expect(result).toEqual([]);
     });
 });
 

--- a/frontend/src/lib/utils/__tests__/searchUtils.test.ts
+++ b/frontend/src/lib/utils/__tests__/searchUtils.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { filterByConfig, FilterConfig } from '../searchUtils';
+
+interface TestItem {
+    code: string;
+    name: string;
+    category: string;
+    date: Date;
+    amount: number;
+}
+
+const testData: TestItem[] = [
+    { code: '1234', name: 'テスト商品1', category: 'A', date: new Date('2023-01-15'), amount: 100 },
+    { code: '5678', name: 'サンプル品', category: 'B', date: new Date('2023-02-20'), amount: 200 },
+    { code: '9012', name: 'テスト商品2', category: 'A', date: new Date('2024-01-10'), amount: 300 },
+];
+
+describe('filterByConfig', () => {
+    describe('stringFields（完全一致）', () => {
+        it('完全一致する場合にマッチする', () => {
+            const config: FilterConfig<TestItem> = {
+                stringFields: [item => item.code],
+            };
+            const result = filterByConfig(testData, '1234', config);
+            expect(result).toHaveLength(1);
+            expect(result[0].code).toBe('1234');
+        });
+
+        it('部分一致ではマッチしない', () => {
+            const config: FilterConfig<TestItem> = {
+                stringFields: [item => item.code],
+            };
+            const result = filterByConfig(testData, '123', config);
+            expect(result).toHaveLength(0);
+        });
+    });
+
+    describe('partialStringFields（部分一致）', () => {
+        it('部分一致する場合にマッチする', () => {
+            const config: FilterConfig<TestItem> = {
+                partialStringFields: [item => item.name],
+            };
+            const result = filterByConfig(testData, 'テスト', config);
+            expect(result).toHaveLength(2);
+        });
+
+        it('大文字小文字を区別しない', () => {
+            const config: FilterConfig<TestItem> = {
+                partialStringFields: [item => item.category],
+            };
+            const result = filterByConfig(testData, 'a', config);
+            expect(result).toHaveLength(2);
+        });
+
+        it('複数フィールドで検索できる', () => {
+            const config: FilterConfig<TestItem> = {
+                partialStringFields: [
+                    item => item.code,
+                    item => item.name,
+                ],
+            };
+            // コード「12」を含む商品
+            const result = filterByConfig(testData, '12', config);
+            expect(result).toHaveLength(2); // 1234とテスト商品1・2
+        });
+    });
+
+    describe('複合条件', () => {
+        it('stringFieldsとpartialStringFieldsを組み合わせられる', () => {
+            const config: FilterConfig<TestItem> = {
+                stringFields: [item => item.code],
+                partialStringFields: [item => item.name],
+            };
+            // コード完全一致 または 名前部分一致
+            const result = filterByConfig(testData, 'テスト', config);
+            expect(result).toHaveLength(2); // テスト商品1, テスト商品2
+        });
+
+        it('クエリが空の場合は全データを返す', () => {
+            const config: FilterConfig<TestItem> = {
+                partialStringFields: [item => item.name],
+            };
+            const result = filterByConfig(testData, '', config);
+            expect(result).toHaveLength(3);
+        });
+    });
+});

--- a/frontend/src/lib/utils/columnUtils.ts
+++ b/frontend/src/lib/utils/columnUtils.ts
@@ -1,0 +1,44 @@
+import { TableColumnConfig } from '@/lib/interfaces/receipt';
+
+/**
+ * 列の前面配置ルール
+ */
+export interface ColumnReorderRule<T> {
+    /** 前面に配置する列のkey */
+    columnKey: string;
+    /** データがこのルールに該当するか判定する関数 */
+    match: (item: T, query: string) => boolean;
+}
+
+/**
+ * 検索クエリに応じて特定の列を前面に配置する
+ * @param baseColumns ベースの列定義
+ * @param data フィルタ済みデータ
+ * @param searchQuery 検索クエリ
+ * @param rules 前面配置ルールの配列（優先度順）
+ * @param fixedColumnCount 先頭の固定列数（この列の後ろに移動列を挿入）
+ */
+export function reorderColumnsBySearch<T>(
+    baseColumns: TableColumnConfig[],
+    data: T[],
+    searchQuery: string,
+    rules: ColumnReorderRule<T>[],
+    fixedColumnCount: number
+): TableColumnConfig[] {
+    if (!searchQuery) return baseColumns;
+
+    const query = searchQuery.toLowerCase();
+
+    for (const rule of rules) {
+        if (data.some(item => rule.match(item, query))) {
+            const targetCol = baseColumns.find(col => col.key === rule.columnKey);
+            if (!targetCol) continue;
+
+            const fixedCols = baseColumns.slice(0, fixedColumnCount);
+            const otherCols = baseColumns.filter(col => col.key !== rule.columnKey);
+            return [...fixedCols, targetCol, ...otherCols.slice(fixedColumnCount)];
+        }
+    }
+
+    return baseColumns;
+}

--- a/frontend/src/lib/utils/dataTransformer.ts
+++ b/frontend/src/lib/utils/dataTransformer.ts
@@ -17,24 +17,6 @@ export function createSearchOptions<T>(
         .sort((a, b) => a.value.localeCompare(b.value));
 }
 
-export function filterDataBySearchQuery<T>(
-    data: T[],
-    searchQuery: string,
-    searchFields: (keyof T)[]
-): T[] {
-    const query = searchQuery.toLowerCase();
-
-    if (!query) {
-        return data;
-    }
-
-    return data.filter(item =>
-        searchFields.some(field =>
-            String(item[field]).toLowerCase().includes(query)
-        )
-    );
-}
-
 export type SummaryResult<K extends string | number | symbol> = {
     filter: string;
     [key: string]: unknown;

--- a/frontend/src/lib/utils/searchUtils.ts
+++ b/frontend/src/lib/utils/searchUtils.ts
@@ -88,6 +88,8 @@ export function matchesAmounts(amounts: number[], query: string): boolean {
 export interface FilterConfig<T> {
   /** 文字列完全一致検索対象フィールド */
   stringFields?: ((item: T) => string)[];
+  /** 文字列部分一致検索対象フィールド */
+  partialStringFields?: ((item: T) => string)[];
   /** 日付フィールド（年/年月/日付検索用） */
   dateField?: (item: T) => Date;
   /** 年度検索を有効にするか */
@@ -121,6 +123,15 @@ export function filterByConfig<T>(
     if (config.stringFields) {
       for (const getter of config.stringFields) {
         if (getter(item).toLowerCase() === normalizedQuery) {
+          return true;
+        }
+      }
+    }
+
+    // 文字列フィールドの部分一致検索
+    if (config.partialStringFields) {
+      for (const getter of config.partialStringFields) {
+        if (getter(item).toLowerCase().includes(normalizedQuery)) {
           return true;
         }
       }

--- a/frontend/src/pages/AssetBalance.tsx
+++ b/frontend/src/pages/AssetBalance.tsx
@@ -12,10 +12,8 @@ import { parseNumber } from '@/lib/utils/formatters';
 import { useReceiptData } from '@/hooks/receipt/useReceiptData';
 import { assetBalanceApi } from '@/features/receipt/api/receiptApi';
 import { useReceiptDataSource } from '@/hooks/common/useReceiptDataSource';
-import {
-  createSearchOptions,
-  filterDataBySearchQuery,
-} from '@/lib/utils/dataTransformer';
+import { createSearchOptions } from '@/lib/utils/dataTransformer';
+import { filterByConfig, FilterConfig } from '@/lib/utils/searchUtils';
 
 // rechartsを含むコンポーネントを遅延読み込み（バンドルサイズ最適化）
 const AssetPortfolioSummary = lazy(() =>
@@ -124,12 +122,19 @@ export function AssetBalancePage() {
     securities: createSearchOptions(assetBalanceData, 'security_code', 'security_name', true)
   }), [assetBalanceData]);
 
+  // フィルタ設定（部分一致検索）
+  const filterConfig: FilterConfig<AssetBalanceData> = useMemo(() => ({
+    partialStringFields: [
+      item => item.security_code,
+      item => item.security_name,
+    ],
+  }), []);
+
   // 検索クエリに基づくフィルタリング
-  const filteredData = useMemo(() => filterDataBySearchQuery(
-    assetBalanceData,
-    searchQuery,
-    ['security_code', 'security_name']
-  ), [assetBalanceData, searchQuery]);
+  const filteredData = useMemo(
+    () => filterByConfig(assetBalanceData, searchQuery, filterConfig),
+    [assetBalanceData, searchQuery, filterConfig]
+  );
 
   const handleSearch = (query: string) => {
     setSearchQuery(query);

--- a/frontend/src/pages/Receipt/Dividend.tsx
+++ b/frontend/src/pages/Receipt/Dividend.tsx
@@ -29,6 +29,7 @@ import {
 import { DividendInfo } from '@/components/molecules/DividendInfo/DividendInfo';
 import { parseDividendCsvItem, sortDividendBySettlementDate } from '@/features/receipt/parsers';
 import { calculateDividends } from '@/features/receipt/calculations';
+import { reorderColumnsBySearch, ColumnReorderRule } from '@/lib/utils/columnUtils';
 
 interface DividendProps {
     csvData: Record<string, unknown>[];
@@ -179,28 +180,17 @@ export const Dividend: React.FC<DividendProps> = ({ csvData }) => {
         { key: 'net_amount_received', header: '受取額', width: '90px', textAlign: 'right', format: formatCurrency },
     ]), []);
 
+    // 列の前面配置ルール（商品 > 口座の優先順）
+    const columnRules: ColumnReorderRule<DividendData>[] = useMemo(() => [
+        { columnKey: 'product', match: (item, q) => item.product.toLowerCase().includes(q) },
+        { columnKey: 'account', match: (item, q) => item.account.toLowerCase().includes(q) },
+    ], []);
+
     // 検索タイプに応じて重要なカラムを前面に配置
-    const columns = useMemo(() => {
-        if (!searchQuery) return baseColumns;
-
-        const query = searchQuery.toLowerCase();
-
-        // 商品検索の場合、商品カラムを前面に
-        if (filteredData.some(item => item.product.toLowerCase().includes(query))) {
-            const productCol = baseColumns.find(col => col.key === 'product')!;
-            const otherCols = baseColumns.filter(col => col.key !== 'product');
-            return [baseColumns[0], productCol, ...otherCols.slice(1)];
-        }
-
-        // 口座検索の場合、口座カラムを前面に
-        if (filteredData.some(item => item.account.toLowerCase().includes(query))) {
-            const accountCol = baseColumns.find(col => col.key === 'account')!;
-            const otherCols = baseColumns.filter(col => col.key !== 'account');
-            return [baseColumns[0], accountCol, ...otherCols.slice(1)];
-        }
-
-        return baseColumns;
-    }, [baseColumns, filteredData, searchQuery]);
+    const columns = useMemo(
+        () => reorderColumnsBySearch(baseColumns, filteredData, searchQuery, columnRules, 1),
+        [baseColumns, filteredData, searchQuery, columnRules]
+    );
 
     // サマリーカラムの定義
     const summaryColumns: SummaryColumnConfig[] = [

--- a/frontend/src/pages/Receipt/Dividend.tsx
+++ b/frontend/src/pages/Receipt/Dividend.tsx
@@ -1,7 +1,7 @@
 import { ReceiptTemplate } from '@/components/templates/ReceiptTemplate';
 import { ReceiptHeader } from '@/components/molecules/ReceiptHeader/ReceiptHeader';
 import { ReceiptTable } from '@/components/organisms/ReceiptTable/ReceiptTable';
-import React, { useMemo, useCallback, useState } from 'react';
+import React, { useMemo, useCallback } from 'react';
 import { DividendData } from '@/lib/interfaces/dividend';
 import { TableColumnConfig, SummaryColumnConfig } from '@/lib/interfaces/receipt';
 import {
@@ -17,13 +17,13 @@ import {
 } from '@/lib/utils/formatters';
 import { renderSecurityCode } from '@/components/atoms/SecurityCodeLink';
 import { useReceiptData, useReceiptCalculations } from '@/hooks/receipt/useReceiptData';
+import { useReceiptPageState } from '@/hooks/receipt/useReceiptPageState';
 import {
     createYearOptions,
     createYearMonthOptions,
     getUniqueValues,
     matchesYear,
     matchesYearMonth,
-    filterByConfig,
     FilterConfig
 } from '@/lib/utils/searchUtils';
 import { DividendInfo } from '@/components/molecules/DividendInfo/DividendInfo';
@@ -38,7 +38,6 @@ interface DividendProps {
  * 配当金データを表示するコンポーネント
  */
 export const Dividend: React.FC<DividendProps> = ({ csvData }) => {
-    const [searchQuery, setSearchQuery] = useState('');
 
     // CSVデータを配当データ形式に変換
     const dividendData = useReceiptData(csvData, parseDividendCsvItem, sortDividendBySettlementDate);
@@ -74,10 +73,7 @@ export const Dividend: React.FC<DividendProps> = ({ csvData }) => {
     }), []);
 
     // 検索クエリに基づくフィルタリング
-    const filteredData = useMemo(
-        () => filterByConfig(dividendData, searchQuery, filterConfig),
-        [dividendData, searchQuery, filterConfig]
-    );
+    const { searchQuery, setSearchQuery, filteredData } = useReceiptPageState(dividendData, filterConfig);
 
     // 表示用の集計（検索前後で同一ロジック: フィルタ後データから計算）
     const calculations = useReceiptCalculations(filteredData, calculateDividends);

--- a/frontend/src/pages/Receipt/DomesticStock.tsx
+++ b/frontend/src/pages/Receipt/DomesticStock.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/lib/utils/searchUtils';
 import { parseDomesticStockCsvItem, sortDomesticStockByTradeDate } from '@/features/receipt/parsers';
 import { calculateDailyData, calculateDomesticStock } from '@/features/receipt/calculations';
+import { reorderColumnsBySearch, ColumnReorderRule } from '@/lib/utils/columnUtils';
 
 interface DomesticStockProps {
     csvData: Record<string, unknown>[];
@@ -116,21 +117,16 @@ export const DomesticStock: React.FC<DomesticStockProps> = ({ csvData }) => {
         { key: 'realized_profit_and_loss_after_tax', header: '税引後', width: '90px', textAlign: 'right', format: formatCurrency },
     ]), []);
 
-    // 検索タイプに応じて重要なカラムを前面に配置
-    const columns = useMemo(() => {
-        if (!searchQuery) return baseColumns;
+    // 列の前面配置ルール（口座のみ）
+    const columnRules: ColumnReorderRule<DomesticStockData>[] = useMemo(() => [
+        { columnKey: 'account', match: (item, q) => item.account.toLowerCase().includes(q) },
+    ], []);
 
-        const query = searchQuery.toLowerCase();
-
-        // 口座検索の場合、口座カラムを前面に
-        if (filteredData.some(item => item.account.toLowerCase().includes(query))) {
-            const accountCol = baseColumns.find(col => col.key === 'account')!;
-            const otherCols = baseColumns.filter(col => col.key !== 'account');
-            return [baseColumns[0], baseColumns[1], accountCol, ...otherCols.slice(2)];
-        }
-
-        return baseColumns;
-    }, [baseColumns, filteredData, searchQuery]);
+    // 検索タイプに応じて重要なカラムを前面に配置（日付・コードの2列固定）
+    const columns = useMemo(
+        () => reorderColumnsBySearch(baseColumns, filteredData, searchQuery, columnRules, 2),
+        [baseColumns, filteredData, searchQuery, columnRules]
+    );
 
     // サマリーカラムの定義（最後の3カラムと一致）
     const summaryColumns: SummaryColumnConfig[] = [

--- a/frontend/src/pages/Receipt/DomesticStock.tsx
+++ b/frontend/src/pages/Receipt/DomesticStock.tsx
@@ -1,7 +1,7 @@
 import { ReceiptTemplate } from '@/components/templates/ReceiptTemplate';
 import { ReceiptHeader } from '@/components/molecules/ReceiptHeader/ReceiptHeader';
 import { ReceiptTable } from '@/components/organisms/ReceiptTable/ReceiptTable';
-import React, { useMemo, useCallback, useState } from 'react';
+import React, { useMemo, useCallback } from 'react';
 import { DomesticStockData } from '@/lib/interfaces/domesticStock';
 import { TableColumnConfig, SummaryColumnConfig } from '@/lib/interfaces/receipt';
 import { createSearchOptions } from '@/lib/utils/dataTransformer';
@@ -13,11 +13,11 @@ import {
 } from '@/lib/utils/formatters';
 import { renderSecurityCode } from '@/components/atoms/SecurityCodeLink';
 import { useReceiptData, useReceiptCalculations } from '@/hooks/receipt/useReceiptData';
+import { useReceiptPageState } from '@/hooks/receipt/useReceiptPageState';
 import {
     createYearOptions,
     createYearMonthOptions,
     getUniqueValues,
-    filterByConfig,
     FilterConfig
 } from '@/lib/utils/searchUtils';
 import { parseDomesticStockCsvItem, sortDomesticStockByTradeDate } from '@/features/receipt/parsers';
@@ -31,7 +31,6 @@ interface DomesticStockProps {
  * 国内株式取引データを表示するコンポーネント
  */
 export const DomesticStock: React.FC<DomesticStockProps> = ({ csvData }) => {
-    const [searchQuery, setSearchQuery] = useState('');
 
     // CSVデータを国内株式データ形式に変換
     const domesticStockData = useReceiptData(csvData, parseDomesticStockCsvItem, sortDomesticStockByTradeDate);
@@ -66,10 +65,7 @@ export const DomesticStock: React.FC<DomesticStockProps> = ({ csvData }) => {
     }), []);
 
     // 検索クエリに基づくフィルタリング
-    const filteredData = useMemo(
-        () => filterByConfig(domesticStockData, searchQuery, filterConfig),
-        [domesticStockData, searchQuery, filterConfig]
-    );
+    const { searchQuery, setSearchQuery, filteredData } = useReceiptPageState(domesticStockData, filterConfig);
 
     // フィルタ後の日次集計
     const filteredDailyData = useMemo(

--- a/frontend/src/pages/Receipt/Mutualfund.tsx
+++ b/frontend/src/pages/Receipt/Mutualfund.tsx
@@ -1,7 +1,7 @@
 import { ReceiptTemplate } from '@/components/templates/ReceiptTemplate';
 import { ReceiptHeader } from '@/components/molecules/ReceiptHeader/ReceiptHeader';
 import { ReceiptTable } from '@/components/organisms/ReceiptTable/ReceiptTable';
-import React, { useMemo, useCallback, useState } from 'react';
+import React, { useMemo, useCallback } from 'react';
 import {
     MutualfundData,
     MutualfundCalculations
@@ -14,7 +14,8 @@ import {
     formatCurrency,
     formatNumber
 } from '@/lib/utils/formatters';
-import { createYearOptions, filterByConfig, FilterConfig } from '@/lib/utils/searchUtils';
+import { createYearOptions, FilterConfig } from '@/lib/utils/searchUtils';
+import { useReceiptPageState } from '@/hooks/receipt/useReceiptPageState';
 import { parseMutualfundCsvItem, sortMutualfundByTradeDate } from '@/features/receipt/parsers';
 
 interface MutualfundProps {
@@ -25,7 +26,6 @@ interface MutualfundProps {
  * 投資信託データを表示するコンポーネント
  */
 export const Mutualfund: React.FC<MutualfundProps> = ({ csvData }) => {
-    const [searchQuery, setSearchQuery] = useState('');
 
     /**
      * CSVまたはDBデータをMutualfundData形式に変換
@@ -53,10 +53,7 @@ export const Mutualfund: React.FC<MutualfundProps> = ({ csvData }) => {
     }), []);
 
     // 検索クエリに基づくフィルタリング
-    const filteredData = useMemo(
-        () => filterByConfig(mutualfundData, searchQuery, filterConfig),
-        [mutualfundData, searchQuery, filterConfig]
-    );
+    const { searchQuery, setSearchQuery, filteredData } = useReceiptPageState(mutualfundData, filterConfig);
 
     /**
      * 表示用の集計（検索前後で同一ロジック: フィルタ後データから計算）

--- a/frontend/src/types/common.ts
+++ b/frontend/src/types/common.ts
@@ -5,8 +5,8 @@ export type FormatFunction<T = unknown> = (value: T) => string | number | React.
 
 export interface HeaderItem {
   title: string;
-  value: number | string;
-  format?: FormatFunction;
+  value: number;
+  format: (value: number) => string;
 }
 
 export interface SelectOption {


### PR DESCRIPTION
## 概要
- フロントエンド共通ユーティリティのリファクタリング（型統一、フック抽出、重複関数の統合）
- 保有銘柄ページのUI刷新とコードレビュー対応
- UIレビュー指摘事項の改善（アクセシビリティ、視認性、レスポンシブ対応）
- バックエンドモジュール構成の整理とユニットテスト追加

## 変更種別
- [x] 新機能
- [x] バグ修正
- [x] リファクタリング

## 主な変更内容

### フロントエンドリファクタリング
- `HeaderItem`型を`types/common.ts`に統一
- 受取金ページ共通の`useReceiptPageState`フックを抽出
- columns動的調整ロジックを`reorderColumnsBySearch`に共通化
- `filterDataBySearchQuery`を廃止し`filterByConfig`に統合（`partialStringFields`追加）

### UI改善
- 保有銘柄ページを概要重視のUIに刷新（ポートフォリオ構成比グラフ追加）
- 検索カード・テーブル・ヘッダーのスタイル改善
- アクセシビリティとセキュリティの改善

### バックエンド
- モジュール構成の整理（routes, services, config分離）
- db, logging, routes, services/auth, configモジュールのユニットテスト追加

## テスト
- [x] フロントエンド: 32ファイル・354テスト全パス
- [x] バックエンド: cargo test パス
- [x] 新規テスト追加（columnUtils, searchUtils, PortfolioPieChart, AssetPortfolioSummary）

## チェックリスト
- [x] CIパス確認
- [x] 機密情報がコミットされていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)