### PR TITLE
Refactor frontend state flow and shared UI safety

### DIFF
--- a/frontend/src/components/atoms/InputField.tsx
+++ b/frontend/src/components/atoms/InputField.tsx
@@ -60,6 +60,15 @@ const InputField = forwardRef<HTMLInputElement, InputFieldProps>(
       </label>
     );
 
+    const describedByIds: string[] = [];
+    if (error) {
+      describedByIds.push(`${inputId}-error`);
+    }
+    if (helpText) {
+      describedByIds.push(`${inputId}-help`);
+    }
+    const ariaDescribedBy = describedByIds.length > 0 ? describedByIds.join(' ') : undefined;
+
     return (
       <div className={widthClass}>
         {labelElement}
@@ -70,12 +79,7 @@ const InputField = forwardRef<HTMLInputElement, InputFieldProps>(
           placeholder={placeholder}
           required={required}
           aria-invalid={error ? 'true' : 'false'}
-          aria-describedby={
-            [
-              error ? `${inputId}-error` : '',
-              helpText ? `${inputId}-help` : ''
-            ].filter(Boolean).join(' ') || undefined
-          }
+          aria-describedby={ariaDescribedBy}
           {...rest}
         />
         {error && (

--- a/frontend/src/components/atoms/StatItem.tsx
+++ b/frontend/src/components/atoms/StatItem.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { cn } from '../../lib/utils/classNames';
 
+const defaultValueFormat = (value: number): string => value.toLocaleString('ja-JP');
+const defaultRateFormat = (rate: number): string => `${rate.toFixed(2)}%`;
+
 export interface StatItemProps {
   title: string;
   value: string | React.ReactNode;
@@ -79,8 +82,8 @@ export const StatItemWithRate: React.FC<StatItemWithRateProps> = ({
   title,
   value,
   rate,
-  format = (v) => v.toLocaleString('ja-JP'),
-  rateFormat = (r) => `${r.toFixed(2)}%`,
+  format = defaultValueFormat,
+  rateFormat = defaultRateFormat,
   className = '',
   showRate = true,
   variant = 'default'

--- a/frontend/src/components/atoms/Table.tsx
+++ b/frontend/src/components/atoms/Table.tsx
@@ -35,7 +35,6 @@ export interface TableCellProps extends HTMLAttributes<HTMLTableCellElement> {
   as?: 'td' | 'th';
   scope?: 'col' | 'row' | 'colgroup' | 'rowgroup';
   colSpan?: number;
-  dangerouslySetInnerHTML?: { __html: string };
 }
 
 // バリアント別の背景色
@@ -189,7 +188,6 @@ const TableCell = forwardRef<HTMLTableCellElement, TableCellProps>(
       scope = 'col',
       colSpan = 1,
       className,
-      dangerouslySetInnerHTML,
       ...rest
     },
     ref
@@ -197,19 +195,6 @@ const TableCell = forwardRef<HTMLTableCellElement, TableCellProps>(
     const Cell = as;
     const scopeAttr = as === 'th' ? { scope } : {};
     const cellClasses = cn(as === 'th' && 'font-semibold text-slate-700', className);
-
-    if (dangerouslySetInnerHTML) {
-      return (
-        <Cell
-          ref={ref}
-          className={cellClasses}
-          {...scopeAttr}
-          {...rest}
-          colSpan={colSpan}
-          dangerouslySetInnerHTML={dangerouslySetInnerHTML}
-        />
-      );
-    }
 
     return (
       <Cell ref={ref} className={cellClasses} {...scopeAttr} {...rest} colSpan={colSpan}>

--- a/frontend/src/components/atoms/__tests__/Table.test.tsx
+++ b/frontend/src/components/atoms/__tests__/Table.test.tsx
@@ -201,12 +201,12 @@ describe('Table', () => {
     expect(screen.getByRole('table')).toBeInTheDocument();
   });
 
-  test('dangerouslySetInnerHTMLが正しく適用される', () => {
+  test('childrenが正しく表示される', () => {
     render(
       <Table>
         <TableBody>
           <TableRow>
-            <TableCell dangerouslySetInnerHTML={{ __html: '<strong>HTML内容</strong>' }} />
+            <TableCell><strong>HTML内容</strong></TableCell>
           </TableRow>
         </TableBody>
       </Table>

--- a/frontend/src/components/molecules/ConfirmDeleteModal/ConfirmDeleteModal.tsx
+++ b/frontend/src/components/molecules/ConfirmDeleteModal/ConfirmDeleteModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect } from 'react';
 import { Button } from '@/components/atoms/Button';
 
 interface ConfirmDeleteModalProps {
@@ -27,15 +27,6 @@ export const ConfirmDeleteModal: React.FC<ConfirmDeleteModalProps> = ({
   confirmLabel = '削除する',
   loading = false,
 }) => {
-  const cancelRef = useRef<HTMLButtonElement>(null);
-
-  // モーダル表示時にキャンセルボタンにフォーカス（誤クリック防止）
-  useEffect(() => {
-    if (isOpen) {
-      cancelRef.current?.focus();
-    }
-  }, [isOpen]);
-
   // Escapeキーで閉じる
   useEffect(() => {
     if (!isOpen) return;
@@ -52,12 +43,19 @@ export const ConfirmDeleteModal: React.FC<ConfirmDeleteModalProps> = ({
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
       onClick={onCancel}
+      onKeyDown={(e) => { if (e.key === 'Escape') onCancel(); }}
       role="dialog"
       aria-modal="true"
       aria-labelledby="confirm-delete-title"
       aria-describedby="confirm-delete-desc"
+      tabIndex={-1}
     >
-      <div className="w-full max-w-md" onClick={(e) => e.stopPropagation()}>
+      <div
+        className="w-full max-w-md"
+        role="presentation"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+      >
         <div className="rounded-lg bg-white shadow-lg">
           <div className="flex items-center justify-between border-b border-border px-4 py-3">
             <h5 id="confirm-delete-title" className="text-danger font-semibold">
@@ -83,7 +81,7 @@ export const ConfirmDeleteModal: React.FC<ConfirmDeleteModalProps> = ({
           </div>
           <div className="flex justify-end gap-2 border-t border-border px-4 py-3">
             <Button
-              ref={cancelRef}
+              autoFocus
               variant="secondary"
               onClick={onCancel}
             >

--- a/frontend/src/components/molecules/DividendInfo/DividendInfo.tsx
+++ b/frontend/src/components/molecules/DividendInfo/DividendInfo.tsx
@@ -7,6 +7,18 @@ import { useAssetBalance } from '@/hooks/common/useAssetBalance';
 import { SummaryResult } from '@/lib/utils/dataTransformer';
 import { DividendData } from '@/lib/interfaces/dividend';
 
+const AssetBadge = () => (
+  <span className="ml-1 inline-flex items-center rounded bg-emerald-100 px-1.5 py-0.5 text-xs font-medium text-emerald-700">
+    保有銘柄
+  </span>
+);
+
+const JQuantsBadge = () => (
+  <span className="ml-1 inline-flex items-center rounded bg-blue-100 px-1.5 py-0.5 text-xs font-medium text-blue-700">
+    J-Quants
+  </span>
+);
+
 interface DividendInfoProps {
   searchQuery: string;
   securityCode?: string;
@@ -116,18 +128,6 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({
   const assetBalanceData = isValidSecurityCode
     ? getAssetBalanceByCode(effectiveSecurityCode)
     : undefined;
-
-  // 自動入力バッジ（データ元を明示）
-  const AssetBadge = () => (
-    <span className="ml-1 inline-flex items-center rounded bg-emerald-100 px-1.5 py-0.5 text-xs font-medium text-emerald-700">
-      保有銘柄
-    </span>
-  );
-  const JQuantsBadge = () => (
-    <span className="ml-1 inline-flex items-center rounded bg-blue-100 px-1.5 py-0.5 text-xs font-medium text-blue-700">
-      J-Quants
-    </span>
-  );
 
   const content = (
     <>

--- a/frontend/src/components/molecules/ReceiptHeader/ReceiptHeader.tsx
+++ b/frontend/src/components/molecules/ReceiptHeader/ReceiptHeader.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useEffect, useId, useState } from 'react';
+import React, { ReactNode, useId, useState } from 'react';
 import { StatItem } from '@/components/atoms/StatItem';
 import { Card, CardBody, CardHeader } from '@/components/atoms/Card';
 import { HeaderItem } from '@/types/common';
@@ -18,17 +18,9 @@ export const ReceiptHeader: React.FC<ReceiptHeaderProps> = ({
     collapsible = false,
     defaultExpanded = true
 }) => {
-    const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+    const [isExpanded, setIsExpanded] = useState(() => (collapsible ? defaultExpanded : true));
     const bodyId = useId();
-
-    // 折りたたみ状態が変わったら展開状態をリセット
-    useEffect(() => {
-        if (collapsible) {
-            setIsExpanded(defaultExpanded);
-        } else {
-            setIsExpanded(true);
-        }
-    }, [collapsible, defaultExpanded]);
+    const effectiveExpanded = collapsible ? isExpanded : true;
 
     const handleToggleExpanded = () => {
         if (!collapsible) return;
@@ -52,25 +44,25 @@ export const ReceiptHeader: React.FC<ReceiptHeaderProps> = ({
                 onKeyDown={collapsible ? handleKeyDown : undefined}
                 role={collapsible ? 'button' : undefined}
                 tabIndex={collapsible ? 0 : undefined}
-                aria-expanded={collapsible ? isExpanded : undefined}
+                aria-expanded={collapsible ? effectiveExpanded : undefined}
                 aria-controls={collapsible ? bodyId : undefined}
                 data-testid="receipt-header"
             >
                 <h5>{title}</h5>
                 {collapsible && (
                     <span className="flex items-center gap-1 text-xs font-medium bg-white/20 px-2 py-1 rounded">
-                        {isExpanded ? '▲ 閉じる' : '▼ 開く'}
+                        {effectiveExpanded ? '▲ 閉じる' : '▼ 開く'}
                     </span>
                 )}
             </CardHeader>
             {/* 折りたたみ時はhiddenで非表示（children内のstateを保持するため） */}
-            <CardBody id={bodyId} className="p-4" hidden={collapsible && !isExpanded}>
+            <CardBody id={bodyId} className="p-4" hidden={collapsible && !effectiveExpanded}>
                 {/* stat-gridはitemsがある場合のみ表示 */}
                 {items.length > 0 && (
                     <div className="stat-grid">
-                        {items.map((item, index) => (
+                        {items.map((item) => (
                             <StatItem
-                                key={index}
+                                key={item.title}
                                 title={item.title}
                                 value={
                                     <span data-negative={item.value < 0 ? 'true' : undefined}>

--- a/frontend/src/components/molecules/StockInfoLinks.tsx
+++ b/frontend/src/components/molecules/StockInfoLinks.tsx
@@ -28,7 +28,7 @@ export const StockInfoLinks = ({ code }: StockInfoLinksProps) => {
   return (
     <div className="flex flex-wrap items-center text-sm">
       {STOCK_INFO_LINKS_OBJECTS.map((item, index) => (
-        <Fragment key={index}>
+        <Fragment key={item.name}>
           <a
             className="font-semibold text-primary hover:underline"
             href={item.url.replace('{}', code)}

--- a/frontend/src/components/organisms/Header.tsx
+++ b/frontend/src/components/organisms/Header.tsx
@@ -196,14 +196,18 @@ export function Header() {
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
           onClick={() => setShowDeleteConfirm(false)}
+          onKeyDown={(e) => { if (e.key === 'Escape') setShowDeleteConfirm(false); }}
           role="dialog"
           aria-modal="true"
           aria-labelledby="delete-modal-title"
           aria-describedby="delete-modal-description"
+          tabIndex={-1}
         >
           <div
             className="w-full max-w-md"
+            role="presentation"
             onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => e.stopPropagation()}
           >
             <div className="rounded-lg bg-white shadow-lg">
               <div className="flex items-center justify-between border-b border-border px-4 py-3">

--- a/frontend/src/components/organisms/ReceiptTable/ReceiptTable.tsx
+++ b/frontend/src/components/organisms/ReceiptTable/ReceiptTable.tsx
@@ -216,12 +216,12 @@ export function ReceiptTable<T extends DataItem, S extends SummaryItem>({
         >
             <TableHeader>
                 <TableRow className="bg-slate-50 text-center">
-                    {columns.map((column, index) => (
+                    {columns.map((column) => (
                         <TableCell
                             as="th"
                             className="text-center whitespace-nowrap"
                             style={{ minWidth: column.width }}
-                            key={index}
+                            key={column.header}
                         >
                             {column.header}
                         </TableCell>

--- a/frontend/src/components/organisms/SearchCard/SearchCard.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { SearchCategories } from '@/types/common';
 import { Button } from '@/components/atoms/Button';
 import { Card, CardBody, CardHeader } from '@/components/atoms/Card';
@@ -25,14 +25,8 @@ export const SearchCard: React.FC<SearchCardProps> = ({
     const [searchQuery, setSearchQuery] = useState('');
     // アクティブな検索タイプを追跡（ドロップダウンの表示制御用）
     const [activeSearchType, setActiveSearchType] = useState<'securities' | 'years' | 'products' | 'accounts' | null>(null);
-
-    // 親の検索状態と同期（外部からのクリア時に内部状態をリセット）
-    useEffect(() => {
-        if (value !== undefined && value !== searchQuery) {
-            setSearchQuery(value);
-            setActiveSearchType(value ? activeSearchType : null);
-        }
-    }, [value]); // eslint-disable-line react-hooks/exhaustive-deps
+    const effectiveSearchQuery = value ?? searchQuery;
+    const effectiveActiveSearchType = value === '' ? null : activeSearchType;
 
     // データが存在するかチェックするヘルパー関数
     const hasData = (data: unknown[] | undefined): boolean => {
@@ -70,7 +64,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
     };
 
     // 検索条件が初期状態かどうか
-    const isDefaultState = searchQuery === '' && activeSearchType === null;
+    const isDefaultState = effectiveSearchQuery === '' && effectiveActiveSearchType === null;
 
     // 検索条件をクリア
     const handleClearSearch = () => {
@@ -88,13 +82,13 @@ export const SearchCard: React.FC<SearchCardProps> = ({
         if (!items || items.length === 0) return null;
 
         // いずれかが選択中かどうか（未選択チップをミュートするため）
-        const hasSelection = activeSearchType === searchType;
+        const hasSelection = effectiveActiveSearchType === searchType;
 
         return items.map((item, index) => {
-            const isSelected = activeSearchType === searchType && searchQuery === item;
+            const isSelected = effectiveActiveSearchType === searchType && effectiveSearchQuery === item;
 
             return (
-                <React.Fragment key={index}>
+                <React.Fragment key={item}>
                     <Button
                         type="button"
                         variant={isSelected ? 'primary' : 'outline-secondary'}
@@ -122,8 +116,8 @@ export const SearchCard: React.FC<SearchCardProps> = ({
 
     const renderQuickSearchDropdown = (items: { value: string, label: string }[], id: string, searchType: 'securities' | 'years') => {
         // このドロップダウンがアクティブな検索タイプの場合のみ値を表示
-        const displayValue = activeSearchType === searchType ? searchQuery : '';
-        const isSelected = activeSearchType === searchType && displayValue !== '';
+        const displayValue = effectiveActiveSearchType === searchType ? effectiveSearchQuery : '';
+        const isSelected = effectiveActiveSearchType === searchType && displayValue !== '';
 
         return (
             <div className="relative">
@@ -139,8 +133,8 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                     aria-label="検索フィルター"
                 >
                     <option value="">全て表示</option>
-                    {items.map((option, index) => (
-                        <option key={`search-option-${option.value}-${index}`} value={option.value}>
+                    {items.map((option) => (
+                        <option key={option.value} value={option.value}>
                             {option.label}
                         </option>
                     ))}
@@ -180,7 +174,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
                     </svg>
                     <h5 className="text-sm font-semibold">検索オプション</h5>
-                    {!isExpanded && activeSearchType && (
+                    {!isExpanded && effectiveActiveSearchType && (
                         <span className="text-xs bg-white/20 px-2 py-0.5 rounded">
                             フィルタ適用中
                         </span>

--- a/frontend/src/features/auth/context/AuthContext.tsx
+++ b/frontend/src/features/auth/context/AuthContext.tsx
@@ -38,22 +38,23 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const controller = new AbortController();
 
     const checkSession = async () => {
-      try {
-        // 認証確認専用クライアントで取得（timeout/retry最小化）
-        const userInfo = await authApiClient.get<UserInfo>('/auth/me', {
-          withCredentials: true,
-          signal: controller.signal,
-        });
-        setUser(userInfo);
-      } catch {
-        // StrictModeクリーンアップによるabortは無視
-        if (controller.signal.aborted) return;
-        // セッションが無効な場合
-        setUser(null);
-      } finally {
+      await authApiClient.get<UserInfo>('/auth/me', {
+        withCredentials: true,
+        signal: controller.signal,
+      }).then((userInfo) => {
         if (!controller.signal.aborted) {
-          setIsLoading(false);
+          setUser(userInfo);
         }
+      }).catch(() => {
+        // StrictModeクリーンアップによるabortは無視
+        if (!controller.signal.aborted) {
+          // セッションが無効な場合
+          setUser(null);
+        }
+      });
+
+      if (!controller.signal.aborted) {
+        setIsLoading(false);
       }
     };
 
@@ -75,18 +76,23 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // バックエンドの認証エンドポイントに直接リダイレクト
     // バックエンドがGoogleの認証ページにリダイレクトする
     const apiBaseUrl = import.meta.env.VITE_SHOKEN_WEBAPI_API_URL;
-    window.location.href = `${apiBaseUrl}/auth/google`;
+    window.location.assign(`${apiBaseUrl}/auth/google`);
   };
 
   const logout = useCallback(async () => {
     // 登録されたコールバックを先に実行（状態クリア用）
     logoutCallbacksRef.current.forEach(callback => callback());
-    try {
-      await apiClient.post('/auth/logout', {}, {
-        withCredentials: true,
-      });
-    } finally {
-      setUser(null);
+    let hasError = false;
+    let caughtError: unknown;
+    await apiClient.post('/auth/logout', {}, {
+      withCredentials: true,
+    }).catch((error: unknown) => {
+      hasError = true;
+      caughtError = error;
+    });
+    setUser(null);
+    if (hasError) {
+      throw caughtError;
     }
   }, []);
 
@@ -102,12 +108,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const deleteAccount = useCallback(async () => {
     // 登録されたコールバックを先に実行（状態クリア用）
     logoutCallbacksRef.current.forEach(callback => callback());
-    try {
-      await apiClient.delete('/auth/delete-account', {
-        withCredentials: true,
-      });
-    } finally {
-      setUser(null);
+    let hasError = false;
+    let caughtError: unknown;
+    await apiClient.delete('/auth/delete-account', {
+      withCredentials: true,
+    }).catch((error: unknown) => {
+      hasError = true;
+      caughtError = error;
+    });
+    setUser(null);
+    if (hasError) {
+      throw caughtError;
     }
   }, []);
 

--- a/frontend/src/pages/AssetBalance.tsx
+++ b/frontend/src/pages/AssetBalance.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useMemo, useCallback, Suspense, lazy } from 'react';
+import React, { useState, useMemo, useCallback, Suspense, lazy } from 'react';
 import { Layout } from '../components/templates/Layout';
 import { PageHeader } from '../components/atoms/PageHeader';
 import { CSVFileInput } from '../components/molecules/CSVFileInput';
@@ -107,7 +107,6 @@ export function AssetBalancePage() {
 
   // CSVデータの変換（空の銘柄コードをフィルタ）
   const tmpAssetBalanceData = useReceiptData(csvData, parseCsvItem, sortBySecurityCode);
-  const [assetBalanceData, setAssetBalanceData] = useState<AssetBalanceData[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
@@ -116,16 +115,15 @@ export function AssetBalancePage() {
     await handleDeleteAll();
   }, [handleDeleteAll]);
 
-  // CSVデータが読み込まれたらフィルタして設定
-  useEffect(() => {
+  const assetBalanceData = useMemo(() => {
     if (csvData.length > 0) {
-      setAssetBalanceData(tmpAssetBalanceData.filter(item => item.security_code !== ''));
-    } else if (dbData.length > 0) {
-      setAssetBalanceData(dbData);
-    } else {
-      setAssetBalanceData([]);
+      return tmpAssetBalanceData.filter(item => item.security_code !== '');
     }
-  }, [csvData, tmpAssetBalanceData, dbData]);
+    if (dbData.length > 0) {
+      return dbData;
+    }
+    return [];
+  }, [csvData.length, tmpAssetBalanceData, dbData]);
 
   // J-Quants APIから1株配当を一括取得
   const securityCodes = useMemo(

--- a/frontend/src/pages/Receipts.tsx
+++ b/frontend/src/pages/Receipts.tsx
@@ -135,30 +135,32 @@ export function ReceiptsPage() {
     setDbLoading(true);
     setDbError(null);
 
-    try {
-      const [dividends, stocks, funds] = await Promise.all([
-        dividendApi.list(),
-        domesticStockApi.list(),
-        mutualfundApi.list(),
-      ]);
-
+    await Promise.all([
+      dividendApi.list(),
+      domesticStockApi.list(),
+      mutualfundApi.list(),
+    ]).then(([dividends, stocks, funds]) => {
       setDividendDBData(dividends.map(d => transformDBDividend(d as unknown as Record<string, unknown>)));
       setDomesticStockDBData(stocks.map(d => transformDBDomesticStock(d as unknown as Record<string, unknown>)));
       setMutualfundDBData(funds.map(d => transformDBMutualfund(d as unknown as Record<string, unknown>)));
       hasFetched.current = true;
-    } catch (err) {
+    }).catch((err) => {
       setDbError(getDisplayErrorMessage(err, 'データ取得に失敗しました'));
-    } finally {
-      setDbLoading(false);
-      isFetchingRef.current = false;
-    }
+    });
+
+    setDbLoading(false);
+    isFetchingRef.current = false;
   }, [isAuthenticated, authLoading]);
 
   // 認証状態が確定したらDBからデータを取得
   useEffect(() => {
-    if (!authLoading) {
-      fetchFromDB();
-    }
+    if (authLoading) return;
+    const timeoutId = window.setTimeout(() => {
+      void fetchFromDB();
+    }, 0);
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
   }, [authLoading, fetchFromDB]);
 
   // ログアウト時に全データをクリア
@@ -204,16 +206,15 @@ export function ReceiptsPage() {
     const config = RECEIPT_TYPE_CONFIG[receiptsType];
     const { csvData, setCsvData } = runtimeDataMap[receiptsType];
 
-    try {
-      const items = csvData.map(config.parser);
-      await config.api.bulkCreate(items);
+    const items = csvData.map(config.parser);
+    await config.api.bulkCreate(items).then(async () => {
       setCsvData([]);
       await fetchFromDB(true);
-    } catch (err) {
+    }).catch((err) => {
       setDbError(getDisplayErrorMessage(err, '保存に失敗しました'));
-    } finally {
-      setSaving(false);
-    }
+    });
+
+    setSaving(false);
   };
 
   /**
@@ -229,14 +230,13 @@ export function ReceiptsPage() {
     const config = RECEIPT_TYPE_CONFIG[receiptsType];
     const { setDbData } = runtimeDataMap[receiptsType];
 
-    try {
-      await config.api.deleteAll();
+    await config.api.deleteAll().then(() => {
       setDbData([]);
-    } catch (err) {
+    }).catch((err) => {
       setDbError(getDisplayErrorMessage(err, '削除に失敗しました'));
-    } finally {
-      setDeleting(false);
-    }
+    });
+
+    setDeleting(false);
   };
 
   /**
@@ -256,9 +256,7 @@ export function ReceiptsPage() {
   const hasCsvData = csvData.length > 0;
 
   // 現在のタブのDBデータ件数を取得
-  const dbDataCount = useMemo(() => {
-    return runtimeDataMap[receiptsType].dbData.length;
-  }, [runtimeDataMap, receiptsType]);
+  const dbDataCount = runtimeDataMap[receiptsType].dbData.length;
 
   // 現在のタブのDBデータがあるか判定
   const hasDbData = dbDataCount > 0;


### PR DESCRIPTION
## 概要
フロントエンドの状態管理と共通UIコンポーネントをリファクタリングし、可読性・安全性・アクセシビリティを改善しました。

## 変更種別
- [ ] 新機能
- [ ] バグ修正
- [x] リファクタリング

## 主な変更内容
- `AuthContext` / `Receipts` / `AssetBalance` / `SearchCard` / `ReceiptHeader` の状態遷移と非同期処理を整理
- `TableCell` の `dangerouslySetInnerHTML` 対応を廃止し、テストを children ベースへ更新
- モーダルのキーボード操作改善、`key` 安定化、`aria-describedby` 構築の明確化など共通UIの改善

## コミット
- `refactor: improve shared UI safety and accessibility`
- `refactor: simplify auth and receipt state flows`

## テスト
- [x] `npm run lint`
- [x] `npm run test -- src/components/atoms/__tests__/Table.test.tsx --run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)