### PR TITLE
refactor: 取引明細の集計表示と検索ヘッダーの視認性を改善

### DIFF
--- a/frontend/src/components/atoms/StatItem.tsx
+++ b/frontend/src/components/atoms/StatItem.tsx
@@ -10,7 +10,7 @@ export interface StatItemProps {
   className?: string;
   titleClassName?: string;
   valueClassName?: string;
-  variant?: 'default' | 'card' | 'inline';
+  variant?: 'default' | 'card' | 'inline' | 'flat';
 }
 
 /**
@@ -38,6 +38,12 @@ export const StatItem: React.FC<StatItemProps> = ({
           container: 'flex justify-between items-center py-3 border-b border-gray-200 last:border-b-0',
           title: 'text-secondary',
           value: 'font-bold'
+        };
+      case 'flat':
+        return {
+          container: 'rounded-lg px-4 py-3',
+          title: 'text-xs font-medium text-slate-600 mb-1',
+          value: 'text-2xl font-bold tabular-nums'
         };
       default:
         return {

--- a/frontend/src/components/molecules/DividendInfo/DividendInfo.tsx
+++ b/frontend/src/components/molecules/DividendInfo/DividendInfo.tsx
@@ -41,15 +41,12 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({
     return normalizeSecurityCode(match?.[1] || searchQuery);
   }, [securityCode, searchQuery]);
 
-  // 銘柄コード形式かどうかを判定（商品/口座/年月検索では不要なAPI呼び出しを防ぐ）
   const isValidSecurityCode = React.useMemo(() => {
     return !!effectiveSecurityCode && SECURITY_CODE_REGEX.test(effectiveSecurityCode);
   }, [effectiveSecurityCode]);
 
-  // 保有銘柄データを取得（銘柄コード形式の場合のみフェッチ）
   const { assetBalanceData: assetBalances, getAssetBalanceByCode } = useAssetBalance({ enabled: isValidSecurityCode });
 
-  // バックエンドキャッシュ経由で配当情報を取得（銘柄コード形式の場合のみ）
   const dividendBatchCodes = React.useMemo(
     () => (isValidSecurityCode ? [effectiveSecurityCode] : []),
     [effectiveSecurityCode, isValidSecurityCode]
@@ -57,7 +54,6 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({
   const { dividendPerShareMap, loading: apiLoading } = useDividendBatch(dividendBatchCodes, isValidSecurityCode);
   const apiDividendPerShare = dividendPerShareMap.get(effectiveSecurityCode);
 
-  // searchQueryが変更されたときにstateを初期化し、保有銘柄データがあれば自動入力
   React.useEffect(() => {
     if (isValidSecurityCode) {
       const assetBalanceData = getAssetBalanceByCode(effectiveSecurityCode);
@@ -74,7 +70,6 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({
     }
   }, [effectiveSecurityCode, isValidSecurityCode, getAssetBalanceByCode, assetBalances]);
 
-  // APIからデータが取得されたら自動設定
   React.useEffect(() => {
     setDividendPerShare(undefined);
     if (isValidSecurityCode && apiDividendPerShare !== undefined && apiDividendPerShare > 0) {
@@ -82,7 +77,6 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({
     }
   }, [apiDividendPerShare, isValidSecurityCode]);
 
-  // 各種計算値
   const dividendYield = (() => {
     if (averageUnitPrice && dividendPerShare) {
       return (dividendPerShare / averageUnitPrice) * 100;
@@ -91,20 +85,16 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({
   })();
 
   const annualDividendAmount = parseNumber(holdingQuantity) * parseNumber(dividendPerShare);
-
   const totalInvestment = parseNumber(averageUnitPrice) * parseNumber(holdingQuantity);
 
-  // 全グループの合計受取金額を計算
   const totalNetAmountReceived = React.useMemo(() => {
     return summary.reduce((sum, item) => sum + (item.net_amount_received || 0), 0);
   }, [summary]);
 
-  // 全グループの合計配当金（税引前）を計算
   const totalDividendsBeforeTax = React.useMemo(() => {
     return summary.reduce((sum, item) => sum + (item.dividends_before_tax || 0), 0);
   }, [summary]);
 
-  // 全グループの合計税額を計算
   const totalTaxes = React.useMemo(() => {
     return summary.reduce((sum, item) => sum + (item.taxes || 0), 0);
   }, [summary]);
@@ -131,61 +121,110 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({
     ? getAssetBalanceByCode(effectiveSecurityCode)
     : undefined;
 
-  const content = (
-    <>
-      <div className="stat-grid">
-        <div>
-          <NumberInputField
-            label={<>平均取得価格{assetBalanceData && <AssetBadge />}</>}
-            value={averageUnitPrice}
-            onChange={setAverageUnitPrice}
-          />
+  // embedded モード: 資産管理・J-Quants データを read-only KPI カードで表示
+  if (embedded) {
+    return (
+      <div>
+        {/* パラメータ行（資産管理・J-Quants データ） */}
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+          <div className="rounded-lg bg-slate-50 px-4 py-3">
+            <p className="text-xs font-medium text-slate-600 mb-1">
+              平均取得価格{assetBalanceData && <AssetBadge />}
+            </p>
+            <p className="text-2xl font-bold tabular-nums text-primary">
+              {averageUnitPrice !== undefined ? formatCurrency(averageUnitPrice) : '---'}
+            </p>
+          </div>
+          <div className="rounded-lg bg-slate-50 px-4 py-3">
+            <p className="text-xs font-medium text-slate-600 mb-1">
+              保有数量(株){assetBalanceData && <AssetBadge />}
+            </p>
+            <p className="text-2xl font-bold tabular-nums text-primary">
+              {holdingQuantity !== undefined ? holdingQuantity.toLocaleString('ja-JP') : '---'}
+            </p>
+          </div>
+          <div className="rounded-lg bg-slate-50 px-4 py-3">
+            <p className="text-xs font-medium text-slate-600 mb-1">
+              一株配当{dividendPerShare !== undefined && <JQuantsBadge />}
+            </p>
+            <p className="text-2xl font-bold tabular-nums text-primary">
+              {apiLoading ? '取得中...' : dividendPerShare !== undefined ? formatCurrency(dividendPerShare) : '---'}
+            </p>
+          </div>
         </div>
