### PR TITLE
Improve table readability and homepage navigation UI

### DIFF
--- a/frontend/src/components/atoms/Table.tsx
+++ b/frontend/src/components/atoms/Table.tsx
@@ -80,10 +80,10 @@ const Table = forwardRef<HTMLTableElement, TableProps>(
     // CSSクラスの構築（モバイル対応: パディング縮小、フォント調整）
     const tableClasses = cn(
       'w-full text-left border-collapse',
-      small ? 'text-xs sm:text-sm' : 'text-sm sm:text-base',
+      small ? 'text-sm' : 'text-sm sm:text-base',
       bordered && '[&_th]:border [&_th]:border-slate-200 [&_td]:border [&_td]:border-slate-200 print:[&_th]:border-black print:[&_td]:border-black',
       small
-        ? '[&_th]:py-1.5 [&_th]:px-2 [&_td]:py-1.5 [&_td]:px-2 sm:[&_th]:py-2.5 sm:[&_th]:px-3 sm:[&_td]:py-2.5 sm:[&_td]:px-3'
+        ? '[&_th]:py-2 [&_th]:px-2 [&_td]:py-2 [&_td]:px-2 sm:[&_th]:py-2.5 sm:[&_th]:px-3 sm:[&_td]:py-2.5 sm:[&_td]:px-3'
         : '[&_th]:py-2 [&_th]:px-2 [&_td]:py-2 [&_td]:px-2 sm:[&_th]:py-3 sm:[&_th]:px-4 sm:[&_td]:py-3 sm:[&_td]:px-4',
       variant && variantBgColors[variant],
       striped && '[&_tbody_tr:nth-child(even)]:bg-slate-50',

--- a/frontend/src/components/atoms/__tests__/Table.test.tsx
+++ b/frontend/src/components/atoms/__tests__/Table.test.tsx
@@ -111,7 +111,7 @@ describe('Table', () => {
     );
 
     const table = screen.getByRole('table');
-    expect(table).toHaveClass('text-xs');
+    expect(table).toHaveClass('text-sm');
   });
 
   test('responsiveプロパティが正しく適用される', () => {

--- a/frontend/src/components/molecules/StockInfoLinks.tsx
+++ b/frontend/src/components/molecules/StockInfoLinks.tsx
@@ -1,4 +1,3 @@
-import { Fragment } from 'react';
 
 interface StockInfoLinkObject {
   name: string;
@@ -26,19 +25,20 @@ export const StockInfoLinks = ({ code }: StockInfoLinksProps) => {
   if (!code) return null;
 
   return (
-    <div className="flex flex-wrap items-center text-sm">
-      {STOCK_INFO_LINKS_OBJECTS.map((item, index) => (
-        <Fragment key={item.name}>
-          <a
-            className="font-semibold text-primary hover:underline"
-            href={item.url.replace('{}', code)}
-            target='_blank'
-            rel="noopener noreferrer"
-          >
-            {item.name}
-          </a>
-          {index < STOCK_INFO_LINKS_OBJECTS.length - 1 && (<span className="mx-2">|</span>)}
-        </Fragment>
+    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-2">
+      {STOCK_INFO_LINKS_OBJECTS.map((item) => (
+        <a
+          key={item.name}
+          className="inline-flex items-center justify-between gap-1 rounded-md border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-primary hover:bg-slate-50 hover:border-primary transition-colors"
+          href={item.url.replace('{}', code)}
+          target='_blank'
+          rel="noopener noreferrer"
+        >
+          {item.name}
+          <svg className="h-3.5 w-3.5 shrink-0 text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+          </svg>
+        </a>
       ))}
     </div>
   );

--- a/frontend/src/components/organisms/AssetPortfolioSummary/AssetPortfolioSummary.tsx
+++ b/frontend/src/components/organisms/AssetPortfolioSummary/AssetPortfolioSummary.tsx
@@ -120,31 +120,35 @@ export const AssetPortfolioSummary: React.FC<AssetPortfolioSummaryProps> = ({
               </div>
             )}
             {/* KPI行 */}
-            <div className="flex items-end gap-6">
-              <div>
-                <p className="text-sm text-slate-500">合計取得総額</p>
-                <p className="text-3xl font-bold text-primary" data-negative={totalPurchaseAmount < 0 ? 'true' : undefined}>
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+              <div className="rounded-lg bg-slate-50 px-4 py-3">
+                <p className="text-xs text-slate-500 mb-1">合計取得総額</p>
+                <p className="text-2xl font-bold text-primary tabular-nums" data-negative={totalPurchaseAmount < 0 ? 'true' : undefined}>
                   {formatCurrency(totalPurchaseAmount)}
                 </p>
               </div>
-              <div>
-                <p className="text-sm text-slate-500">年間配当金額</p>
-                <p className="text-3xl font-bold text-emerald-600" data-testid="portfolio-annual-dividends">
+              <div className="rounded-lg bg-emerald-50 px-4 py-3">
+                <p className="text-xs text-slate-500 mb-1">年間配当金額</p>
+                <p className="text-2xl font-bold text-emerald-600 tabular-nums" data-testid="portfolio-annual-dividends">
                   {totalAnnualDividends !== null ? formatCurrency(totalAnnualDividends) : '---'}
                 </p>
               </div>
-              <div>
-                <p className="text-sm text-slate-500">配当利回り</p>
-                <p className="text-3xl font-bold text-emerald-600" data-testid="portfolio-dividend-yield">
+              <div className="rounded-lg bg-emerald-50 px-4 py-3">
+                <p className="text-xs text-slate-500 mb-1">配当利回り</p>
+                <p className="text-2xl font-bold text-emerald-600 tabular-nums" data-testid="portfolio-dividend-yield">
                   {portfolioDividendYield !== null ? formatPercentageValue(portfolioDividendYield) : '---'}
                 </p>
               </div>
-              <p className="pb-1 text-sm text-slate-500">
-                {isFiltered
-                  ? `${displayCount}銘柄（全${actualTotalCount}銘柄中）`
-                  : `${displayCount}銘柄を保有`
-                }
-              </p>
+              <div className="rounded-lg bg-slate-50 px-4 py-3">
+                <p className="text-xs text-slate-500 mb-1">保有銘柄数</p>
+                <p className="text-2xl font-bold text-slate-700 tabular-nums">
+                  {isFiltered
+                    ? `${displayCount} / ${actualTotalCount}`
+                    : `${displayCount}`
+                  }
+                  <span className="text-sm font-normal text-slate-500 ml-1">銘柄</span>
+                </p>
+              </div>
             </div>
           </div>
           {/* 銘柄別構成比 */}

--- a/frontend/src/components/organisms/ReceiptTable/ReceiptTable.tsx
+++ b/frontend/src/components/organisms/ReceiptTable/ReceiptTable.tsx
@@ -96,6 +96,7 @@ export function ReceiptTable<T extends DataItem, S extends SummaryItem>({
         const cellStyle: React.CSSProperties = {
             minWidth: 'width' in column ? column.width : undefined,
             textAlign: column.textAlign,
+            fontVariantNumeric: column.textAlign === 'right' ? 'tabular-nums' : undefined,
             ...style
         };
 

--- a/frontend/src/components/organisms/SearchCard/SearchCard.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchCard.tsx
@@ -180,7 +180,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                         </span>
                     )}
                 </div>
-                <div className="flex items-center gap-3">
+                <div className="flex items-center gap-6">
                     {/* 条件クリアボタン（ヘッダー内・常にレンダリングし高さを固定） */}
                     <Button
                         type="button"

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -14,6 +14,7 @@ const FEATURES = [
   {
     title: '銘柄検索',
     description: '日本の株式銘柄情報を検索できます。',
+    detail: '銘柄コード・会社名で検索し、各証券サイトへのリンクを一覧表示。',
     to: '/search',
     icon: (
       <svg className="h-6 w-6 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true" focusable="false">
@@ -24,6 +25,7 @@ const FEATURES = [
   {
     title: '資産管理',
     description: '保有している銘柄の一覧と評価額を確認できます。',
+    detail: 'CSVをインポートして取得単価・時価・配当利回りをまとめて管理。',
     to: '/assetbalance',
     icon: (
       <svg className="h-6 w-6 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true" focusable="false">
@@ -34,6 +36,7 @@ const FEATURES = [
   {
     title: '取引明細',
     description: '配当金や分配金の記録を管理できます。',
+    detail: '配当金・国内株式・投資信託の取引履歴を年別・銘柄別で絞り込み確認。',
     to: '/receipts',
     icon: (
       <svg className="h-6 w-6 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true" focusable="false">
@@ -53,17 +56,21 @@ export function HomePage() {
         />
 
         <div className="grid gap-4 md:grid-cols-3">
-          {FEATURES.map(({ title, description, to, icon }) => (
+          {FEATURES.map(({ title, description, detail, to, icon }) => (
             <Link key={to} to={to} className="block group">
               <Card className="h-full transition-shadow hover:shadow-md">
-                <CardBody className="space-y-2 p-3">
+                <CardBody className="space-y-3 p-4">
                   <div className="flex items-center gap-2">
                     {icon}
                     <h3 className="text-base font-semibold text-slate-900 group-hover:text-primary transition-colors">
                       {title}
                     </h3>
                   </div>
-                  <p className="text-sm text-slate-600">{description}</p>
+                  <p className="text-sm text-slate-700 font-medium">{description}</p>
+                  <p className="text-xs text-slate-500">{detail}</p>
+                  <div className="pt-1 text-xs text-primary font-medium group-hover:underline">
+                    開く →
+                  </div>
                 </CardBody>
               </Card>
             </Link>


### PR DESCRIPTION
## 概要
UIレビュー観点の改善として、数値可読性と画面導線を中心にフロントエンドUIを調整しました。

## 変更内容
- テーブルとKPI表示の可読性改善
  - Table の small variant でフォント/余白を調整
  - ReceiptTable の右寄せ数値に tabular-nums を適用
  - AssetPortfolioSummary のKPI表示をカード化して比較しやすく整理
- 導線・リンクUIの改善
  - StockInfoLinks を区切り文字列からグリッド型リンクボタンへ変更
  - Home の機能カードに詳細説明とCTAを追加
  - SearchCard ヘッダー操作群の間隔を拡大して誤操作リスクを軽減

## コミット
1. refactor: improve numeric readability in portfolio and receipt tables
2. feat: enhance navigation and link affordance on top pages

## テスト
- [x] cd frontend && npm run lint
- [x] cd frontend && npm run build
