### PR TITLE
feat: 検索オプションに条件クリアボタンを追加

### DIFF
--- a/frontend/src/components/organisms/AssetPortfolioSummary/AssetPortfolioSummary.tsx
+++ b/frontend/src/components/organisms/AssetPortfolioSummary/AssetPortfolioSummary.tsx
@@ -89,19 +89,10 @@ export const AssetPortfolioSummary: React.FC<AssetPortfolioSummaryProps> = ({
             {/* 絞り込み中バナー */}
             {isFiltered && (
               <div className="mb-4 pb-4 border-b border-slate-100">
-                <div className="flex items-center justify-between rounded-md bg-blue-50 px-3 py-2">
+                <div className="flex items-center rounded-md bg-blue-50 px-3 py-2">
                   <span className="text-sm font-medium text-blue-700">
                     🔍 絞り込み中: {displayCount}/{actualTotalCount}件を表示
                   </span>
-                  {onClearFilter && (
-                    <button
-                      type="button"
-                      onClick={onClearFilter}
-                      className="text-sm text-blue-600 hover:text-blue-800 hover:underline"
-                    >
-                      解除
-                    </button>
-                  )}
                 </div>
               </div>
             )}

--- a/frontend/src/components/organisms/SearchCard/SearchCard.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { SearchCategories } from '@/types/common';
 import { Button } from '@/components/atoms/Button';
 import { Card, CardBody, CardHeader } from '@/components/atoms/Card';
@@ -7,6 +7,7 @@ interface SearchCardProps {
     onSearch: (query: string) => void;
     categories?: SearchCategories;
     onExpandToggle?: (isExpanded: boolean) => void; // 展開状態変更の通知
+    value?: string; // 親の検索状態と同期（外部クリア対応）
 }
 
 /**
@@ -16,13 +17,22 @@ interface SearchCardProps {
 export const SearchCard: React.FC<SearchCardProps> = ({
     onSearch,
     categories,
-    onExpandToggle
+    onExpandToggle,
+    value
 }) => {
 
     const [isExpanded, setIsExpanded] = useState(true);
     const [searchQuery, setSearchQuery] = useState('');
     // アクティブな検索タイプを追跡（ドロップダウンの表示制御用）
     const [activeSearchType, setActiveSearchType] = useState<'securities' | 'years' | 'products' | 'accounts' | null>(null);
+
+    // 親の検索状態と同期（外部からのクリア時に内部状態をリセット）
+    useEffect(() => {
+        if (value !== undefined && value !== searchQuery) {
+            setSearchQuery(value);
+            setActiveSearchType(value ? activeSearchType : null);
+        }
+    }, [value]); // eslint-disable-line react-hooks/exhaustive-deps
 
     // データが存在するかチェックするヘルパー関数
     const hasData = (data: unknown[] | undefined): boolean => {
@@ -194,10 +204,13 @@ export const SearchCard: React.FC<SearchCardProps> = ({
             {isExpanded && categories && (
                 <CardBody id="search-options-body" className="p-3">
                     {/* 条件クリアボタン（上部右寄せ） */}
-                    <div className="mb-2 flex justify-end">
+                    <div className="mb-2 flex items-center justify-end gap-2">
+                        {isDefaultState && (
+                            <span className="text-xs text-slate-400" aria-hidden="true">条件を選択すると解除できます</span>
+                        )}
                         <Button
                             type="button"
-                            variant="outline-secondary"
+                            variant={isDefaultState ? 'outline-secondary' : 'outline-danger'}
                             size="sm"
                             onClick={handleClearSearch}
                             disabled={isDefaultState}

--- a/frontend/src/components/organisms/SearchCard/SearchCard.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchCard.tsx
@@ -186,43 +186,50 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                         </span>
                     )}
                 </div>