-        <div>
-          <NumberInputField
-            label={<>保有数量(株){assetBalanceData && <AssetBadge />}</>}
-            value={holdingQuantity}
-            onChange={setHoldingQuantity}
-          />
-        </div>
-        <div>
-          <NumberInputField
-            label={<>一株配当{dividendPerShare !== undefined && <JQuantsBadge />}</>}
-            value={dividendPerShare}
-            onChange={setDividendPerShare}
-            disabled={apiLoading}
-            placeholder={apiLoading ? "データ取得中..." : ""}
-          />
+
+        {/* 結果行（受取実績） */}
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-3 mt-4 pt-4 border-t border-slate-200">
+          <div className="rounded-lg bg-emerald-50 px-4 py-3">
+            <p className="text-xs font-medium text-slate-600 mb-1">配当金額 (配当利回り)</p>
+            <p className="text-2xl font-bold tabular-nums text-emerald-600">
+              {formatCurrency(totalDividendsBeforeTax)}
+              {grossDividendReturnRate > 0 && (
+                <span className="text-sm font-normal text-slate-500 ml-1">
+                  ({grossDividendReturnRate.toFixed(2)}%)
+                </span>
+              )}
+            </p>
+          </div>
+          <div className="rounded-lg bg-red-50 px-4 py-3">
+            <p className="text-xs font-medium text-slate-600 mb-1">税額</p>
+            <p className="text-2xl font-bold tabular-nums text-red-500">
+              {formatCurrency(totalTaxes)}
+            </p>
+          </div>
+          <div className="rounded-lg bg-emerald-50 px-4 py-3">
+            <p className="text-xs font-medium text-slate-600 mb-1">受取金額 (累積利回り)</p>
+            <p className="text-2xl font-bold tabular-nums text-emerald-600">
+              {formatCurrency(totalNetAmountReceived)}
+              {dividendReturnRate > 0 && (
+                <span className="text-sm font-normal text-slate-500 ml-1">
+                  ({dividendReturnRate.toFixed(2)}%)
+                </span>
+              )}
+            </p>
+          </div>
         </div>
       </div>
