### PR TITLE
Optimize Fly.io backend config for lower free-tier usage

### DIFF
--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -11,7 +11,7 @@ primary_region = 'nrt'
 
 [env]
   PORT = '8080'
-  RUST_LOG = 'info'
+  RUST_LOG = 'warn'
 
 [http_service]
   internal_port = 8080
@@ -22,14 +22,13 @@ primary_region = 'nrt'
   processes = ['app']
 
   [[http_service.checks]]
-    interval = '30s'
-    timeout = '5s'
+    interval = '60s'
+    timeout = '3s'
     grace_period = '10s'
     method = 'GET'
     path = '/health'
 
 [[vm]]
-  memory = '512mb'
+  memory = '256mb'
   cpu_kind = 'shared'
   cpus = 1
-  memory_mb = 512


### PR DESCRIPTION
## 概要
Fly.io の無料運用を継続しやすくするため、バックエンドの実行設定を軽量化しました。

## 変更種別
- [ ] 新機能
- [ ] バグ修正
- [x] 設定変更（chore）

## 主な変更内容
- `backend/fly.toml` の VM メモリを `512mb` から `256mb` に削減
- ヘルスチェックを `30s` 間隔から `60s` 間隔に変更し、`timeout` を `3s` に短縮
- `RUST_LOG` を `info` から `warn` に変更してログ出力量を抑制
- 重複していた `memory_mb` 設定を削除

## テスト
- [ ] 自動テスト実行（設定ファイル変更のみのため未実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)