### PR TITLE
feat: backend-refactor skill を追加

### DIFF
--- a/.claude/skills/backend-refactor/SKILL.md
+++ b/.claude/skills/backend-refactor/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: backend-refactor
+description: |
+  shoken-webapp の Rust/Axum バックエンドを安全にリファクタするためのガイド。handlers/services/models/extractors/routes/errors/state の責務整理、重複削除、命名/モジュール分割、依存関係の解消を、API/DB/認証の互換性を保ちながら進める。
+  Use when: バックエンドの「挙動は維持したまま構造を変える」作業（整理/共通化/分割/統合/層分離/名前変更/エラーハンドリング見直し）を依頼された時。
+---
+
+# Backend Refactor (shoken-webapp)
+
+## Goal
+
+- 外部仕様（APIパス・JSON形・DBスキーマ・認証挙動）を、ユーザーが明示的に依頼しない限り変更しない
+- 変更容易性を上げる（責務の分離、重複削除、依存関係の単純化、モジュール境界の明確化）
+
+## Fast Triage (Confirm First)
+
+- リファクタの対象範囲を確認する（どのモジュール/機能、完了条件、優先順位）
+- 互換性制約を確認する
+- APIパス/JSON形は不変か
+- DBスキーマ変更（マイグレーション）は許可されるか
+- 認証（Cookie/SameSite/Secure）挙動は不変か
+- フロントエンド同時修正はOKか
+
+## Workflow
+
+1. ベースラインを取る
+2. 変更計画を短く作る（コンパイル単位で段階化）
+3. 機械的な変更から入る（移動/命名/import 修正）
+4. 境界ごとに責務を寄せる（handler -> service -> model の順で整理）
+5. 仕上げ（fmt/clippy/test と、外部仕様の再確認）
+
+### 1) Baseline
+
+- `cd backend && cargo test` を実行して現状を固定する
+- 大きめの移動をする場合は、まず `backend/src/routes.rs` のルートと、エラーレスポンス形式を把握する
+- 以降の作業は「ビルドが通る状態」を保ちながら進める
+
+### 2) Plan
+
+- 対象を「どの境界の整理か」で分類する
+- HTTP層: `backend/src/handlers/*`
+- ドメイン/外部API: `backend/src/services/*`
+- モデル/DTO: `backend/src/models/*`
+- 横断: `backend/src/errors.rs`, `backend/src/extractors/*`, `backend/src/middleware.rs`, `backend/src/routes.rs`, `backend/src/state.rs`
+- 「移動 -> コンパイル -> 置換 -> コンパイル」のように、戻しやすい順序にする
+
+### 3) Execute
+
+- まずは機械的変更（ファイル移動、モジュール分割、命名）を行い、動作変更を混ぜない
+- handler は薄くする
+- handler は「入力の抽出/認証/バリデーション」と「service 呼び出し」に寄せる
+- service は「外部API/DB操作」と「ドメインロジック」に寄せる
+- 型は境界に置く
+- request: `Validate` + `ValidatedJson<T>`
+- response: 既存 JSON 形を維持する DTO を用意する
+
+### 4) Validate
+
+- 途中でも `cargo test` または `cargo check` を小刻みに回す
+- 最後に以下を通す（可能な範囲で）
+- `cd backend && cargo fmt`
+- `cd backend && cargo clippy -- -D warnings`
+- `cd backend && cargo test`
+
+## Project-Specific Guardrails
+
+### Routes
+
+- ルート登録は `backend/src/routes.rs` に集約する
+- `app_router` は各 `*_routes()` を `merge` して構成する
+- パス変更はフロントエンド互換性に直結するため、要求がない限り変更しない
+
+### Error Contract
+
+- エラーレスポンス形式を崩さない（`backend/src/errors.rs`）
+- `{ "error": { "code": "...", "message": "...", "details": ... } }`
+- 本番で詳細を出しすぎない（`is_production()` の判定を尊重する）
+
+### Auth / Cookies
+
+- Cookie 名は `session_token`（`backend/src/services/auth.rs`）
+- クロスオリジン運用では `SameSite=None` + `Secure` が必要になり得る（`services/auth.rs` / `handlers/auth.rs`）
+- 認証済みチェックは `AuthenticatedUser` エクストラクターに寄せる（`backend/src/extractors/auth.rs`）
+
+### Module Registries
+
+- 新規作成/分割/移動の時は、対応する registry を必ず更新する
+- `backend/src/handlers.rs`
+- `backend/src/services.rs`
+- `backend/src/models.rs`
+- `backend/src/extractors.rs`
+
+## Recipes
+
+### Extract DB Logic From Handler
+
+- 1つの handler から 1つのクエリ単位で service 関数に切り出す
+- 引数は `&PgPool` と必要な値（`user_id`, payload 等）を取る
+- エラー変換は「どの層で ApiError に寄せるか」を決めて統一する
+
+### Introduce ValidatedJson
+
+- request struct を `models/<domain>.rs` に置く
+- `#[derive(Validate)]` を付ける
+- handler の引数を `ValidatedJson<T>` に差し替える
+
+### Split A Large Module
+
+- 新ファイルを `handlers/` / `services/` / `models/` / `extractors/` に追加する
+- registry（`handlers.rs` など）に `pub mod <name>;` を追加する
+- まとまりの良い型/関数を少しずつ移動する
+
+## Related Skills
+
+- API追加/エンドポイント実装が主目的なら `backend-api` を使う
+- cargo fmt/clippy/test を回すだけなら `backend-build-test` を使う
+
+## References
+
+- `references/project-structure.md`
+- `references/refactor-recipes.md`

