### PR TITLE
feat: ナビゲーション画面名を変更（受取金→取引明細、保有銘柄→資産管理）

### DIFF
--- a/.claude/skills/ui-review/SKILL.md
+++ b/.claude/skills/ui-review/SKILL.md
@@ -3,7 +3,7 @@ description: "開発サーバーに対してUIレビューを自動実行し、�
 ---
 # UI Review
 
-主要ページ（ホーム・銘柄検索・保有銘柄・受取金）のUIレビューを実施し、スクリーンショットと改善提案を作成する。  
+主要ページ（ホーム・銘柄検索・資産管理・取引明細）のUIレビューを実施し、スクリーンショットと改善提案を作成する。  
 **MCPでもE2Eでも、やることと成果物は同じ。**
 
 ## Usage
@@ -25,8 +25,8 @@ description: "開発サーバーに対してUIレビューを自動実行し、�
 |---|---|
 | `home-initial.png` | ホームページの初期表示 |
 | `search-nintendo-result.png` | 銘柄検索で「任天堂」を検索した結果 |
-| `assetbalance-initial.png` | 保有銘柄ページの初期表示 |
-| `assetbalance-search-security.png` | 保有銘柄ページの銘柄検索結果 |
+| `assetbalance-initial.png` | 資産管理ページの初期表示 |
+| `assetbalance-search-security.png` | 資産管理ページの銘柄検索結果 |
 | `receipts-dividend-initial.png` | 配当金タブの初期表示 |
 | `receipts-domestic-stock-initial.png` | 国内株式タブの初期表示 |
 | `receipts-mutualfund-initial.png` | 投資信託タブの初期表示 |
@@ -46,7 +46,7 @@ description: "開発サーバーに対してUIレビューを自動実行し、�
 | `header-delete-account-modal.png` | アカウント削除の確認モーダル（**ログイン時**） |
 | `search-empty.png` | 銘柄検索の初期状態（EmptyState表示） |
 | `search-invalid-code-param.png` | `?code=` が不正な場合の警告表示 |
-| `assetbalance-empty.png` | 保有銘柄が0件のEmptyState（**ログイン時**） |
+| `assetbalance-empty.png` | 資産管理が0件のEmptyState（**ログイン時**） |
 | `assetbalance-filter-empty.png` | 絞り込み0件のEmptyState（解除リンク表示） |
 
 ## 実施手順（共通）
