### PR TITLE
docs: スキルdescription日本語化とUIレビュー手順追加

### DIFF
--- a/.claude/rules/04-frontend-ui-review.md
+++ b/.claude/rules/04-frontend-ui-review.md
@@ -1,0 +1,143 @@
+# フロントエンドUIレビュー
+
+## 概要
+
+主要ページ（ホーム・銘柄検索・資産管理・取引明細）のUIレビューを実施し、スクリーンショットと改善提案を作成する。  
+**MCPでもE2Eでも、やることと成果物は同じ。**
+
+## Usage
+```
+/ui-review                    # 完全自動レビュー
+/ui-review --screenshots-only # スクリーンショットのみ
+/ui-review --review-only      # 既存画像の分析のみ
+```
+
+## 完了条件
+1. `.playwright-mcp/` に対象スクリーンショットが揃っている  
+2. UIレビューレポート（日本語）が出ている  
+3. 改善提案に優先度（高/中/低）が付いている
+
+## 保存先・成果物（共通）
+保存先: `.playwright-mcp/`
+
+| ファイル名 | 内容 |
+|---|---|
+| `home-initial.png` | ホームページの初期表示 |
+| `search-nintendo-result.png` | 銘柄検索で「任天堂」を検索した結果 |
+| `assetbalance-initial.png` | 資産管理ページの初期表示 |
+| `assetbalance-search-security.png` | 資産管理ページの銘柄検索結果 |
+| `receipts-dividend-initial.png` | 配当金タブの初期表示 |
+| `receipts-domestic-stock-initial.png` | 国内株式タブの初期表示 |
+| `receipts-mutualfund-initial.png` | 投資信託タブの初期表示 |
+| `receipts-dividend-search-year.png` | 配当金 - 西暦検索結果 |
+| `receipts-dividend-search-security.png` | 配当金 - 銘柄検索結果 |
+| `receipts-domestic-stock-search-year.png` | 国内株式 - 西暦検索結果 |
+| `receipts-domestic-stock-search-account.png` | 国内株式 - 口座検索結果 |
+| `receipts-mutualfund-search-year.png` | 投資信託 - 西暦検索結果 |
+| `receipts-mutualfund-search-fund.png` | 投資信託 - ファンド検索結果 |
+
+## 追加であると安心なスクショ（任意）
+| ファイル名 | 内容 |
+|---|---|
+| `login-initial.png` | ログインページの初期表示（**未ログイン時**） |
+| `notfound-404.png` | 404ページ（関連リンク表示） |
+| `header-user-menu.png` | ヘッダーのユーザーメニュー展開（**ログイン時**） |
+| `header-delete-account-modal.png` | アカウント削除の確認モーダル（**ログイン時**） |
+| `search-empty.png` | 銘柄検索の初期状態（EmptyState表示） |
+| `search-invalid-code-param.png` | `?code=` が不正な場合の警告表示 |
+| `assetbalance-empty.png` | 資産管理が0件のEmptyState（**ログイン時**） |
+| `assetbalance-filter-empty.png` | 絞り込み0件のEmptyState（解除リンク表示） |
+
+## 実施手順（共通）
+
+### 1) 事前確認
+- 本レビューは **8080固定**（`http://127.0.0.1:8080` を使用）
+- **ログインは必須**。必ず認証状態を準備する
+- このアプリのレビューは **PC表示前提**（モバイル評価は対象外）
+- スクショは **FHD（1920x1080）** を基準に取得する
+- 開発サーバー運用は以下を厳守する
+  - 8080が既に起動中なら **再利用**（新規起動しない）
+  - 新規起動時は `--strictPort` を必須化（8081/8082への自動フォールバック禁止）
+  - 新規起動したプロセスは `trap` で必ず停止する（残留防止）
+
+### 2) 既存スクショを削除
+```bash
+rm -f .playwright-mcp/*.png
+```
+
+### 3) スクショを取得（MCPかE2Eのどちらか）
+
+#### A. MCPで取得する場合
+- 先にログインを完了してから開始する
+- `http://localhost:8080/` に遷移して `home-initial.png` を保存
+- `http://localhost:8080/search` で `任天堂` を検索し、`search-nintendo-result.png` を保存
+- `http://localhost:8080/assetbalance` に遷移し、初期表示を `assetbalance-initial.png` として保存
+- 資産管理の検索オプション（銘柄）を1つ選択し、`assetbalance-search-security.png` を保存
+- `http://localhost:8080/receipts` に遷移し、各タブ/検索状態を操作して取引明細の9枚を保存
+- 設定は `fullPage: true`
+
+#### B. E2Eで取得する場合
+```bash
+set -euo pipefail
+cd frontend
+
+# ログイン状態を保存（初回のみ/期限切れ時）
+# npm run ui:save-auth
+
+STARTED=0
+if curl -sSf http://127.0.0.1:8080/ >/dev/null 2>&1; then
+  echo "reuse existing server on :8080"
+else
+  npm run dev -- --host 127.0.0.1 --port 8080 --strictPort >/tmp/shoken-dev.log 2>&1 &
+  DEV_PID=$!
+  STARTED=1
+fi
+
+cleanup() {
+  if [ "$STARTED" -eq 1 ]; then
+    kill "$DEV_PID" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+# 保存した認証情報を使ってスクショ取得
+npm run ui:screenshot:auth
+```
+
+※ `npm run ui:screenshot` は認証情報を読み込まないため、本レビューでは使用しない。  
+※ `npm run dev` を単独でバックグラウンド起動して放置しないこと（プロセス残留の原因）。
+
+### 4) UIレビュー（画像分析）
+以下の観点で評価する:
+- 視認性（文字サイズ、コントラスト、情報の階層）
+- 操作性（クリック領域、状態の分かりやすさ、導線）
+- 一貫性（配色、余白、コンポーネント挙動）
+- データ表示の妥当性（ラベル誤り、不自然な空白、誤解を生む表現）
+- アクセシビリティ（フォーカス、ラベル、可読性）
+
+### 5) レポート出力
+```markdown
+## UIレビューレポート
+
+### 総合評価
+- スコア: X/10
+- 概要: ...
+
+### 優れている点
+- ...
+
+### 改善提案
+| 優先度 | 画面 | 問題 | 改善案 |
+|---|---|---|---|
+| 高 | ... | ... | ... |
+
+### 推奨アクション
+1. ...
+2. ...
+```
+
+## 運用ルール
+- スクショ取得に一部失敗しても、取得できた分でレビューを継続
+- 失敗ファイルは「未取得」と明記
+- レポートは必ず日本語で出力
+- 作業終了時に `8080/8081/8082` の不要プロセスが残っていないことを確認する