--- a/.claude/skills/backend-refactor/references/project-structure.md
+++ b/.claude/skills/backend-refactor/references/project-structure.md
@@ -1,0 +1,74 @@
+# Backend Project Structure (shoken-webapp)
+
+Refactor 時に「どこに何を置くか」を迷わないための、backend crate の簡易マップ。
+
+## Entry Points
+
+- `backend/src/main.rs`
+- 環境変数読み込み、tracing 初期化、DB 接続+マイグレーション、`AppState` 作成、`routes::app_router` でルーティング構築、起動
+
+- `backend/src/routes.rs`
+- ルート登録の集約。`app_router` が各 `*_routes()` を `merge` して構成する
+
+- `backend/src/lib.rs`
+- re-export の集約（他 crate やテストから参照されることがある）
+
+## Cross-Cutting
+
+- `backend/src/state.rs`
+- `AppState { pool, secrets, client }` と `Secrets`
+
+- `backend/src/errors.rs`
+- `ApiError` と JSON エラー契約
+- 本番環境で詳細を出しすぎないガード（`is_production()`）を持つ
+
+- `backend/src/middleware.rs`
+- `validate_origin` など
+
+- `backend/src/config.rs`
+- サーバー設定、CORS、`BACKEND_URL` 等
+
+- `backend/src/db.rs`
+- DB 接続とマイグレーション関連
+
+## Feature Modules
+
+- `backend/src/handlers/*`
+- HTTP ハンドラ。入力抽出/認証/バリデーションを行い、service を呼ぶ
+
+- `backend/src/services/*`
+- ビジネスロジックと外部 API 呼び出し（例: OAuth/J-Quants）
+
+- `backend/src/models/*`
+- DB row（`FromRow`）や request/response DTO（`Validate`）を置く
+
+- `backend/src/extractors/*`
+- axum extractor（例: `AuthenticatedUser`, `ValidatedJson<T>`）
+
+## Module Registries
+
+新規ファイル追加/分割/移動時に更新する。
+
+- `backend/src/handlers.rs`
+- `backend/src/services.rs`
+- `backend/src/models.rs`
+- `backend/src/extractors.rs`
+
+## Current Routes (Reference)
+
+`backend/src/routes.rs` で定義されている主なパス。
+
+- `/stock`, `/stock/{query}`
+- `/jquants/fins/statements`
+- `/auth/google`, `/auth/google/callback`, `/auth/me`, `/auth/logout`, `/auth/delete-account`
+- `/dividends`, `/dividends/bulk`, `/dividends/all`
+- `/domestic-stocks`, `/domestic-stocks/bulk`, `/domestic-stocks/all`
+- `/mutualfunds`, `/mutualfunds/bulk`, `/mutualfunds/all`
+- `/asset-balances`, `/asset-balances/bulk`, `/asset-balances/all`
+- `/health`
+
+## Invariants To Preserve (Unless Requested)
+
+- API のパスと JSON 形
+- `ApiError` のレスポンス形式（`errors.rs`）
+- Cookie 名 `session_token`（`services/auth.rs`）