@@ -73,8 +73,8 @@ rm -f .playwright-mcp/*.png
 - `http://localhost:8080/` に遷移して `home-initial.png` を保存
 - `http://localhost:8080/search` で `任天堂` を検索し、`search-nintendo-result.png` を保存
 - `http://localhost:8080/assetbalance` に遷移し、初期表示を `assetbalance-initial.png` として保存
-- 保有銘柄の検索オプション（銘柄）を1つ選択し、`assetbalance-search-security.png` を保存
-- `http://localhost:8080/receipts` に遷移し、各タブ/検索状態を操作して受取金の9枚を保存
+- 資産管理の検索オプション（銘柄）を1つ選択し、`assetbalance-search-security.png` を保存
+- `http://localhost:8080/receipts` に遷移し、各タブ/検索状態を操作して取引明細の9枚を保存
 - 設定は `fullPage: true`
 
 #### B. E2Eで取得する場合

--- a/frontend/e2e/ui-screenshots.spec.ts
+++ b/frontend/e2e/ui-screenshots.spec.ts
@@ -96,7 +96,7 @@ test.describe('主要ページ', () => {
     });
   });
 
-  test('保有銘柄 - 初期表示', async ({ page }) => {
+  test('資産管理 - 初期表示', async ({ page }) => {
     await page.goto('/assetbalance');
     await waitForPageReady(page);
     await page.waitForTimeout(2000);
@@ -107,7 +107,7 @@ test.describe('主要ページ', () => {
     });
   });
 
-  test('保有銘柄 - 銘柄検索', async ({ page }) => {
+  test('資産管理 - 銘柄検索', async ({ page }) => {
     await page.goto('/assetbalance');
     await waitForPageReady(page);
     await page.waitForTimeout(2000);
@@ -122,7 +122,7 @@ test.describe('主要ページ', () => {
 });
 
 // 各タブの初期表示をスクショ
-test.describe('受取金ページ - タブ初期表示', () => {
+test.describe('取引明細ページ - タブ初期表示', () => {
   for (const tab of TABS) {
     test(`${tab.label}タブの初期表示`, async ({ page }) => {
       await page.goto('/receipts');
@@ -148,7 +148,7 @@ test.describe('受取金ページ - タブ初期表示', () => {
 });
 
 // 各タブの検索結果をスクショ
-test.describe('受取金ページ - 検索結果', () => {
+test.describe('取引明細ページ - 検索結果', () => {
   test('配当金 - 西暦検索', async ({ page }) => {
     await page.goto('/receipts');
     await waitForPageReady(page);

--- a/frontend/src/components/organisms/AssetPortfolioSummary/AssetPortfolioSummary.tsx
+++ b/frontend/src/components/organisms/AssetPortfolioSummary/AssetPortfolioSummary.tsx
@@ -53,7 +53,7 @@ export const AssetPortfolioSummary: React.FC<AssetPortfolioSummaryProps> = ({
       <Card className="mb-3">
         <CardBody>
           <EmptyState
-            title={isFiltered ? "該当する銘柄がありません" : "保有銘柄がありません"}
+            title={isFiltered ? "該当する銘柄がありません" : "資産管理データがありません"}
             description={isFiltered
               ? "検索条件を変更するか、絞り込みを解除してください。"
               : "CSVファイルをインポートするか、データを登録してください。"

--- a/frontend/src/components/organisms/AssetPortfolioSummary/__tests__/AssetPortfolioSummary.test.tsx
+++ b/frontend/src/components/organisms/AssetPortfolioSummary/__tests__/AssetPortfolioSummary.test.tsx
@@ -67,7 +67,7 @@ describe('AssetPortfolioSummary', () => {
   it('データがない場合は空状態が表示される', () => {
     render(<AssetPortfolioSummary assetBalanceData={[]} />);
 
-    expect(screen.getByText('保有銘柄がありません')).toBeInTheDocument();
+    expect(screen.getByText('資産管理データがありません')).toBeInTheDocument();
     expect(screen.getByText('CSVファイルをインポートするか、データを登録してください。')).toBeInTheDocument();
   });
 

--- a/frontend/src/components/organisms/Footer.tsx
+++ b/frontend/src/components/organisms/Footer.tsx
@@ -10,7 +10,7 @@ export function Footer() {
           <div>
             <h5 className="text-base font-semibold">証券Webapp</h5>
             <p className="mt-2 text-sm text-secondary">
-              投資情報と受取金管理のためのプラットフォーム
+              投資情報と取引明細管理のためのプラットフォーム
             </p>
           </div>
 
@@ -24,7 +24,7 @@ export function Footer() {
                 <Link className="text-primary hover:underline" to="/search">銘柄検索</Link>
               </li>
               <li>
-                <Link className="text-primary hover:underline" to="/receipts">受取金管理</Link>
+                <Link className="text-primary hover:underline" to="/receipts">取引明細管理</Link>
               </li>
             </ul>
           </div>

--- a/frontend/src/components/organisms/Header.tsx
+++ b/frontend/src/components/organisms/Header.tsx
@@ -7,8 +7,8 @@ import { cn } from '../../lib/utils/classNames';
 // ナビゲーションリンクの設定
 const NAV_LINKS = [
   { to: '/search', label: '銘柄検索' },
-  { to: '/assetbalance', label: '保有銘柄' },
-  { to: '/receipts', label: '受取金' },
+  { to: '/assetbalance', label: '資産管理' },
+  { to: '/receipts', label: '取引明細' },
 ] as const;
 
 // ユーザー名からイニシャルを取得
@@ -223,7 +223,7 @@ export function Header() {
                 <p>本当にアカウントを削除しますか？</p>
                 <p className="mt-2 text-danger">
                   <strong>警告:</strong> この操作は取り消せません。
-                  保有銘柄、配当金、取引履歴などすべてのデータが削除されます。
+                  資産管理、配当金、取引履歴などすべてのデータが削除されます。
                 </p>
               </div>
               <div className="flex justify-end gap-2 border-t border-border px-4 py-3">

--- a/frontend/src/components/templates/ErrorPage.tsx
+++ b/frontend/src/components/templates/ErrorPage.tsx
@@ -12,7 +12,7 @@ interface ErrorPageProps {
 const RELATED_LINKS = [
   { to: '/', label: 'ホーム' },
   { to: '/search', label: '銘柄検索' },
-  { to: '/receipts', label: '受取金' },
+  { to: '/receipts', label: '取引明細' },
 ] as const;
 
 export function ErrorPage({

--- a/frontend/src/pages/AssetBalance.tsx
+++ b/frontend/src/pages/AssetBalance.tsx
@@ -155,7 +155,7 @@ export function AssetBalancePage() {
   return (
     <Layout>
       <PageHeader
-        title="保有銘柄"
+        title="資産管理"
         description="保有している銘柄の一覧と評価額を確認できます。"
       />
       <div className="mt-2" aria-busy={isProcessing}>
@@ -170,7 +170,7 @@ export function AssetBalancePage() {
         {/* 未ログイン時のログイン誘導 */}
         {!authLoading && !isAuthenticated && (
           <Alert variant="info" className="my-3" role="status" aria-live="polite">
-            <p className="mb-2 text-sm">保有銘柄データを管理するにはログインが必要です。</p>
+            <p className="mb-2 text-sm">資産管理データを管理するにはログインが必要です。</p>
             <Button
               variant="primary"
               size="sm"
@@ -263,8 +263,8 @@ export function AssetBalancePage() {
               isOpen={showDeleteConfirm}
               onConfirm={handleConfirmDelete}
               onCancel={() => setShowDeleteConfirm(false)}
-              title="保有銘柄データの全件削除"
-              description="保存された保有銘柄データをすべて削除します。"
+              title="資産管理データの全件削除"
+              description="保存された資産管理データをすべて削除します。"
               itemCount={dbData.length}
               loading={deleting}
             />

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -6,7 +6,7 @@ import { PageHeader } from '../components/atoms/PageHeader';
 // クイックアクション（ショートカット）
 const QUICK_ACTIONS = [
   { label: '配当金を確認', to: '/receipts', icon: '💰' },
-  { label: '保有銘柄を確認', to: '/assetbalance', icon: '📊' },
+  { label: '資産管理を確認', to: '/assetbalance', icon: '📊' },
   { label: '銘柄を検索', to: '/search', icon: '🔍' },
 ] as const;
 
@@ -22,7 +22,7 @@ const FEATURES = [
     ),
   },
   {
-    title: '保有銘柄',
+    title: '資産管理',
     description: '保有している銘柄の一覧と評価額を確認できます。',
     to: '/assetbalance',
     icon: (
@@ -32,7 +32,7 @@ const FEATURES = [
     ),
   },
   {
-    title: '受取金',
+    title: '取引明細',
     description: '配当金や分配金の記録を管理できます。',
     to: '/receipts',
     icon: (
@@ -49,7 +49,7 @@ export function HomePage() {
       <div className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
         <PageHeader
           title="証券Webへようこそ"
-          description="銘柄検索や受取金の管理ができます。"
+          description="銘柄検索や取引明細の管理ができます。"
         />
 
         <div className="grid gap-4 md:grid-cols-3">
@@ -101,7 +101,7 @@ export function HomePage() {
             </div>
             <div className="rounded-lg border border-slate-200 bg-slate-50 p-3">
               <p className="text-xs font-semibold text-slate-500 mb-1">STEP 3</p>
-              <p className="text-sm text-slate-700">配当金や保有銘柄の情報を確認</p>
+              <p className="text-sm text-slate-700">配当金や資産管理の情報を確認</p>
             </div>
           </div>
         </div>

--- a/frontend/src/pages/Receipts.tsx
+++ b/frontend/src/pages/Receipts.tsx
@@ -283,8 +283,8 @@ export function ReceiptsPage() {
   return (
     <Layout>
       <PageHeader
-        title="受取金"
-        description="配当金・国内株式・投資信託の受取金を管理します。"
+        title="取引明細"
+        description="配当金・国内株式・投資信託の取引明細を管理します。"
       />
       <nav className="border-b border-slate-200 no-print">
         <div className="flex flex-wrap gap-1">

--- a/frontend/src/pages/__tests__/AssetBalance.test.tsx
+++ b/frontend/src/pages/__tests__/AssetBalance.test.tsx
@@ -92,7 +92,7 @@ describe('AssetBalanceInfo', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText('保有銘柄がありません')).toBeInTheDocument();
+      expect(screen.getByText('資産管理データがありません')).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## 概要
ナビゲーション/画面名の命名を変更します。
- 「受取金」→「取引明細」
- 「保有銘柄」→「資産管理」

## 変更種別
- [x] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] その他

## 主な変更内容
- ヘッダー/フッター/ホーム/エラーページのナビラベルを更新
- 各ページのPageHeader見出し・説明文を更新
- EmptyState/削除モーダル等のUI文言を追従
- テスト期待文言・E2Eテスト記述名を追従修正
- UIレビューSKILL.mdの画面名を更新

## 変更しないもの
- URLパス（`/receipts`, `/assetbalance`）→ 後方互換維持
- 「受取金額」等のデータ項目名、タブ名（配当・国内株式・投資信託）
- DividendInfoの「保有銘柄」バッジ（データソース表示用）
- スクショファイル名（`assetbalance-*`, `receipts-*`）
- バックエンド（API、DB、コメント）

## テスト
- [x] `npm run lint` 通過
- [x] `npm test` 通過（354 passed）
- [x] `npm run build` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)