### PR TITLE
認証確認の遅延改善とAPIクライアント定数化

### DIFF
--- a/frontend/src/features/auth/context/AuthContext.tsx
+++ b/frontend/src/features/auth/context/AuthContext.tsx
@@ -4,15 +4,20 @@ import { AuthContext } from './context';
 import { apiClient, createApiClient } from '@/lib/api/client';
 import { useIdleTimer } from '../hooks/useIdleTimer';
 
-// 認証確認専用クライアント（timeout/retryを最小化）
+// 認証確認専用クライアント設定
 // デフォルト設定(timeout=30s, retry=3回, 指数バックオフ)では
 // fly.ioコールドスタート時に最大127秒待ちになるため、専用設定で短縮
+const AUTH_CHECK_TIMEOUT_MS = 5_000;
+const AUTH_CHECK_MAX_RETRIES = 1;
+const AUTH_CHECK_RETRY_DELAY_MS = 500;
+const AUTH_CHECK_RETRY_DELAY_MULTIPLIER = 1;
+
 const authApiClient = createApiClient({
-  timeout: 5000,
+  timeout: AUTH_CHECK_TIMEOUT_MS,
   retry: {
-    maxRetries: 1,
-    retryDelay: 500,
-    retryDelayMultiplier: 1,
+    maxRetries: AUTH_CHECK_MAX_RETRIES,
+    retryDelay: AUTH_CHECK_RETRY_DELAY_MS,
+    retryDelayMultiplier: AUTH_CHECK_RETRY_DELAY_MULTIPLIER,
   },
 });
 

--- a/frontend/src/features/auth/context/AuthContext.tsx
+++ b/frontend/src/features/auth/context/AuthContext.tsx
@@ -1,8 +1,20 @@
 import { useState, useEffect, useCallback, useRef, ReactNode } from 'react';
 import { UserInfo } from '../types';
 import { AuthContext } from './context';
-import { apiClient } from '@/lib/api/client';
+import { apiClient, createApiClient } from '@/lib/api/client';
 import { useIdleTimer } from '../hooks/useIdleTimer';
+
+// 認証確認専用クライアント（timeout/retryを最小化）
+// デフォルト設定(timeout=30s, retry=3回, 指数バックオフ)では
+// fly.ioコールドスタート時に最大127秒待ちになるため、専用設定で短縮
+const authApiClient = createApiClient({
+  timeout: 5000,
+  retry: {
+    maxRetries: 1,
+    retryDelay: 500,
+    retryDelayMultiplier: 1,
+  },
+});
 
 // アイドルタイムアウト: 30分
 const IDLE_TIMEOUT = 30 * 60 * 1000;
@@ -12,13 +24,19 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [isLoading, setIsLoading] = useState(true);
   // ログアウト時に呼び出されるコールバックのリスト
   const logoutCallbacksRef = useRef<Set<() => void>>(new Set());
+  // 重複呼び出し防止フラグ
+  const isCheckingRef = useRef(false);
 
   // 初期化時にバックエンドからセッションを確認
   useEffect(() => {
     const checkSession = async () => {
+      // 重複呼び出し防止
+      if (isCheckingRef.current) return;
+      isCheckingRef.current = true;
+
       try {
-        // バックエンドからユーザー情報を取得（Cookieベースの認証）
-        const userInfo = await apiClient.get<UserInfo>('/auth/me', {
+        // 認証確認専用クライアントで取得（timeout/retry最小化）
+        const userInfo = await authApiClient.get<UserInfo>('/auth/me', {
           withCredentials: true,
         });
         setUser(userInfo);
@@ -27,6 +45,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setUser(null);
       } finally {
         setIsLoading(false);
+        isCheckingRef.current = false;
       }
     };
 

--- a/frontend/src/features/auth/context/__tests__/AuthContext.test.tsx
+++ b/frontend/src/features/auth/context/__tests__/AuthContext.test.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AuthProvider } from '../AuthContext';
+import { useAuth } from '../../hooks/useAuth';
+
+// アイドルタイマーのモック
+vi.mock('../../hooks/useIdleTimer', () => ({
+  useIdleTimer: vi.fn(),
+}));
+
+// vi.hoisted でモック関数をホイスティング対応にする
+const { mockGet } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+}));
+
+// APIクライアントのモック
+vi.mock('@/lib/api/client', () => ({
+  apiClient: {
+    post: vi.fn(),
+    delete: vi.fn(),
+  },
+  createApiClient: () => ({
+    get: mockGet,
+  }),
+}));
+
+// テスト用コンシューマーコンポーネント
+function TestConsumer() {
+  const { user, isLoading, isAuthenticated } = useAuth();
+  return (
+    <div>
+      <span data-testid="loading">{String(isLoading)}</span>
+      <span data-testid="authenticated">{String(isAuthenticated)}</span>
+      <span data-testid="user-name">{user?.name ?? 'none'}</span>
+    </div>
+  );
+}
+
+describe('AuthProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('認証成功時にユーザー情報がセットされる', async () => {
+    const mockUser = { id: '1', email: 'test@example.com', name: 'テストユーザー' };
+    mockGet.mockResolvedValueOnce(mockUser);
+
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>
+    );
+
+    // 初期状態: ローディング中
+    expect(screen.getByTestId('loading').textContent).toBe('true');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false');
+    });
+
+    expect(screen.getByTestId('authenticated').textContent).toBe('true');
+    expect(screen.getByTestId('user-name').textContent).toBe('テストユーザー');
+    expect(mockGet).toHaveBeenCalledTimes(1);
+    expect(mockGet).toHaveBeenCalledWith('/auth/me', { withCredentials: true });
+  });
+
+  it('認証失敗時(401)にuser=nullになる', async () => {
+    mockGet.mockRejectedValueOnce(new Error('Unauthorized'));
+
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false');
+    });
+
+    expect(screen.getByTestId('authenticated').textContent).toBe('false');
+    expect(screen.getByTestId('user-name').textContent).toBe('none');
+    expect(mockGet).toHaveBeenCalledTimes(1);
+  });
+
+  it('checkSessionが重複して呼ばれない', async () => {
+    // 遅延レスポンスをシミュレート
+    mockGet.mockImplementation(() =>
+      new Promise(resolve => setTimeout(() => resolve({ id: '1', email: 'test@example.com', name: 'ユーザー' }), 50))
+    );
+
+    const { unmount } = render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>
+    );
+
+    unmount();
+
+    // 再マウント（StrictModeでの二重レンダリングを模倣）
+    render(
+      <React.StrictMode>
+        <AuthProvider>
+          <TestConsumer />
+        </AuthProvider>
+      </React.StrictMode>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false');
+    });
+
+    // StrictModeでも過剰な呼び出しが起きないことを確認
+    // unmount後は新インスタンスなので再マウント時に1回呼ばれる
+    expect(mockGet.mock.calls.length).toBeGreaterThanOrEqual(1);
+    expect(mockGet.mock.calls.length).toBeLessThanOrEqual(2);
+  });
+
+  it('認証確認専用クライアントが使用される', async () => {
+    mockGet.mockResolvedValueOnce({ id: '1', email: 'test@example.com' });
+
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false');
+    });
+
+    // createApiClientで生成されたクライアントのgetが呼ばれていること
+    expect(mockGet).toHaveBeenCalledWith('/auth/me', { withCredentials: true });
+  });
+});

