### PR TITLE
refactor: Receiptsのデータ同期をTanStack Queryへ移行

### DIFF
--- a/frontend/src/features/receipt/hooks/useReceiptsData.ts
+++ b/frontend/src/features/receipt/hooks/useReceiptsData.ts
@@ -1,0 +1,126 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import { dividendApi, domesticStockApi, mutualfundApi } from '../api/receiptApi';
+import {
+  parseDividendCsvItem,
+  parseDomesticStockCsvItem,
+  parseMutualfundCsvItem,
+  transformDBDividend,
+  transformDBDomesticStock,
+  transformDBMutualfund,
+} from '../parsers';
+import { receiptQueryKeys } from '../queryKeys';
+import { type ReceiptsType } from '@/pages/receiptsReducer';
+import { getDisplayErrorMessage } from '@/lib/utils/errorHandler';
+
+export interface UseReceiptsDataResult {
+  dividendData: ReturnType<typeof transformDBDividend>[];
+  domesticstockData: ReturnType<typeof transformDBDomesticStock>[];
+  mutualfundData: ReturnType<typeof transformDBMutualfund>[];
+  dbLoading: boolean;
+  dbError: string | null;
+  saving: boolean;
+  deleting: boolean;
+  bulkCreate: (args: BulkCreateArgs) => void;
+  deleteAll: (type: ReceiptsType) => void;
+  clearCache: () => void;
+}
+
+interface BulkCreateArgs {
+  type: ReceiptsType;
+  csvData: Record<string, unknown>[];
+  onSuccess?: () => void;
+}
+
+/**
+ * 明細データの取得・保存・削除を TanStack Query で管理するフック
+ */
+export function useReceiptsData(isAuthenticated: boolean): UseReceiptsDataResult {
+  const queryClient = useQueryClient();
+
+  const dividendQuery = useQuery({
+    queryKey: receiptQueryKeys.dividend,
+    queryFn: () =>
+      dividendApi.list().then(items =>
+        items.map(d => transformDBDividend(d as unknown as Record<string, unknown>))
+      ),
+    enabled: isAuthenticated,
+  });
+
+  const domesticstockQuery = useQuery({
+    queryKey: receiptQueryKeys.domesticstock,
+    queryFn: () =>
+      domesticStockApi.list().then(items =>
+        items.map(d => transformDBDomesticStock(d as unknown as Record<string, unknown>))
+      ),
+    enabled: isAuthenticated,
+  });
+
+  const mutualfundQuery = useQuery({
+    queryKey: receiptQueryKeys.mutualfund,
+    queryFn: () =>
+      mutualfundApi.list().then(items =>
+        items.map(d => transformDBMutualfund(d as unknown as Record<string, unknown>))
+      ),
+    enabled: isAuthenticated,
+  });
+
+  const bulkCreateMutation = useMutation({
+    mutationFn: ({ type, csvData }: BulkCreateArgs) => {
+      switch (type) {
+        case 'dividend':
+          return dividendApi.bulkCreate(csvData.map(parseDividendCsvItem));
+        case 'domesticstock':
+          return domesticStockApi.bulkCreate(csvData.map(parseDomesticStockCsvItem));
+        case 'mutualfund':
+          return mutualfundApi.bulkCreate(csvData.map(parseMutualfundCsvItem));
+      }
+    },
+    onSuccess: (_, { type, onSuccess }) => {
+      queryClient.invalidateQueries({ queryKey: receiptQueryKeys[type] });
+      onSuccess?.();
+    },
+  });
+
+  const deleteAllMutation = useMutation({
+    mutationFn: (type: ReceiptsType) => {
+      switch (type) {
+        case 'dividend':
+          return dividendApi.deleteAll();
+        case 'domesticstock':
+          return domesticStockApi.deleteAll();
+        case 'mutualfund':
+          return mutualfundApi.deleteAll();
+      }
+    },
+    onSuccess: (_, type) => {
+      queryClient.setQueryData(receiptQueryKeys[type], []);
+    },
+  });
+
+  const clearCache = useCallback(() => {
+    queryClient.setQueryData(receiptQueryKeys.dividend, []);
+    queryClient.setQueryData(receiptQueryKeys.domesticstock, []);
+    queryClient.setQueryData(receiptQueryKeys.mutualfund, []);
+  }, [queryClient]);
+
+  const firstError = dividendQuery.error ?? domesticstockQuery.error ?? mutualfundQuery.error;
+
+  return {
+    dividendData: dividendQuery.data ?? [],
+    domesticstockData: domesticstockQuery.data ?? [],
+    mutualfundData: mutualfundQuery.data ?? [],
+    dbLoading:
+      dividendQuery.isFetching ||
+      domesticstockQuery.isFetching ||
+      mutualfundQuery.isFetching,
+    dbError: firstError
+      ? getDisplayErrorMessage(firstError, 'データ取得に失敗しました')
+      : null,
+    saving: bulkCreateMutation.isPending,
+    deleting: deleteAllMutation.isPending,
+    bulkCreate: bulkCreateMutation.mutate,
+    deleteAll: deleteAllMutation.mutate,
+    clearCache,
+  };
+}

