### PR TITLE
Add dividend per-share batch API with cache/rate-limit handling

### DIFF
--- a/backend/migrations/0009_create_jquants_dividend_cache.sql
+++ b/backend/migrations/0009_create_jquants_dividend_cache.sql
@@ -1,0 +1,25 @@
+-- JQuants 配当キャッシュテーブル
+-- 銘柄コード単位で1株配当をキャッシュし、レート制限を吸収する
+CREATE TABLE IF NOT EXISTS jquants_dividend_cache (
+    security_code       VARCHAR(10) PRIMARY KEY,
+    dividend_per_share  DOUBLE PRECISION,
+    -- ok: 有配当、zero: ゼロ配当、error: 取得失敗、pending: 未取得/更新待ち
+    status              VARCHAR(20) NOT NULL DEFAULT 'pending',
+    fetched_at          TIMESTAMPTZ,
+    source              VARCHAR(50) NOT NULL DEFAULT 'jquants',
+    error_message       TEXT,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- JQuants グローバルレート制御テーブル（単一行、全インスタンス共有）
+-- 1分5回 = 12秒間隔を DB トランザクションで原子的に保証する
+CREATE TABLE IF NOT EXISTS jquants_rate_control (
+    id                INTEGER PRIMARY KEY,
+    next_available_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT single_row CHECK (id = 1)
+);
+
+INSERT INTO jquants_rate_control (id, next_available_at)
+    VALUES (1, NOW())
+    ON CONFLICT (id) DO NOTHING;

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -203,6 +203,7 @@ mod tests {
             pool,
             secrets,
             client,
+            background_task_running: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
         app_router(state, config)
     }

--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -1,6 +1,7 @@
 pub mod asset_balance;
 pub mod auth;
 pub mod dividend;
+pub mod dividend_per_share;
 pub mod domestic_stock;
 pub mod jquants;
 pub mod mutualfund;

--- a/backend/src/handlers/dividend_per_share.rs
+++ b/backend/src/handlers/dividend_per_share.rs
@@ -1,0 +1,35 @@
+use crate::{
+    errors::ApiError,
+    extractors::validated_json::ValidatedJson,
+    models::dividend_cache::{DividendPerShareBatchRequest, DividendPerShareBatchResponse},
+    services::dividend_cache as dividend_cache_service,
+    AppState,
+};
+use axum::{extract::State, response::IntoResponse, Json};
+
+/// 配当利回り一括取得（認証不要）
+pub async fn batch(
+    State(state): State<AppState>,
+    ValidatedJson(data): ValidatedJson<DividendPerShareBatchRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    let api_key = state.secrets.jquants_api_key.as_deref();
+
+    let items = dividend_cache_service::get_batch(
+        &state.pool,
+        &state.client,
+        api_key,
+        &data.security_codes,
+        &state.background_task_running,
+    )
+    .await?;
+
+    Ok(Json(DividendPerShareBatchResponse { items }))
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_module_compilation() {
+        assert!(true);
+    }
+}

--- a/backend/src/handlers/stock.rs
+++ b/backend/src/handlers/stock.rs
@@ -124,6 +124,7 @@ mod tests {
             pool: pool.clone(),
             secrets,
             client,
+            background_task_running: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
 
         Router::new()

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -16,7 +16,7 @@ use dotenvy::dotenv;
 use reqwest::Client;
 use routes::app_router;
 use state::{AppState, Secrets};
-use std::sync::Arc;
+use std::sync::{atomic::AtomicBool, Arc};
 use tokio::net::TcpListener;
 
 #[cfg(test)]
@@ -52,6 +52,7 @@ async fn main() {
         pool,
         secrets,
         client,
+        background_task_running: Arc::new(AtomicBool::new(false)),
     };
 
     let router = app_router(state, &config);
@@ -93,6 +94,7 @@ mod tests {
             pool,
             secrets,
             client,
+            background_task_running: Arc::new(AtomicBool::new(false)),
         };
 
         let config = Config::default();
@@ -148,6 +150,7 @@ mod tests {
             pool,
             secrets,
             client,
+            background_task_running: Arc::new(AtomicBool::new(false)),
         };
 
         // AppStateが正常に作成されることを確認

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -1,6 +1,7 @@
 pub mod asset_balance;
 pub mod common;
 pub mod dividend;
+pub mod dividend_cache;
 pub mod domestic_stock;
 pub mod jquants;
 pub mod mutualfund;

--- a/backend/src/models/dividend_cache.rs
+++ b/backend/src/models/dividend_cache.rs
@@ -1,0 +1,44 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+use validator::Validate;
+
+/// 配当キャッシュレコード
+#[derive(Debug, Clone, Serialize, FromRow)]
+pub struct DividendCache {
+    pub security_code: String,
+    pub dividend_per_share: Option<f64>,
+    /// ok: 有配当、zero: ゼロ配当、error: 取得失敗、pending: 未取得/更新待ち
+    pub status: String,
+    pub fetched_at: Option<DateTime<Utc>>,
+    pub source: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// バッチリクエスト
+#[derive(Debug, Deserialize, Validate)]
+pub struct DividendPerShareBatchRequest {
+    #[validate(length(min = 1, max = 100))]
+    pub security_codes: Vec<String>,
+}
+
+/// レスポンス内の1銘柄アイテム
+#[derive(Debug, Serialize)]
+pub struct DividendPerShareItem {
+    pub security_code: String,
+    pub dividend_per_share: Option<f64>,
+    /// ok / zero / pending / error
+    pub status: String,
+    pub fetched_at: Option<DateTime<Utc>>,
+    pub is_stale: bool,
+}
+
+/// バッチレスポンス
+#[derive(Debug, Serialize)]
+pub struct DividendPerShareBatchResponse {
+    pub items: Vec<DividendPerShareItem>,
+}
+
+/// キャッシュのTTL（日数）
+pub const CACHE_TTL_DAYS: i64 = 7;

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -14,6 +14,7 @@ pub fn app_router(state: AppState, config: &Config) -> Router {
     Router::new()
         .merge(stock_routes())
         .merge(jquants_routes())
+        .merge(dividend_per_share_routes())
         .merge(auth_routes())
         .merge(dividend_routes())
         .merge(domestic_stock_routes())
@@ -36,6 +37,13 @@ fn jquants_routes() -> Router<AppState> {
     Router::new().route(
         "/jquants/fins/statements",
         get(handlers::jquants::get_fin_summary),
+    )
+}
+
+fn dividend_per_share_routes() -> Router<AppState> {
+    Router::new().route(
+        "/dividends/per-share/batch",
+        post(handlers::dividend_per_share::batch),
     )
 }
 

--- a/backend/src/services.rs
+++ b/backend/src/services.rs
@@ -1,6 +1,7 @@
 pub mod asset_balance;
 pub mod auth;
 pub mod dividend;
+pub mod dividend_cache;
 pub mod domestic_stock;
 pub mod jquants;
 pub mod mutualfund;

--- a/backend/src/services/dividend_cache.rs
+++ b/backend/src/services/dividend_cache.rs
@@ -1,0 +1,393 @@
+use crate::errors::ApiError;
+use crate::models::dividend_cache::{
+    DividendCache, DividendPerShareItem, CACHE_TTL_DAYS,
+};
+use crate::models::jquants::FinSummaryData;
+use crate::services::jquants::JQuantsService;
+use chrono::Utc;
+use reqwest::Client;
+use sqlx::PgPool;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+use tokio::time::Duration;
+
+/// キャッシュをバッチ取得し、未取得/TTL切れ銘柄のバックグラウンド更新をキック
+pub async fn get_batch(
+    pool: &PgPool,
+    client: &Client,
+    api_key: Option<&str>,
+    codes: &[String],
+    background_task_running: &Arc<AtomicBool>,
+) -> Result<Vec<DividendPerShareItem>, ApiError> {
+    if codes.is_empty() {
+        return Ok(vec![]);
+    }
+
+    // DB からキャッシュを一括取得
+    let cached: Vec<DividendCache> = sqlx::query_as::<_, DividendCache>(
+        r#"
+        SELECT security_code, dividend_per_share, status, fetched_at, source,
+               created_at, updated_at
+        FROM jquants_dividend_cache
+        WHERE security_code = ANY($1)
+        "#,
+    )
+    .bind(codes)
+    .fetch_all(pool)
+    .await?;
+
+    let now = Utc::now();
+    let ttl_threshold =
+        now - chrono::Duration::days(CACHE_TTL_DAYS);
+
+    // コードをキーにしてキャッシュをマップ化
+    let cache_map: std::collections::HashMap<&str, &DividendCache> = cached
+        .iter()
+        .map(|c| (c.security_code.as_str(), c))
+        .collect();
+
+    // 未キャッシュ or TTL切れのコードを収集（バックグラウンド更新対象）
+    let mut refresh_codes: Vec<String> = Vec::new();
+
+    let items: Vec<DividendPerShareItem> = codes
+        .iter()
+        .map(|code| {
+            if let Some(cached_item) = cache_map.get(code.as_str()) {
+                let is_stale = cached_item
+                    .fetched_at
+                    .map(|t| t < ttl_threshold)
+                    .unwrap_or(true);
+                if is_stale && cached_item.status != "pending" {
+                    refresh_codes.push(code.clone());
+                }
+                DividendPerShareItem {
+                    security_code: code.clone(),
+                    dividend_per_share: cached_item.dividend_per_share,
+                    status: cached_item.status.clone(),
+                    fetched_at: cached_item.fetched_at,
+                    is_stale,
+                }
+            } else {
+                // 未キャッシュ → pending としてキューに積む
+                refresh_codes.push(code.clone());
+                DividendPerShareItem {
+                    security_code: code.clone(),
+                    dividend_per_share: None,
+                    status: "pending".to_string(),
+                    fetched_at: None,
+                    is_stale: false,
+                }
+            }
+        })
+        .collect();
+
+    // バックグラウンド更新をキック（多重起動防止）
+    if !refresh_codes.is_empty() {
+        if let Some(key) = api_key {
+            spawn_background_refresh(
+                pool.clone(),
+                client.clone(),
+                key.to_string(),
+                refresh_codes,
+                Arc::clone(background_task_running),
+            );
+        } else {
+            tracing::warn!("JQUANTS_API_KEY が未設定のためバックグラウンド更新をスキップ");
+        }
+    }
+
+    Ok(items)
+}
+
+/// バックグラウンドで未取得/TTL切れ銘柄を順次更新する（1分5回レート制御）
+fn spawn_background_refresh(
+    pool: PgPool,
+    client: Client,
+    api_key: String,
+    codes: Vec<String>,
+    running: Arc<AtomicBool>,
+) {
+    // 多重起動防止: false → true の比較交換に成功した場合のみ実行
+    if running
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        tracing::debug!("バックグラウンド更新タスクはすでに実行中");
+        return;
+    }
+
+    tokio::spawn(async move {
+        // タスク完了時（パニック含む）に必ずフラグをリセット
+        struct Guard(Arc<AtomicBool>);
+        impl Drop for Guard {
+            fn drop(&mut self) {
+                self.0.store(false, Ordering::SeqCst);
+            }
+        }
+        let _guard = Guard(Arc::clone(&running));
+
+        tracing::info!(
+            "配当キャッシュ バックグラウンド更新開始: {}銘柄",
+            codes.len()
+        );
+
+        for code in &codes {
+            // DBレート制御: 1分5回(12秒間隔)を全インスタンスで保証
+            match acquire_rate_slot(&pool).await {
+                Ok(()) => {}
+                Err(e) => {
+                    tracing::error!("レート制御スロット取得エラー: {}", e);
+                    break;
+                }
+            }
+
+            match fetch_and_cache(&pool, &client, &api_key, code).await {
+                Ok(status) => {
+                    tracing::info!(
+                        "配当キャッシュ更新完了: code={}, status={}",
+                        code,
+                        status
+                    );
+                }
+                Err(e) => {
+                    tracing::error!("配当キャッシュ更新エラー: code={}, err={}", code, e);
+                    // エラーをキャッシュに記録
+                    let _ = update_cache_error(&pool, code, &e.to_string()).await;
+                }
+            }
+        }
+
+        tracing::info!("配当キャッシュ バックグラウンド更新完了");
+    });
+}
+
+/// DBレート制御テーブルを使って次の実行スロットを予約し、必要なら待機する
+/// 1リクエスト = 12秒間隔（60秒 / 5回）を全インスタンスで原子的に保証
+pub async fn acquire_rate_slot(pool: &PgPool) -> Result<(), ApiError> {
+    // UPSERT でスロットを予約し、前のスロット開始時刻を返す
+    let row: (Option<chrono::DateTime<chrono::Utc>>,) = sqlx::query_as(
+        r#"
+        INSERT INTO jquants_rate_control (id, next_available_at)
+            VALUES (1, NOW() + INTERVAL '12 seconds')
+        ON CONFLICT (id) DO UPDATE
+            SET next_available_at =
+                GREATEST(jquants_rate_control.next_available_at, NOW()) + INTERVAL '12 seconds'
+        RETURNING
+            GREATEST(next_available_at - INTERVAL '12 seconds', NOW() - INTERVAL '1 second')
+        "#,
+    )
+    .fetch_one(pool)
+    .await?;
+
+    if let Some(slot_time) = row.0 {
+        let now = Utc::now();
+        if slot_time > now {
+            let wait_ms = (slot_time - now)
+                .num_milliseconds()
+                .max(0) as u64;
+            if wait_ms > 0 {
+                tracing::debug!("レート制御: {}ms 待機", wait_ms);
+                tokio::time::sleep(Duration::from_millis(wait_ms)).await;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// JQuants API から取得してキャッシュを更新する
+async fn fetch_and_cache(
+    pool: &PgPool,
+    client: &Client,
+    api_key: &str,
+    code: &str,
+) -> Result<String, ApiError> {
+    use crate::models::jquants::FinSummaryQuery;
+
+    let params = FinSummaryQuery {
+        code: code.to_string(),
+        from: None,
+        to: None,
+    };
+
+    let response = JQuantsService::get_fin_summary(client, params, api_key).await?;
+
+    let (dividend_per_share, status) = extract_dividend(&response.data);
+
+    sqlx::query(
+        r#"
+        INSERT INTO jquants_dividend_cache
+            (security_code, dividend_per_share, status, fetched_at, source, updated_at)
+        VALUES ($1, $2, $3, NOW(), 'jquants', NOW())
+        ON CONFLICT (security_code) DO UPDATE
+            SET dividend_per_share = EXCLUDED.dividend_per_share,
+                status             = EXCLUDED.status,
+                fetched_at         = EXCLUDED.fetched_at,
+                source             = EXCLUDED.source,
+                error_message      = NULL,
+                updated_at         = NOW()
+        "#,
+    )
+    .bind(code)
+    .bind(dividend_per_share)
+    .bind(&status)
+    .execute(pool)
+    .await?;
+
+    Ok(status)
+}
+
+/// エラー情報をキャッシュに記録する
+async fn update_cache_error(pool: &PgPool, code: &str, error_msg: &str) -> Result<(), ApiError> {
+    // エラーメッセージは最大 200 文字に切り捨て（機密情報混入を防ぐため短く保つ）
+    let truncated = if error_msg.len() > 200 {
+        &error_msg[..200]
+    } else {
+        error_msg
+    };
+
+    sqlx::query(
+        r#"
+        INSERT INTO jquants_dividend_cache
+            (security_code, dividend_per_share, status, error_message, source, updated_at)
+        VALUES ($1, NULL, 'error', $2, 'jquants', NOW())
+        ON CONFLICT (security_code) DO UPDATE
+            SET dividend_per_share = NULL,
+                status             = 'error',
+                error_message      = EXCLUDED.error_message,
+                updated_at         = NOW()
+        "#,
+    )
+    .bind(code)
+    .bind(truncated)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+/// 決算サマリーから1株配当を抽出する
+/// 優先順位: 来期予想(NxFDivAnn) > 今期予想(FDivAnn) > 実績(DivAnn)
+fn extract_dividend(data: &[FinSummaryData]) -> (Option<f64>, String) {
+    // 開示日で降順ソート（最新データを優先）
+    let mut sorted: Vec<&FinSummaryData> = data.iter().collect();
+    sorted.sort_by(|a, b| b.disclosed_date.cmp(&a.disclosed_date));
+
+    for summary in &sorted {
+        let raw = summary
+            .next_year_forecast_dividend_per_share_annual
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .or_else(|| {
+                summary
+                    .forecast_dividend_per_share_annual
+                    .as_deref()
+                    .filter(|s| !s.is_empty())
+            })
+            .or_else(|| {
+                summary
+                    .result_dividend_per_share_annual
+                    .as_deref()
+                    .filter(|s| !s.is_empty())
+            });
+
+        if let Some(val_str) = raw {
+            if let Ok(val) = val_str.parse::<f64>() {
+                let status = if val > 0.0 { "ok" } else { "zero" };
+                return (Some(val), status.to_string());
+            }
+        }
+    }
+
+    // 配当情報が見つからない → ゼロ配当として扱う
+    (Some(0.0), "zero".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::jquants::FinSummaryData;
+
+    fn make_summary(
+        disc_date: &str,
+        nx_div: Option<&str>,
+        f_div: Option<&str>,
+        div: Option<&str>,
+    ) -> FinSummaryData {
+        // FinSummaryData のデフォルト値を生成するためにデシリアライズを利用
+        let json = serde_json::json!({
+            "DiscDate": disc_date,
+            "Code": "1234",
+            "DocType": "test",
+            "NxFDivAnn": nx_div,
+            "FDivAnn": f_div,
+            "DivAnn": div,
+        });
+        serde_json::from_value(json).expect("FinSummaryData のパースに失敗")
+    }
+
+    #[test]
+    fn test_extract_dividend_ok() {
+        let data = vec![make_summary("2024-01-01", Some("100.0"), None, None)];
+        let (val, status) = extract_dividend(&data);
+        assert_eq!(val, Some(100.0));
+        assert_eq!(status, "ok");
+    }
+
+    #[test]
+    fn test_extract_dividend_zero() {
+        let data = vec![make_summary("2024-01-01", Some("0.0"), None, None)];
+        let (val, status) = extract_dividend(&data);
+        assert_eq!(val, Some(0.0));
+        assert_eq!(status, "zero");
+    }
+
+    #[test]
+    fn test_extract_dividend_priority_nx_over_f() {
+        // NxFDivAnn が優先
+        let data = vec![make_summary(
+            "2024-01-01",
+            Some("200.0"),
+            Some("100.0"),
+            Some("50.0"),
+        )];
+        let (val, status) = extract_dividend(&data);
+        assert_eq!(val, Some(200.0));
+        assert_eq!(status, "ok");
+    }
+
+    #[test]
+    fn test_extract_dividend_falls_back_to_result() {
+        // NxFDivAnn, FDivAnn が None → DivAnn を使用
+        let data = vec![make_summary("2024-01-01", None, None, Some("75.0"))];
+        let (val, status) = extract_dividend(&data);
+        assert_eq!(val, Some(75.0));
+        assert_eq!(status, "ok");
+    }
+
+    #[test]
+    fn test_extract_dividend_empty_data() {
+        // データなし → ゼロ配当
+        let (val, status) = extract_dividend(&[]);
+        assert_eq!(val, Some(0.0));
+        assert_eq!(status, "zero");
+    }
+
+    #[test]
+    fn test_extract_dividend_newest_first() {
+        // 開示日が新しいほうを優先
+        let data = vec![
+            make_summary("2023-01-01", None, None, Some("30.0")),
+            make_summary("2024-01-01", None, None, Some("60.0")),
+        ];
+        let (val, _) = extract_dividend(&data);
+        assert_eq!(val, Some(60.0));
+    }
+
+    #[test]
+    fn test_cache_ttl_constant() {
+        assert_eq!(CACHE_TTL_DAYS, 7);
+    }
+}

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -1,6 +1,9 @@
 use reqwest::Client;
 use sqlx::PgPool;
-use std::sync::Arc;
+use std::sync::{
+    atomic::AtomicBool,
+    Arc,
+};
 
 /// 環境変数から取得するシークレット情報
 #[derive(Clone, Debug)]
@@ -32,6 +35,8 @@ pub struct AppState {
     pub pool: PgPool,
     pub secrets: Arc<Secrets>,
     pub client: Client,
+    /// 配当キャッシュのバックグラウンド更新タスクが実行中かどうか（多重起動防止）
+    pub background_task_running: Arc<AtomicBool>,
 }
 
 #[cfg(test)]
@@ -65,6 +70,7 @@ mod tests {
             pool: pool.clone(),
             secrets: secrets.clone(),
             client: client.clone(),
+            background_task_running: Arc::new(AtomicBool::new(false)),
         };
 
         // AppStateが正常に作成されることを確認
@@ -94,6 +100,7 @@ mod tests {
             pool,
             secrets,
             client,
+            background_task_running: Arc::new(AtomicBool::new(false)),
         };
 
         let cloned_state = original_state.clone();

--- a/backend/tests/db_integration.rs
+++ b/backend/tests/db_integration.rs
@@ -111,6 +111,7 @@ async fn db_integration_with_docker_and_migrations() {
         pool,
         secrets,
         client,
+        background_task_running: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
 
     let config = Config::from_env();

--- a/frontend/src/components/molecules/PortfolioPieChart/PortfolioPieChart.tsx
+++ b/frontend/src/components/molecules/PortfolioPieChart/PortfolioPieChart.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { SecurityCodeLink } from '@/components/atoms/SecurityCodeLink';
 import { formatCurrency, formatNumber, formatPercentageValue } from '@/lib/utils/formatters';
+import { DividendStatus } from '@/features/jquants/api/dividendPerShareApi';
 
 // 横棒グラフ用の配色（視認性を考慮した10色）
 const COLORS = [
@@ -34,6 +35,7 @@ interface PortfolioPieChartProps {
   data: PortfolioItem[];
   className?: string;
   dividendPerShareMap?: Map<string, number>; // 銘柄別1株配当（J-Quants予想）
+  dividendStatusMap?: Map<string, DividendStatus>; // 銘柄別取得ステータス
 }
 
 /**
@@ -43,6 +45,7 @@ export const PortfolioPieChart: React.FC<PortfolioPieChartProps> = ({
   data,
   className = '',
   dividendPerShareMap,
+  dividendStatusMap,
 }) => {
   const [showAll, setShowAll] = useState(false);
 
@@ -82,11 +85,41 @@ export const PortfolioPieChart: React.FC<PortfolioPieChartProps> = ({
   // 銘柄別の配当情報を計算
   const getDividendInfo = (securityCode: string, shares: number, averagePrice: number) => {
     if (!dividendPerShareMap) return null;
+    const status = dividendStatusMap?.get(securityCode);
     const perShare = dividendPerShareMap.get(securityCode);
-    if (perShare === undefined) return { perShare: null, annual: null, yieldValue: null };
+
+    if (status === 'pending') return { perShare: null, annual: null, yieldValue: null, status };
+    if (status === 'error') return { perShare: null, annual: null, yieldValue: null, status };
+    if (status === 'zero') return { perShare: 0, annual: 0, yieldValue: null, status };
+    if (perShare === undefined) return { perShare: null, annual: null, yieldValue: null, status };
+
     const annual = perShare * shares;
     const yieldValue = averagePrice > 0 ? (perShare / averagePrice) * 100 : null;
-    return { perShare, annual, yieldValue };
+    return { perShare, annual, yieldValue, status };
+  };
+
+  const formatPerShare = (divInfo: ReturnType<typeof getDividendInfo>) => {
+    if (!divInfo) return '---';
+    if (divInfo.status === 'pending') return '取得中...';
+    if (divInfo.status === 'error') return '取得失敗';
+    if (divInfo.perShare === null) return '---';
+    return formatCurrency(divInfo.perShare);
+  };
+
+  const formatAnnual = (divInfo: ReturnType<typeof getDividendInfo>) => {
+    if (!divInfo) return '---';
+    if (divInfo.status === 'pending') return '取得中...';
+    if (divInfo.status === 'error') return '取得失敗';
+    if (divInfo.annual === null) return '---';
+    return formatCurrency(divInfo.annual);
+  };
+
+  const formatYield = (divInfo: ReturnType<typeof getDividendInfo>) => {
+    if (!divInfo) return '---';
+    if (divInfo.status === 'pending') return '取得中...';
+    if (divInfo.status === 'error') return '取得失敗';
+    if (divInfo.yieldValue === null) return '---';
+    return formatPercentageValue(divInfo.yieldValue);
   };
 
   return (
@@ -145,26 +178,20 @@ export const PortfolioPieChart: React.FC<PortfolioPieChartProps> = ({
                 </div>
                 <div className="flex items-center gap-1">
                   <span className="text-slate-500">1株配当:</span>
-                  <span className={`font-medium ${divInfo?.perShare !== null && divInfo?.perShare !== undefined ? 'text-emerald-600' : ''}`}>
-                    {divInfo?.perShare !== null && divInfo?.perShare !== undefined
-                      ? formatCurrency(divInfo.perShare)
-                      : '---'}
+                  <span className={`font-medium ${divInfo?.perShare !== null && divInfo?.perShare !== undefined ? 'text-emerald-600' : 'text-slate-500'}`}>
+                    {formatPerShare(divInfo)}
                   </span>
                 </div>
                 <div className="flex items-center gap-1">
                   <span className="text-slate-500">年間配当:</span>
-                  <span className={`font-medium ${divInfo?.annual !== null && divInfo?.annual !== undefined ? 'text-emerald-600' : ''}`}>
-                    {divInfo?.annual !== null && divInfo?.annual !== undefined
-                      ? formatCurrency(divInfo.annual)
-                      : '---'}
+                  <span className={`font-medium ${divInfo?.annual !== null && divInfo?.annual !== undefined ? 'text-emerald-600' : 'text-slate-500'}`}>
+                    {formatAnnual(divInfo)}
                   </span>
                 </div>
                 <div className="flex items-center gap-1">
                   <span className="text-slate-500">配当利回り:</span>
-                  <span className={`font-medium ${divInfo?.yieldValue !== null && divInfo?.yieldValue !== undefined ? 'text-emerald-600' : ''}`}>
-                    {divInfo?.yieldValue !== null && divInfo?.yieldValue !== undefined
-                      ? formatPercentageValue(divInfo.yieldValue)
-                      : '---'}
+                  <span className={`font-medium ${divInfo?.yieldValue !== null && divInfo?.yieldValue !== undefined ? 'text-emerald-600' : 'text-slate-500'}`}>
+                    {formatYield(divInfo)}
                   </span>
                 </div>
               </div>

--- a/frontend/src/components/molecules/PortfolioPieChart/__tests__/PortfolioPieChart.test.tsx
+++ b/frontend/src/components/molecules/PortfolioPieChart/__tests__/PortfolioPieChart.test.tsx
@@ -93,6 +93,33 @@ describe('PortfolioPieChart', () => {
       expect(dashes.length).toBeGreaterThanOrEqual(2);
     });
 
+    it('pending ステータスの銘柄は "取得中..." が表示される', () => {
+      const dividendMap = new Map<string, number>();
+      const statusMap = new Map([['7203', 'pending' as const]]);
+      render(<PortfolioPieChart data={mockData} dividendPerShareMap={dividendMap} dividendStatusMap={statusMap} />);
+
+      expect(screen.getAllByText('取得中...')).not.toHaveLength(0);
+    });
+
+    it('error ステータスの銘柄は "取得失敗" が表示される', () => {
+      const dividendMap = new Map<string, number>();
+      const statusMap = new Map([['7203', 'error' as const]]);
+      render(<PortfolioPieChart data={mockData} dividendPerShareMap={dividendMap} dividendStatusMap={statusMap} />);
+
+      expect(screen.getAllByText('取得失敗')).not.toHaveLength(0);
+    });
+
+    it('zero ステータスの銘柄は 0円 が表示される（error と区別）', () => {
+      const dividendMap = new Map<string, number>();
+      const statusMap = new Map([['7203', 'zero' as const], ['6758', 'error' as const]]);
+      render(<PortfolioPieChart data={mockData} dividendPerShareMap={dividendMap} dividendStatusMap={statusMap} />);
+
+      // zero: 0円表示（formatCurrency(0) = "¥ 0"）
+      expect(screen.getAllByText(/¥\s*0/).length).toBeGreaterThanOrEqual(1);
+      // error: 取得失敗表示
+      expect(screen.getAllByText('取得失敗').length).toBeGreaterThanOrEqual(1);
+    });
+
     it('dividendPerShareMapが未指定の場合は全銘柄---表示', () => {
       render(<PortfolioPieChart data={mockData} />);
 

--- a/frontend/src/components/organisms/AssetPortfolioSummary/AssetPortfolioSummary.tsx
+++ b/frontend/src/components/organisms/AssetPortfolioSummary/AssetPortfolioSummary.tsx
@@ -4,6 +4,7 @@ import { EmptyState } from '@/components/atoms/EmptyState';
 import { PortfolioPieChart, PortfolioItem } from '@/components/molecules/PortfolioPieChart';
 import { AssetBalanceData } from '@/lib/interfaces/assetBalance';
 import { formatCurrency, formatPercentageValue, safeAdd } from '@/lib/utils/formatters';
+import { DividendStatus } from '@/features/jquants/api/dividendPerShareApi';
 
 interface AssetPortfolioSummaryProps {
   assetBalanceData: AssetBalanceData[];
@@ -11,6 +12,7 @@ interface AssetPortfolioSummaryProps {
   isFiltered?: boolean; // 絞り込み中かどうか
   onClearFilter?: () => void; // 絞り込み解除
   dividendPerShareMap?: Map<string, number>; // 銘柄別1株配当（J-Quants予想）
+  dividendStatusMap?: Map<string, DividendStatus>; // 銘柄別取得ステータス
 }
 
 /**
@@ -23,6 +25,7 @@ export const AssetPortfolioSummary: React.FC<AssetPortfolioSummaryProps> = ({
   isFiltered = false,
   onClearFilter,
   dividendPerShareMap,
+  dividendStatusMap,
 }) => {
   // 合計取得総額を計算（null/undefinedは0として扱う）
   const totalPurchaseAmount = useMemo(() => {
@@ -146,7 +149,7 @@ export const AssetPortfolioSummary: React.FC<AssetPortfolioSummaryProps> = ({
           </div>
           {/* 銘柄別構成比 */}
           <h3 className="mb-3 text-sm font-semibold text-slate-700">銘柄別構成比</h3>
-          <PortfolioPieChart data={chartData} dividendPerShareMap={dividendPerShareMap} />
+          <PortfolioPieChart data={chartData} dividendPerShareMap={dividendPerShareMap} dividendStatusMap={dividendStatusMap} />
         </CardBody>
       </Card>
     </div>

--- a/frontend/src/components/organisms/AssetPortfolioSummary/__tests__/AssetPortfolioSummary.test.tsx
+++ b/frontend/src/components/organisms/AssetPortfolioSummary/__tests__/AssetPortfolioSummary.test.tsx
@@ -160,5 +160,14 @@ describe('AssetPortfolioSummary', () => {
 
       expect(screen.getByTestId('portfolio-dividend-yield')).toHaveTextContent('---');
     });
+
+    it('dividendStatusMap を渡すと pending 銘柄で取得中...が表示される', () => {
+      const mockData = createMockData();
+      const dividendMap = new Map<string, number>();
+      const statusMap = new Map([['7203', 'pending' as const]]);
+      render(<AssetPortfolioSummary assetBalanceData={mockData} dividendPerShareMap={dividendMap} dividendStatusMap={statusMap} />);
+
+      expect(screen.getAllByText('取得中...')).not.toHaveLength(0);
+    });
   });
 });

--- a/frontend/src/features/jquants/api/dividendPerShareApi.ts
+++ b/frontend/src/features/jquants/api/dividendPerShareApi.ts
@@ -1,0 +1,25 @@
+import { apiClient } from '@/lib/api/client';
+
+export type DividendStatus = 'ok' | 'zero' | 'pending' | 'error';
+
+export interface DividendPerShareItem {
+  security_code: string;
+  dividend_per_share: number | null;
+  status: DividendStatus;
+  fetched_at: string | null;
+  is_stale: boolean;
+}
+
+interface BatchResponse {
+  items: DividendPerShareItem[];
+}
+
+export async function fetchDividendPerShareBatch(
+  securityCodes: string[]
+): Promise<DividendPerShareItem[]> {
+  const response = await apiClient.post<BatchResponse>(
+    '/dividends/per-share/batch',
+    { security_codes: securityCodes }
+  );
+  return response.items;
+}

--- a/frontend/src/features/jquants/hooks/__tests__/useDividendBatch.test.ts
+++ b/frontend/src/features/jquants/hooks/__tests__/useDividendBatch.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useDividendBatch } from '../useDividendBatch';
+import * as api from '../../api/dividendPerShareApi';
+import { DividendPerShareItem } from '../../api/dividendPerShareApi';
+
+vi.mock('../../api/dividendPerShareApi', () => ({
+  fetchDividendPerShareBatch: vi.fn(),
+}));
+
+const mockFetch = api.fetchDividendPerShareBatch as Mock;
+
+const makeItem = (code: string, status: DividendPerShareItem['status'], div: number | null): DividendPerShareItem => ({
+  security_code: code,
+  dividend_per_share: div,
+  status,
+  fetched_at: status === 'ok' || status === 'zero' ? '2025-01-01T00:00:00Z' : null,
+  is_stale: false,
+});
+
+describe('useDividendBatch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('zero と error のステータスが区別され、dividendPerShareMap には含まれない', async () => {
+    mockFetch.mockResolvedValue([
+      makeItem('1234', 'zero', 0),
+      makeItem('5678', 'error', null),
+    ]);
+
+    const { result } = renderHook(() => useDividendBatch(['1234', '5678'], true));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.dividendStatusMap.get('1234')).toBe('zero');
+    expect(result.current.dividendStatusMap.get('5678')).toBe('error');
+    expect(result.current.dividendPerShareMap.has('1234')).toBe(false);
+    expect(result.current.dividendPerShareMap.has('5678')).toBe(false);
+  });
+
+  it('ok の配当は dividendPerShareMap に格納され、ok+zero が fetchedCount に加算される', async () => {
+    mockFetch.mockResolvedValue([
+      makeItem('7203', 'ok', 50),
+      makeItem('6758', 'zero', 0),
+    ]);
+
+    const { result } = renderHook(() => useDividendBatch(['7203', '6758'], true));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.dividendPerShareMap.get('7203')).toBe(50);
+    expect(result.current.dividendPerShareMap.has('6758')).toBe(false);
+    expect(result.current.fetchedCount).toBe(2);
+    expect(result.current.totalCount).toBe(2);
+  });
+
+  it('pending が残る場合は fetchedCount < totalCount になる（再試行条件）', async () => {
+    mockFetch.mockResolvedValue([
+      makeItem('1111', 'ok', 100),
+      makeItem('2222', 'pending', null),
+    ]);
+
+    const { result } = renderHook(() => useDividendBatch(['1111', '2222'], true));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.fetchedCount).toBe(1);
+    expect(result.current.totalCount).toBe(2);
+    expect(result.current.dividendStatusMap.get('2222')).toBe('pending');
+  });
+});