-                {/* シェブロンアイコン: 回転で開閉状態を表現 */}
-                <span className="flex items-center gap-1.5 -mr-1" aria-hidden="true">
-                    <span className="text-xs font-medium opacity-80">
-                        {isExpanded ? '閉じる' : '開く'}
-                    </span>
-                    <svg
-                        className={`w-4 h-4 transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`}
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                    >
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                    </svg>
-                </span>
-            </CardHeader>
-            {isExpanded && categories && (
-                <CardBody id="search-options-body" className="p-3">
-                    {/* 条件クリアボタン（上部右寄せ） */}
-                    <div className="mb-2 flex items-center justify-end gap-2">
-                        {isDefaultState && (
-                            <span className="text-xs text-slate-400" aria-hidden="true">条件を選択すると解除できます</span>
-                        )}
+                <div className="flex items-center gap-2">
+                    {/* 条件クリアボタン（ヘッダー内） */}
+                    {!isDefaultState && (
                         <Button
                             type="button"
-                            variant={isDefaultState ? 'outline-secondary' : 'outline-danger'}
+                            variant="outline-danger"
                             size="sm"
-                            onClick={handleClearSearch}
-                            disabled={isDefaultState}
+                            onClick={(e: React.MouseEvent) => {
+                                e.stopPropagation();
+                                handleClearSearch();
+                            }}
+                            onKeyDown={(e: React.KeyboardEvent) => {
+                                if (e.key === 'Enter' || e.key === ' ') {
+                                    e.stopPropagation();
+                                }
+                            }}
+                            className="text-xs px-2 py-0.5 border-white/40 text-white hover:bg-white/20 hover:border-white/60"
                             aria-label="検索条件をクリア"
                             data-testid="search-clear-button"
                         >
-                            <svg className="w-3.5 h-3.5 mr-1 inline-block" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                            <svg className="w-3 h-3 mr-1 inline-block" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
                             </svg>
                             条件をクリア
                         </Button>
-                    </div>
+                    )}
+                    {/* シェブロンアイコン: 回転で開閉状態を表現 */}
+                    <span className="flex items-center gap-1.5" aria-hidden="true">
+                        <span className="text-xs font-medium opacity-80">
+                            {isExpanded ? '閉じる' : '開く'}
+                        </span>
+                        <svg
+                            className={`w-4 h-4 transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`}
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                        >
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                        </svg>
+                    </span>
+                </div>
+            </CardHeader>
+            {isExpanded && categories && (
+                <CardBody id="search-options-body" className="p-3">
                     {/* グリッドレイアウト: モバイル1列、sm2列、lg4列 */}
                     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
                         {/* 銘柄検索 */}

--- a/frontend/src/components/organisms/SearchCard/SearchCard.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchCard.tsx
@@ -161,7 +161,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
         <Card className="mt-1">
             <CardHeader
                 variant="secondary"
-                className={`flex cursor-pointer items-center justify-between select-none transition-colors focus-within:ring-2 focus-within:ring-white/50 focus-within:ring-inset ${
+                className={`flex min-h-[2.25rem] cursor-pointer items-center justify-between select-none transition-colors focus-within:ring-2 focus-within:ring-white/50 focus-within:ring-inset ${
                     isExpanded
                         ? 'bg-slate-600 hover:bg-slate-700 border-b-2 border-slate-700'
                         : 'bg-slate-400 hover:bg-slate-500'

--- a/frontend/src/components/organisms/SearchCard/SearchCard.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchCard.tsx
@@ -193,6 +193,23 @@ export const SearchCard: React.FC<SearchCardProps> = ({
             </CardHeader>
             {isExpanded && categories && (
                 <CardBody id="search-options-body" className="p-3">
+                    {/* 条件クリアボタン（上部右寄せ） */}
+                    <div className="mb-2 flex justify-end">
+                        <Button
+                            type="button"
+                            variant="outline-secondary"
+                            size="sm"
+                            onClick={handleClearSearch}
+                            disabled={isDefaultState}
+                            aria-label="検索条件をクリア"
+                            data-testid="search-clear-button"
+                        >
+                            <svg className="w-3.5 h-3.5 mr-1 inline-block" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                            </svg>
+                            条件をクリア
+                        </Button>
+                    </div>
                     {/* グリッドレイアウト: モバイル1列、sm2列、lg4列 */}
                     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
                         {/* 銘柄検索 */}
@@ -226,23 +243,6 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                                 <div className="flex flex-wrap gap-1">{renderQuickSearchButtons(categories.accounts!, 'accounts')}</div>
                             </div>
                         )}
-                    </div>
-                    {/* 条件クリアボタン */}
-                    <div className="mt-3 flex justify-end">
-                        <Button
-                            type="button"
-                            variant="outline-secondary"
-                            size="sm"
-                            onClick={handleClearSearch}
-                            disabled={isDefaultState}
-                            aria-label="検索条件をクリア"
-                            data-testid="search-clear-button"
-                        >
-                            <svg className="w-3.5 h-3.5 mr-1 inline-block" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                            </svg>
-                            条件をクリア
-                        </Button>
                     </div>
                 </CardBody>
             )}

--- a/frontend/src/components/organisms/SearchCard/SearchCard.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchCard.tsx
@@ -161,7 +161,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
         <Card className="mt-1">
             <CardHeader
                 variant="secondary"
-                className={`flex min-h-[2.25rem] cursor-pointer items-center justify-between select-none transition-colors focus-within:ring-2 focus-within:ring-white/50 focus-within:ring-inset ${
+                className={`flex cursor-pointer items-center justify-between select-none transition-colors focus-within:ring-2 focus-within:ring-white/50 focus-within:ring-inset ${
                     isExpanded
                         ? 'bg-slate-600 hover:bg-slate-700 border-b-2 border-slate-700'
                         : 'bg-slate-400 hover:bg-slate-500'
@@ -187,31 +187,33 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                     )}
                 </div>
                 <div className="flex items-center gap-2">
-                    {/* 条件クリアボタン（ヘッダー内） */}
-                    {!isDefaultState && (
-                        <Button
-                            type="button"
-                            variant="outline-danger"
-                            size="sm"
-                            onClick={(e: React.MouseEvent) => {
+                    {/* 条件クリアボタン（ヘッダー内・常にレンダリングし高さを固定） */}
+                    <Button
+                        type="button"
+                        variant="outline-danger"
+                        size="sm"
+                        onClick={(e: React.MouseEvent) => {
+                            e.stopPropagation();
+                            handleClearSearch();
+                        }}
+                        onKeyDown={(e: React.KeyboardEvent) => {
+                            if (e.key === 'Enter' || e.key === ' ') {
                                 e.stopPropagation();
-                                handleClearSearch();
-                            }}
-                            onKeyDown={(e: React.KeyboardEvent) => {
-                                if (e.key === 'Enter' || e.key === ' ') {
-                                    e.stopPropagation();
-                                }
-                            }}
-                            className="text-xs px-2 py-0.5 border-white/40 text-white hover:bg-white/20 hover:border-white/60"
-                            aria-label="検索条件をクリア"
-                            data-testid="search-clear-button"
-                        >
-                            <svg className="w-3 h-3 mr-1 inline-block" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                            </svg>
-                            条件をクリア
-                        </Button>
-                    )}
+                            }
+                        }}
+                        className={`text-xs px-2 py-0.5 border-white/40 text-white hover:bg-white/20 hover:border-white/60 transition-opacity ${
+                            isDefaultState ? 'opacity-0 pointer-events-none' : 'opacity-100'
+                        }`}
+                        aria-label="検索条件をクリア"
+                        aria-hidden={isDefaultState}
+                        tabIndex={isDefaultState ? -1 : 0}
+                        data-testid="search-clear-button"
+                    >
+                        <svg className="w-3 h-3 mr-1 inline-block" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                        </svg>
+                        条件をクリア
+                    </Button>
                     {/* シェブロンアイコン: 回転で開閉状態を表現 */}
                     <span className="flex items-center gap-1.5" aria-hidden="true">
                         <span className="text-xs font-medium opacity-80">

--- a/frontend/src/components/organisms/SearchCard/SearchCard.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchCard.tsx
@@ -59,6 +59,16 @@ export const SearchCard: React.FC<SearchCardProps> = ({
         onSearch(value);
     };
 
+    // 検索条件が初期状態かどうか
+    const isDefaultState = searchQuery === '' && activeSearchType === null;
+
+    // 検索条件をクリア
+    const handleClearSearch = () => {
+        setSearchQuery('');
+        setActiveSearchType(null);
+        onSearch('');
+    };
+
     // カテゴリが何もない場合は SearchCard 自体を非表示
     if (!hasAnyCategories()) {
         return null;
@@ -216,6 +226,23 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                                 <div className="flex flex-wrap gap-1">{renderQuickSearchButtons(categories.accounts!, 'accounts')}</div>
                             </div>
                         )}
+                    </div>
+                    {/* 条件クリアボタン */}
+                    <div className="mt-3 flex justify-end">
+                        <Button
+                            type="button"
+                            variant="outline-secondary"
+                            size="sm"
+                            onClick={handleClearSearch}
+                            disabled={isDefaultState}
+                            aria-label="検索条件をクリア"
+                            data-testid="search-clear-button"
+                        >
+                            <svg className="w-3.5 h-3.5 mr-1 inline-block" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                            </svg>
+                            条件をクリア
+                        </Button>
                     </div>
                 </CardBody>
             )}

--- a/frontend/src/components/organisms/SearchCard/__tests__/SearchCard.test.tsx
+++ b/frontend/src/components/organisms/SearchCard/__tests__/SearchCard.test.tsx
@@ -214,7 +214,7 @@ describe('SearchCard', () => {
     expect(screen.getByText('商品21')).toBeInTheDocument();
   });
 
-  test('初期状態では「条件をクリア」ボタンが非表示である', () => {
+  test('初期状態では「条件をクリア」ボタンが操作不可である', () => {
     render(
       <SearchCard
         onSearch={mockOnSearch}
@@ -222,10 +222,12 @@ describe('SearchCard', () => {
       />
     );
 
-    expect(screen.queryByTestId('search-clear-button')).not.toBeInTheDocument();
+    const clearButton = screen.getByTestId('search-clear-button');
+    expect(clearButton).toHaveClass('opacity-0');
+    expect(clearButton).toHaveClass('pointer-events-none');
   });
 
-  test('検索条件を選択すると「条件をクリア」ボタンが表示される', () => {
+  test('検索条件を選択すると「条件をクリア」ボタンが操作可能になる', () => {
     render(
       <SearchCard
         onSearch={mockOnSearch}
@@ -237,7 +239,8 @@ describe('SearchCard', () => {
     fireEvent.click(screen.getByText('株式'));
 
     const clearButton = screen.getByTestId('search-clear-button');
-    expect(clearButton).toBeInTheDocument();
+    expect(clearButton).toHaveClass('opacity-100');
+    expect(clearButton).not.toHaveClass('pointer-events-none');
   });
 
   test('「条件をクリア」ボタンをクリックすると検索条件が初期状態に戻る', () => {
@@ -258,8 +261,8 @@ describe('SearchCard', () => {
     fireEvent.click(clearButton);
 
     expect(mockOnSearch).toHaveBeenCalledWith('');
-    // クリア後はボタンが非表示になる
-    expect(screen.queryByTestId('search-clear-button')).not.toBeInTheDocument();
+    // クリア後はボタンが操作不可になる
+    expect(clearButton).toHaveClass('opacity-0');
     // ドロップダウンが初期値に戻る
     expect(select.value).toBe('');
   });

--- a/frontend/src/components/organisms/SearchCard/__tests__/SearchCard.test.tsx
+++ b/frontend/src/components/organisms/SearchCard/__tests__/SearchCard.test.tsx
@@ -214,6 +214,56 @@ describe('SearchCard', () => {
     expect(screen.getByText('商品21')).toBeInTheDocument();
   });
 
+  test('初期状態では「条件をクリア」ボタンが無効である', () => {
+    render(
+      <SearchCard
+        onSearch={mockOnSearch}
+        categories={defaultCategories}
+      />
+    );
+
+    const clearButton = screen.getByTestId('search-clear-button');
+    expect(clearButton).toBeDisabled();
+  });
+
+  test('検索条件を選択すると「条件をクリア」ボタンが有効になる', () => {
+    render(
+      <SearchCard
+        onSearch={mockOnSearch}
+        categories={defaultCategories}
+      />
+    );
+
+    // 商品ボタンをクリックして検索条件を設定
+    fireEvent.click(screen.getByText('株式'));
+
+    const clearButton = screen.getByTestId('search-clear-button');
+    expect(clearButton).toBeEnabled();
+  });
+
+  test('「条件をクリア」ボタンをクリックすると検索条件が初期状態に戻る', () => {
+    const { container } = render(
+      <SearchCard
+        onSearch={mockOnSearch}
+        categories={defaultCategories}
+      />
+    );
+
+    // 銘柄を選択
+    const select = container.querySelector('#securities-search') as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: 'AAPL' } });
+    expect(mockOnSearch).toHaveBeenCalledWith('AAPL');
+
+    // クリアボタンをクリック
+    const clearButton = screen.getByTestId('search-clear-button');
+    fireEvent.click(clearButton);
+
+    expect(mockOnSearch).toHaveBeenCalledWith('');
+    expect(clearButton).toBeDisabled();
+    // ドロップダウンが初期値に戻る
+    expect(select.value).toBe('');
+  });
+
   test('ドロップダウンの「全て表示」オプションが正しく動作する', () => {
     const { container } = render(
       <SearchCard

--- a/frontend/src/components/organisms/SearchCard/__tests__/SearchCard.test.tsx
+++ b/frontend/src/components/organisms/SearchCard/__tests__/SearchCard.test.tsx
@@ -214,7 +214,7 @@ describe('SearchCard', () => {
     expect(screen.getByText('商品21')).toBeInTheDocument();
   });
 
-  test('初期状態では「条件をクリア」ボタンが無効である', () => {
+  test('初期状態では「条件をクリア」ボタンが非表示である', () => {
     render(
       <SearchCard
         onSearch={mockOnSearch}
@@ -222,11 +222,10 @@ describe('SearchCard', () => {
       />
     );
 
-    const clearButton = screen.getByTestId('search-clear-button');
-    expect(clearButton).toBeDisabled();
+    expect(screen.queryByTestId('search-clear-button')).not.toBeInTheDocument();
   });
 
-  test('検索条件を選択すると「条件をクリア」ボタンが有効になる', () => {
+  test('検索条件を選択すると「条件をクリア」ボタンが表示される', () => {
     render(
       <SearchCard
         onSearch={mockOnSearch}
@@ -238,7 +237,7 @@ describe('SearchCard', () => {
     fireEvent.click(screen.getByText('株式'));
 
     const clearButton = screen.getByTestId('search-clear-button');
-    expect(clearButton).toBeEnabled();
+    expect(clearButton).toBeInTheDocument();
   });
 
   test('「条件をクリア」ボタンをクリックすると検索条件が初期状態に戻る', () => {
@@ -259,7 +258,8 @@ describe('SearchCard', () => {
     fireEvent.click(clearButton);
 
     expect(mockOnSearch).toHaveBeenCalledWith('');
-    expect(clearButton).toBeDisabled();
+    // クリア後はボタンが非表示になる
+    expect(screen.queryByTestId('search-clear-button')).not.toBeInTheDocument();
     // ドロップダウンが初期値に戻る
     expect(select.value).toBe('');
   });

--- a/frontend/src/pages/AssetBalance.tsx
+++ b/frontend/src/pages/AssetBalance.tsx
@@ -246,6 +246,7 @@ export function AssetBalancePage() {
               <SearchCard
                 onSearch={handleSearch}
                 categories={searchCategories}
+                value={searchQuery}
               />
             )}
 


### PR DESCRIPTION
## 概要
資産管理・取引明細の検索オプションで「フィルタ解除」が直感的にできない問題を改善。
SearchCardヘッダー行に「条件をクリア」ボタンを追加し、1クリックで初期状態に戻せるようにした。

## 変更種別
- [x] 新機能
- [x] バグ修正

## 主な変更内容
- SearchCardヘッダー右側に「条件をクリア」ボタンを追加（初期状態ではopacity-0で非表示）
- 条件選択時にボタンが表示され、クリックで全条件をリセット
- `value` propで親コンポーネントとの状態同期を実現（外部クリア対応）
- AssetPortfolioSummaryのバナー「解除」ボタンを削除（SearchCardに一本化）
- stopPropagationでヘッダー折りたたみ操作と分離
- ボタン常時レンダリングによりヘッダー高さの変動を防止
- 資産管理・取引明細（配当/国内株式/投資信託）全ページに自動適用

## テスト
- [x] npm run lint - OK
- [x] npm test - 362テスト全合格
- [x] npm run build - 成功
- [x] UIレビュー（スクショ13枚確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)