-
-      {embedded ? (
-        <div className="stat-grid mt-4">
-          <StatItemWithRate title="配当金額 (配当利回り)" value={totalDividendsBeforeTax} rate={grossDividendReturnRate} format={formatCurrency} />
-          <StatItem title="税額" value={formatCurrency(totalTaxes)} />
-          <StatItemWithRate title="受取金額 (累積利回り)" value={totalNetAmountReceived} rate={dividendReturnRate} format={formatCurrency} />
-        </div>
-      ) : (
-        <div className="stat-grid mt-4">
-          <StatItem title="取得総額" value={formatCurrency(totalInvestment)} />
-          <StatItemWithRate title="合計受取金額 (累積利回り)" value={totalNetAmountReceived} rate={dividendReturnRate} format={formatCurrency} />
-          <StatItemWithRate title="年間配当金額 (配当利回り)" value={annualDividendAmount} rate={dividendYield} format={formatCurrency} />
-        </div>
-      )}
-    </>
-  );
-
-  if (embedded) {
-    return <div>{content}</div>;
+    );
   }
 
+  // standalone モード: シミュレーション（入力フォーム）
   return (
     <div className="bg-white rounded-lg shadow-sm border border-border mt-1">
       <div className="bg-slate-600 text-white px-3 py-1.5 rounded-t-lg">
         <h5 className="text-sm font-medium">配当シミュレーション</h5>
       </div>
       <div className="p-3">
-        {content}
+        <div className="stat-grid">
+          <div>
+            <NumberInputField
+              label={<>平均取得価格{assetBalanceData && <AssetBadge />}</>}
+              value={averageUnitPrice}
+              onChange={setAverageUnitPrice}
+            />
+          </div>
+          <div>
+            <NumberInputField
+              label={<>保有数量(株){assetBalanceData && <AssetBadge />}</>}
+              value={holdingQuantity}
+              onChange={setHoldingQuantity}
+            />
+          </div>
+          <div>
+            <NumberInputField
+              label={<>一株配当{dividendPerShare !== undefined && <JQuantsBadge />}</>}
+              value={dividendPerShare}
+              onChange={setDividendPerShare}
+              disabled={apiLoading}
+              placeholder={apiLoading ? "データ取得中..." : ""}
+            />
+          </div>
+        </div>
+        <div className="stat-grid mt-4">
+          <StatItem title="取得総額" value={formatCurrency(totalInvestment)} />
+          <StatItemWithRate title="合計受取金額 (累積利回り)" value={totalNetAmountReceived} rate={dividendReturnRate} format={formatCurrency} />
+          <StatItemWithRate title="年間配当金額 (配当利回り)" value={annualDividendAmount} rate={dividendYield} format={formatCurrency} />
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/molecules/ReceiptHeader/ReceiptHeader.tsx
+++ b/frontend/src/components/molecules/ReceiptHeader/ReceiptHeader.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, useEffect, useId, useState } from 'react';
-import { StatItem } from '@/components/atoms/StatItem';
-import { Card, CardBody, CardHeader } from '@/components/atoms/Card';
+import { cn } from '@/lib/utils/classNames';
+import { Card, CardHeader, CardBody } from '@/components/atoms/Card';
 import { HeaderItem } from '@/types/common';
 
 interface ReceiptHeaderProps {
@@ -21,7 +21,6 @@ export const ReceiptHeader: React.FC<ReceiptHeaderProps> = ({
     const [isExpanded, setIsExpanded] = useState(() => (collapsible ? defaultExpanded : true));
     const bodyId = useId();
 
-    // collapsible が切り替わった際に展開状態をリセット（指摘 #1 対応）
     useEffect(() => {
         setIsExpanded(collapsible ? defaultExpanded : true);
     }, [collapsible, defaultExpanded]);
@@ -43,8 +42,13 @@ export const ReceiptHeader: React.FC<ReceiptHeaderProps> = ({
     return (
         <Card>
             <CardHeader
-                variant="primary"
-                className={collapsible ? 'flex cursor-pointer items-center justify-between' : undefined}
+                variant="secondary"
+                className={cn(
+                    'flex items-center justify-between',
+                    collapsible
+                        ? cn('cursor-pointer select-none transition-colors', effectiveExpanded ? 'bg-slate-600 hover:bg-slate-700' : 'bg-slate-400 hover:bg-slate-500')
+                        : 'bg-slate-600'
+                )}
                 onClick={collapsible ? handleToggleExpanded : undefined}
                 onKeyDown={collapsible ? handleKeyDown : undefined}
                 role={collapsible ? 'button' : undefined}
@@ -53,38 +57,49 @@ export const ReceiptHeader: React.FC<ReceiptHeaderProps> = ({
                 aria-controls={collapsible ? bodyId : undefined}
                 data-testid="receipt-header"
             >
-                <h5>{title}</h5>
+                <h5 className="text-sm font-semibold text-white">{title}</h5>
                 {collapsible && (
-                    <span className="flex items-center gap-1 text-xs font-medium bg-white/20 px-2 py-1 rounded">
-                        {effectiveExpanded ? '▲ 閉じる' : '▼ 開く'}
+                    <span className="flex items-center gap-1.5 rounded border border-white/30 bg-white/10 px-2 py-0.5" aria-hidden="true">
+                        <span className="text-xs font-semibold text-white">
+                            {effectiveExpanded ? '閉じる' : '開く'}
+                        </span>
+                        <svg
+                            className={`w-4 h-4 transition-transform duration-200 ${effectiveExpanded ? 'rotate-180' : ''}`}
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                        >
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                        </svg>
                     </span>
                 )}
             </CardHeader>
             {/* 折りたたみ時はhiddenで非表示（children内のstateを保持するため） */}
-            <CardBody id={bodyId} className="p-4" hidden={collapsible && !effectiveExpanded}>
-                {/* stat-gridはitemsがある場合のみ表示 */}
+            <CardBody id={bodyId} hidden={collapsible && !effectiveExpanded} className="p-4">
                 {items.length > 0 && (
-                    <div className="stat-grid">
+                    <div className="grid grid-cols-1 gap-4 md:grid-cols-3" data-testid="kpi-grid">
                         {items.map((item) => (
-                            <StatItem
+                            <div
                                 key={item.title}
-                                title={item.title}
-                                value={
-                                    <span data-negative={item.value < 0 ? 'true' : undefined}>
-                                        {item.format(item.value)}
-                                    </span>
-                                }
-                            />
+                                className={cn('rounded-lg px-4 py-3', item.className ?? 'bg-slate-50')}
+                            >
+                                <p className="text-xs font-medium text-slate-600 mb-1">{item.title}</p>
+                                <p
+                                    className={cn('text-2xl font-bold tabular-nums', item.valueClassName ?? 'text-slate-800')}
+                                    data-negative={item.value < 0 ? 'true' : undefined}
+                                >
+                                    {item.format(item.value)}
+                                </p>
+                            </div>
                         ))}
                     </div>
                 )}
-                {/* childrenはitemsがある場合のみ上余白を設ける */}
                 {children && (
                     <div className={items.length > 0 ? 'mt-4 pt-4 border-t border-slate-200' : ''}>
                         {children}
                     </div>
                 )}
             </CardBody>
-        </Card >
+        </Card>
     );
 };

--- a/frontend/src/components/molecules/ReceiptHeader/__tests__/ReceiptHeader.test.tsx
+++ b/frontend/src/components/molecules/ReceiptHeader/__tests__/ReceiptHeader.test.tsx
@@ -43,7 +43,7 @@ describe('ReceiptHeader', () => {
 
     const { container } = render(<ReceiptHeader items={items} />);
     
-    const columns = container.querySelectorAll('.stat-grid > div');
+    const columns = container.querySelectorAll('[data-testid="kpi-grid"] > div');
     expect(columns).toHaveLength(3);
   });
 

--- a/frontend/src/components/organisms/AssetPortfolioSummary/AssetPortfolioSummary.tsx
+++ b/frontend/src/components/organisms/AssetPortfolioSummary/AssetPortfolioSummary.tsx
@@ -122,25 +122,25 @@ export const AssetPortfolioSummary: React.FC<AssetPortfolioSummaryProps> = ({
             {/* KPI行 */}
             <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
               <div className="rounded-lg bg-slate-50 px-4 py-3">
-                <p className="text-xs text-slate-500 mb-1">合計取得総額</p>
+                <p className="text-xs font-medium text-slate-600 mb-1">合計取得総額</p>
                 <p className="text-2xl font-bold text-primary tabular-nums" data-negative={totalPurchaseAmount < 0 ? 'true' : undefined}>
                   {formatCurrency(totalPurchaseAmount)}
                 </p>
               </div>
               <div className="rounded-lg bg-emerald-50 px-4 py-3">
-                <p className="text-xs text-slate-500 mb-1">年間配当金額</p>
+                <p className="text-xs font-medium text-slate-600 mb-1">年間配当金額</p>
                 <p className="text-2xl font-bold text-emerald-600 tabular-nums" data-testid="portfolio-annual-dividends">
                   {totalAnnualDividends !== null ? formatCurrency(totalAnnualDividends) : '---'}
                 </p>
               </div>
               <div className="rounded-lg bg-emerald-50 px-4 py-3">
-                <p className="text-xs text-slate-500 mb-1">配当利回り</p>
+                <p className="text-xs font-medium text-slate-600 mb-1">配当利回り</p>
                 <p className="text-2xl font-bold text-emerald-600 tabular-nums" data-testid="portfolio-dividend-yield">
                   {portfolioDividendYield !== null ? formatPercentageValue(portfolioDividendYield) : '---'}
                 </p>
               </div>
               <div className="rounded-lg bg-slate-50 px-4 py-3">
-                <p className="text-xs text-slate-500 mb-1">保有銘柄数</p>
+                <p className="text-xs font-medium text-slate-600 mb-1">保有銘柄数</p>
                 <p className="text-2xl font-bold text-slate-700 tabular-nums">
                   {isFiltered
                     ? `${displayCount} / ${actualTotalCount}`

--- a/frontend/src/components/organisms/SearchCard/SearchCard.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchCard.tsx
@@ -211,8 +211,8 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                         絞り込み解除
                     </Button>
                     {/* シェブロンアイコン: 回転で開閉状態を表現 */}
-                    <span className="flex items-center gap-1.5" aria-hidden="true">
-                        <span className="text-xs font-medium opacity-80">
+                    <span className="flex items-center gap-1.5 rounded border border-white/30 bg-white/10 px-2 py-0.5" aria-hidden="true">
+                        <span className="text-xs font-semibold text-white">
                             {isExpanded ? '閉じる' : '開く'}
                         </span>
                         <svg

--- a/frontend/src/pages/Receipt/Dividend.tsx
+++ b/frontend/src/pages/Receipt/Dividend.tsx
@@ -149,17 +149,23 @@ export const Dividend: React.FC<DividendProps> = ({ csvData }) => {
         {
             title: '配当金',
             value: calculations.total_dividends_before_tax,
-            format: formatCurrency
+            format: formatCurrency,
+            className: 'bg-emerald-50',
+            valueClassName: 'text-emerald-600'
         },
         {
             title: '税額',
             value: calculations.total_taxes,
-            format: formatCurrency
+            format: formatCurrency,
+            className: 'bg-red-50',
+            valueClassName: 'text-red-500'
         },
         {
             title: '受取金額',
             value: calculations.total_net_amount_received,
-            format: formatCurrency
+            format: formatCurrency,
+            className: 'bg-emerald-50',
+            valueClassName: 'text-emerald-600'
         }
     ];
 

--- a/frontend/src/pages/Receipt/DomesticStock.tsx
+++ b/frontend/src/pages/Receipt/DomesticStock.tsx
@@ -87,17 +87,23 @@ export const DomesticStock: React.FC<DomesticStockProps> = ({ csvData }) => {
         {
             title: '実現損益',
             value: calculations.total_realized_profit_and_loss,
-            format: formatCurrency
+            format: formatCurrency,
+            className: 'bg-emerald-50',
+            valueClassName: 'text-emerald-600'
         },
         {
             title: '税額',
             value: calculations.total_taxes,
-            format: formatCurrency
+            format: formatCurrency,
+            className: 'bg-red-50',
+            valueClassName: 'text-red-500'
         },
         {
             title: '実現損益(税引)',
             value: calculations.total_realized_profit_and_loss_after_tax,
-            format: formatCurrency
+            format: formatCurrency,
+            className: 'bg-emerald-50',
+            valueClassName: 'text-emerald-600'
         }
     ];
 

--- a/frontend/src/pages/Receipt/Mutualfund.tsx
+++ b/frontend/src/pages/Receipt/Mutualfund.tsx
@@ -86,17 +86,23 @@ export const Mutualfund: React.FC<MutualfundProps> = ({ csvData }) => {
         {
             title: '実現損益',
             value: calculations.total_realized_profit_and_loss,
-            format: formatCurrency
+            format: formatCurrency,
+            className: 'bg-emerald-50',
+            valueClassName: 'text-emerald-600'
         },
         {
             title: '税額',
             value: calculations.total_taxes,
-            format: formatCurrency
+            format: formatCurrency,
+            className: 'bg-red-50',
+            valueClassName: 'text-red-500'
         },
         {
             title: '実現損益(税引)',
             value: calculations.total_realized_profit_and_loss_after_tax,
-            format: formatCurrency
+            format: formatCurrency,
+            className: 'bg-emerald-50',
+            valueClassName: 'text-emerald-600'
         }
     ];
 

--- a/frontend/src/types/common.ts
+++ b/frontend/src/types/common.ts
@@ -7,6 +7,8 @@ export interface HeaderItem {
   title: string;
   value: number;
   format: (value: number) => string;
+  className?: string;
+  valueClassName?: string;
 }
 
 export interface SelectOption {


### PR DESCRIPTION
## 概要
取引明細の集計表示を資産管理のKPIトーンに寄せて統一し、検索オプションの開閉ラベルの視認性を改善しました。

## 変更種別
- [ ] 新機能
- [x] リファクタリング
- [ ] バグ修正

## 主な変更内容
- `ReceiptHeader` のKPI表示を項目単位のブロック構成へ調整し、ラベル/数値の階層を統一
- `HeaderItem` に表示スタイル指定（`className` / `valueClassName`）を追加し、各取引明細タブで集計色を明示
- `DividendInfo` の埋め込み表示をKPIブロックに合わせて再構成
- `SearchCard` の開閉ラベルに背景・境界線を付与して可読性を改善

## テスト
- `cd frontend && npm test -- src/components/molecules/ReceiptHeader/__tests__/ReceiptHeader.test.tsx src/components/organisms/AssetPortfolioSummary/__tests__/AssetPortfolioSummary.test.tsx src/components/organisms/SearchCard/__tests__/SearchCard.test.tsx --run`
  - 3 files, 32 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)