### PR TITLE
Dockerfile の Rust バージョンを 1.88 に更新

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # ビルドステージ
-FROM rust:1.86-bookworm AS builder
+FROM rust:1.88-bookworm AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## 概要
Fly.io デプロイで Rust 1.88.0 が必要なため、Dockerfile のビルドステージを更新

## 変更種別
- [ ] 新機能
- [x] バグ修正

## 主な変更内容
- `backend/Dockerfile` の Rust イメージを `1.86` → `1.88` に更新

## テスト
- [x] ビルド確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)