--- a/frontend/src/features/jquants/hooks/useDividendBatch.ts
+++ b/frontend/src/features/jquants/hooks/useDividendBatch.ts
@@ -1,0 +1,95 @@
+import { useState, useEffect, useRef } from 'react';
+import { fetchDividendPerShareBatch, DividendStatus } from '../api/dividendPerShareApi';
+
+const MAX_RETRIES = 3;
+const RETRY_DELAY_MS = 15_000;
+
+/**
+ * バックエンド集約APIを使って複数銘柄の1株配当を取得するフック
+ * キャッシュ・レート制御はバックエンドが担う
+ */
+export const useDividendBatch = (
+  securityCodes: string[],
+  enabled: boolean = true
+) => {
+  const [dividendPerShareMap, setDividendPerShareMap] = useState<Map<string, number>>(new Map());
+  const [dividendStatusMap, setDividendStatusMap] = useState<Map<string, DividendStatus>>(new Map());
+  const [loading, setLoading] = useState<boolean>(false);
+  const [fetchedCount, setFetchedCount] = useState(0);
+  const [totalCount, setTotalCount] = useState(0);
+  const [retryCount, setRetryCount] = useState(0);
+  const retryCountRef = useRef(0);
+  const prevCodesRef = useRef<string>('');
+
+  useEffect(() => {
+    const codesKey = securityCodes.slice().sort().join(',');
+    if (!enabled || securityCodes.length === 0) {
+      setDividendPerShareMap(new Map());
+      setDividendStatusMap(new Map());
+      setFetchedCount(0);
+      setTotalCount(0);
+      prevCodesRef.current = '';
+      retryCountRef.current = 0;
+      return;
+    }
+
+    if (codesKey === prevCodesRef.current && retryCount === 0) return;
+
+    let isActive = true;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const fetchAll = async () => {
+      setLoading(true);
+      const uniqueCodes = Array.from(new Set(securityCodes));
+      setTotalCount(uniqueCodes.length);
+
+      const items = await fetchDividendPerShareBatch(uniqueCodes);
+
+      const perShareMap = new Map<string, number>();
+      const statusMap = new Map<string, DividendStatus>();
+      let confirmed = 0;
+
+      for (const item of items) {
+        statusMap.set(item.security_code, item.status);
+        if (item.status === 'ok' && item.dividend_per_share !== null && item.dividend_per_share > 0) {
+          perShareMap.set(item.security_code, item.dividend_per_share);
+        }
+        if (item.status === 'ok' || item.status === 'zero') {
+          confirmed++;
+        }
+      }
+
+      const hasPending = items.some(item => item.status === 'pending' || item.status === 'error');
+
+      if (isActive) {
+        setDividendPerShareMap(perShareMap);
+        setDividendStatusMap(statusMap);
+        setFetchedCount(confirmed);
+        prevCodesRef.current = codesKey;
+        setLoading(false);
+
+        if (hasPending && retryCountRef.current < MAX_RETRIES) {
+          retryCountRef.current += 1;
+          prevCodesRef.current = '';
+          retryTimer = setTimeout(() => {
+            if (isActive) setRetryCount(c => c + 1);
+          }, RETRY_DELAY_MS);
+        }
+      }
+    };
+
+    fetchAll().catch(() => {
+      if (isActive) {
+        setLoading(false);
+        prevCodesRef.current = codesKey;
+      }
+    });
+
+    return () => {
+      isActive = false;
+      if (retryTimer !== null) clearTimeout(retryTimer);
+    };
+  }, [securityCodes, enabled, retryCount]);
+
+  return { dividendPerShareMap, dividendStatusMap, loading, fetchedCount, totalCount };
+};