--- a/.claude/skills/backend-refactor/references/refactor-recipes.md
+++ b/.claude/skills/backend-refactor/references/refactor-recipes.md
@@ -1,0 +1,59 @@
+# Refactor Recipes (backend)
+
+backend のリファクタで頻出の「安全な進め方」まとめ。
+
+## Recipe: Handler から DB 操作を切り出す
+
+目的: handler を「HTTP 入出力」に寄せ、DB/ドメイン処理を service に集約する。
+
+手順:
+
+1. handler 内の SQLx 部分を最小単位で選ぶ（まず 1 クエリ）
+2. `backend/src/services/<domain>.rs` に関数を作る
+3. handler から service を呼ぶように置き換える
+4. `cargo test`（最低でも `cargo check`）で都度確認する
+
+関数シグネチャ指針:
+
+- `pool: &PgPool` を受け取る
+- 認証が必要な場合は `user_id: Uuid` を明示的に渡す
+- `Result<T, sqlx::Error>` にして handler 側で `ApiError` に寄せるか、service 側で `ApiError` を返すかを決めて統一する
+
+## Recipe: request のバリデーションを追加する
+
+目的: `Json<T>` の parse と `validator` の検証を標準化する。
+
+手順:
+
+1. request struct を `backend/src/models/<domain>.rs` に置く
+2. `#[derive(Validate)]` を付けて、フィールドに `#[validate(...)]` を付ける
+3. handler を `ValidatedJson<T>` に置き換える（`backend/src/extractors/validated_json.rs`）
+4. バリデーションエラーが `ApiError::ValidationError` に落ちることを確認する
+
+## Recipe: 大きい module を分割する
+
+目的: 変更単位を小さくして見通しを良くする。
+
+手順:
+
+1. 分割先のファイルを追加する（例: `backend/src/handlers/<new>.rs`）
+2. registry に `pub mod <new>;` を追加する（例: `backend/src/handlers.rs`）
+3. 依存の少ない型/関数から順に移動する
+4. move ごとに `cargo check` を通す
+
+## Recipe: ApiError を拡張する
+
+目的: エラー契約を保ったまま、責務に沿ったエラー表現を増やす。
+
+手順:
+
+1. `backend/src/errors.rs` の `ApiError` に variant を追加する
+2. `IntoResponse` のマッピングに status/code/message を追加する
+3. 本番で詳細を出さない方針（`is_production()`）を崩さない
+4. 既存の呼び出し側を置き換える
+
+## Recipe: Auth 周りを触る時の注意点
+
+- Cookie 名は `backend/src/services/auth.rs` の定数を参照する
+- SameSite/Secure はクロスオリジン要件に影響するため、変更前に仕様確認する
+- 認証必須の endpoint は `AuthenticatedUser` を handler 引数に入れる（`backend/src/extractors/auth.rs`）


### PR DESCRIPTION
## 概要
バックエンドのリファクタ作業を安全に進めるための skill（`backend-refactor`）を追加しました。

## 変更種別
- [x] 新機能
- [ ] バグ修正

## 主な変更内容
- `.claude/skills/backend-refactor/SKILL.md` を追加（ワークフロー/ガードレール/レシピ）
- `references/` にプロジェクト構造とリファクタレシピを追加

## テスト
- [x] `python3 .claude/skills/skill-creator/scripts/quick_validate.py .claude/skills/backend-refactor`
