### PR TITLE
バックエンドのサービス層リファクタリング

### DIFF
--- a/backend/src/handlers/asset_balance.rs
+++ b/backend/src/handlers/asset_balance.rs
@@ -1,34 +1,17 @@
 use crate::{
-    errors::ApiError,
-    extractors::auth::AuthenticatedUser,
+    errors::ApiError, extractors::auth::AuthenticatedUser,
     extractors::validated_json::ValidatedJson,
-    models::asset_balance::{AssetBalance, BulkCreateAssetBalanceRequest, BulkCreateResponse},
-    state::AppState,
+    models::asset_balance::BulkCreateAssetBalanceRequest,
+    services::asset_balance as asset_balance_service, state::AppState,
 };
 use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
-use std::time::Instant;
-use tracing::info;
 
 /// 認証ユーザーの保有銘柄一覧を取得
 pub async fn list(
     State(state): State<AppState>,
     auth_user: AuthenticatedUser,
 ) -> Result<impl IntoResponse, ApiError> {
-    info!("[asset_balance.list] リクエスト受信");
-    let balances = sqlx::query_as::<_, AssetBalance>(
-        r#"
-        SELECT id, user_id, security_code, security_name, shares, executing_shares,
-               average_purchase_price, total_purchase_amount, current_price,
-               daily_change, market_value, profit_loss_rate, created_at, updated_at
-        FROM asset_balances
-        WHERE user_id = $1
-        ORDER BY security_code
-        "#,
-    )
-    .bind(auth_user.id())
-    .fetch_all(&state.pool)
-    .await?;
-
+    let balances = asset_balance_service::list(&state.pool, auth_user.id()).await?;
     Ok((StatusCode::OK, Json(balances)))
 }
 
@@ -38,99 +21,9 @@ pub async fn bulk_create(
     auth_user: AuthenticatedUser,
     ValidatedJson(data): ValidatedJson<BulkCreateAssetBalanceRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
-    let total = data.items.len();
-    info!("[asset_balance.bulk_create] リクエスト受信: {}件", total);
-    let start = Instant::now();
-
-    if data.items.is_empty() {
-        return Ok((
-            StatusCode::CREATED,
-            Json(BulkCreateResponse {
-                inserted: 0,
-                skipped: 0,
-            }),
-        ));
-    }
-
-    let user_id = auth_user.id();
-
-    // 各フィールドを配列に変換
-    let user_ids: Vec<uuid::Uuid> = vec![user_id; total];
-    let security_codes: Vec<&str> = data
-        .items
-        .iter()
-        .map(|i| i.security_code.as_str())
-        .collect();
-    let security_names: Vec<&str> = data
-        .items
-        .iter()
-        .map(|i| i.security_name.as_str())
-        .collect();
-    let shares: Vec<f64> = data.items.iter().map(|i| i.shares).collect();
-    let executing_shares: Vec<f64> = data.items.iter().map(|i| i.executing_shares).collect();
-    let average_purchase_prices: Vec<f64> = data
-        .items
-        .iter()
-        .map(|i| i.average_purchase_price)
-        .collect();
-    let total_purchase_amounts: Vec<f64> =
-        data.items.iter().map(|i| i.total_purchase_amount).collect();
-    let current_prices: Vec<f64> = data.items.iter().map(|i| i.current_price).collect();
-    let daily_changes: Vec<f64> = data.items.iter().map(|i| i.daily_change).collect();
-    let market_values: Vec<f64> = data.items.iter().map(|i| i.market_value).collect();
-    let profit_loss_rates: Vec<f64> = data.items.iter().map(|i| i.profit_loss_rate).collect();
-
-    // UNNESTを使ったバルクUPSERT（1回のクエリで全件挿入/更新）
-    let result = sqlx::query(
-        r#"
-        INSERT INTO asset_balances (user_id, security_code, security_name, shares, executing_shares,
-                                    average_purchase_price, total_purchase_amount, current_price,
-                                    daily_change, market_value, profit_loss_rate)
-        SELECT * FROM UNNEST(
-            $1::uuid[], $2::text[], $3::text[], $4::float8[], $5::float8[],
-            $6::float8[], $7::float8[], $8::float8[], $9::float8[], $10::float8[], $11::float8[]
-        )
-        ON CONFLICT (user_id, security_code)
-        DO UPDATE SET
-            security_name = EXCLUDED.security_name,
-            shares = EXCLUDED.shares,
-            executing_shares = EXCLUDED.executing_shares,
-            average_purchase_price = EXCLUDED.average_purchase_price,
-            total_purchase_amount = EXCLUDED.total_purchase_amount,
-            current_price = EXCLUDED.current_price,
-            daily_change = EXCLUDED.daily_change,
-            market_value = EXCLUDED.market_value,
-            profit_loss_rate = EXCLUDED.profit_loss_rate,
-            updated_at = NOW()
-        "#,
-    )
-    .bind(&user_ids)
-    .bind(&security_codes)
-    .bind(&security_names)
-    .bind(&shares)
-    .bind(&executing_shares)
-    .bind(&average_purchase_prices)
-    .bind(&total_purchase_amounts)
-    .bind(&current_prices)
-    .bind(&daily_changes)
-    .bind(&market_values)
-    .bind(&profit_loss_rates)
-    .execute(&state.pool)
-    .await?;
-
-    let inserted = result.rows_affected() as usize;
-    let skipped = 0; // UPSERT のため skipped は常に 0
-    let elapsed = start.elapsed();
-
-    info!(
-        "[asset_balance.bulk_create] 完了: upserted={}, 処理時間={:.2}ms",
-        inserted,
-        elapsed.as_secs_f64() * 1000.0
-    );
-    Ok((
-        StatusCode::CREATED,
-        Json(BulkCreateResponse { inserted, skipped }),
-    ))
+    let response =
+        asset_balance_service::bulk_create(&state.pool, auth_user.id(), &data.items).await?;
+    Ok((StatusCode::CREATED, Json(response)))
 }
 
 /// 認証ユーザーの保有銘柄を全削除
