### PR TITLE
Use cached dividend batch API in dividend search flow

### DIFF
--- a/frontend/src/components/molecules/DividendInfo/DividendInfo.tsx
+++ b/frontend/src/components/molecules/DividendInfo/DividendInfo.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { NumberInputField } from '@/components/atoms/NumberInputField';
 import { StatItem, StatItemWithRate } from '@/components/atoms/StatItem';
 import { formatCurrency, parseNumber, normalizeSecurityCode, SECURITY_CODE_REGEX } from '@/lib/utils/formatters';
-import { useJQuantsDividend } from '@/features/jquants/hooks/useJQuantsDividend';
+import { useDividendBatch } from '@/features/jquants/hooks/useDividendBatch';
 import { useAssetBalance } from '@/hooks/common/useAssetBalance';
 import { SummaryResult } from '@/lib/utils/dataTransformer';
 import { DividendData } from '@/lib/interfaces/dividend';
@@ -49,11 +49,13 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({
   // 保有銘柄データを取得（銘柄コード形式の場合のみフェッチ）
   const { assetBalanceData: assetBalances, getAssetBalanceByCode } = useAssetBalance({ enabled: isValidSecurityCode });
 
-  // J-Quants APIから配当情報を取得（銘柄コード形式の場合のみ）
-  const {
-    dividendPerShare: apiDividendPerShare,
-    loading: apiLoading,
-  } = useJQuantsDividend(effectiveSecurityCode, isValidSecurityCode);
+  // バックエンドキャッシュ経由で配当情報を取得（銘柄コード形式の場合のみ）
+  const dividendBatchCodes = React.useMemo(
+    () => (isValidSecurityCode ? [effectiveSecurityCode] : []),
+    [effectiveSecurityCode, isValidSecurityCode]
+  );
+  const { dividendPerShareMap, loading: apiLoading } = useDividendBatch(dividendBatchCodes, isValidSecurityCode);
+  const apiDividendPerShare = dividendPerShareMap.get(effectiveSecurityCode);
 
   // searchQueryが変更されたときにstateを初期化し、保有銘柄データがあれば自動入力
   React.useEffect(() => {

--- a/frontend/src/pages/Receipt/__tests__/Dividend.test.tsx
+++ b/frontend/src/pages/Receipt/__tests__/Dividend.test.tsx
@@ -23,12 +23,14 @@ vi.mock('@tanstack/react-query', () => ({
   }),
 }));
 
-// J-Quants APIフックのモック
-vi.mock('@/features/jquants/hooks/useJQuantsDividend', () => ({
-  useJQuantsDividend: vi.fn(() => ({
-    dividendPerShare: undefined,
+// J-Quants バッチ配当フックのモック
+vi.mock('@/features/jquants/hooks/useDividendBatch', () => ({
+  useDividendBatch: vi.fn(() => ({
+    dividendPerShareMap: new Map(),
+    dividendStatusMap: new Map(),
     loading: false,
-    error: null,
+    fetchedCount: 0,
+    totalCount: 0,
   })),
 }));
 


### PR DESCRIPTION
## 概要
配当金検索の `DividendInfo` が旧 `useJQuantsDividend` を直接利用していたため、`useDividendBatch` 経由（`/dividends/per-share/batch`）に統一しました。

## 変更種別
- [ ] 新機能
- [x] バグ修正
- [ ] リファクタリング

## 主な変更内容
- `DividendInfo` の配当取得フックを `useJQuantsDividend` から `useDividendBatch` に変更
- 1銘柄検索時もバッチAPI契約を使うように単一コード配列で取得
- `Dividend` ページテストのフックモックを新契約に合わせて更新

## テスト
- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npm run test -- src/pages/Receipt/__tests__/Dividend.test.tsx --run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)