--- a/frontend/src/features/jquants/hooks/useJQuantsDividendBatch.ts
+++ b/frontend/src/features/jquants/hooks/useJQuantsDividendBatch.ts
@@ -4,10 +4,14 @@ import { parseNumber } from '@/lib/utils/formatters';
 import { extractDividendFromSummary } from './useJQuantsDividend';
 
 const MAX_CONCURRENT_REQUESTS = 3;
+const MAX_RETRIES = 3;
+const RETRY_DELAY_MS = 60_000;
 
 /**
  * 複数銘柄の1株配当を一括取得するフック
  * J-Quants APIから最新予想配当を取得し、Map<銘柄コード, 1株配当>を返す
+ *
+ * @deprecated バックエンド集約API移行後は useDividendBatch を使用すること
  */
 export const useJQuantsDividendBatch = (
   securityCodes: string[],
@@ -15,6 +19,10 @@ export const useJQuantsDividendBatch = (
 ) => {
   const [dividendPerShareMap, setDividendPerShareMap] = useState<Map<string, number>>(new Map());
   const [loading, setLoading] = useState<boolean>(false);
+  // 再試行トリガー（失敗時にインクリメントしてuseEffectを再実行）
+  const [retryCount, setRetryCount] = useState(0);
+  // 再試行回数の上限管理
+  const retryCountRef = useRef(0);
   // 前回のコード一覧を保持（不要な再取得を防止）
   const prevCodesRef = useRef<string>('');
 
@@ -23,13 +31,36 @@ export const useJQuantsDividendBatch = (
     if (!enabled || securityCodes.length === 0) {
       setDividendPerShareMap(new Map());
       prevCodesRef.current = '';
+      retryCountRef.current = 0;
       return;
     }
 
-    // 同じコード一覧なら再取得しない
-    if (codesKey === prevCodesRef.current) return;
+    // 同じコード一覧かつ再試行でなければスキップ
+    if (codesKey === prevCodesRef.current && retryCount === 0) return;
 
     let isActive = true;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const fetchOneCode = async (code: string) => {
+      const response = await jquantsApiClient.getStatements(code);
+      if (!response?.data || !Array.isArray(response.data)) return { code, value: null };
+
+      // 開示日で降順ソート（最新データを優先）
+      const sortedData = [...response.data].sort((a, b) => {
+        const dateA = a.DiscDate || '';
+        const dateB = b.DiscDate || '';
+        return dateB.localeCompare(dateA);
+      });
+
+      // 最新の決算データから順に配当情報を検索
+      for (const summary of sortedData) {
+        const dividendValue = extractDividendFromSummary(summary);
+        if (dividendValue) {
+          return { code, value: parseNumber(dividendValue) };
+        }
+      }
+      return { code, value: null };
+    };
 
     const fetchAll = async () => {
       setLoading(true);
@@ -37,51 +68,46 @@ export const useJQuantsDividendBatch = (
       const uniqueCodes = Array.from(new Set(securityCodes));
       const results: PromiseSettledResult<{ code: string; value: number | null }>[] = [];
 
-      const fetchOneCode = async (code: string) => {
-        const response = await jquantsApiClient.getStatements(code);
-        if (!response?.data || !Array.isArray(response.data)) return { code, value: null };
-
-        // 開示日で降順ソート（最新データを優先）
-        const sortedData = [...response.data].sort((a, b) => {
-          const dateA = a.DiscDate || '';
-          const dateB = b.DiscDate || '';
-          return dateB.localeCompare(dateA);
-        });
-
-        // 最新の決算データから順に配当情報を検索
-        for (const summary of sortedData) {
-          const dividendValue = extractDividendFromSummary(summary);
-          if (dividendValue) {
-            return { code, value: parseNumber(dividendValue) };
-          }
-        }
-        return { code, value: null };
-      };
-
       for (let i = 0; i < uniqueCodes.length; i += MAX_CONCURRENT_REQUESTS) {
         const chunk = uniqueCodes.slice(i, i + MAX_CONCURRENT_REQUESTS);
         const chunkResults = await Promise.allSettled(chunk.map(fetchOneCode));
         results.push(...chunkResults);
       }
 
+      // value !== null のみ格納（0配当も含む）
       for (const result of results) {
-        if (result.status === 'fulfilled' && result.value.value !== null && result.value.value > 0) {
+        if (result.status === 'fulfilled' && result.value.value !== null) {
           map.set(result.value.code, result.value.value);
         }
       }
+
+      const hasAnyFailure = results.some(
+        r => r.status === 'rejected' ||
+          (r.status === 'fulfilled' && r.value.value === null)
+      );
 
       if (isActive) {
         setDividendPerShareMap(map);
         prevCodesRef.current = codesKey;
         setLoading(false);
+
+        // 失敗があれば一定時間後に再試行（上限あり）
+        if (hasAnyFailure && retryCountRef.current < MAX_RETRIES) {
+          retryCountRef.current += 1;
+          prevCodesRef.current = ''; // 次回 useEffect で再実行されるよう初期化
+          retryTimer = setTimeout(() => {
+            if (isActive) setRetryCount(c => c + 1);
+          }, RETRY_DELAY_MS);
+        }
       }
     };
 
     fetchAll();
     return () => {
       isActive = false;
+      if (retryTimer !== null) clearTimeout(retryTimer);
     };
-  }, [securityCodes, enabled]);
+  }, [securityCodes, enabled, retryCount]);
 
   return { dividendPerShareMap, loading };
 };