--- a/frontend/src/lib/api/__tests__/client.test.ts
+++ b/frontend/src/lib/api/__tests__/client.test.ts
@@ -255,6 +255,26 @@ describe('ApiClient', () => {
         },
       });
     });
+
+    it('認証確認用にtimeout/retryをカスタマイズできる', () => {
+      createApiClient({
+        timeout: 10000,
+        retry: {
+          maxRetries: 1,
+          retryDelay: 500,
+          retryDelayMultiplier: 1,
+        },
+      });
+
+      expect(mockedAxiosCreate).toHaveBeenCalledWith({
+        baseURL: import.meta.env.VITE_SHOKEN_WEBAPI_API_URL,
+        timeout: 10000,
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+        },
+      });
+    });
   });
 });
 

--- a/frontend/src/lib/api/__tests__/client.test.ts
+++ b/frontend/src/lib/api/__tests__/client.test.ts
@@ -258,7 +258,7 @@ describe('ApiClient', () => {
 
     it('認証確認用にtimeout/retryをカスタマイズできる', () => {
       createApiClient({
-        timeout: 10000,
+        timeout: 5000,
         retry: {
           maxRetries: 1,
           retryDelay: 500,
@@ -268,7 +268,7 @@ describe('ApiClient', () => {
 
       expect(mockedAxiosCreate).toHaveBeenCalledWith({
         baseURL: import.meta.env.VITE_SHOKEN_WEBAPI_API_URL,
-        timeout: 10000,
+        timeout: 5000,
         headers: {
           'Content-Type': 'application/json',
           'Accept': 'application/json',

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -22,10 +22,17 @@ interface ApiClientConfig {
   headers?: Record<string, string>;
 }
 
+// デフォルトタイムアウト: fly.ioの起動待ち時間を考慮
+const DEFAULT_TIMEOUT_MS = 30_000;
+// デフォルトリトライ設定
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_RETRY_DELAY_MS = 1000;
+const DEFAULT_RETRY_DELAY_MULTIPLIER = 2;
+
 const DEFAULT_RETRY_CONFIG: RetryConfig = {
-  maxRetries: 3,
-  retryDelay: 1000,
-  retryDelayMultiplier: 2,
+  maxRetries: DEFAULT_MAX_RETRIES,
+  retryDelay: DEFAULT_RETRY_DELAY_MS,
+  retryDelayMultiplier: DEFAULT_RETRY_DELAY_MULTIPLIER,
   shouldRetry: (error: ApiError) => error.isRetryable(),
 };
 
@@ -36,7 +43,7 @@ class ApiClient {
   constructor(config: ApiClientConfig = {}) {
     const {
       baseURL = import.meta.env.VITE_SHOKEN_WEBAPI_API_URL,
-      timeout = 30000, // fly.ioの起動待ち時間を考慮して30秒に設定
+      timeout = DEFAULT_TIMEOUT_MS,
       retry = {},
       headers = {},
     } = config;


### PR DESCRIPTION
## 概要
ログイン状態確認（`GET /auth/me`）の遅延問題を修正し、APIクライアントのマジックナンバーを定数化。

## 変更種別
- [x] バグ修正
- [x] リファクタリング

## 主な変更内容
- 認証確認専用APIクライアントの導入（timeout: 30s→5s, retry: 3回→1回, 指数バックオフ無効化）
- `useRef` による `checkSession` の重複呼び出し防止
- APIクライアントのマジックナンバーを名前付き定数に置換
- AuthContext のユニットテスト追加

## 改善効果
| 項目 | 修正前 | 修正後 |
|------|--------|--------|
| timeout | 30秒 | 5秒 |
| maxRetries | 3回 | 1回 |
| 指数バックオフ | 1s→2s→4s | 500ms固定 |
| 最悪待ち時間 | ~127秒 | ~10.5秒 |

## テスト
- [x] npm run lint 通過
- [x] npm run tsc 通過（既存の型エラーのみ）
- [x] npm test 通過（既存のタイムアウト失敗のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)