### PR TITLE
UIレビュー修正・リファクタリング・バックエンドセキュリティ対策

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ frontend/src/env.rs
 .shuttle*
 Secrets*.toml
 *.log
+.env
 .playwright-mcp

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,7 @@
 DATABASE_URL=postgres://user:password@localhost:5432/dbname
 PORT=3001
-GOOGLE_OAUTH_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
-GOOGLE_OAUTH_CLIENT_SECRET_ID=your-google-client-secret
-REDIRECT_URL=http://localhost:8080/shoken-webapp/auth/google/callback
+BACKEND_URL=http://localhost:3001
+FRONTEND_URL=http://localhost:8080
+GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=your-google-client-secret
 JQUANTS_API_KEY=your-jquants-api-key

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,6 @@
+DATABASE_URL=postgres://user:password@localhost:5432/dbname
+PORT=3001
+GOOGLE_OAUTH_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
+GOOGLE_OAUTH_CLIENT_SECRET_ID=your-google-client-secret
+REDIRECT_URL=http://localhost:8080/shoken-webapp/auth/google/callback
+JQUANTS_API_KEY=your-jquants-api-key

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2579,6 +2579,7 @@ dependencies = [
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
  "tower",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -19,7 +19,7 @@ thiserror = "2.0.18"
 tokio = { version = "1.49.0", features = ["full"] }
 validator = { version = "0.20.0", features = ["derive"] }
 tower = "0.5.3"
-tower-http = { version = "0.6.8", features = ["cors"] }
+tower-http = { version = "0.6.8", features = ["cors", "limit"] }
 oauth2 = "5.0.0"
 dotenvy = "0.15.7"
 mockall = "0.14.0"

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -4,6 +4,7 @@ pub mod errors;
 pub mod extractors;
 pub mod handlers;
 pub mod logging;
+pub mod middleware;
 pub mod models;
 pub mod routes;
 pub mod services;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -4,6 +4,7 @@ mod errors;
 mod extractors;
 mod handlers;
 mod logging;
+mod middleware;
 mod models;
 mod routes;
 mod services;

--- a/backend/src/middleware.rs
+++ b/backend/src/middleware.rs
@@ -1,0 +1,158 @@
+use axum::{
+    body::Body,
+    http::{Method, Request, StatusCode},
+    middleware::Next,
+    response::{IntoResponse, Response},
+    Json,
+};
+
+use crate::errors::{ErrorDetails, ErrorResponse};
+
+/// Origin検証ミドルウェア（CSRF対策）
+/// POST/PUT/DELETE リクエストに対して Origin ヘッダーを検証し、
+/// 許可されたオリジンからのリクエストのみ通過させる
+pub async fn validate_origin(
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    let method = request.method().clone();
+
+    // GET/HEAD/OPTIONS はスキップ
+    if method == Method::GET || method == Method::HEAD || method == Method::OPTIONS {
+        return next.run(request).await;
+    }
+
+    // Origin ヘッダーを取得
+    let origin = request
+        .headers()
+        .get("origin")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+
+    // 許可されたオリジンリスト
+    let allowed_origins = [
+        "https://shoken-webapp.vercel.app",
+        "http://localhost:8080",
+        "http://127.0.0.1:8080",
+        "http://[::1]:8080",
+        "http://localhost.:8080",
+    ];
+
+    match origin {
+        Some(ref o) if allowed_origins.contains(&o.as_str()) => {
+            // 許可されたオリジン → 通過
+            next.run(request).await
+        }
+        None => {
+            // Origin なし（同一オリジンリクエストまたはcurlなど）→ 通過
+            // ブラウザはクロスオリジンPOSTに必ずOriginヘッダーを付与するため、
+            // Originなしは同一オリジンまたは非ブラウザクライアント
+            next.run(request).await
+        }
+        Some(_) => {
+            // 不正なオリジン → 拒否
+            let error_response = ErrorResponse {
+                error: ErrorDetails {
+                    code: "CSRF_ERROR".to_string(),
+                    message: "不正なリクエスト元です".to_string(),
+                    details: None,
+                },
+            };
+            (StatusCode::FORBIDDEN, Json(error_response)).into_response()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, http::Request, middleware, routing::post, Router};
+    use tower::ServiceExt;
+
+    fn test_app() -> Router {
+        Router::new()
+            .route("/test", post(|| async { "ok" }))
+            .layer(middleware::from_fn(validate_origin))
+    }
+
+    #[tokio::test]
+    async fn test_get_request_passes() {
+        let app = test_app();
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("/test")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        // GET はルート定義がないので 405 だが、ミドルウェアは通過
+        assert_ne!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_post_with_allowed_origin() {
+        let app = test_app();
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/test")
+            .header("origin", "http://localhost:8080")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_post_with_disallowed_origin() {
+        let app = test_app();
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/test")
+            .header("origin", "https://evil.example.com")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_post_without_origin() {
+        let app = test_app();
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/test")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        // Origin なしは同一オリジンとみなし通過
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_delete_with_disallowed_origin() {
+        let app = Router::new()
+            .route("/test", axum::routing::delete(|| async { "ok" }))
+            .layer(middleware::from_fn(validate_origin));
+
+        let req = Request::builder()
+            .method(Method::DELETE)
+            .uri("/test")
+            .header("origin", "https://evil.example.com")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_post_with_production_origin() {
+        let app = test_app();
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/test")
+            .header("origin", "https://shoken-webapp.vercel.app")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+}

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -1,9 +1,14 @@
 use axum::{
+    middleware,
     routing::{delete, get, post},
     Router,
 };
+use tower_http::limit::RequestBodyLimitLayer;
 
-use crate::{config::Config, handlers, state::AppState};
+use crate::{config::Config, handlers, middleware::validate_origin, state::AppState};
+
+/// リクエストボディの上限サイズ（10MB）
+const REQUEST_BODY_LIMIT: usize = 10 * 1024 * 1024;
 
 pub fn app_router(state: AppState, config: &Config) -> Router {
     Router::new()
@@ -15,6 +20,8 @@ pub fn app_router(state: AppState, config: &Config) -> Router {
         .merge(mutualfund_routes())
         .merge(asset_balance_routes())
         .route("/health", get(|| async { "OK" }))
+        .layer(middleware::from_fn(validate_origin))
+        .layer(RequestBodyLimitLayer::new(REQUEST_BODY_LIMIT))
         .layer(config.build_cors_layer())
         .with_state(state)
 }

--- a/frontend/src/components/molecules/PortfolioPieChart/PortfolioPieChart.tsx
+++ b/frontend/src/components/molecules/PortfolioPieChart/PortfolioPieChart.tsx
@@ -21,9 +21,9 @@ const TOP_N = 20; // デフォルト表示件数
 export interface PortfolioItem {
   name: string;
   value: number;
-  averagePrice?: number;
-  securityCode?: string;
-  shares?: number;
+  averagePrice: number;
+  securityCode: string;
+  shares: number;
 }
 
 interface ChartDataItem extends PortfolioItem {
@@ -83,7 +83,7 @@ export const PortfolioPieChart: React.FC<PortfolioPieChartProps> = ({
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
         {displayData.map((item, index) => (
           <div
-            key={item.securityCode || item.name}
+            key={item.securityCode}
             className="rounded-lg border border-slate-200 bg-white p-3"
           >
             {/* 上段: 銘柄名 + 構成比 */}
@@ -115,23 +115,15 @@ export const PortfolioPieChart: React.FC<PortfolioPieChartProps> = ({
             <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-slate-600">
               <div className="flex items-center gap-1">
                 <span className="text-slate-500">コード:</span>
-                {item.securityCode ? (
-                  <SecurityCodeLink value={item.securityCode} className="text-xs" />
-                ) : (
-                  <span className="text-slate-400">-</span>
-                )}
+                <SecurityCodeLink value={item.securityCode} className="text-xs" />
               </div>
               <div className="flex items-center gap-1">
                 <span className="text-slate-500">取得単価:</span>
-                <span className="font-medium">
-                  {item.averagePrice == null ? '-' : formatCurrency(item.averagePrice)}
-                </span>
+                <span className="font-medium">{formatCurrency(item.averagePrice)}</span>
               </div>
               <div className="flex items-center gap-1">
                 <span className="text-slate-500">数量:</span>
-                <span className="font-medium">
-                  {item.shares !== undefined ? `${formatNumber(item.shares)}株` : '-'}
-                </span>
+                <span className="font-medium">{`${formatNumber(item.shares)}株`}</span>
               </div>
               <div className="flex items-center gap-1">
                 <span className="text-slate-500">取得総額:</span>

--- a/frontend/src/components/molecules/PortfolioPieChart/PortfolioPieChart.tsx
+++ b/frontend/src/components/molecules/PortfolioPieChart/PortfolioPieChart.tsx
@@ -21,6 +21,7 @@ const TOP_N = 20; // デフォルト表示件数
 export interface PortfolioItem {
   name: string;
   value: number;
+  averagePrice?: number;
   securityCode?: string;
   shares?: number;
 }
@@ -121,14 +122,20 @@ export const PortfolioPieChart: React.FC<PortfolioPieChartProps> = ({
                 )}
               </div>
               <div className="flex items-center gap-1">
-                <span className="text-slate-500">取得総額:</span>
-                <span className="font-medium">{formatCurrency(item.value)}</span>
+                <span className="text-slate-500">取得単価:</span>
+                <span className="font-medium">
+                  {item.averagePrice == null ? '-' : formatCurrency(item.averagePrice)}
+                </span>
               </div>
               <div className="flex items-center gap-1">
                 <span className="text-slate-500">数量:</span>
                 <span className="font-medium">
                   {item.shares !== undefined ? `${formatNumber(item.shares)}株` : '-'}
                 </span>
+              </div>
+              <div className="flex items-center gap-1">
+                <span className="text-slate-500">取得総額:</span>
+                <span className="font-medium">{formatCurrency(item.value)}</span>
               </div>
             </div>
           </div>

--- a/frontend/src/components/molecules/PortfolioPieChart/__tests__/PortfolioPieChart.test.tsx
+++ b/frontend/src/components/molecules/PortfolioPieChart/__tests__/PortfolioPieChart.test.tsx
@@ -9,9 +9,9 @@ vi.mock('@/components/atoms/SecurityCodeLink', () => ({
 
 describe('PortfolioPieChart', () => {
   const mockData: PortfolioItem[] = [
-    { name: 'トヨタ自動車', value: 250000, securityCode: '7203', shares: 100 },
-    { name: 'ソニーグループ', value: 600000, securityCode: '6758', shares: 50 },
-    { name: '任天堂', value: 150000, securityCode: '7974', shares: 30 },
+    { name: 'トヨタ自動車', value: 250000, securityCode: '7203', shares: 100, averagePrice: 2500 },
+    { name: 'ソニーグループ', value: 600000, securityCode: '6758', shares: 50, averagePrice: 12000 },
+    { name: '任天堂', value: 150000, securityCode: '7974', shares: 30, averagePrice: 5000 },
   ];
 
   it('横棒グラフが表示される', () => {
@@ -46,8 +46,8 @@ describe('PortfolioPieChart', () => {
 
   it('すべての値が0の場合は何も表示しない', () => {
     const zeroData: PortfolioItem[] = [
-      { name: '銘柄A', value: 0 },
-      { name: '銘柄B', value: 0 },
+      { name: '銘柄A', value: 0, securityCode: '0001', shares: 0, averagePrice: 0 },
+      { name: '銘柄B', value: 0, securityCode: '0002', shares: 0, averagePrice: 0 },
     ];
     const { container } = render(<PortfolioPieChart data={zeroData} />);
 

--- a/frontend/src/components/organisms/AssetPortfolioSummary/AssetPortfolioSummary.tsx
+++ b/frontend/src/components/organisms/AssetPortfolioSummary/AssetPortfolioSummary.tsx
@@ -39,6 +39,7 @@ export const AssetPortfolioSummary: React.FC<AssetPortfolioSummaryProps> = ({
         value: item.total_purchase_amount || 0,
         securityCode: item.security_code,
         shares: item.shares,
+        averagePrice: item.average_purchase_price,
       }))
       .sort((a, b) => b.value - a.value);
   }, [assetBalanceData]);


### PR DESCRIPTION
## 概要
UIレビュー指摘事項の修正、フロントエンドのリファクタリング、バックエンドのセキュリティ対策に加えて、保有銘柄ポートフォリオの詳細表示を最新仕様に合わせ、環境変数例も現行のキーに更新しました。

## 問題と影響
これまでポートフォリオ構成比のカードは取得単価・数量・銘柄コードを任意扱いにしていたため、実データが揃っていても `-` や `¥ 0` と表示される可能性があり、ユーザーには保有情報が欠けているように見えていました。あわせて backend の `.env.example` が旧キー名のままで、新規環境構築時に OAuth 設定を誤るリスクがありました。

## 根本原因
`PortfolioItem` の型定義が optional になっていたことと、UI側でフォールバック表示を持っていたため、欠損がない前提のドメインモデルがUIに反映されていませんでした。`.env.example` は最近の設定仕様変更を反映しきれていませんでした。

## 対応内容
取得単価・数量・銘柄コードを必須プロパティとして型で固定し、カード表示も実値をそのまま出すように整理しました。併せてテストデータを更新し、`.env.example` に現行の `BACKEND_URL` / `FRONTEND_URL` と `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` を追加しました。

## テスト
- フロントエンド: `npm test -- --run src/components/molecules/PortfolioPieChart/__tests__/PortfolioPieChart.test.tsx`