--- a/.claude/skills/claude-code-terminal-title/SKILL.md
+++ b/.claude/skills/claude-code-terminal-title/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: terminal-title
-description: Automatically updates terminal window title to reflect the current high-level task. Use at the start of every Claude Code session when the user provides their first prompt, and whenever the user switches to a distinctly new high-level task. Helps developers manage multiple Claude Code terminals by providing clear, at-a-glance identification of what each terminal is working on.
+description: |
+  現在の高レベルな作業内容に合わせてターミナルのタイトルを自動更新する。
+  ユーザーの最初の依頼直後、および明確に別の作業へ切り替わったときに使用する。
+  複数の Claude Code ターミナルを並行利用する際に、各ターミナルの作業内容をひと目で識別できるようにする。
 min_claude_code_version: "1.0.0"
 version: "1.1.0"
 ---

--- a/.claude/skills/git-pushing/SKILL.md
+++ b/.claude/skills/git-pushing/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: git-pushing
-description: Stage, commit, and push git changes with conventional commit messages. Use when user wants to commit and push changes, mentions pushing to remote, or asks to save and push their work. Also activates when user says "push changes", "commit and push", "push this", "push to github", or similar git workflow requests.
+description: |
+  変更をステージングし、コミットしてリモートへ push する。
+  Use when: コミットと push を依頼された時、リモートへ push したいと明示された時、
+  または「push して」「commit and push」「push to github」などの表現がある時。
 ---
 
 # Git Push Workflow

--- a/.claude/skills/plugin-authoring/SKILL.md
+++ b/.claude/skills/plugin-authoring/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: plugin-authoring
-description: Use when creating, modifying, or debugging Claude Code plugins. Triggers on .claude-plugin/, plugin.json, marketplace.json, commands/, agents/, skills/, hooks/ directories. Provides schemas, templates, validation workflows, and troubleshooting.
+description: |
+  Claude Code プラグインの作成・変更・デバッグ時に使用する。
+  .claude-plugin/、plugin.json、marketplace.json、commands/、agents/、skills/、hooks/ の変更があるときにトリガー。
+  スキーマ、テンプレート、検証フロー、トラブルシューティングを提供する。
 allowed-tools: Read, Grep, Glob
 ---
 

--- a/.claude/skills/postgres/SKILL.md
+++ b/.claude/skills/postgres/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: postgres
-description: "Execute read-only SQL queries against multiple PostgreSQL databases. Use when: (1) querying PostgreSQL databases, (2) exploring database schemas/tables, (3) running SELECT queries for data analysis, (4) checking database contents. Supports multiple database connections with descriptions for intelligent auto-selection. Blocks all write operations (INSERT, UPDATE, DELETE, DROP, etc.) for safety."
+description: |
+  複数の PostgreSQL データベースに対して読み取り専用 SQL を実行する。
+  Use when: (1) PostgreSQL の問い合わせ、(2) スキーマ/テーブルの調査、
+  (3) SELECT による分析、(4) データ内容の確認。
+  接続候補に説明を持たせて自動選択を支援する。
+  安全のため INSERT/UPDATE/DELETE/DROP などの書き込み操作はすべてブロックする。
 ---
 
 # PostgreSQL Read-Only Query Skill

