### PR TITLE
資産配当サマリー追加とAPI安定化・環境変数案内改善

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -75,6 +75,8 @@
 
 ### 環境変数
 
+バックエンドは `backend/.env` の環境変数を読み込みます。
+
 ```bash
 # 必須
 DATABASE_URL=postgresql://user:pass@host/db

--- a/backend/src/errors.rs
+++ b/backend/src/errors.rs
@@ -46,6 +46,8 @@ pub enum ApiError {
     NetworkError(String),
     #[error("API error: {0}")]
     ApiError(String),
+    #[error("Rate limit exceeded: {0}")]
+    RateLimitError(String),
     #[error("Serde JSON error: {0}")]
     SerdeJsonError(#[from] serde_json::Error),
 }
@@ -177,6 +179,14 @@ impl IntoResponse for ApiError {
                     details: None,
                 },
             ),
+            ApiError::RateLimitError(msg) => (
+                StatusCode::TOO_MANY_REQUESTS,
+                ErrorDetails {
+                    code: "RATE_LIMIT_EXCEEDED".to_string(),
+                    message: msg,
+                    details: None,
+                },
+            ),
             ApiError::SerdeJsonError(ref e) => {
                 tracing::error!("JSON processing error: {}", e);
                 (
@@ -257,6 +267,13 @@ mod tests {
         let error = ApiError::EnvVarError(env_error);
         let response = error.into_response();
         assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[test]
+    fn test_rate_limit_error_into_response() {
+        let error = ApiError::RateLimitError("Rate limit exceeded".to_string());
+        let response = error.into_response();
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
     }
 
     #[test]

--- a/backend/src/services/jquants.rs
+++ b/backend/src/services/jquants.rs
@@ -52,6 +52,12 @@ impl JQuantsService {
                 status,
                 error_text
             );
+            if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+                return Err(ApiError::RateLimitError(format!(
+                    "J-Quants APIのレート制限に達しました: {}",
+                    error_text
+                )));
+            }
             return Err(ApiError::ApiError(format!(
                 "JQuants決算サマリー取得エラー ({}): {}",
                 status, error_text

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -17,7 +17,7 @@ impl Secrets {
     pub fn from_env() -> Result<Self, String> {
         Ok(Self {
             database_url: std::env::var("DATABASE_URL")
-                .map_err(|_| "DATABASE_URL が設定されていません".to_string())?,
+                .map_err(|_| "DATABASE_URL が設定されていません（backend/.env を確認してください）".to_string())?,
             jquants_api_key: std::env::var("JQUANTS_API_KEY").ok(),
             google_client_id: std::env::var("GOOGLE_CLIENT_ID").ok(),
             google_client_secret: std::env::var("GOOGLE_CLIENT_SECRET").ok(),

--- a/frontend/src/components/molecules/PortfolioPieChart/PortfolioPieChart.tsx
+++ b/frontend/src/components/molecules/PortfolioPieChart/PortfolioPieChart.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { SecurityCodeLink } from '@/components/atoms/SecurityCodeLink';
-import { formatCurrency, formatNumber } from '@/lib/utils/formatters';
+import { formatCurrency, formatNumber, formatPercentageValue } from '@/lib/utils/formatters';
 
 // 横棒グラフ用の配色（視認性を考慮した10色）
 const COLORS = [
@@ -33,6 +33,7 @@ interface ChartDataItem extends PortfolioItem {
 interface PortfolioPieChartProps {
   data: PortfolioItem[];
   className?: string;
+  dividendPerShareMap?: Map<string, number>; // 銘柄別1株配当（J-Quants予想）
 }
 
 /**
@@ -41,6 +42,7 @@ interface PortfolioPieChartProps {
 export const PortfolioPieChart: React.FC<PortfolioPieChartProps> = ({
   data,
   className = '',
+  dividendPerShareMap,
 }) => {
   const [showAll, setShowAll] = useState(false);
 
@@ -77,61 +79,98 @@ export const PortfolioPieChart: React.FC<PortfolioPieChartProps> = ({
 
   const remainingCount = chartData.length - TOP_N;
 
+  // 銘柄別の配当情報を計算
+  const getDividendInfo = (securityCode: string, shares: number, averagePrice: number) => {
+    if (!dividendPerShareMap) return null;
+    const perShare = dividendPerShareMap.get(securityCode);
+    if (perShare === undefined) return { perShare: null, annual: null, yieldValue: null };
+    const annual = perShare * shares;
+    const yieldValue = averagePrice > 0 ? (perShare / averagePrice) * 100 : null;
+    return { perShare, annual, yieldValue };
+  };
+
   return (
     <div className={className} data-testid="portfolio-pie-chart">
       {/* 横棒グラフリスト（2-3列グリッド） */}
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        {displayData.map((item, index) => (
-          <div
-            key={item.securityCode}
-            className="rounded-lg border border-slate-200 bg-white p-3"
-          >
-            {/* 上段: 銘柄名 + 構成比 */}
-            <div className="flex items-center justify-between gap-2 mb-2">
-              <div className="flex items-center gap-2 min-w-0 flex-1">
-                <span
-                  className="h-3 w-3 shrink-0 rounded-sm"
-                  style={{ backgroundColor: COLORS[index % COLORS.length] }}
-                />
-                <span className="truncate text-sm font-medium text-slate-700" title={item.name}>
-                  {item.name}
+        {displayData.map((item, index) => {
+          const divInfo = getDividendInfo(item.securityCode, item.shares, item.averagePrice);
+          return (
+            <div
+              key={item.securityCode}
+              className="rounded-lg border border-slate-200 bg-white p-3"
+            >
+              {/* 上段: 銘柄名 + 構成比 */}
+              <div className="flex items-center justify-between gap-2 mb-2">
+                <div className="flex items-center gap-2 min-w-0 flex-1">
+                  <span
+                    className="h-3 w-3 shrink-0 rounded-sm"
+                    style={{ backgroundColor: COLORS[index % COLORS.length] }}
+                  />
+                  <span className="truncate text-sm font-medium text-slate-700" title={item.name}>
+                    {item.name}
+                  </span>
+                </div>
+                <span className="shrink-0 text-lg font-bold text-slate-800">
+                  {item.percentage.toFixed(1)}%
                 </span>
               </div>
-              <span className="shrink-0 text-lg font-bold text-slate-800">
-                {item.percentage.toFixed(1)}%
-              </span>
+              {/* 横棒グラフ */}
+              <div className="h-2.5 w-full rounded-full bg-slate-100 mb-2">
+                <div
+                  className="h-full rounded-full transition-all duration-300"
+                  style={{
+                    width: `${Math.min(item.percentage, 100)}%`,
+                    backgroundColor: COLORS[index % COLORS.length],
+                  }}
+                />
+              </div>
+              {/* 下段: 詳細情報 */}
+              <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-slate-600">
+                <div className="flex items-center gap-1">
+                  <span className="text-slate-500">コード:</span>
+                  <SecurityCodeLink value={item.securityCode} className="text-xs" />
+                </div>
+                <div className="flex items-center gap-1">
+                  <span className="text-slate-500">取得単価:</span>
+                  <span className="font-medium">{formatCurrency(item.averagePrice)}</span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <span className="text-slate-500">数量:</span>
+                  <span className="font-medium">{`${formatNumber(item.shares)}株`}</span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <span className="text-slate-500">取得総額:</span>
+                  <span className="font-medium">{formatCurrency(item.value)}</span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <span className="text-slate-500">1株配当:</span>
+                  <span className={`font-medium ${divInfo?.perShare !== null && divInfo?.perShare !== undefined ? 'text-emerald-600' : ''}`}>
+                    {divInfo?.perShare !== null && divInfo?.perShare !== undefined
+                      ? formatCurrency(divInfo.perShare)
+                      : '---'}
+                  </span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <span className="text-slate-500">年間配当:</span>
+                  <span className={`font-medium ${divInfo?.annual !== null && divInfo?.annual !== undefined ? 'text-emerald-600' : ''}`}>
+                    {divInfo?.annual !== null && divInfo?.annual !== undefined
+                      ? formatCurrency(divInfo.annual)
+                      : '---'}
+                  </span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <span className="text-slate-500">配当利回り:</span>
+                  <span className={`font-medium ${divInfo?.yieldValue !== null && divInfo?.yieldValue !== undefined ? 'text-emerald-600' : ''}`}>
+                    {divInfo?.yieldValue !== null && divInfo?.yieldValue !== undefined
+                      ? formatPercentageValue(divInfo.yieldValue)
+                      : '---'}
+                  </span>
+                </div>
+              </div>
             </div>
-            {/* 横棒グラフ */}
-            <div className="h-2.5 w-full rounded-full bg-slate-100 mb-2">
-              <div
-                className="h-full rounded-full transition-all duration-300"
-                style={{
-                  width: `${Math.min(item.percentage, 100)}%`,
-                  backgroundColor: COLORS[index % COLORS.length],
-                }}
-              />
-            </div>
-            {/* 下段: 詳細情報 */}
-            <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-slate-600">
-              <div className="flex items-center gap-1">
-                <span className="text-slate-500">コード:</span>
-                <SecurityCodeLink value={item.securityCode} className="text-xs" />
-              </div>
-              <div className="flex items-center gap-1">
-                <span className="text-slate-500">取得単価:</span>
-                <span className="font-medium">{formatCurrency(item.averagePrice)}</span>
-              </div>
-              <div className="flex items-center gap-1">
-                <span className="text-slate-500">数量:</span>
-                <span className="font-medium">{`${formatNumber(item.shares)}株`}</span>
-              </div>
-              <div className="flex items-center gap-1">
-                <span className="text-slate-500">取得総額:</span>
-                <span className="font-medium">{formatCurrency(item.value)}</span>
-              </div>
-            </div>
-          </div>
-        ))}
+          );
+        })}
 
         {/* その他（折りたたみ時） */}
         {!showAll && othersPercentage > 0 && (

--- a/frontend/src/components/molecules/PortfolioPieChart/__tests__/PortfolioPieChart.test.tsx
+++ b/frontend/src/components/molecules/PortfolioPieChart/__tests__/PortfolioPieChart.test.tsx
@@ -60,4 +60,52 @@ describe('PortfolioPieChart', () => {
     const chartContainer = screen.getByTestId('portfolio-pie-chart');
     expect(chartContainer).toHaveClass('custom-chart');
   });
+
+  describe('配当金額・配当利回り', () => {
+    it('配当データがある銘柄は1株配当・年間配当・利回りが表示される', () => {
+      // 1株配当マップ（J-Quants予想値）
+      const dividendMap = new Map([
+        ['7203', 50],   // 1株配当50円、年間: 50*100=5000、利回り: 50/2500*100=2.00%
+        ['6758', 360],  // 1株配当360円、年間: 360*50=18000、利回り: 360/12000*100=3.00%
+      ]);
+      render(<PortfolioPieChart data={mockData} dividendPerShareMap={dividendMap} />);
+
+      // 1株配当ラベルが各カードに表示される
+      const perShareLabels = screen.getAllByText('1株配当:');
+      expect(perShareLabels.length).toBeGreaterThanOrEqual(2);
+      // 年間配当ラベルが各カードに表示される
+      const dividendLabels = screen.getAllByText('年間配当:');
+      expect(dividendLabels.length).toBeGreaterThanOrEqual(2);
+      // 利回りが表示される
+      expect(screen.getByText('2.00%')).toBeInTheDocument();
+      expect(screen.getByText('3.00%')).toBeInTheDocument();
+    });
+
+    it('配当データがない銘柄は---が表示される', () => {
+      // 7974（任天堂）の配当データなし
+      const dividendMap = new Map([
+        ['7203', 50],
+      ]);
+      render(<PortfolioPieChart data={mockData} dividendPerShareMap={dividendMap} />);
+
+      // 配当データなしの銘柄で---が表示される
+      const dashes = screen.getAllByText('---');
+      expect(dashes.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('dividendPerShareMapが未指定の場合は全銘柄---表示', () => {
+      render(<PortfolioPieChart data={mockData} />);
+
+      // 1株配当・年間配当・配当利回りラベルが各カードに表示される
+      const perShareLabels = screen.getAllByText('1株配当:');
+      expect(perShareLabels).toHaveLength(3);
+      const dividendLabels = screen.getAllByText('年間配当:');
+      expect(dividendLabels).toHaveLength(3);
+      const yieldLabels = screen.getAllByText('配当利回り:');
+      expect(yieldLabels).toHaveLength(3);
+      // 全て---表示（1株配当 + 年間配当 + 配当利回り = 9個）
+      const dashes = screen.getAllByText('---');
+      expect(dashes).toHaveLength(9);
+    });
+  });
 });

--- a/frontend/src/components/organisms/AssetPortfolioSummary/AssetPortfolioSummary.tsx
+++ b/frontend/src/components/organisms/AssetPortfolioSummary/AssetPortfolioSummary.tsx
@@ -3,13 +3,14 @@ import { Card, CardBody } from '@/components/atoms/Card';
 import { EmptyState } from '@/components/atoms/EmptyState';
 import { PortfolioPieChart, PortfolioItem } from '@/components/molecules/PortfolioPieChart';
 import { AssetBalanceData } from '@/lib/interfaces/assetBalance';
-import { formatCurrency, safeAdd } from '@/lib/utils/formatters';
+import { formatCurrency, formatPercentageValue, safeAdd } from '@/lib/utils/formatters';
 
 interface AssetPortfolioSummaryProps {
   assetBalanceData: AssetBalanceData[];
   totalCount?: number; // 全件数（絞り込み前）
   isFiltered?: boolean; // 絞り込み中かどうか
   onClearFilter?: () => void; // 絞り込み解除
+  dividendPerShareMap?: Map<string, number>; // 銘柄別1株配当（J-Quants予想）
 }
 
 /**
@@ -21,6 +22,7 @@ export const AssetPortfolioSummary: React.FC<AssetPortfolioSummaryProps> = ({
   totalCount,
   isFiltered = false,
   onClearFilter,
+  dividendPerShareMap,
 }) => {
   // 合計取得総額を計算（null/undefinedは0として扱う）
   const totalPurchaseAmount = useMemo(() => {
@@ -29,6 +31,24 @@ export const AssetPortfolioSummary: React.FC<AssetPortfolioSummaryProps> = ({
       0
     );
   }, [assetBalanceData]);
+
+  // ポートフォリオ全体の年間配当金額と配当利回り（%）
+  // 年間配当 = Σ(1株配当 × 保有株数)、配当利回り = 年間配当 / 取得総額 × 100
+  const { totalAnnualDividends, portfolioDividendYield } = useMemo(() => {
+    if (!dividendPerShareMap || dividendPerShareMap.size === 0) {
+      return { totalAnnualDividends: null, portfolioDividendYield: null };
+    }
+    let total = 0;
+    assetBalanceData.forEach(item => {
+      const perShare = dividendPerShareMap.get(item.security_code);
+      if (perShare !== undefined) {
+        total += perShare * (item.shares || 0);
+      }
+    });
+    if (total === 0) return { totalAnnualDividends: null, portfolioDividendYield: null };
+    const yieldValue = totalPurchaseAmount > 0 ? (total / totalPurchaseAmount) * 100 : null;
+    return { totalAnnualDividends: total, portfolioDividendYield: yieldValue };
+  }, [dividendPerShareMap, assetBalanceData, totalPurchaseAmount]);
 
   // 横棒グラフ用データを生成（詳細情報付き）
   const chartData: PortfolioItem[] = useMemo(() => {
@@ -97,11 +117,23 @@ export const AssetPortfolioSummary: React.FC<AssetPortfolioSummaryProps> = ({
               </div>
             )}
             {/* KPI行 */}
-            <div className="flex items-end gap-4">
+            <div className="flex items-end gap-6">
               <div>
                 <p className="text-sm text-slate-500">合計取得総額</p>
                 <p className="text-3xl font-bold text-primary" data-negative={totalPurchaseAmount < 0 ? 'true' : undefined}>
                   {formatCurrency(totalPurchaseAmount)}
+                </p>
+              </div>
+              <div>
+                <p className="text-sm text-slate-500">年間配当金額</p>
+                <p className="text-3xl font-bold text-emerald-600" data-testid="portfolio-annual-dividends">
+                  {totalAnnualDividends !== null ? formatCurrency(totalAnnualDividends) : '---'}
+                </p>
+              </div>
+              <div>
+                <p className="text-sm text-slate-500">配当利回り</p>
+                <p className="text-3xl font-bold text-emerald-600" data-testid="portfolio-dividend-yield">
+                  {portfolioDividendYield !== null ? formatPercentageValue(portfolioDividendYield) : '---'}
                 </p>
               </div>
               <p className="pb-1 text-sm text-slate-500">
@@ -114,7 +146,7 @@ export const AssetPortfolioSummary: React.FC<AssetPortfolioSummaryProps> = ({
           </div>
           {/* 銘柄別構成比 */}
           <h3 className="mb-3 text-sm font-semibold text-slate-700">銘柄別構成比</h3>
-          <PortfolioPieChart data={chartData} />
+          <PortfolioPieChart data={chartData} dividendPerShareMap={dividendPerShareMap} />
         </CardBody>
       </Card>
     </div>

--- a/frontend/src/components/organisms/AssetPortfolioSummary/__tests__/AssetPortfolioSummary.test.tsx
+++ b/frontend/src/components/organisms/AssetPortfolioSummary/__tests__/AssetPortfolioSummary.test.tsx
@@ -122,4 +122,43 @@ describe('AssetPortfolioSummary', () => {
 
     expect(screen.getByTestId('asset-portfolio-summary')).toBeInTheDocument();
   });
+
+  describe('配当金額・配当利回り', () => {
+    it('ポートフォリオ全体の年間配当金額と配当利回りが正しく表示される', () => {
+      const mockData = createMockData();
+      // 1株配当マップ: 7203: 50円/株, 6758: 240円/株
+      // 年間配当: 50*100 + 240*50 = 5000 + 12000 = 17000
+      // 配当利回り: 17000 / 850000 * 100 = 2.00%
+      const dividendMap = new Map([
+        ['7203', 50],
+        ['6758', 240],
+      ]);
+      render(<AssetPortfolioSummary assetBalanceData={mockData} dividendPerShareMap={dividendMap} />);
+
+      // 年間配当金額ラベルが表示される
+      expect(screen.getByText('年間配当金額')).toBeInTheDocument();
+      // 50*100 + 240*50 = 17,000
+      expect(screen.getByTestId('portfolio-annual-dividends')).toHaveTextContent(/17,000/);
+      // 配当利回りラベルが表示される
+      expect(screen.getByText('配当利回り')).toBeInTheDocument();
+      // 17000 / 850000 * 100 = 2.00%
+      expect(screen.getByTestId('portfolio-dividend-yield')).toHaveTextContent('2.00%');
+    });
+
+    it('dividendPerShareMapが未指定の場合は---が表示される', () => {
+      const mockData = createMockData();
+      render(<AssetPortfolioSummary assetBalanceData={mockData} />);
+
+      expect(screen.getByTestId('portfolio-annual-dividends')).toHaveTextContent('---');
+      expect(screen.getByTestId('portfolio-dividend-yield')).toHaveTextContent('---');
+    });
+
+    it('配当データが空の場合は---が表示される', () => {
+      const mockData = createMockData();
+      const emptyMap = new Map<string, number>();
+      render(<AssetPortfolioSummary assetBalanceData={mockData} dividendPerShareMap={emptyMap} />);
+
+      expect(screen.getByTestId('portfolio-dividend-yield')).toHaveTextContent('---');
+    });
+  });
 });

--- a/frontend/src/features/jquants/hooks/__tests__/useJQuantsDividendBatch.test.ts
+++ b/frontend/src/features/jquants/hooks/__tests__/useJQuantsDividendBatch.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useJQuantsDividendBatch } from '../useJQuantsDividendBatch';
+import { jquantsApiClient } from '../../api/client';
+import { parseNumber } from '@/lib/utils/formatters';
+
+vi.mock('../../api/client', () => ({
+  jquantsApiClient: {
+    getStatements: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/utils/formatters', () => ({
+  parseNumber: vi.fn(),
+}));
+
+describe('useJQuantsDividendBatch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (parseNumber as Mock).mockImplementation((val) => Number(val) || 0);
+  });
+
+  it('同時実行数を3件以下に制限する', async () => {
+    const codes = ['1605', '2933', '3627', '4912', '7974', '8591'];
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const resolvers: Array<() => void> = [];
+
+    (jquantsApiClient.getStatements as Mock).mockImplementation((code: string) => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      return new Promise((resolve) => {
+        resolvers.push(() => {
+          inFlight -= 1;
+          resolve({
+            data: [{ DiscDate: '2025-01-01', NxFDivAnn: '10.0', Code: code }],
+          });
+        });
+      });
+    });
+
+    const { result } = renderHook(() => useJQuantsDividendBatch(codes, true));
+
+    await waitFor(() => {
+      expect(jquantsApiClient.getStatements).toHaveBeenCalledTimes(3);
+    });
+
+    resolvers.splice(0, 3).forEach((resolve) => resolve());
+
+    await waitFor(() => {
+      expect(jquantsApiClient.getStatements).toHaveBeenCalledTimes(6);
+    });
+
+    resolvers.splice(0).forEach((resolve) => resolve());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(maxInFlight).toBeLessThanOrEqual(3);
+    expect(result.current.dividendPerShareMap.size).toBe(6);
+  });
+});

--- a/frontend/src/features/jquants/hooks/useJQuantsDividend.ts
+++ b/frontend/src/features/jquants/hooks/useJQuantsDividend.ts
@@ -7,7 +7,7 @@ import { parseNumber } from '@/lib/utils/formatters';
  * 決算データから配当情報を抽出する
  * 優先順位: 来期予想 > 今期予想 > 実績
  */
-const extractDividendFromSummary = (summary: JQuantsStatementData): string | null => {
+export const extractDividendFromSummary = (summary: JQuantsStatementData): string | null => {
   if (summary.NxFDivAnn && summary.NxFDivAnn !== '') {
     return summary.NxFDivAnn;
   }

--- a/frontend/src/features/jquants/hooks/useJQuantsDividendBatch.ts
+++ b/frontend/src/features/jquants/hooks/useJQuantsDividendBatch.ts
@@ -1,0 +1,80 @@
+import { useState, useEffect, useRef } from 'react';
+import { jquantsApiClient } from '../api/client';
+import { parseNumber } from '@/lib/utils/formatters';
+import { extractDividendFromSummary } from './useJQuantsDividend';
+
+/**
+ * 複数銘柄の1株配当を一括取得するフック
+ * J-Quants APIから最新予想配当を取得し、Map<銘柄コード, 1株配当>を返す
+ */
+export const useJQuantsDividendBatch = (
+  securityCodes: string[],
+  enabled: boolean = true
+) => {
+  const [dividendPerShareMap, setDividendPerShareMap] = useState<Map<string, number>>(new Map());
+  const [loading, setLoading] = useState<boolean>(false);
+  // 前回のコード一覧を保持（不要な再取得を防止）
+  const prevCodesRef = useRef<string>('');
+
+  useEffect(() => {
+    const codesKey = securityCodes.slice().sort().join(',');
+    if (!enabled || securityCodes.length === 0) {
+      setDividendPerShareMap(new Map());
+      prevCodesRef.current = '';
+      return;
+    }
+
+    // 同じコード一覧なら再取得しない
+    if (codesKey === prevCodesRef.current) return;
+
+    let isActive = true;
+
+    const fetchAll = async () => {
+      setLoading(true);
+      const map = new Map<string, number>();
+
+      // 並列で取得
+      const results = await Promise.allSettled(
+        securityCodes.map(async (code) => {
+          const response = await jquantsApiClient.getStatements(code);
+          if (!response?.data || !Array.isArray(response.data)) return { code, value: null };
+
+          // 開示日で降順ソート（最新データを優先）
+          const sortedData = [...response.data].sort((a, b) => {
+            const dateA = a.DiscDate || '';
+            const dateB = b.DiscDate || '';
+            return dateB.localeCompare(dateA);
+          });
+
+          // 最新の決算データから順に配当情報を検索
+          for (const summary of sortedData) {
+            const dividendValue = extractDividendFromSummary(summary);
+            if (dividendValue) {
+              return { code, value: parseNumber(dividendValue) };
+            }
+          }
+          return { code, value: null };
+        })
+      );
+
+      for (const result of results) {
+        if (result.status === 'fulfilled' && result.value.value !== null && result.value.value > 0) {
+          map.set(result.value.code, result.value.value);
+        }
+      }
+
+      if (isActive) {
+        setDividendPerShareMap(map);
+        prevCodesRef.current = codesKey;
+        setLoading(false);
+      }
+    };
+
+    fetchAll();
+    return () => {
+      isActive = false;
+    };
+  }, [securityCodes, enabled]);
+
+  return { dividendPerShareMap, loading };
+};

--- a/frontend/src/features/jquants/hooks/useJQuantsDividendBatch.ts
+++ b/frontend/src/features/jquants/hooks/useJQuantsDividendBatch.ts
@@ -3,6 +3,8 @@ import { jquantsApiClient } from '../api/client';
 import { parseNumber } from '@/lib/utils/formatters';
 import { extractDividendFromSummary } from './useJQuantsDividend';
 
+const MAX_CONCURRENT_REQUESTS = 3;
+
 /**
  * 複数銘柄の1株配当を一括取得するフック
  * J-Quants APIから最新予想配当を取得し、Map<銘柄コード, 1株配当>を返す
@@ -32,30 +34,35 @@ export const useJQuantsDividendBatch = (
     const fetchAll = async () => {
       setLoading(true);
       const map = new Map<string, number>();
+      const uniqueCodes = Array.from(new Set(securityCodes));
+      const results: PromiseSettledResult<{ code: string; value: number | null }>[] = [];
 
-      // 並列で取得
-      const results = await Promise.allSettled(
-        securityCodes.map(async (code) => {
-          const response = await jquantsApiClient.getStatements(code);
-          if (!response?.data || !Array.isArray(response.data)) return { code, value: null };
+      const fetchOneCode = async (code: string) => {
+        const response = await jquantsApiClient.getStatements(code);
+        if (!response?.data || !Array.isArray(response.data)) return { code, value: null };
 
-          // 開示日で降順ソート（最新データを優先）
-          const sortedData = [...response.data].sort((a, b) => {
-            const dateA = a.DiscDate || '';
-            const dateB = b.DiscDate || '';
-            return dateB.localeCompare(dateA);
-          });
+        // 開示日で降順ソート（最新データを優先）
+        const sortedData = [...response.data].sort((a, b) => {
+          const dateA = a.DiscDate || '';
+          const dateB = b.DiscDate || '';
+          return dateB.localeCompare(dateA);
+        });
 
-          // 最新の決算データから順に配当情報を検索
-          for (const summary of sortedData) {
-            const dividendValue = extractDividendFromSummary(summary);
-            if (dividendValue) {
-              return { code, value: parseNumber(dividendValue) };
-            }
+        // 最新の決算データから順に配当情報を検索
+        for (const summary of sortedData) {
+          const dividendValue = extractDividendFromSummary(summary);
+          if (dividendValue) {
+            return { code, value: parseNumber(dividendValue) };
           }
-          return { code, value: null };
-        })
-      );
+        }
+        return { code, value: null };
+      };
+
+      for (let i = 0; i < uniqueCodes.length; i += MAX_CONCURRENT_REQUESTS) {
+        const chunk = uniqueCodes.slice(i, i + MAX_CONCURRENT_REQUESTS);
+        const chunkResults = await Promise.allSettled(chunk.map(fetchOneCode));
+        results.push(...chunkResults);
+      }
 
       for (const result of results) {
         if (result.status === 'fulfilled' && result.value.value !== null && result.value.value > 0) {

--- a/frontend/src/pages/AssetBalance.tsx
+++ b/frontend/src/pages/AssetBalance.tsx
@@ -11,6 +11,7 @@ import { AssetBalanceData } from '@/lib/interfaces/assetBalance';
 import { parseNumber } from '@/lib/utils/formatters';
 import { useReceiptData } from '@/hooks/receipt/useReceiptData';
 import { assetBalanceApi } from '@/features/receipt/api/receiptApi';
+import { useJQuantsDividendBatch } from '@/features/jquants/hooks/useJQuantsDividendBatch';
 import { useReceiptDataSource } from '@/hooks/common/useReceiptDataSource';
 import { createSearchOptions } from '@/lib/utils/dataTransformer';
 import { filterByConfig, FilterConfig } from '@/lib/utils/searchUtils';
@@ -49,6 +50,7 @@ interface AssetBalanceInfoProps {
   filteredData: AssetBalanceData[];
   searchQuery: string;
   onClearFilter: () => void;
+  dividendPerShareMap: Map<string, number>;
 }
 
 /**
@@ -59,6 +61,7 @@ export const AssetBalanceInfo: React.FC<AssetBalanceInfoProps> = ({
   filteredData,
   searchQuery,
   onClearFilter,
+  dividendPerShareMap,
 }) => {
   const isFiltered = searchQuery !== '';
 
@@ -69,6 +72,7 @@ export const AssetBalanceInfo: React.FC<AssetBalanceInfoProps> = ({
         totalCount={assetBalanceData.length}
         isFiltered={isFiltered}
         onClearFilter={isFiltered ? onClearFilter : undefined}
+        dividendPerShareMap={dividendPerShareMap}
       />
     </Suspense>
   );
@@ -122,6 +126,13 @@ export function AssetBalancePage() {
       setAssetBalanceData([]);
     }
   }, [csvData, tmpAssetBalanceData, dbData]);
+
+  // J-Quants APIから1株配当を一括取得
+  const securityCodes = useMemo(
+    () => assetBalanceData.map(item => item.security_code),
+    [assetBalanceData]
+  );
+  const { dividendPerShareMap } = useJQuantsDividendBatch(securityCodes, isAuthenticated);
 
   // 検索オプションの生成
   const searchCategories = useMemo(() => ({
@@ -257,6 +268,7 @@ export function AssetBalancePage() {
                 filteredData={filteredData}
                 searchQuery={searchQuery}
                 onClearFilter={handleClearFilter}
+                dividendPerShareMap={dividendPerShareMap}
               />
             )}
 

--- a/frontend/src/pages/__tests__/AssetBalance.test.tsx
+++ b/frontend/src/pages/__tests__/AssetBalance.test.tsx
@@ -12,6 +12,7 @@ vi.mock('@/components/atoms/SecurityCodeLink', () => ({
 vi.mock('@/lib/utils/formatters', () => ({
   formatCurrency: vi.fn().mockImplementation((value: number) => `¥${value.toLocaleString()}`),
   formatNumber: vi.fn().mockImplementation((value: number) => value.toLocaleString()),
+  formatPercentageValue: vi.fn().mockImplementation((value: number) => `${value.toFixed(2)}%`),
   safeAdd: vi.fn().mockImplementation((a: number, b: number) => a + b),
 }));
 
@@ -48,6 +49,7 @@ describe('AssetBalanceInfo', () => {
     filteredData: mockAssetBalanceData,
     searchQuery: '',
     onClearFilter: vi.fn(),
+    dividendPerShareMap: new Map<string, number>(),
   };
 
   beforeEach(() => {
@@ -87,6 +89,7 @@ describe('AssetBalanceInfo', () => {
         filteredData={[]}
         searchQuery=""
         onClearFilter={vi.fn()}
+        dividendPerShareMap={new Map()}
       />
     );
 
@@ -103,6 +106,7 @@ describe('AssetBalanceInfo', () => {
         filteredData={filteredData}
         searchQuery="7203"
         onClearFilter={vi.fn()}
+        dividendPerShareMap={new Map()}
       />
     );
 
@@ -120,6 +124,7 @@ describe('AssetBalanceInfo', () => {
         filteredData={[]}
         searchQuery="9999"
         onClearFilter={vi.fn()}
+        dividendPerShareMap={new Map()}
       />
     );
 


### PR DESCRIPTION
## 概要
- 資産ポートフォリオ画面に配当サマリー表示を追加
- J-Quants API の 429 応答を透過し、同時実行数を制限して安定性を改善
- バックエンドの環境変数案内を README とエラーメッセージで改善

## 変更種別
- [x] 新機能
- [x] バグ修正
- [x] ドキュメント

## 主な変更内容
- 資産ポートフォリオに配当サマリー表示を追加（UI/関連ロジック）
- J-Quants 呼び出しで 429 を適切に扱うように修正
- `backend/README.md` に `backend/.env` 読み込みを明記
- `backend/src/state.rs` の DATABASE_URL 未設定メッセージに確認手順を追記

## テスト
- [x] `cd backend && cargo check`
- [ ] 自動テスト一式（未実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