@@ -138,16 +31,7 @@ pub async fn delete_all(
     State(state): State<AppState>,
     auth_user: AuthenticatedUser,
 ) -> Result<impl IntoResponse, ApiError> {
-    info!("[asset_balance.delete_all] リクエスト受信");
-    let result = sqlx::query("DELETE FROM asset_balances WHERE user_id = $1")
-        .bind(auth_user.id())
-        .execute(&state.pool)
-        .await?;
-
-    info!(
-        "[asset_balance.delete_all] 完了: {}件削除",
-        result.rows_affected()
-    );
+    asset_balance_service::delete_all(&state.pool, auth_user.id()).await?;
     Ok((
         StatusCode::OK,
         Json(serde_json::json!({"message": "全ての保有銘柄データを削除しました"})),

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -212,10 +212,7 @@ pub async fn delete_account(
         .ok_or_else(|| ApiError::Unauthorized("セッションが無効または期限切れです".to_string()))?;
 
     // ユーザーを削除（CASCADE により関連データも削除）
-    sqlx::query("DELETE FROM users WHERE id = $1")
-        .bind(user_id)
-        .execute(&state.pool)
-        .await?;
+    auth_service::delete_account(&state.pool, user_id).await?;
 
     // セッションCookieを削除
     let is_secure = config::is_secure_cookie();

--- a/backend/src/handlers/dividend.rs
+++ b/backend/src/handlers/dividend.rs
@@ -1,34 +1,16 @@
 use crate::{
-    errors::ApiError,
-    extractors::auth::AuthenticatedUser,
-    extractors::validated_json::ValidatedJson,
-    models::dividend::{BulkCreateDividendRequest, BulkCreateResponse, Dividend},
-    state::AppState,
+    errors::ApiError, extractors::auth::AuthenticatedUser,
+    extractors::validated_json::ValidatedJson, models::dividend::BulkCreateDividendRequest,
+    services::dividend as dividend_service, state::AppState,
 };
 use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
-use std::time::Instant;
-use tracing::info;
 
 /// 認証ユーザーの配当金一覧を取得
 pub async fn list(
     State(state): State<AppState>,
     auth_user: AuthenticatedUser,
 ) -> Result<impl IntoResponse, ApiError> {
-    info!("[dividend.list] リクエスト受信");
-    let dividends = sqlx::query_as::<_, Dividend>(
-        r#"
-        SELECT id, user_id, settlement_date, product, account, security_code, security_name,
-               unit_price, shares, dividends_before_tax, taxes, net_amount_received,
-               created_at, updated_at
-        FROM dividends
-        WHERE user_id = $1
-        ORDER BY settlement_date DESC
-        "#,
-    )
-    .bind(auth_user.id())
-    .fetch_all(&state.pool)
-    .await?;
-
+    let dividends = dividend_service::list(&state.pool, auth_user.id()).await?;
     Ok((StatusCode::OK, Json(dividends)))
 }
 
@@ -38,88 +20,8 @@ pub async fn bulk_create(
     auth_user: AuthenticatedUser,
     ValidatedJson(data): ValidatedJson<BulkCreateDividendRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
-    let total = data.items.len();
-    info!("[dividend.bulk_create] リクエスト受信: {}件", total);
-    let start = Instant::now();
-
-    if data.items.is_empty() {
-        return Ok((
-            StatusCode::CREATED,
-            Json(BulkCreateResponse {
-                inserted: 0,
-                skipped: 0,
-            }),
-        ));
-    }
-
-    let user_id = auth_user.id();
-
-    // 各フィールドを配列に変換
-    let user_ids: Vec<uuid::Uuid> = vec![user_id; total];
-    let settlement_dates: Vec<chrono::NaiveDate> =
-        data.items.iter().map(|i| i.settlement_date).collect();
-    let products: Vec<&str> = data.items.iter().map(|i| i.product.as_str()).collect();
-    let accounts: Vec<&str> = data.items.iter().map(|i| i.account.as_str()).collect();
-    let security_codes: Vec<&str> = data
-        .items
-        .iter()
-        .map(|i| i.security_code.as_str())
-        .collect();
-    let security_names: Vec<&str> = data
-        .items
-        .iter()
-        .map(|i| i.security_name.as_str())
-        .collect();
-    let unit_prices: Vec<f64> = data.items.iter().map(|i| i.unit_price).collect();
-    let shares: Vec<f64> = data.items.iter().map(|i| i.shares).collect();
-    let dividends_before_taxes: Vec<f64> =
-        data.items.iter().map(|i| i.dividends_before_tax).collect();
-    let taxes: Vec<f64> = data.items.iter().map(|i| i.taxes).collect();
-    let net_amounts: Vec<f64> = data.items.iter().map(|i| i.net_amount_received).collect();
-
-    // UNNESTを使ったバルクINSERT（1回のクエリで全件挿入）
-    let result = sqlx::query(
-        r#"
-        INSERT INTO dividends (user_id, settlement_date, product, account, security_code,
-                               security_name, unit_price, shares, dividends_before_tax,
-                               taxes, net_amount_received)
-        SELECT * FROM UNNEST(
-            $1::uuid[], $2::date[], $3::text[], $4::text[], $5::text[],
-            $6::text[], $7::float8[], $8::float8[], $9::float8[],
-            $10::float8[], $11::float8[]
-        )
-        ON CONFLICT (user_id, settlement_date, security_code, shares, dividends_before_tax)
-        DO NOTHING
-        "#,
-    )
-    .bind(&user_ids)
-    .bind(&settlement_dates)
-    .bind(&products)
-    .bind(&accounts)
-    .bind(&security_codes)
-    .bind(&security_names)
-    .bind(&unit_prices)
-    .bind(&shares)
-    .bind(&dividends_before_taxes)
-    .bind(&taxes)
-    .bind(&net_amounts)
-    .execute(&state.pool)
-    .await?;
-
-    let inserted = result.rows_affected() as usize;
-    let skipped = total - inserted;
-    let elapsed = start.elapsed();
-
-    info!(
-        "[dividend.bulk_create] 完了: inserted={}, skipped={}, 処理時間={:.2}ms",
-        inserted,
-        skipped,
-        elapsed.as_secs_f64() * 1000.0
-    );
-    Ok((
-        StatusCode::CREATED,
-        Json(BulkCreateResponse { inserted, skipped }),
-    ))
+    let response = dividend_service::bulk_create(&state.pool, auth_user.id(), &data.items).await?;
+    Ok((StatusCode::CREATED, Json(response)))
 }
 
 /// 認証ユーザーの配当金を全削除
@@ -127,16 +29,7 @@ pub async fn delete_all(
     State(state): State<AppState>,
     auth_user: AuthenticatedUser,
 ) -> Result<impl IntoResponse, ApiError> {
-    info!("[dividend.delete_all] リクエスト受信");
-    let result = sqlx::query("DELETE FROM dividends WHERE user_id = $1")
-        .bind(auth_user.id())
-        .execute(&state.pool)
-        .await?;
-
-    info!(
-        "[dividend.delete_all] 完了: {}件削除",
-        result.rows_affected()
-    );
+    dividend_service::delete_all(&state.pool, auth_user.id()).await?;
     Ok((
         StatusCode::OK,
         Json(serde_json::json!({"message": "全ての配当金データを削除しました"})),

--- a/backend/src/handlers/domestic_stock.rs
+++ b/backend/src/handlers/domestic_stock.rs
@@ -1,36 +1,17 @@
 use crate::{
-    errors::ApiError,
-    extractors::auth::AuthenticatedUser,
+    errors::ApiError, extractors::auth::AuthenticatedUser,
     extractors::validated_json::ValidatedJson,
-    models::dividend::BulkCreateResponse,
-    models::domestic_stock::{BulkCreateDomesticStockRequest, DomesticStock},
-    state::AppState,
+    models::domestic_stock::BulkCreateDomesticStockRequest,
+    services::domestic_stock as domestic_stock_service, state::AppState,
 };
 use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
-use std::time::Instant;
-use tracing::info;
 
 /// 認証ユーザーの国内株式取引一覧を取得
 pub async fn list(
     State(state): State<AppState>,
     auth_user: AuthenticatedUser,
 ) -> Result<impl IntoResponse, ApiError> {
-    info!("[domestic_stock.list] リクエスト受信");
-    let stocks = sqlx::query_as::<_, DomesticStock>(
-        r#"
-        SELECT id, user_id, trade_date, settlement_date, security_code, security_name,
-               account, shares, asked_price, proceeds, purchase_price,
-               realized_profit_and_loss, taxes, realized_profit_and_loss_after_tax,
-               created_at, updated_at
-        FROM domestic_stocks
-        WHERE user_id = $1
-        ORDER BY trade_date DESC
-        "#,
-    )
-    .bind(auth_user.id())
-    .fetch_all(&state.pool)
-    .await?;
-
+    let stocks = domestic_stock_service::list(&state.pool, auth_user.id()).await?;
     Ok((StatusCode::OK, Json(stocks)))
 }
 
@@ -40,100 +21,9 @@ pub async fn bulk_create(
     auth_user: AuthenticatedUser,
     ValidatedJson(data): ValidatedJson<BulkCreateDomesticStockRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
-    let total = data.items.len();
-    info!("[domestic_stock.bulk_create] リクエスト受信: {}件", total);
-    let start = Instant::now();
-
-    if data.items.is_empty() {
-        return Ok((
-            StatusCode::CREATED,
-            Json(BulkCreateResponse {
-                inserted: 0,
-                skipped: 0,
-            }),
-        ));
-    }
-
-    let user_id = auth_user.id();
-
-    // 各フィールドを配列に変換
-    let user_ids: Vec<uuid::Uuid> = vec![user_id; total];
-    let trade_dates: Vec<chrono::NaiveDate> = data.items.iter().map(|i| i.trade_date).collect();
-    let settlement_dates: Vec<chrono::NaiveDate> =
-        data.items.iter().map(|i| i.settlement_date).collect();
-    let security_codes: Vec<&str> = data
-        .items
-        .iter()
-        .map(|i| i.security_code.as_str())
-        .collect();
-    let security_names: Vec<&str> = data
-        .items
-        .iter()
-        .map(|i| i.security_name.as_str())
-        .collect();
-    let accounts: Vec<&str> = data.items.iter().map(|i| i.account.as_str()).collect();
-    let shares: Vec<f64> = data.items.iter().map(|i| i.shares).collect();
-    let asked_prices: Vec<f64> = data.items.iter().map(|i| i.asked_price).collect();
-    let proceeds: Vec<f64> = data.items.iter().map(|i| i.proceeds).collect();
-    let purchase_prices: Vec<f64> = data.items.iter().map(|i| i.purchase_price).collect();
-    let realized_pls: Vec<f64> = data
-        .items
-        .iter()
-        .map(|i| i.realized_profit_and_loss)
-        .collect();
-    let taxes: Vec<f64> = data.items.iter().map(|i| i.taxes).collect();
-    let realized_pls_after_tax: Vec<f64> = data
-        .items
-        .iter()
-        .map(|i| i.realized_profit_and_loss_after_tax)
-        .collect();
-
-    // UNNESTを使ったバルクINSERT（1回のクエリで全件挿入）
-    let result = sqlx::query(
-        r#"
-        INSERT INTO domestic_stocks (user_id, trade_date, settlement_date, security_code,
-                                     security_name, account, shares, asked_price, proceeds,
-                                     purchase_price, realized_profit_and_loss, taxes,
-                                     realized_profit_and_loss_after_tax)
-        SELECT * FROM UNNEST(
-            $1::uuid[], $2::date[], $3::date[], $4::text[],
-            $5::text[], $6::text[], $7::float8[], $8::float8[], $9::float8[],
-            $10::float8[], $11::float8[], $12::float8[], $13::float8[]
-        )
-        ON CONFLICT (user_id, trade_date, security_code, shares, proceeds)
-        DO NOTHING
-        "#,
-    )
-    .bind(&user_ids)
-    .bind(&trade_dates)
-    .bind(&settlement_dates)
-    .bind(&security_codes)
-    .bind(&security_names)
-    .bind(&accounts)
-    .bind(&shares)
-    .bind(&asked_prices)
-    .bind(&proceeds)
-    .bind(&purchase_prices)
-    .bind(&realized_pls)
-    .bind(&taxes)
-    .bind(&realized_pls_after_tax)
-    .execute(&state.pool)
-    .await?;
-
-    let inserted = result.rows_affected() as usize;
-    let skipped = total - inserted;
-    let elapsed = start.elapsed();
-
-    info!(
-        "[domestic_stock.bulk_create] 完了: inserted={}, skipped={}, 処理時間={:.2}ms",
-        inserted,
-        skipped,
-        elapsed.as_secs_f64() * 1000.0
-    );
-    Ok((
-        StatusCode::CREATED,
-        Json(BulkCreateResponse { inserted, skipped }),
-    ))
+    let response =
+        domestic_stock_service::bulk_create(&state.pool, auth_user.id(), &data.items).await?;
+    Ok((StatusCode::CREATED, Json(response)))
 }
 
 /// 認証ユーザーの国内株式取引を全削除
@@ -141,16 +31,7 @@ pub async fn delete_all(
     State(state): State<AppState>,
     auth_user: AuthenticatedUser,
 ) -> Result<impl IntoResponse, ApiError> {
-    info!("[domestic_stock.delete_all] リクエスト受信");
-    let result = sqlx::query("DELETE FROM domestic_stocks WHERE user_id = $1")
-        .bind(auth_user.id())
-        .execute(&state.pool)
-        .await?;
-
-    info!(
-        "[domestic_stock.delete_all] 完了: {}件削除",
-        result.rows_affected()
-    );
+    domestic_stock_service::delete_all(&state.pool, auth_user.id()).await?;
     Ok((
         StatusCode::OK,
         Json(serde_json::json!({"message": "全ての国内株式取引データを削除しました"})),

--- a/backend/src/handlers/mutualfund.rs
+++ b/backend/src/handlers/mutualfund.rs
@@ -1,36 +1,16 @@
 use crate::{
-    errors::ApiError,
-    extractors::auth::AuthenticatedUser,
-    extractors::validated_json::ValidatedJson,
-    models::dividend::BulkCreateResponse,
-    models::mutualfund::{BulkCreateMutualfundRequest, Mutualfund},
-    state::AppState,
+    errors::ApiError, extractors::auth::AuthenticatedUser,
+    extractors::validated_json::ValidatedJson, models::mutualfund::BulkCreateMutualfundRequest,
+    services::mutualfund as mutualfund_service, state::AppState,
 };
 use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
-use std::time::Instant;
-use tracing::info;
 
 /// 認証ユーザーの投資信託一覧を取得
 pub async fn list(
     State(state): State<AppState>,
     auth_user: AuthenticatedUser,
 ) -> Result<impl IntoResponse, ApiError> {
-    info!("[mutualfund.list] リクエスト受信");
-    let funds = sqlx::query_as::<_, Mutualfund>(
-        r#"
-        SELECT id, user_id, trade_date, settlement_date, fund_name, dividends, account,
-               shares, exchange_rate, cancellation_unit_price_yen, cancellation_amount_yen,
-               average_acquisition_price_yen, realized_profit_and_loss, taxes,
-               realized_profit_and_loss_after_tax, created_at, updated_at
-        FROM mutualfunds
-        WHERE user_id = $1
-        ORDER BY trade_date DESC
-        "#,
-    )
-    .bind(auth_user.id())
-    .fetch_all(&state.pool)
-    .await?;
-
+    let funds = mutualfund_service::list(&state.pool, auth_user.id()).await?;
     Ok((StatusCode::OK, Json(funds)))
 }
 
@@ -40,106 +20,9 @@ pub async fn bulk_create(
     auth_user: AuthenticatedUser,
     ValidatedJson(data): ValidatedJson<BulkCreateMutualfundRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
-    let total = data.items.len();
-    info!("[mutualfund.bulk_create] リクエスト受信: {}件", total);
-    let start = Instant::now();
-
-    if data.items.is_empty() {
-        return Ok((
-            StatusCode::CREATED,
-            Json(BulkCreateResponse {
-                inserted: 0,
-                skipped: 0,
-            }),
-        ));
-    }
-
-    let user_id = auth_user.id();
-
-    // 各フィールドを配列に変換
-    let user_ids: Vec<uuid::Uuid> = vec![user_id; total];
-    let trade_dates: Vec<chrono::NaiveDate> = data.items.iter().map(|i| i.trade_date).collect();
-    let settlement_dates: Vec<chrono::NaiveDate> =
-        data.items.iter().map(|i| i.settlement_date).collect();
-    let fund_names: Vec<&str> = data.items.iter().map(|i| i.fund_name.as_str()).collect();
-    let dividends: Vec<Option<&str>> = data.items.iter().map(|i| i.dividends.as_deref()).collect();
-    let accounts: Vec<&str> = data.items.iter().map(|i| i.account.as_str()).collect();
-    let shares: Vec<f64> = data.items.iter().map(|i| i.shares).collect();
-    let exchange_rates: Vec<f64> = data.items.iter().map(|i| i.exchange_rate).collect();
-    let cancellation_unit_prices: Vec<f64> = data
-        .items
-        .iter()
-        .map(|i| i.cancellation_unit_price_yen)
-        .collect();
-    let cancellation_amounts: Vec<f64> = data
-        .items
-        .iter()
-        .map(|i| i.cancellation_amount_yen)
-        .collect();
-    let avg_acquisition_prices: Vec<f64> = data
-        .items
-        .iter()
-        .map(|i| i.average_acquisition_price_yen)
-        .collect();
-    let realized_pls: Vec<f64> = data
-        .items
-        .iter()
-        .map(|i| i.realized_profit_and_loss)
-        .collect();
-    let taxes: Vec<f64> = data.items.iter().map(|i| i.taxes).collect();
-    let realized_pls_after_tax: Vec<f64> = data
-        .items
-        .iter()
-        .map(|i| i.realized_profit_and_loss_after_tax)
-        .collect();
-
-    // UNNESTを使ったバルクINSERT（1回のクエリで全件挿入）
-    let result = sqlx::query(
-        r#"
-        INSERT INTO mutualfunds (user_id, trade_date, settlement_date, fund_name, dividends,
-                                 account, shares, exchange_rate, cancellation_unit_price_yen,
-                                 cancellation_amount_yen, average_acquisition_price_yen,
-                                 realized_profit_and_loss, taxes, realized_profit_and_loss_after_tax)
-        SELECT * FROM UNNEST(
-            $1::uuid[], $2::date[], $3::date[], $4::text[], $5::text[],
-            $6::text[], $7::float8[], $8::float8[], $9::float8[],
-            $10::float8[], $11::float8[], $12::float8[], $13::float8[], $14::float8[]
-        )
-        ON CONFLICT (user_id, trade_date, fund_name, shares, cancellation_amount_yen)
-        DO NOTHING
-        "#,
-    )
-    .bind(&user_ids)
-    .bind(&trade_dates)
-    .bind(&settlement_dates)
-    .bind(&fund_names)
-    .bind(&dividends)
-    .bind(&accounts)
-    .bind(&shares)
-    .bind(&exchange_rates)
-    .bind(&cancellation_unit_prices)
-    .bind(&cancellation_amounts)
-    .bind(&avg_acquisition_prices)
-    .bind(&realized_pls)
-    .bind(&taxes)
-    .bind(&realized_pls_after_tax)
-    .execute(&state.pool)
-    .await?;
-
-    let inserted = result.rows_affected() as usize;
-    let skipped = total - inserted;
-    let elapsed = start.elapsed();
-
-    info!(
-        "[mutualfund.bulk_create] 完了: inserted={}, skipped={}, 処理時間={:.2}ms",
-        inserted,
-        skipped,
-        elapsed.as_secs_f64() * 1000.0
-    );
-    Ok((
-        StatusCode::CREATED,
-        Json(BulkCreateResponse { inserted, skipped }),
-    ))
+    let response =
+        mutualfund_service::bulk_create(&state.pool, auth_user.id(), &data.items).await?;
+    Ok((StatusCode::CREATED, Json(response)))
 }
 
 /// 認証ユーザーの投資信託を全削除
@@ -147,16 +30,7 @@ pub async fn delete_all(
     State(state): State<AppState>,
     auth_user: AuthenticatedUser,
 ) -> Result<impl IntoResponse, ApiError> {
-    info!("[mutualfund.delete_all] リクエスト受信");
-    let result = sqlx::query("DELETE FROM mutualfunds WHERE user_id = $1")
-        .bind(auth_user.id())
-        .execute(&state.pool)
-        .await?;
-
-    info!(
-        "[mutualfund.delete_all] 完了: {}件削除",
-        result.rows_affected()
-    );
+    mutualfund_service::delete_all(&state.pool, auth_user.id()).await?;
     Ok((
         StatusCode::OK,
         Json(serde_json::json!({"message": "全ての投資信託データを削除しました"})),

--- a/backend/src/handlers/stock.rs
+++ b/backend/src/handlers/stock.rs
@@ -1,10 +1,8 @@
 use crate::{
     errors::ApiError,
-    extractors::{
-        auth::AuthenticatedUser, char_width_converter::halfwidth_to_fullwidth,
-        validated_json::ValidatedJson,
-    },
+    extractors::{auth::AuthenticatedUser, validated_json::ValidatedJson},
     models::stock::Stock,
+    services::stock as stock_service,
     AppState,
 };
 use axum::{
@@ -18,19 +16,7 @@ pub async fn select_stock_info(
     Path(search_query): Path<String>,
     State(state): State<AppState>,
 ) -> Result<impl IntoResponse, ApiError> {
-    let search_query = search_query
-        .chars()
-        .map(halfwidth_to_fullwidth)
-        .collect::<String>();
-    let stock = sqlx::query_as::<_, Stock>(
-        "SELECT * FROM stock WHERE code = $1 OR name ILIKE $2 ORDER BY date DESC LIMIT 1",
-    )
-    .bind(&search_query)
-    .bind(format!("%{search_query}%"))
-    .fetch_optional(&state.pool)
-    .await?
-    .ok_or(ApiError::NotFound)?;
-
+    let stock = stock_service::search(&state.pool, &search_query).await?;
     Ok((StatusCode::OK, Json(stock)))
 }
 
@@ -40,24 +26,7 @@ pub async fn add_stock_info(
     _auth_user: AuthenticatedUser,
     ValidatedJson(data): ValidatedJson<Stock>,
 ) -> Result<impl IntoResponse, ApiError> {
-    let stock = sqlx::query_as::<_, Stock>(
-        "INSERT INTO stock (date, code, name, market_category, industry_code_33, industry_category_33, industry_code_17, industry_category_17, size_code, size_category) 
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) 
-         RETURNING *"
-    )
-    .bind(data.date)
-    .bind(&data.code)
-    .bind(&data.name)
-    .bind(&data.market_category)
-    .bind(&data.industry_code_33)
-    .bind(&data.industry_category_33)
-    .bind(&data.industry_code_17)
-    .bind(&data.industry_category_17)
-    .bind(&data.size_code)
-    .bind(&data.size_category)
-    .fetch_one(&state.pool)
-    .await?;
-
+    let stock = stock_service::create(&state.pool, &data).await?;
     Ok((StatusCode::CREATED, Json(stock)))
 }
 
@@ -119,9 +88,9 @@ mod tests {
 
         sqlx::query(
             r#"
-            INSERT INTO stock 
+            INSERT INTO stock
             (date, code, name, market_category, industry_code_33, industry_category_33, industry_code_17, industry_category_17, size_code, size_category)
-            VALUES 
+            VALUES
             ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
             "#,
         )

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -1,4 +1,5 @@
 pub mod asset_balance;
+pub mod common;
 pub mod dividend;
 pub mod domestic_stock;
 pub mod jquants;

--- a/backend/src/models/asset_balance.rs
+++ b/backend/src/models/asset_balance.rs
@@ -49,13 +49,6 @@ pub struct BulkCreateAssetBalanceRequest {
     pub items: Vec<CreateAssetBalanceRequest>,
 }
 
-/// 一括作成レスポンス
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BulkCreateResponse {
-    pub inserted: usize,
-    pub skipped: usize,
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/backend/src/models/common.rs
+++ b/backend/src/models/common.rs
@@ -1,0 +1,8 @@
+use serde::{Deserialize, Serialize};
+
+/// 一括作成レスポンス（全ドメイン共通）
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BulkCreateResponse {
+    pub inserted: usize,
+    pub skipped: usize,
+}

--- a/backend/src/models/dividend.rs
+++ b/backend/src/models/dividend.rs
@@ -51,13 +51,6 @@ pub struct BulkCreateDividendRequest {
     pub items: Vec<CreateDividendRequest>,
 }
 
-/// 一括作成レスポンス
-#[derive(Debug, Clone, Serialize)]
-pub struct BulkCreateResponse {
-    pub inserted: usize,
-    pub skipped: usize,
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/backend/src/services.rs
+++ b/backend/src/services.rs
@@ -1,2 +1,7 @@
+pub mod asset_balance;
 pub mod auth;
+pub mod dividend;
+pub mod domestic_stock;
 pub mod jquants;
+pub mod mutualfund;
+pub mod stock;

--- a/backend/src/services/asset_balance.rs
+++ b/backend/src/services/asset_balance.rs
@@ -1,0 +1,121 @@
+use crate::errors::ApiError;
+use crate::models::asset_balance::{AssetBalance, CreateAssetBalanceRequest};
+use crate::models::common::BulkCreateResponse;
+use sqlx::PgPool;
+use std::time::Instant;
+use tracing::info;
+use uuid::Uuid;
+
+/// 認証ユーザーの保有銘柄一覧を取得
+pub async fn list(pool: &PgPool, user_id: Uuid) -> Result<Vec<AssetBalance>, ApiError> {
+    info!("[asset_balance.list] リクエスト受信");
+    let balances = sqlx::query_as::<_, AssetBalance>(
+        r#"
+        SELECT id, user_id, security_code, security_name, shares, executing_shares,
+               average_purchase_price, total_purchase_amount, current_price,
+               daily_change, market_value, profit_loss_rate, created_at, updated_at
+        FROM asset_balances
+        WHERE user_id = $1
+        ORDER BY security_code
+        "#,
+    )
+    .bind(user_id)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(balances)
+}
+
+/// 保有銘柄を一括追加（既存は更新）
+pub async fn bulk_create(
+    pool: &PgPool,
+    user_id: Uuid,
+    items: &[CreateAssetBalanceRequest],
+) -> Result<BulkCreateResponse, ApiError> {
+    let total = items.len();
+    info!("[asset_balance.bulk_create] リクエスト受信: {}件", total);
+    let start = Instant::now();
+
+    if items.is_empty() {
+        return Ok(BulkCreateResponse {
+            inserted: 0,
+            skipped: 0,
+        });
+    }
+
+    // 各フィールドを配列に変換
+    let user_ids: Vec<Uuid> = vec![user_id; total];
+    let security_codes: Vec<&str> = items.iter().map(|i| i.security_code.as_str()).collect();
+    let security_names: Vec<&str> = items.iter().map(|i| i.security_name.as_str()).collect();
+    let shares: Vec<f64> = items.iter().map(|i| i.shares).collect();
+    let executing_shares: Vec<f64> = items.iter().map(|i| i.executing_shares).collect();
+    let average_purchase_prices: Vec<f64> =
+        items.iter().map(|i| i.average_purchase_price).collect();
+    let total_purchase_amounts: Vec<f64> = items.iter().map(|i| i.total_purchase_amount).collect();
+    let current_prices: Vec<f64> = items.iter().map(|i| i.current_price).collect();
+    let daily_changes: Vec<f64> = items.iter().map(|i| i.daily_change).collect();
+    let market_values: Vec<f64> = items.iter().map(|i| i.market_value).collect();
+    let profit_loss_rates: Vec<f64> = items.iter().map(|i| i.profit_loss_rate).collect();
+
+    // UNNESTを使ったバルクUPSERT（1回のクエリで全件挿入/更新）
+    let result = sqlx::query(
+        r#"
+        INSERT INTO asset_balances (user_id, security_code, security_name, shares, executing_shares,
+                                    average_purchase_price, total_purchase_amount, current_price,
+                                    daily_change, market_value, profit_loss_rate)
+        SELECT * FROM UNNEST(
+            $1::uuid[], $2::text[], $3::text[], $4::float8[], $5::float8[],
+            $6::float8[], $7::float8[], $8::float8[], $9::float8[], $10::float8[], $11::float8[]
+        )
+        ON CONFLICT (user_id, security_code)
+        DO UPDATE SET
+            security_name = EXCLUDED.security_name,
+            shares = EXCLUDED.shares,
+            executing_shares = EXCLUDED.executing_shares,
+            average_purchase_price = EXCLUDED.average_purchase_price,
+            total_purchase_amount = EXCLUDED.total_purchase_amount,
+            current_price = EXCLUDED.current_price,
+            daily_change = EXCLUDED.daily_change,
+            market_value = EXCLUDED.market_value,
+            profit_loss_rate = EXCLUDED.profit_loss_rate,
+            updated_at = NOW()
+        "#,
+    )
+    .bind(&user_ids)
+    .bind(&security_codes)
+    .bind(&security_names)
+    .bind(&shares)
+    .bind(&executing_shares)
+    .bind(&average_purchase_prices)
+    .bind(&total_purchase_amounts)
+    .bind(&current_prices)
+    .bind(&daily_changes)
+    .bind(&market_values)
+    .bind(&profit_loss_rates)
+    .execute(pool)
+    .await?;
+
+    let inserted = result.rows_affected() as usize;
+    let skipped = 0; // UPSERT のため skipped は常に 0
+    let elapsed = start.elapsed();
+
+    info!(
+        "[asset_balance.bulk_create] 完了: upserted={}, 処理時間={:.2}ms",
+        inserted,
+        elapsed.as_secs_f64() * 1000.0
+    );
+    Ok(BulkCreateResponse { inserted, skipped })
+}
+
+/// 認証ユーザーの保有銘柄を全削除
+pub async fn delete_all(pool: &PgPool, user_id: Uuid) -> Result<u64, ApiError> {
+    info!("[asset_balance.delete_all] リクエスト受信");
+    let result = sqlx::query("DELETE FROM asset_balances WHERE user_id = $1")
+        .bind(user_id)
+        .execute(pool)
+        .await?;
+
+    let deleted = result.rows_affected();
+    info!("[asset_balance.delete_all] 完了: {}件削除", deleted);
+    Ok(deleted)
+}

--- a/backend/src/services/auth.rs
+++ b/backend/src/services/auth.rs
@@ -150,6 +150,16 @@ pub async fn delete_session(pool: &PgPool, session_id: uuid::Uuid) -> Result<(),
     Ok(())
 }
 
+/// ユーザーを削除（CASCADE により関連データも削除）
+pub async fn delete_account(pool: &PgPool, user_id: uuid::Uuid) -> Result<(), sqlx::Error> {
+    sqlx::query("DELETE FROM users WHERE id = $1")
+        .bind(user_id)
+        .execute(pool)
+        .await?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/backend/src/services/dividend.rs
+++ b/backend/src/services/dividend.rs
@@ -1,0 +1,113 @@
+use crate::errors::ApiError;
+use crate::models::common::BulkCreateResponse;
+use crate::models::dividend::{CreateDividendRequest, Dividend};
+use sqlx::PgPool;
+use std::time::Instant;
+use tracing::info;
+use uuid::Uuid;
+
+/// 認証ユーザーの配当金一覧を取得
+pub async fn list(pool: &PgPool, user_id: Uuid) -> Result<Vec<Dividend>, ApiError> {
+    info!("[dividend.list] リクエスト受信");
+    let dividends = sqlx::query_as::<_, Dividend>(
+        r#"
+        SELECT id, user_id, settlement_date, product, account, security_code, security_name,
+               unit_price, shares, dividends_before_tax, taxes, net_amount_received,
+               created_at, updated_at
+        FROM dividends
+        WHERE user_id = $1
+        ORDER BY settlement_date DESC
+        "#,
+    )
+    .bind(user_id)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(dividends)
+}
+
+/// 配当金を一括追加（重複はスキップ）
+pub async fn bulk_create(
+    pool: &PgPool,
+    user_id: Uuid,
+    items: &[CreateDividendRequest],
+) -> Result<BulkCreateResponse, ApiError> {
+    let total = items.len();
+    info!("[dividend.bulk_create] リクエスト受信: {}件", total);
+    let start = Instant::now();
+
+    if items.is_empty() {
+        return Ok(BulkCreateResponse {
+            inserted: 0,
+            skipped: 0,
+        });
+    }
+
+    // 各フィールドを配列に変換
+    let user_ids: Vec<Uuid> = vec![user_id; total];
+    let settlement_dates: Vec<chrono::NaiveDate> =
+        items.iter().map(|i| i.settlement_date).collect();
+    let products: Vec<&str> = items.iter().map(|i| i.product.as_str()).collect();
+    let accounts: Vec<&str> = items.iter().map(|i| i.account.as_str()).collect();
+    let security_codes: Vec<&str> = items.iter().map(|i| i.security_code.as_str()).collect();
+    let security_names: Vec<&str> = items.iter().map(|i| i.security_name.as_str()).collect();
+    let unit_prices: Vec<f64> = items.iter().map(|i| i.unit_price).collect();
+    let shares: Vec<f64> = items.iter().map(|i| i.shares).collect();
+    let dividends_before_taxes: Vec<f64> = items.iter().map(|i| i.dividends_before_tax).collect();
+    let taxes: Vec<f64> = items.iter().map(|i| i.taxes).collect();
+    let net_amounts: Vec<f64> = items.iter().map(|i| i.net_amount_received).collect();
+
+    // UNNESTを使ったバルクINSERT（1回のクエリで全件挿入）
+    let result = sqlx::query(
+        r#"
+        INSERT INTO dividends (user_id, settlement_date, product, account, security_code,
+                               security_name, unit_price, shares, dividends_before_tax,
+                               taxes, net_amount_received)
+        SELECT * FROM UNNEST(
+            $1::uuid[], $2::date[], $3::text[], $4::text[], $5::text[],
+            $6::text[], $7::float8[], $8::float8[], $9::float8[],
+            $10::float8[], $11::float8[]
+        )
+        ON CONFLICT (user_id, settlement_date, security_code, shares, dividends_before_tax)
+        DO NOTHING
+        "#,
+    )
+    .bind(&user_ids)
+    .bind(&settlement_dates)
+    .bind(&products)
+    .bind(&accounts)
+    .bind(&security_codes)
+    .bind(&security_names)
+    .bind(&unit_prices)
+    .bind(&shares)
+    .bind(&dividends_before_taxes)
+    .bind(&taxes)
+    .bind(&net_amounts)
+    .execute(pool)
+    .await?;
+
+    let inserted = result.rows_affected() as usize;
+    let skipped = total - inserted;
+    let elapsed = start.elapsed();
+
+    info!(
+        "[dividend.bulk_create] 完了: inserted={}, skipped={}, 処理時間={:.2}ms",
+        inserted,
+        skipped,
+        elapsed.as_secs_f64() * 1000.0
+    );
+    Ok(BulkCreateResponse { inserted, skipped })
+}
+
+/// 認証ユーザーの配当金を全削除
+pub async fn delete_all(pool: &PgPool, user_id: Uuid) -> Result<u64, ApiError> {
+    info!("[dividend.delete_all] リクエスト受信");
+    let result = sqlx::query("DELETE FROM dividends WHERE user_id = $1")
+        .bind(user_id)
+        .execute(pool)
+        .await?;
+
+    let deleted = result.rows_affected();
+    info!("[dividend.delete_all] 完了: {}件削除", deleted);
+    Ok(deleted)
+}

--- a/backend/src/services/domestic_stock.rs
+++ b/backend/src/services/domestic_stock.rs
@@ -1,0 +1,122 @@
+use crate::errors::ApiError;
+use crate::models::common::BulkCreateResponse;
+use crate::models::domestic_stock::{CreateDomesticStockRequest, DomesticStock};
+use sqlx::PgPool;
+use std::time::Instant;
+use tracing::info;
+use uuid::Uuid;
+
+/// 認証ユーザーの国内株式取引一覧を取得
+pub async fn list(pool: &PgPool, user_id: Uuid) -> Result<Vec<DomesticStock>, ApiError> {
+    info!("[domestic_stock.list] リクエスト受信");
+    let stocks = sqlx::query_as::<_, DomesticStock>(
+        r#"
+        SELECT id, user_id, trade_date, settlement_date, security_code, security_name,
+               account, shares, asked_price, proceeds, purchase_price,
+               realized_profit_and_loss, taxes, realized_profit_and_loss_after_tax,
+               created_at, updated_at
+        FROM domestic_stocks
+        WHERE user_id = $1
+        ORDER BY trade_date DESC
+        "#,
+    )
+    .bind(user_id)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(stocks)
+}
+
+/// 国内株式取引を一括追加（重複はスキップ）
+pub async fn bulk_create(
+    pool: &PgPool,
+    user_id: Uuid,
+    items: &[CreateDomesticStockRequest],
+) -> Result<BulkCreateResponse, ApiError> {
+    let total = items.len();
+    info!("[domestic_stock.bulk_create] リクエスト受信: {}件", total);
+    let start = Instant::now();
+
+    if items.is_empty() {
+        return Ok(BulkCreateResponse {
+            inserted: 0,
+            skipped: 0,
+        });
+    }
+
+    // 各フィールドを配列に変換
+    let user_ids: Vec<Uuid> = vec![user_id; total];
+    let trade_dates: Vec<chrono::NaiveDate> = items.iter().map(|i| i.trade_date).collect();
+    let settlement_dates: Vec<chrono::NaiveDate> =
+        items.iter().map(|i| i.settlement_date).collect();
+    let security_codes: Vec<&str> = items.iter().map(|i| i.security_code.as_str()).collect();
+    let security_names: Vec<&str> = items.iter().map(|i| i.security_name.as_str()).collect();
+    let accounts: Vec<&str> = items.iter().map(|i| i.account.as_str()).collect();
+    let shares: Vec<f64> = items.iter().map(|i| i.shares).collect();
+    let asked_prices: Vec<f64> = items.iter().map(|i| i.asked_price).collect();
+    let proceeds: Vec<f64> = items.iter().map(|i| i.proceeds).collect();
+    let purchase_prices: Vec<f64> = items.iter().map(|i| i.purchase_price).collect();
+    let realized_pls: Vec<f64> = items.iter().map(|i| i.realized_profit_and_loss).collect();
+    let taxes: Vec<f64> = items.iter().map(|i| i.taxes).collect();
+    let realized_pls_after_tax: Vec<f64> = items
+        .iter()
+        .map(|i| i.realized_profit_and_loss_after_tax)
+        .collect();
+
+    // UNNESTを使ったバルクINSERT（1回のクエリで全件挿入）
+    let result = sqlx::query(
+        r#"
+        INSERT INTO domestic_stocks (user_id, trade_date, settlement_date, security_code,
+                                     security_name, account, shares, asked_price, proceeds,
+                                     purchase_price, realized_profit_and_loss, taxes,
+                                     realized_profit_and_loss_after_tax)
+        SELECT * FROM UNNEST(
+            $1::uuid[], $2::date[], $3::date[], $4::text[],
+            $5::text[], $6::text[], $7::float8[], $8::float8[], $9::float8[],
+            $10::float8[], $11::float8[], $12::float8[], $13::float8[]
+        )
+        ON CONFLICT (user_id, trade_date, security_code, shares, proceeds)
+        DO NOTHING
+        "#,
+    )
+    .bind(&user_ids)
+    .bind(&trade_dates)
+    .bind(&settlement_dates)
+    .bind(&security_codes)
+    .bind(&security_names)
+    .bind(&accounts)
+    .bind(&shares)
+    .bind(&asked_prices)
+    .bind(&proceeds)
+    .bind(&purchase_prices)
+    .bind(&realized_pls)
+    .bind(&taxes)
+    .bind(&realized_pls_after_tax)
+    .execute(pool)
+    .await?;
+
+    let inserted = result.rows_affected() as usize;
+    let skipped = total - inserted;
+    let elapsed = start.elapsed();
+
+    info!(
+        "[domestic_stock.bulk_create] 完了: inserted={}, skipped={}, 処理時間={:.2}ms",
+        inserted,
+        skipped,
+        elapsed.as_secs_f64() * 1000.0
+    );
+    Ok(BulkCreateResponse { inserted, skipped })
+}
+
+/// 認証ユーザーの国内株式取引を全削除
+pub async fn delete_all(pool: &PgPool, user_id: Uuid) -> Result<u64, ApiError> {
+    info!("[domestic_stock.delete_all] リクエスト受信");
+    let result = sqlx::query("DELETE FROM domestic_stocks WHERE user_id = $1")
+        .bind(user_id)
+        .execute(pool)
+        .await?;
+
+    let deleted = result.rows_affected();
+    info!("[domestic_stock.delete_all] 完了: {}件削除", deleted);
+    Ok(deleted)
+}

--- a/backend/src/services/mutualfund.rs
+++ b/backend/src/services/mutualfund.rs
@@ -1,0 +1,130 @@
+use crate::errors::ApiError;
+use crate::models::common::BulkCreateResponse;
+use crate::models::mutualfund::{CreateMutualfundRequest, Mutualfund};
+use sqlx::PgPool;
+use std::time::Instant;
+use tracing::info;
+use uuid::Uuid;
+
+/// 認証ユーザーの投資信託一覧を取得
+pub async fn list(pool: &PgPool, user_id: Uuid) -> Result<Vec<Mutualfund>, ApiError> {
+    info!("[mutualfund.list] リクエスト受信");
+    let funds = sqlx::query_as::<_, Mutualfund>(
+        r#"
+        SELECT id, user_id, trade_date, settlement_date, fund_name, dividends, account,
+               shares, exchange_rate, cancellation_unit_price_yen, cancellation_amount_yen,
+               average_acquisition_price_yen, realized_profit_and_loss, taxes,
+               realized_profit_and_loss_after_tax, created_at, updated_at
+        FROM mutualfunds
+        WHERE user_id = $1
+        ORDER BY trade_date DESC
+        "#,
+    )
+    .bind(user_id)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(funds)
+}
+
+/// 投資信託を一括追加（重複はスキップ）
+pub async fn bulk_create(
+    pool: &PgPool,
+    user_id: Uuid,
+    items: &[CreateMutualfundRequest],
+) -> Result<BulkCreateResponse, ApiError> {
+    let total = items.len();
+    info!("[mutualfund.bulk_create] リクエスト受信: {}件", total);
+    let start = Instant::now();
+
+    if items.is_empty() {
+        return Ok(BulkCreateResponse {
+            inserted: 0,
+            skipped: 0,
+        });
+    }
+
+    // 各フィールドを配列に変換
+    let user_ids: Vec<Uuid> = vec![user_id; total];
+    let trade_dates: Vec<chrono::NaiveDate> = items.iter().map(|i| i.trade_date).collect();
+    let settlement_dates: Vec<chrono::NaiveDate> =
+        items.iter().map(|i| i.settlement_date).collect();
+    let fund_names: Vec<&str> = items.iter().map(|i| i.fund_name.as_str()).collect();
+    let dividends: Vec<Option<&str>> = items.iter().map(|i| i.dividends.as_deref()).collect();
+    let accounts: Vec<&str> = items.iter().map(|i| i.account.as_str()).collect();
+    let shares: Vec<f64> = items.iter().map(|i| i.shares).collect();
+    let exchange_rates: Vec<f64> = items.iter().map(|i| i.exchange_rate).collect();
+    let cancellation_unit_prices: Vec<f64> = items
+        .iter()
+        .map(|i| i.cancellation_unit_price_yen)
+        .collect();
+    let cancellation_amounts: Vec<f64> = items.iter().map(|i| i.cancellation_amount_yen).collect();
+    let avg_acquisition_prices: Vec<f64> = items
+        .iter()
+        .map(|i| i.average_acquisition_price_yen)
+        .collect();
+    let realized_pls: Vec<f64> = items.iter().map(|i| i.realized_profit_and_loss).collect();
+    let taxes: Vec<f64> = items.iter().map(|i| i.taxes).collect();
+    let realized_pls_after_tax: Vec<f64> = items
+        .iter()
+        .map(|i| i.realized_profit_and_loss_after_tax)
+        .collect();
+
+    // UNNESTを使ったバルクINSERT（1回のクエリで全件挿入）
+    let result = sqlx::query(
+        r#"
+        INSERT INTO mutualfunds (user_id, trade_date, settlement_date, fund_name, dividends,
+                                 account, shares, exchange_rate, cancellation_unit_price_yen,
+                                 cancellation_amount_yen, average_acquisition_price_yen,
+                                 realized_profit_and_loss, taxes, realized_profit_and_loss_after_tax)
+        SELECT * FROM UNNEST(
+            $1::uuid[], $2::date[], $3::date[], $4::text[], $5::text[],
+            $6::text[], $7::float8[], $8::float8[], $9::float8[],
+            $10::float8[], $11::float8[], $12::float8[], $13::float8[], $14::float8[]
+        )
+        ON CONFLICT (user_id, trade_date, fund_name, shares, cancellation_amount_yen)
+        DO NOTHING
+        "#,
+    )
+    .bind(&user_ids)
+    .bind(&trade_dates)
+    .bind(&settlement_dates)
+    .bind(&fund_names)
+    .bind(&dividends)
+    .bind(&accounts)
+    .bind(&shares)
+    .bind(&exchange_rates)
+    .bind(&cancellation_unit_prices)
+    .bind(&cancellation_amounts)
+    .bind(&avg_acquisition_prices)
+    .bind(&realized_pls)
+    .bind(&taxes)
+    .bind(&realized_pls_after_tax)
+    .execute(pool)
+    .await?;
+
+    let inserted = result.rows_affected() as usize;
+    let skipped = total - inserted;
+    let elapsed = start.elapsed();
+
+    info!(
+        "[mutualfund.bulk_create] 完了: inserted={}, skipped={}, 処理時間={:.2}ms",
+        inserted,
+        skipped,
+        elapsed.as_secs_f64() * 1000.0
+    );
+    Ok(BulkCreateResponse { inserted, skipped })
+}
+
+/// 認証ユーザーの投資信託を全削除
+pub async fn delete_all(pool: &PgPool, user_id: Uuid) -> Result<u64, ApiError> {
+    info!("[mutualfund.delete_all] リクエスト受信");
+    let result = sqlx::query("DELETE FROM mutualfunds WHERE user_id = $1")
+        .bind(user_id)
+        .execute(pool)
+        .await?;
+
+    let deleted = result.rows_affected();
+    info!("[mutualfund.delete_all] 完了: {}件削除", deleted);
+    Ok(deleted)
+}

--- a/backend/src/services/stock.rs
+++ b/backend/src/services/stock.rs
@@ -1,0 +1,42 @@
+use crate::errors::ApiError;
+use crate::extractors::char_width_converter::halfwidth_to_fullwidth;
+use crate::models::stock::Stock;
+use sqlx::PgPool;
+
+/// 銘柄コードまたは銘柄名で検索
+pub async fn search(pool: &PgPool, query: &str) -> Result<Stock, ApiError> {
+    let search_query: String = query.chars().map(halfwidth_to_fullwidth).collect();
+    let stock = sqlx::query_as::<_, Stock>(
+        "SELECT * FROM stock WHERE code = $1 OR name ILIKE $2 ORDER BY date DESC LIMIT 1",
+    )
+    .bind(&search_query)
+    .bind(format!("%{search_query}%"))
+    .fetch_optional(pool)
+    .await?
+    .ok_or(ApiError::NotFound)?;
+
+    Ok(stock)
+}
+
+/// 銘柄情報を追加
+pub async fn create(pool: &PgPool, data: &Stock) -> Result<Stock, ApiError> {
+    let stock = sqlx::query_as::<_, Stock>(
+        "INSERT INTO stock (date, code, name, market_category, industry_code_33, industry_category_33, industry_code_17, industry_category_17, size_code, size_category)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+         RETURNING *"
+    )
+    .bind(data.date)
+    .bind(&data.code)
+    .bind(&data.name)
+    .bind(&data.market_category)
+    .bind(&data.industry_code_33)
+    .bind(&data.industry_category_33)
+    .bind(&data.industry_code_17)
+    .bind(&data.industry_category_17)
+    .bind(&data.size_code)
+    .bind(&data.size_category)
+    .fetch_one(pool)
+    .await?;
+
+    Ok(stock)
+}


### PR DESCRIPTION
## 概要
ハンドラーに直接埋め込まれていたDB操作をサービス層に分離し、責務を明確化

## 変更種別
- [x] リファクタリング

## 主な変更内容
- `BulkCreateResponse` を `models/common.rs` に共通化（dividend/asset_balance の重複削除）
- dividend/domestic_stock/mutualfund/asset_balance/stock のサービス層を新規作成
- 各ハンドラーからSQL直接実行を除去し、サービス関数呼び出しのみに変更
- auth ハンドラーの `delete_account` も `auth_service` に委譲

## テスト
- [x] cargo fmt
- [x] cargo clippy -- -D warnings（警告なし）
- [x] cargo test（78 passed, 0 failed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)