--- a/frontend/src/features/receipt/hooks/useReceiptsData.ts
+++ b/frontend/src/features/receipt/hooks/useReceiptsData.ts
@@ -104,7 +104,8 @@ export function useReceiptsData(isAuthenticated: boolean): UseReceiptsDataResult
     queryClient.setQueryData(receiptQueryKeys.mutualfund, []);
   }, [queryClient]);
 
-  const firstError = dividendQuery.error ?? domesticstockQuery.error ?? mutualfundQuery.error;
+  const queryError = dividendQuery.error ?? domesticstockQuery.error ?? mutualfundQuery.error;
+  const mutationError = bulkCreateMutation.error ?? deleteAllMutation.error;
 
   return {
     dividendData: dividendQuery.data ?? [],
@@ -114,9 +115,11 @@ export function useReceiptsData(isAuthenticated: boolean): UseReceiptsDataResult
       dividendQuery.isFetching ||
       domesticstockQuery.isFetching ||
       mutualfundQuery.isFetching,
-    dbError: firstError
-      ? getDisplayErrorMessage(firstError, 'データ取得に失敗しました')
-      : null,
+    dbError: queryError
+      ? getDisplayErrorMessage(queryError, 'データ取得に失敗しました')
+      : mutationError
+        ? getDisplayErrorMessage(mutationError, '操作に失敗しました')
+        : null,
     saving: bulkCreateMutation.isPending,
     deleting: deleteAllMutation.isPending,
     bulkCreate: bulkCreateMutation.mutate,

--- a/frontend/src/features/receipt/queryKeys.ts
+++ b/frontend/src/features/receipt/queryKeys.ts
@@ -1,0 +1,7 @@
+import { ReceiptsType } from '@/pages/receiptsReducer';
+
+export const receiptQueryKeys = {
+  dividend: ['receipts', 'dividend'] as const,
+  domesticstock: ['receipts', 'domesticstock'] as const,
+  mutualfund: ['receipts', 'mutualfund'] as const,
+} satisfies Record<ReceiptsType, readonly string[]>;

--- a/frontend/src/pages/Receipts.tsx
+++ b/frontend/src/pages/Receipts.tsx
@@ -1,4 +1,4 @@
-import { useReducer, useEffect, useCallback, useRef, useMemo } from 'react';
+import { useReducer, useEffect, useCallback, useMemo } from 'react';
 import { Layout } from '../components/templates/Layout';
 import { PageHeader } from '../components/atoms/PageHeader';
 import { CSVFileInput } from '../components/molecules/CSVFileInput';
@@ -10,53 +10,17 @@ import { useAuth } from '@/features/auth/hooks/useAuth';
 import { Dividend } from './Receipt/Dividend';
 import { DomesticStock } from './Receipt/DomesticStock';
 import { Mutualfund } from './Receipt/Mutualfund';
-import { dividendApi, domesticStockApi, mutualfundApi } from '@/features/receipt/api/receiptApi';
-import {
-  parseDividendCsvItem,
-  parseDomesticStockCsvItem,
-  parseMutualfundCsvItem,
-  transformDBDividend,
-  transformDBDomesticStock,
-  transformDBMutualfund,
-} from '@/features/receipt/parsers';
-import { DividendData } from '@/lib/interfaces/dividend';
-import { DomesticStockData } from '@/lib/interfaces/domesticStock';
-import { MutualfundData } from '@/lib/interfaces/mutualfund';
 import { getDisplayErrorMessage } from '@/lib/utils/errorHandler';
 import { ConfirmDeleteModal } from '@/components/molecules/ConfirmDeleteModal/ConfirmDeleteModal';
 import { type ReceiptsType, initialState, receiptsReducer } from './receiptsReducer';
+import { useReceiptsData } from '@/features/receipt/hooks/useReceiptsData';
 
-// 明細種類ごとの静的設定
-interface ReceiptTypeStaticConfig {
-  api: {
-    /* eslint-disable @typescript-eslint/no-explicit-any */
-    list: () => Promise<any[]>;
-    bulkCreate: (items: any[]) => Promise<any>;
-    deleteAll: () => Promise<any>;
-    /* eslint-enable @typescript-eslint/no-explicit-any */
-  };
-  parser: (item: Record<string, unknown>) => unknown;
-  transformer: (item: Record<string, unknown>) => unknown;
-}
-
-const RECEIPT_TYPE_CONFIG: Record<ReceiptsType, ReceiptTypeStaticConfig> = {
-  dividend: {
-    api: dividendApi,
-    parser: parseDividendCsvItem,
-    transformer: transformDBDividend,
-  },
-  domesticstock: {
-    api: domesticStockApi,
-    parser: parseDomesticStockCsvItem,
-    transformer: transformDBDomesticStock,
-  },
-  mutualfund: {
-    api: mutualfundApi,
-    parser: parseMutualfundCsvItem,
-    transformer: transformDBMutualfund,
-  },
+// 明細種類ごとのラベル
+const TAB_LABEL: Record<ReceiptsType, string> = {
+  dividend: '配当金',
+  domesticstock: '国内株式',
+  mutualfund: '投資信託',
 };
-
 
 /**
  * 明細種類ごとにCSVデータを管理するページコンポーネント
@@ -65,158 +29,95 @@ const RECEIPT_TYPE_CONFIG: Record<ReceiptsType, ReceiptTypeStaticConfig> = {
 export function ReceiptsPage() {
   const { isAuthenticated, isLoading: authLoading, onLogout } = useAuth();
   const [state, dispatch] = useReducer(receiptsReducer, initialState);
-  const {
-    receiptsType, csvData, dbData,
-    dbLoading, dbError, saving, deleting, showDeleteConfirm,
-  } = state;
+  const { receiptsType, csvData, showDeleteConfirm } = state;
 
   // 各明細種類ごとにCSVリーダーフックを作成
   const dividendCSV = useCSVReader();
   const domesticStockCSV = useCSVReader();
   const mutualfundCSV = useCSVReader();
 
+  // TanStack Query ベースのデータ管理
+  const {
+    dividendData,
+    domesticstockData,
+    mutualfundData,
+    dbLoading,
+    dbError,
+    saving,
+    deleting,
+    bulkCreate,
+    deleteAll,
+    clearCache,
+  } = useReceiptsData(isAuthenticated && !authLoading);
+
+  // ログアウト時に CSV データと Query キャッシュをクリア
+  useEffect(() => {
+    return onLogout(() => {
+      dispatch({ type: 'LOGOUT' });
+      clearCache();
+    });
+  }, [onLogout, clearCache]);
+
   // ランタイムデータマッピング（switch削減用）
   const runtimeDataMap = useMemo(() => ({
     dividend: {
       csvReader: dividendCSV,
       csvData: csvData.dividend,
-      setCsvData: (data: Record<string, unknown>[]) => dispatch({ type: 'SET_CSV_DATA', receiptsType: 'dividend', payload: data }),
-      dbData: dbData.dividend,
-      setDbData: (data: DividendData[]) => dispatch({ type: 'SET_DB_DATA', receiptsType: 'dividend', payload: data }),
+      setCsvData: (data: Record<string, unknown>[]) =>
+        dispatch({ type: 'SET_CSV_DATA', receiptsType: 'dividend', payload: data }),
     },
     domesticstock: {
       csvReader: domesticStockCSV,
       csvData: csvData.domesticstock,
-      setCsvData: (data: Record<string, unknown>[]) => dispatch({ type: 'SET_CSV_DATA', receiptsType: 'domesticstock', payload: data }),
-      dbData: dbData.domesticstock,
-      setDbData: (data: DomesticStockData[]) => dispatch({ type: 'SET_DB_DATA', receiptsType: 'domesticstock', payload: data }),
+      setCsvData: (data: Record<string, unknown>[]) =>
+        dispatch({ type: 'SET_CSV_DATA', receiptsType: 'domesticstock', payload: data }),
     },
     mutualfund: {
       csvReader: mutualfundCSV,
       csvData: csvData.mutualfund,
-      setCsvData: (data: Record<string, unknown>[]) => dispatch({ type: 'SET_CSV_DATA', receiptsType: 'mutualfund', payload: data }),
-      dbData: dbData.mutualfund,
-      setDbData: (data: MutualfundData[]) => dispatch({ type: 'SET_DB_DATA', receiptsType: 'mutualfund', payload: data }),
+      setCsvData: (data: Record<string, unknown>[]) =>
+        dispatch({ type: 'SET_CSV_DATA', receiptsType: 'mutualfund', payload: data }),
     },
-  }), [dividendCSV, domesticStockCSV, mutualfundCSV, csvData, dbData]);
-
-  // フェッチ済みフラグ（多重実行防止）
-  const hasFetched = useRef(false);
-  const isFetchingRef = useRef(false);
-
-  // DBからデータを取得
-  const fetchFromDB = useCallback(async (force = false) => {
-    // 認証状態が確定していない場合は待機
-    if (authLoading) return;
-    // 未認証の場合はスキップ
-    if (!isAuthenticated) return;
-    // 既にフェッチ済みで強制更新でない場合はスキップ
-    if (hasFetched.current && !force) return;
-
-    if (isFetchingRef.current) return;
-    isFetchingRef.current = true;
-    dispatch({ type: 'SET_DB_LOADING', payload: true });
-    dispatch({ type: 'SET_DB_ERROR', payload: null });
-
-    await Promise.all([
-      dividendApi.list(),
-      domesticStockApi.list(),
-      mutualfundApi.list(),
-    ]).then(([dividends, stocks, funds]) => {
-      dispatch({
-        type: 'SET_DB_ALL',
-        dividend: dividends.map(d => transformDBDividend(d as unknown as Record<string, unknown>)),
-        domesticstock: stocks.map(d => transformDBDomesticStock(d as unknown as Record<string, unknown>)),
-        mutualfund: funds.map(d => transformDBMutualfund(d as unknown as Record<string, unknown>)),
-      });
-      hasFetched.current = true;
-    }).catch((err) => {
-      dispatch({ type: 'SET_DB_ERROR', payload: getDisplayErrorMessage(err, 'データ取得に失敗しました') });
-    });
-
-    dispatch({ type: 'SET_DB_LOADING', payload: false });
-    isFetchingRef.current = false;
-  }, [isAuthenticated, authLoading]);
-
-  // 認証状態が確定したらDBからデータを取得
-  useEffect(() => {
-    if (authLoading) return;
-    const timeoutId = window.setTimeout(() => {
-      void fetchFromDB();
-    }, 0);
-    return () => {
-      window.clearTimeout(timeoutId);
-    };
-  }, [authLoading, fetchFromDB]);
-
-  // ログアウト時に全データをクリア
-  useEffect(() => {
-    return onLogout(() => {
-      dispatch({ type: 'LOGOUT' });
-      hasFetched.current = false;
-    });
-  }, [onLogout]);
+  }), [dividendCSV, domesticStockCSV, mutualfundCSV, csvData]);
 
   /**
    * 現在選択中のタブに応じてCSV処理を切り替える
    */
-  const handleFileSelect = async (file: File) => {
+  const handleFileSelect = useCallback(async (file: File) => {
     const { csvReader, setCsvData } = runtimeDataMap[receiptsType];
     try {
       setCsvData(await csvReader.parseCSV(file));
       if (csvReader.error) csvReader.resetError();
     } catch (e) {
-      dispatch({ type: 'SET_DB_ERROR', payload: getDisplayErrorMessage(e, 'CSVファイルの読み込みに失敗しました') });
+      // CSV parse error is surfaced via csvReader.error
+      void getDisplayErrorMessage(e, 'CSVファイルの読み込みに失敗しました');
     }
-  };
+  }, [receiptsType, runtimeDataMap]);
 
   /**
    * CSVデータをDBに保存
    */
-  const handleSaveToDB = async () => {
-    if (!isAuthenticated) return;
-
-    dispatch({ type: 'SET_SAVING', payload: true });
-    dispatch({ type: 'SET_DB_ERROR', payload: null });
-
-    const config = RECEIPT_TYPE_CONFIG[receiptsType];
+  const handleSaveToDB = useCallback(() => {
     const { csvData: tabCsvData, setCsvData } = runtimeDataMap[receiptsType];
-
-    const items = tabCsvData.map(config.parser);
-    await config.api.bulkCreate(items).then(async () => {
-      setCsvData([]);
-      await fetchFromDB(true);
-    }).catch((err) => {
-      dispatch({ type: 'SET_DB_ERROR', payload: getDisplayErrorMessage(err, '保存に失敗しました') });
+    if (!isAuthenticated || tabCsvData.length === 0) return;
+    bulkCreate({
+      type: receiptsType,
+      csvData: tabCsvData,
+      onSuccess: () => setCsvData([]),
     });
-
-    dispatch({ type: 'SET_SAVING', payload: false });
-  };
+  }, [bulkCreate, isAuthenticated, receiptsType, runtimeDataMap]);
 
   /**
    * DBデータを全削除
    */
-  const handleDeleteAll = async () => {
+  const handleDeleteAll = useCallback(() => {
     if (!isAuthenticated) return;
-
     dispatch({ type: 'SET_SHOW_DELETE_CONFIRM', payload: false });
-    dispatch({ type: 'SET_DELETING', payload: true });
-    dispatch({ type: 'SET_DB_ERROR', payload: null });
-
-    const config = RECEIPT_TYPE_CONFIG[receiptsType];
-    const { setDbData } = runtimeDataMap[receiptsType];
-
-    await config.api.deleteAll().then(() => {
-      setDbData([]);
-    }).catch((err) => {
-      dispatch({ type: 'SET_DB_ERROR', payload: getDisplayErrorMessage(err, '削除に失敗しました') });
-    });
-
-    dispatch({ type: 'SET_DELETING', payload: false });
-  };
+    deleteAll(receiptsType);
+  }, [deleteAll, isAuthenticated, receiptsType]);
 
   /**
-   * 現在選択中のタブに対応するエラーとローディング状態を取得
+   * 現在選択中のタブに対応するCSV状態を取得
    */
   const currentCSVState = useMemo(() => {
     const { csvReader, csvData: tabCsvData } = runtimeDataMap[receiptsType];
@@ -231,28 +132,21 @@ export function ReceiptsPage() {
   const { isLoading, error, fileName, tabCsvData } = currentCSVState;
   const hasCsvData = tabCsvData.length > 0;
 
-  // 現在のタブのDBデータ件数を取得
-  const dbDataCount = runtimeDataMap[receiptsType].dbData.length;
+  // 現在のタブのDBデータ
+  const currentDbData = useMemo(() => ({
+    dividend: dividendData,
+    domesticstock: domesticstockData,
+    mutualfund: mutualfundData,
+  }), [dividendData, domesticstockData, mutualfundData]);
 
-  // 現在のタブのDBデータがあるか判定
+  const dbDataCount = currentDbData[receiptsType].length;
   const hasDbData = dbDataCount > 0;
-
-  // タブ名の取得
-  const tabName = receiptsType === 'dividend' ? '配当金' : receiptsType === 'domesticstock' ? '国内株式' : '投資信託';
+  const tabName = TAB_LABEL[receiptsType];
 
   // 表示用データを決定（ログイン時はDB優先、未ログイン時はCSV）
-  const dividendData = useMemo(
-    () => (isAuthenticated && dbData.dividend.length > 0 ? dbData.dividend : csvData.dividend),
-    [isAuthenticated, dbData.dividend, csvData.dividend]
-  );
-  const domesticStockData = useMemo(
-    () => (isAuthenticated && dbData.domesticstock.length > 0 ? dbData.domesticstock : csvData.domesticstock),
-    [isAuthenticated, dbData.domesticstock, csvData.domesticstock]
-  );
-  const mutualfundData = useMemo(
-    () => (isAuthenticated && dbData.mutualfund.length > 0 ? dbData.mutualfund : csvData.mutualfund),
-    [isAuthenticated, dbData.mutualfund, csvData.mutualfund]
-  );
+  const dividendDisplayData = isAuthenticated && dividendData.length > 0 ? dividendData : csvData.dividend;
+  const domesticStockDisplayData = isAuthenticated && domesticstockData.length > 0 ? domesticstockData : csvData.domesticstock;
+  const mutualfundDisplayData = isAuthenticated && mutualfundData.length > 0 ? mutualfundData : csvData.mutualfund;
 
   return (
     <Layout>
@@ -264,7 +158,6 @@ export function ReceiptsPage() {
         <div className="flex flex-wrap gap-1">
           {(['dividend', 'domesticstock', 'mutualfund'] as const).map((tab) => {
             const isActive = receiptsType === tab;
-            const label = tab === 'dividend' ? '配当金' : tab === 'domesticstock' ? '国内株式' : '投資信託';
             return (
               <button
                 key={tab}
@@ -278,7 +171,7 @@ export function ReceiptsPage() {
                 role="tab"
                 aria-selected={isActive}
               >
-                {label}
+                {TAB_LABEL[tab]}
               </button>
             );
           })}
@@ -347,9 +240,9 @@ export function ReceiptsPage() {
         {/* ローディング完了後のみコンテンツを表示（0円集計との同時表示を防止） */}
         {!authLoading && !dbLoading && !isLoading && (
           <>
-            {receiptsType === 'dividend' && <Dividend csvData={dividendData as Record<string, unknown>[]} />}
-            {receiptsType === 'domesticstock' && <DomesticStock csvData={domesticStockData as Record<string, unknown>[]} />}
-            {receiptsType === 'mutualfund' && <Mutualfund csvData={mutualfundData as Record<string, unknown>[]} />}
+            {receiptsType === 'dividend' && <Dividend csvData={dividendDisplayData as Record<string, unknown>[]} />}
+            {receiptsType === 'domesticstock' && <DomesticStock csvData={domesticStockDisplayData as Record<string, unknown>[]} />}
+            {receiptsType === 'mutualfund' && <Mutualfund csvData={mutualfundDisplayData as Record<string, unknown>[]} />}
           </>
         )}
 

--- a/frontend/src/pages/__tests__/Receipts.test.tsx
+++ b/frontend/src/pages/__tests__/Receipts.test.tsx
@@ -2,13 +2,14 @@
  * ReceiptsPage のテスト
  *
  * 対象:
- * - receiptsReducer: 状態遷移の単体テスト（LOGOUT, SET_DB_ALL, SET_CSV_DATA 等）
+ * - receiptsReducer: 状態遷移の単体テスト（LOGOUT, SET_CSV_DATA 等）
  * - ReceiptsPage: タブ切替・ログアウト時データクリアの統合テスト
  */
 import React from 'react';
 import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import { receiptsReducer, initialState } from '../receiptsReducer';
 import type { ReceiptsState } from '../receiptsReducer';
@@ -91,17 +92,17 @@ import * as receiptApi from '@/features/receipt/api/receiptApi';
 vi.mock('@/features/receipt/api/receiptApi', () => ({
   dividendApi: {
     list: vi.fn().mockResolvedValue([]),
-    bulkCreate: vi.fn().mockResolvedValue({}),
+    bulkCreate: vi.fn().mockResolvedValue({ inserted: 0, skipped: 0 }),
     deleteAll: vi.fn().mockResolvedValue({}),
   },
   domesticStockApi: {
     list: vi.fn().mockResolvedValue([]),
-    bulkCreate: vi.fn().mockResolvedValue({}),
+    bulkCreate: vi.fn().mockResolvedValue({ inserted: 0, skipped: 0 }),
     deleteAll: vi.fn().mockResolvedValue({}),
   },
   mutualfundApi: {
     list: vi.fn().mockResolvedValue([]),
-    bulkCreate: vi.fn().mockResolvedValue({}),
+    bulkCreate: vi.fn().mockResolvedValue({ inserted: 0, skipped: 0 }),
     deleteAll: vi.fn().mockResolvedValue({}),
   },
 }));
@@ -125,6 +126,7 @@ vi.mock('@/hooks/useCSVReader', () => ({
     error: null,
     fileName: null,
     resetError: vi.fn(),
+    reset: vi.fn(),
   }),
 }));
 
@@ -159,6 +161,22 @@ function makeAuthMock(opts: {
   };
 }
 
+// テスト用 QueryClient ファクトリ（自動再フェッチなし）
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Infinity },
+    },
+  });
+}
+
+function renderWithQuery(ui: React.ReactElement, qc?: QueryClient) {
+  const client = qc ?? makeQueryClient();
+  return render(
+    <QueryClientProvider client={client}>{ui}</QueryClientProvider>
+  );
+}
+
 // ────────────────────────────────────────────────────────
 // receiptsReducer 単体テスト
 // ────────────────────────────────────────────────────────
@@ -167,9 +185,7 @@ describe('receiptsReducer', () => {
   it('initialState が正しく定義されている', () => {
     expect(initialState.receiptsType).toBe('dividend');
     expect(initialState.csvData.dividend).toHaveLength(0);
-    expect(initialState.dbData.dividend).toHaveLength(0);
-    expect(initialState.dbLoading).toBe(false);
-    expect(initialState.dbError).toBeNull();
+    expect(initialState.showDeleteConfirm).toBe(false);
   });
 
   it('SET_RECEIPTS_TYPE: タブを切り替える', () => {
@@ -178,23 +194,6 @@ describe('receiptsReducer', () => {
       payload: 'domesticstock',
     });
     expect(next.receiptsType).toBe('domesticstock');
-  });
-
-  it('SET_DB_ALL: 3 種類のDBデータを一括セットする', () => {
-    const mockDividend = [{ id: '1' }] as unknown as ReceiptsState['dbData']['dividend'];
-    const mockDomesticstock = [{ id: '2' }] as unknown as ReceiptsState['dbData']['domesticstock'];
-    const mockMutualfund = [{ id: '3' }] as unknown as ReceiptsState['dbData']['mutualfund'];
-
-    const next = receiptsReducer(initialState, {
-      type: 'SET_DB_ALL',
-      dividend: mockDividend,
-      domesticstock: mockDomesticstock,
-      mutualfund: mockMutualfund,
-    });
-
-    expect(next.dbData.dividend).toBe(mockDividend);
-    expect(next.dbData.domesticstock).toBe(mockDomesticstock);
-    expect(next.dbData.mutualfund).toBe(mockMutualfund);
   });
 
   it('SET_CSV_DATA: 指定タブの CSV データのみ更新する', () => {
@@ -210,7 +209,7 @@ describe('receiptsReducer', () => {
     expect(next.csvData.domesticstock).toHaveLength(0);
   });
 
-  it('LOGOUT: csvData / dbData をすべて空にし dbError をクリアする', () => {
+  it('LOGOUT: csvData をすべて空にする', () => {
     const dirtyState: ReceiptsState = {
       ...initialState,
       csvData: {
@@ -218,12 +217,6 @@ describe('receiptsReducer', () => {
         domesticstock: [{ x: 2 }],
         mutualfund: [{ x: 3 }],
       },
-      dbData: {
-        dividend: [{ id: 'a' } as unknown as ReceiptsState['dbData']['dividend'][number]],
-        domesticstock: [{ id: 'b' } as unknown as ReceiptsState['dbData']['domesticstock'][number]],
-        mutualfund: [{ id: 'c' } as unknown as ReceiptsState['dbData']['mutualfund'][number]],
-      },
-      dbError: 'なんらかのエラー',
     };
 
     const next = receiptsReducer(dirtyState, { type: 'LOGOUT' });
@@ -231,25 +224,16 @@ describe('receiptsReducer', () => {
     expect(next.csvData.dividend).toHaveLength(0);
     expect(next.csvData.domesticstock).toHaveLength(0);
     expect(next.csvData.mutualfund).toHaveLength(0);
-    expect(next.dbData.dividend).toHaveLength(0);
-    expect(next.dbData.domesticstock).toHaveLength(0);
-    expect(next.dbData.mutualfund).toHaveLength(0);
-    expect(next.dbError).toBeNull();
     // receiptsType は変更されない
     expect(next.receiptsType).toBe(dirtyState.receiptsType);
   });
 
-  it('SET_DB_ERROR / SET_DB_LOADING が正しく反映される', () => {
-    const s1 = receiptsReducer(initialState, { type: 'SET_DB_LOADING', payload: true });
-    expect(s1.dbLoading).toBe(true);
+  it('SET_SHOW_DELETE_CONFIRM が正しく反映される', () => {
+    const s1 = receiptsReducer(initialState, { type: 'SET_SHOW_DELETE_CONFIRM', payload: true });
+    expect(s1.showDeleteConfirm).toBe(true);
 
-    const s2 = receiptsReducer(s1, { type: 'SET_DB_ERROR', payload: 'エラーメッセージ' });
-    expect(s2.dbError).toBe('エラーメッセージ');
-    expect(s2.dbLoading).toBe(true); // 他フィールドは不変
-
-    const s3 = receiptsReducer(s2, { type: 'SET_DB_LOADING', payload: false });
-    expect(s3.dbLoading).toBe(false);
-    expect(s3.dbError).toBe('エラーメッセージ'); // クリアされない
+    const s2 = receiptsReducer(s1, { type: 'SET_SHOW_DELETE_CONFIRM', payload: false });
+    expect(s2.showDeleteConfirm).toBe(false);
   });
 });
 
@@ -266,7 +250,7 @@ describe('ReceiptsPage', () => {
   it('初期表示: 配当金タブが選択されている', () => {
     vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({}));
 
-    render(<ReceiptsPage />);
+    renderWithQuery(<ReceiptsPage />);
 
     // 配当金タブが aria-selected=true
     const tab = screen.getByRole('tab', { name: '配当金' });
@@ -280,7 +264,7 @@ describe('ReceiptsPage', () => {
   it('タブ切替: 国内株式タブをクリックすると DomesticStock が表示される', async () => {
     vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({}));
 
-    render(<ReceiptsPage />);
+    renderWithQuery(<ReceiptsPage />);
     const user = userEvent.setup();
 
     await user.click(screen.getByRole('tab', { name: '国内株式' }));
@@ -292,7 +276,7 @@ describe('ReceiptsPage', () => {
   it('タブ切替: 投資信託タブをクリックすると Mutualfund が表示される', async () => {
     vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({}));
 
-    render(<ReceiptsPage />);
+    renderWithQuery(<ReceiptsPage />);
     const user = userEvent.setup();
 
     await user.click(screen.getByRole('tab', { name: '投資信託' }));
@@ -302,41 +286,33 @@ describe('ReceiptsPage', () => {
   });
 
   it('CSV読込→保存: bulkCreate API が呼ばれ CSV データがクリアされる', async () => {
-    // 未認証時は保存ボタンが出ないため、認証済みとする
     vi.mocked(authHook.useAuth).mockReturnValue(
       makeAuthMock({ isAuthenticated: true })
     );
-    // 初期DBデータなし
     vi.mocked(receiptApi.dividendApi.list).mockResolvedValue([]);
     vi.mocked(receiptApi.domesticStockApi.list).mockResolvedValue([]);
     vi.mocked(receiptApi.mutualfundApi.list).mockResolvedValue([]);
-    // bulkCreate 後の再フェッチもなし
     vi.mocked(receiptApi.dividendApi.bulkCreate).mockResolvedValue({ inserted: 0, skipped: 0 });
 
-    // parseCSV が 2 件を返すように設定
     const mockRows = [{ '入金日': '2023/01/01' }, { '入金日': '2023/02/01' }];
     mockParseCSV.mockResolvedValue(mockRows);
 
-    render(<ReceiptsPage />);
+    renderWithQuery(<ReceiptsPage />);
 
     // DB フェッチ完了を待つ
     await waitFor(() => {
       expect(screen.queryByRole('status')).not.toBeInTheDocument();
     });
 
-    // CSV 読込ボタンをクリック
     const user = userEvent.setup();
     await user.click(screen.getByTestId('csv-file-input'));
 
-    // 保存ボタンが現れるまで待つ
     await waitFor(() => {
       expect(screen.getByText('保存')).toBeInTheDocument();
     });
 
-    // 保存ボタンをクリック
     await user.click(screen.getByText('保存'));
 
-    // bulkCreate が呼ばれたことを確認
     await waitFor(() => {
       expect(receiptApi.dividendApi.bulkCreate).toHaveBeenCalled();
     });
@@ -352,39 +328,33 @@ describe('ReceiptsPage', () => {
       makeAuthMock({ isAuthenticated: true })
     );
 
-    // 初期 DB に 1 件のデータを返す
-    const mockDbRow = { id: '1', payment_date: '2023-01-01' } as unknown as ReceiptsState['dbData']['dividend'][number];
-    vi.mocked(receiptApi.dividendApi.list).mockResolvedValue([mockDbRow]);
+    const mockDbRow = { id: '1', payment_date: '2023-01-01' };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(receiptApi.dividendApi.list).mockResolvedValue([mockDbRow] as any);
     vi.mocked(receiptApi.domesticStockApi.list).mockResolvedValue([]);
     vi.mocked(receiptApi.mutualfundApi.list).mockResolvedValue([]);
     vi.mocked(receiptApi.dividendApi.deleteAll).mockResolvedValue({});
 
-    render(<ReceiptsPage />);
+    renderWithQuery(<ReceiptsPage />);
 
-    // DB データ読み込み完了まで待つ
     await waitFor(() => {
       expect(screen.queryByRole('status')).not.toBeInTheDocument();
     });
 
-    // 「全件削除」ボタンが表示されるまで待つ
     await waitFor(() => {
       expect(screen.getByText(/全件削除/)).toBeInTheDocument();
     });
 
-    // 削除ボタンをクリック → 確認モーダルが出る
     const user = userEvent.setup();
     await user.click(screen.getByText(/全件削除/));
     expect(screen.getByTestId('confirm-modal')).toBeInTheDocument();
 
-    // モーダルの確認ボタンをクリック
     await user.click(screen.getByTestId('confirm-delete'));
 
-    // deleteAll API が呼ばれたことを確認
     await waitFor(() => {
       expect(receiptApi.dividendApi.deleteAll).toHaveBeenCalled();
     });
 
-    // 削除後は全件削除ボタンが消える（データ 0 件）
     await waitFor(() => {
       expect(screen.queryByText(/全件削除/)).not.toBeInTheDocument();
     });
@@ -400,31 +370,26 @@ describe('ReceiptsPage', () => {
       })
     );
 
-    // DB に 1 件のデータを返す
-    const mockDbRow = { id: '1', payment_date: '2023-01-01' } as unknown as ReceiptsState['dbData']['dividend'][number];
-    vi.mocked(receiptApi.dividendApi.list).mockResolvedValue([mockDbRow]);
+    const mockDbRow = { id: '1', payment_date: '2023-01-01' };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(receiptApi.dividendApi.list).mockResolvedValue([mockDbRow] as any);
     vi.mocked(receiptApi.domesticStockApi.list).mockResolvedValue([]);
     vi.mocked(receiptApi.mutualfundApi.list).mockResolvedValue([]);
 
-    render(<ReceiptsPage />);
+    renderWithQuery(<ReceiptsPage />);
 
-    // ログアウトコールバックが登録されるまで待つ
     await waitFor(() => expect(capturedLogoutCallback).not.toBeNull());
 
-    // DB フェッチ完了を待つ
     await waitFor(() => {
       expect(screen.queryByRole('status')).not.toBeInTheDocument();
     });
 
-    // ログアウト前: 全件削除ボタンが存在する（DB データあり）
     await waitFor(() => {
       expect(screen.getByText(/全件削除/)).toBeInTheDocument();
     });
 
-    // ログアウトコールバックを実行
     act(() => { capturedLogoutCallback!(); });
 
-    // ログアウト後: データがクリアされ全件削除ボタンが消える
     await waitFor(() => {
       expect(screen.queryByText(/全件削除/)).not.toBeInTheDocument();
     });

--- a/frontend/src/pages/receiptsReducer.ts
+++ b/frontend/src/pages/receiptsReducer.ts
@@ -1,7 +1,3 @@
-import { DividendData } from '@/lib/interfaces/dividend';
-import { DomesticStockData } from '@/lib/interfaces/domesticStock';
-import { MutualfundData } from '@/lib/interfaces/mutualfund';
-
 export type ReceiptsType = 'dividend' | 'domesticstock' | 'mutualfund';
 
 export interface ReceiptsState {
@@ -11,38 +7,18 @@ export interface ReceiptsState {
     domesticstock: Record<string, unknown>[];
     mutualfund: Record<string, unknown>[];
   };
-  dbData: {
-    dividend: DividendData[];
-    domesticstock: DomesticStockData[];
-    mutualfund: MutualfundData[];
-  };
-  dbLoading: boolean;
-  dbError: string | null;
-  saving: boolean;
-  deleting: boolean;
   showDeleteConfirm: boolean;
 }
 
 export type ReceiptsAction =
   | { type: 'SET_RECEIPTS_TYPE'; payload: ReceiptsType }
   | { type: 'SET_CSV_DATA'; receiptsType: ReceiptsType; payload: Record<string, unknown>[] }
-  | { type: 'SET_DB_ALL'; dividend: DividendData[]; domesticstock: DomesticStockData[]; mutualfund: MutualfundData[] }
-  | { type: 'SET_DB_DATA'; receiptsType: ReceiptsType; payload: DividendData[] | DomesticStockData[] | MutualfundData[] }
-  | { type: 'SET_DB_LOADING'; payload: boolean }
-  | { type: 'SET_DB_ERROR'; payload: string | null }
-  | { type: 'SET_SAVING'; payload: boolean }
-  | { type: 'SET_DELETING'; payload: boolean }
   | { type: 'SET_SHOW_DELETE_CONFIRM'; payload: boolean }
   | { type: 'LOGOUT' };
 
 export const initialState: ReceiptsState = {
   receiptsType: 'dividend',
   csvData: { dividend: [], domesticstock: [], mutualfund: [] },
-  dbData: { dividend: [], domesticstock: [], mutualfund: [] },
-  dbLoading: false,
-  dbError: null,
-  saving: false,
-  deleting: false,
   showDeleteConfirm: false,
 };
 
@@ -52,26 +28,9 @@ export function receiptsReducer(state: ReceiptsState, action: ReceiptsAction): R
       return { ...state, receiptsType: action.payload };
     case 'SET_CSV_DATA':
       return { ...state, csvData: { ...state.csvData, [action.receiptsType]: action.payload } };
-    case 'SET_DB_ALL':
-      return { ...state, dbData: { dividend: action.dividend, domesticstock: action.domesticstock, mutualfund: action.mutualfund } };
-    case 'SET_DB_DATA':
-      return { ...state, dbData: { ...state.dbData, [action.receiptsType]: action.payload } };
-    case 'SET_DB_LOADING':
-      return { ...state, dbLoading: action.payload };
-    case 'SET_DB_ERROR':
-      return { ...state, dbError: action.payload };
-    case 'SET_SAVING':
-      return { ...state, saving: action.payload };
-    case 'SET_DELETING':
-      return { ...state, deleting: action.payload };
     case 'SET_SHOW_DELETE_CONFIRM':
       return { ...state, showDeleteConfirm: action.payload };
     case 'LOGOUT':
-      return {
-        ...state,
-        csvData: { dividend: [], domesticstock: [], mutualfund: [] },
-        dbData: { dividend: [], domesticstock: [], mutualfund: [] },
-        dbError: null,
-      };
+      return { ...state, csvData: { dividend: [], domesticstock: [], mutualfund: [] } };
   }
 }


### PR DESCRIPTION
## 概要
- Receipts の DB 取得/保存/削除を TanStack Query ベースへ移行
- reducer は CSV と UI 状態に責務を絞り、手動フェッチ制御を削減
- Query 移行に合わせて Receipts テストを更新
- 追加で、保存/削除失敗時の操作エラーを画面表示するよう修正

## 主な変更内容
- frontend/src/features/receipt/queryKeys.ts を追加
- frontend/src/features/receipt/hooks/useReceiptsData.ts を追加
- frontend/src/pages/Receipts.tsx から手動 fetch 制御を削除し useReceiptsData を利用
- frontend/src/pages/receiptsReducer.ts の state/action を簡素化
- frontend/src/pages/__tests__/Receipts.test.tsx を QueryClientProvider 前提に更新
- frontend/src/features/receipt/hooks/useReceiptsData.ts で mutation error を dbError に集約

## テスト
- [x] cd frontend && npm run lint
- [x] cd frontend && npm test -- src/pages/__tests__/Receipts.test.tsx
- [x] cd frontend && npm run build