--- a/.claude/skills/review-implementing/SKILL.md
+++ b/.claude/skills/review-implementing/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: review-implementing
-description: Process and implement code review feedback systematically. Use when user provides reviewer comments, PR feedback, code review notes, or asks to implement suggestions from reviews.
+description: |
+  コードレビューの指摘を体系的に整理し、実装に反映する。
+  Use when: レビュアーコメント、PR フィードバック、レビュー指摘が提示された時、
+  または指摘対応を依頼された時。
 ---
 
 # Review Feedback Implementation

--- a/.claude/skills/skill-creator/SKILL.md
+++ b/.claude/skills/skill-creator/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: skill-creator
-description: Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Claude's capabilities with specialized knowledge, workflows, or tool integrations.
+description: |
+  効果的なスキルを作るためのガイド。
+  Use when: 専門知識・ワークフロー・ツール連携で Claude の能力を拡張する
+  新規/既存スキルの作成・更新を依頼された時。
 license: Complete terms in LICENSE.txt
 ---
 

--- a/.claude/skills/systematic-debugging/SKILL.md
+++ b/.claude/skills/systematic-debugging/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: systematic-debugging
-description: Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes
+description: |
+  バグ、テスト失敗、予期しない挙動に遭遇したら、修正案を出す前に使用する。
 ---
 
 # Systematic Debugging

--- a/.claude/skills/test-driven-development/SKILL.md
+++ b/.claude/skills/test-driven-development/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: test-driven-development
-description: Use when implementing any feature or bugfix, before writing implementation code
+description: |
+  機能追加やバグ修正を実装する際、実装コードを書く前に使用する。
 ---
 
 # Test-Driven Development (TDD)

--- a/.claude/skills/varlock-claude-skill/SKILL.md
+++ b/.claude/skills/varlock-claude-skill/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: varlock
-description: Secure environment variable management with Varlock. Use when handling secrets, API keys, credentials, or any sensitive configuration. Ensures secrets are never exposed in terminals, logs, traces, or Claude's context. Trigger phrases include "environment variables", "secrets", ".env", "API key", "credentials", "sensitive", "Varlock".
+description: |
+  Varlock で環境変数を安全に管理する。
+  Use when: シークレット、API キー、認証情報など機微な設定を扱う時。
+  ターミナル/ログ/トレース/Claude のコンテキストに秘密情報が露出しないよう保証する。
+  トリガー語: "environment variables", "secrets", ".env", "API key", "credentials", "sensitive", "Varlock"。
 ---
 
 # Varlock Security Skill

--- a/.claude/skills/web-artifacts-builder/SKILL.md
+++ b/.claude/skills/web-artifacts-builder/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: web-artifacts-builder
-description: Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui). Use for complex artifacts requiring state management, routing, or shadcn/ui components - not for simple single-file HTML/JSX artifacts.
+description: |
+  React/Tailwind CSS/shadcn/ui などの最新フロント技術で、
+  claude.ai 向けの複数コンポーネント HTML アーティファクトを作るためのツール群。
+  状態管理、ルーティング、shadcn/ui などが必要な複雑なアーティファクト向けで、
+  単一ファイルの HTML/JSX には使わない。
 license: Complete terms in LICENSE.txt
 ---
 

--- a/.claude/skills/webapp-testing/SKILL.md
+++ b/.claude/skills/webapp-testing/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: webapp-testing
-description: Toolkit for interacting with and testing local web applications using Playwright. Supports verifying frontend functionality, debugging UI behavior, capturing browser screenshots, and viewing browser logs.
+description: |
+  Playwright を使ってローカル Web アプリを操作・テストするためのツールキット。
+  フロントエンド機能の検証、UI 挙動のデバッグ、スクリーンショット取得、
+  ブラウザログ確認に対応する。
 license: Complete terms in LICENSE.txt
 ---
 


### PR DESCRIPTION
## 概要
英語のdescriptionを日本語化し、UIレビュー手順をルールに追加しました。

## 変更種別
- [ ] 新機能
- [ ] バグ修正

## 主な変更内容
- 英語のdescriptionを日本語化
- UIレビュー手順を `.claude/rules` に追加

## テスト
- [ ] テスト実行確認（未実施）
- [ ] ビルド確認（未実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)