--- a/frontend/src/pages/AssetBalance.tsx
+++ b/frontend/src/pages/AssetBalance.tsx
@@ -11,7 +11,8 @@ import { AssetBalanceData } from '@/lib/interfaces/assetBalance';
 import { parseNumber } from '@/lib/utils/formatters';
 import { useReceiptData } from '@/hooks/receipt/useReceiptData';
 import { assetBalanceApi } from '@/features/receipt/api/receiptApi';
-import { useJQuantsDividendBatch } from '@/features/jquants/hooks/useJQuantsDividendBatch';
+import { useDividendBatch } from '@/features/jquants/hooks/useDividendBatch';
+import { DividendStatus } from '@/features/jquants/api/dividendPerShareApi';
 import { useReceiptDataSource } from '@/hooks/common/useReceiptDataSource';
 import { createSearchOptions } from '@/lib/utils/dataTransformer';
 import { filterByConfig, FilterConfig } from '@/lib/utils/searchUtils';
@@ -51,6 +52,7 @@ interface AssetBalanceInfoProps {
   searchQuery: string;
   onClearFilter: () => void;
   dividendPerShareMap: Map<string, number>;
+  dividendStatusMap?: Map<string, DividendStatus>;
 }
 
 /**
@@ -62,6 +64,7 @@ export const AssetBalanceInfo: React.FC<AssetBalanceInfoProps> = ({
   searchQuery,
   onClearFilter,
   dividendPerShareMap,
+  dividendStatusMap,
 }) => {
   const isFiltered = searchQuery !== '';
 
@@ -73,6 +76,7 @@ export const AssetBalanceInfo: React.FC<AssetBalanceInfoProps> = ({
         isFiltered={isFiltered}
         onClearFilter={isFiltered ? onClearFilter : undefined}
         dividendPerShareMap={dividendPerShareMap}
+        dividendStatusMap={dividendStatusMap}
       />
     </Suspense>
   );
@@ -130,7 +134,7 @@ export function AssetBalancePage() {
     () => assetBalanceData.map(item => item.security_code),
     [assetBalanceData]
   );
-  const { dividendPerShareMap } = useJQuantsDividendBatch(securityCodes, isAuthenticated);
+  const { dividendPerShareMap, dividendStatusMap, fetchedCount, totalCount: dividendTotalCount } = useDividendBatch(securityCodes, isAuthenticated);
 
   // 検索オプションの生成
   const searchCategories = useMemo(() => ({
@@ -259,6 +263,13 @@ export function AssetBalancePage() {
               />
             )}
 
+            {/* 配当取得進捗バッジ */}
+            {dividendTotalCount > 0 && fetchedCount < dividendTotalCount && (
+              <div className="mb-2 text-xs text-slate-500" role="status" aria-live="polite">
+                配当情報 {fetchedCount}/{dividendTotalCount} 件 取得済み（取得中...）
+              </div>
+            )}
+
             {/* ローディング完了後に表示（空データでもEmptyStateを表示） */}
             {!loading && !csvReader.isLoading && (
               <AssetBalanceInfo
@@ -267,6 +278,7 @@ export function AssetBalancePage() {
                 searchQuery={searchQuery}
                 onClearFilter={handleClearFilter}
                 dividendPerShareMap={dividendPerShareMap}
+                dividendStatusMap={dividendStatusMap}
               />
             )}
 


### PR DESCRIPTION
## 概要
J-Quants のレート制限（1分5回）で保有銘柄の1株配当が欠損する問題を解消するため、バックエンド集約API + キャッシュ + レート制御を追加し、フロント表示を新APIに切り替えました。

## 変更種別
- [x] 新機能
- [x] バグ修正
- [ ] リファクタリング

## 主な変更内容
- DBマイグレーション追加（配当キャッシュ / レート制御テーブル）
- バックエンドに配当キャッシュサービスと `POST /dividends/per-share/batch` を追加
- フロントを `useDividendBatch` + `dividendPerShareApi` に切り替え
- `pending / error / zero` を UI で区別表示し、取得進捗 (`x/y`) を表示
- 既存 `useJQuantsDividendBatch` の429/失敗時再試行およびゼロ配当の区別修正

## コミット
- `fix: useJQuantsDividendBatch の429/失敗時再試行とゼロ配当区別を修正`
- `feat: JQuantsキャッシュ・レート制御テーブルのマイグレーションを追加`
- `feat: 配当キャッシュ+レート制御のBEサービス層を追加`
- `feat: POST /dividends/per-share/batch エンドポイントを追加`
- `feat: connect asset balance to dividend batch api`

## テスト
- [x] `cd backend && cargo test`
- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npm run test -- src/features/jquants/hooks/__tests__/useDividendBatch.test.ts src/components/molecules/PortfolioPieChart/__tests__/PortfolioPieChart.test.tsx src/components/organisms/AssetPortfolioSummary/__tests__/AssetPortfolioSummary.test.tsx --run`
- [x] `cd frontend && npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)