### PR TITLE
refactor: AssetBalanceとReceiptsのデータ同期をTanStack Queryへ統一

### DIFF
--- a/frontend/src/features/assetBalance/hooks/useAssetBalance.ts
+++ b/frontend/src/features/assetBalance/hooks/useAssetBalance.ts
@@ -1,8 +1,10 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useMemo } from 'react';
 import { AssetBalanceData } from '@/lib/interfaces/assetBalance';
 import { assetBalanceApi } from '@/features/assetBalance/api/assetBalanceApi';
 import { logError } from '@/lib/utils/errorHandler';
 import { normalizeSecurityCode } from '@/lib/utils/formatters';
+import { assetBalanceQueryKeys } from '../queryKeys';
 
 export interface UseAssetBalanceReturn {
   assetBalanceData: AssetBalanceData[];
@@ -17,52 +19,27 @@ interface UseAssetBalanceOptions {
 }
 
 /**
- * 保有銘柄データをDBから取得するフック
+ * 保有銘柄データを Query キャッシュから取得するフック
  */
 export function useAssetBalance(options: UseAssetBalanceOptions = {}): UseAssetBalanceReturn {
-  const [assetBalanceData, setAssetBalanceData] = useState<AssetBalanceData[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
   const { enabled = true } = options;
-  const isFetchingRef = useRef(false);
-  const isActiveRef = useRef(true);
+  const queryClient = useQueryClient();
 
-  // DBから保有銘柄データを取得
-  const fetchAssetBalances = useCallback(async () => {
-    if (isFetchingRef.current) return;
-    isFetchingRef.current = true;
-    if (isActiveRef.current) {
-      setIsLoading(true);
-    }
-    try {
-      const data = await assetBalanceApi.list();
-      if (isActiveRef.current) {
-        setAssetBalanceData(data || []);
+  const query = useQuery({
+    queryKey: assetBalanceQueryKeys.all,
+    queryFn: async () => {
+      try {
+        return await assetBalanceApi.list();
+      } catch (error) {
+        logError('保有銘柄データ取得', error);
+        return [] as AssetBalanceData[];
       }
-    } catch (error) {
-      logError('保有銘柄データ取得', error);
-      if (isActiveRef.current) {
-        setAssetBalanceData([]);
-      }
-    } finally {
-      if (isActiveRef.current) {
-        setIsLoading(false);
-      }
-      isFetchingRef.current = false;
-    }
-  }, []);
+    },
+    enabled,
+  });
 
-  // 初回読み込み
-  useEffect(() => {
-    isActiveRef.current = true;
-    if (enabled) {
-      fetchAssetBalances();
-    }
-    return () => {
-      isActiveRef.current = false;
-    };
-  }, [fetchAssetBalances, enabled]);
+  const assetBalanceData = useMemo(() => query.data ?? [], [query.data]);
 
-  // 銘柄コードで資産を取得
   const getAssetBalanceByCode = useCallback(
     (code: string): AssetBalanceData | undefined => {
       const normalizedCode = normalizeSecurityCode(code);
@@ -74,16 +51,19 @@ export function useAssetBalance(options: UseAssetBalanceOptions = {}): UseAssetB
     [assetBalanceData]
   );
 
-  // 全資産の市場価値合計を計算
   const getTotalMarketValue = useCallback((): number => {
     return assetBalanceData.reduce((total, balance) => total + (balance?.market_value || 0), 0);
   }, [assetBalanceData]);
 
+  const refetch = useCallback(async () => {
+    await queryClient.invalidateQueries({ queryKey: assetBalanceQueryKeys.all });
+  }, [queryClient]);
+
   return {
     assetBalanceData,
-    isLoading,
+    isLoading: query.isLoading,
     getAssetBalanceByCode,
     getTotalMarketValue,
-    refetch: fetchAssetBalances,
+    refetch,
   };
 }

--- a/frontend/src/features/assetBalance/hooks/useAssetBalance.ts
+++ b/frontend/src/features/assetBalance/hooks/useAssetBalance.ts
@@ -2,7 +2,6 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useMemo } from 'react';
 import { AssetBalanceData } from '@/lib/interfaces/assetBalance';
 import { assetBalanceApi } from '@/features/assetBalance/api/assetBalanceApi';
-import { logError } from '@/lib/utils/errorHandler';
 import { normalizeSecurityCode } from '@/lib/utils/formatters';
 import { assetBalanceQueryKeys } from '../queryKeys';
 
@@ -27,14 +26,7 @@ export function useAssetBalance(options: UseAssetBalanceOptions = {}): UseAssetB
 
   const query = useQuery({
     queryKey: assetBalanceQueryKeys.all,
-    queryFn: async () => {
-      try {
-        return await assetBalanceApi.list();
-      } catch (error) {
-        logError('保有銘柄データ取得', error);
-        return [] as AssetBalanceData[];
-      }
-    },
+    queryFn: () => assetBalanceApi.list(),
     enabled,
   });
 

--- a/frontend/src/features/assetBalance/hooks/useAssetBalanceDataSource.ts
+++ b/frontend/src/features/assetBalance/hooks/useAssetBalanceDataSource.ts
@@ -1,9 +1,11 @@
-import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { AssetBalanceData } from '@/lib/interfaces/assetBalance';
 import { assetBalanceApi } from '@/features/assetBalance/api/assetBalanceApi';
 import { useCSVReader, CSVReaderHook } from '@/hooks/useCSVReader';
 import { useAuth } from '@/features/auth/hooks/useAuth';
 import { getDisplayErrorMessage } from '@/lib/utils/errorHandler';
+import { assetBalanceQueryKeys } from '../queryKeys';
 
 export interface UseAssetBalanceDataSourceResult {
   // データ
@@ -26,113 +28,87 @@ export interface UseAssetBalanceDataSourceResult {
 }
 
 /**
- * 保有銘柄データソースを管理するフック
- * 認証→DB取得→CSV→保存/削除→logout時クリアを管理
+ * 保有銘柄データソースを TanStack Query で管理するフック
  */
 export function useAssetBalanceDataSource(
   parseCsvItem: (item: Record<string, unknown>) => AssetBalanceData,
   filterCsvItem?: (item: AssetBalanceData) => boolean
 ): UseAssetBalanceDataSourceResult {
   const { isAuthenticated, isLoading: authLoading, onLogout } = useAuth();
+  const queryClient = useQueryClient();
 
   const [csvData, setCsvData] = useState<Record<string, unknown>[]>([]);
-  const [dbData, setDbData] = useState<AssetBalanceData[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [saving, setSaving] = useState(false);
-  const [deleting, setDeleting] = useState(false);
-
   const csvReader = useCSVReader({ skipHeaderRows: 6 });
 
-  const hasFetched = useRef(false);
-  const isFetchingRef = useRef(false);
+  const dbQuery = useQuery({
+    queryKey: assetBalanceQueryKeys.all,
+    queryFn: () => assetBalanceApi.list(),
+    enabled: isAuthenticated && !authLoading,
+  });
 
-  const refetch = useCallback(async (force = false) => {
-    if (authLoading) return;
-    if (!isAuthenticated) return;
-    if (hasFetched.current && !force) return;
-    if (isFetchingRef.current) return;
+  const bulkCreateMutation = useMutation({
+    mutationFn: (items: AssetBalanceData[]) => assetBalanceApi.bulkCreate(items),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: assetBalanceQueryKeys.all });
+    },
+  });
 
-    isFetchingRef.current = true;
-    setLoading(true);
-    setError(null);
+  const deleteAllMutation = useMutation({
+    mutationFn: () => assetBalanceApi.deleteAll(),
+    onSuccess: () => {
+      queryClient.setQueryData(assetBalanceQueryKeys.all, []);
+    },
+  });
 
-    try {
-      const data = await assetBalanceApi.list();
-      setDbData(data);
-      hasFetched.current = true;
-    } catch (err) {
-      setError(getDisplayErrorMessage(err, 'データ取得に失敗しました'));
-    } finally {
-      setLoading(false);
-      isFetchingRef.current = false;
-    }
-  }, [authLoading, isAuthenticated]);
-
-  useEffect(() => {
-    if (!authLoading) {
-      refetch();
-    }
-  }, [authLoading, refetch]);
-
+  // ログアウト時にキャッシュと CSV をクリア
   useEffect(() => {
     return onLogout(() => {
-      setDbData([]);
       setCsvData([]);
-      setError(null);
-      hasFetched.current = false;
       csvReader.reset();
+      queryClient.setQueryData(assetBalanceQueryKeys.all, []);
     });
-  }, [onLogout, csvReader]);
+  }, [onLogout, csvReader, queryClient]);
 
   const handleFileSelect = useCallback(async (file: File) => {
     try {
       const data = await csvReader.parseCSV(file);
       setCsvData(data);
       if (csvReader.error) csvReader.resetError();
-    } catch (e) {
-      setError(getDisplayErrorMessage(e, 'CSVファイルの読み込みに失敗しました'));
+    } catch {
+      // CSVパースエラーは csvReader.error に反映される
     }
   }, [csvReader]);
 
   const handleSaveToDB = useCallback(async () => {
-    if (!isAuthenticated) return;
-    if (csvData.length === 0) return;
-
-    setSaving(true);
-    setError(null);
-
+    if (!isAuthenticated || csvData.length === 0) return;
+    let items = csvData.map(parseCsvItem);
+    if (filterCsvItem) items = items.filter(filterCsvItem);
     try {
-      let items = csvData.map(parseCsvItem);
-      if (filterCsvItem) {
-        items = items.filter(filterCsvItem);
-      }
-      await assetBalanceApi.bulkCreate(items);
+      await bulkCreateMutation.mutateAsync(items);
       setCsvData([]);
       csvReader.reset();
-      await refetch(true);
-    } catch (err) {
-      setError(getDisplayErrorMessage(err, '保存に失敗しました'));
-    } finally {
-      setSaving(false);
+    } catch {
+      // エラーは bulkCreateMutation.error に反映される
     }
-  }, [csvData, csvReader, filterCsvItem, isAuthenticated, parseCsvItem, refetch]);
+  }, [bulkCreateMutation, csvData, csvReader, filterCsvItem, isAuthenticated, parseCsvItem]);
 
   const handleDeleteAll = useCallback(async () => {
     if (!isAuthenticated) return;
-
-    setDeleting(true);
-    setError(null);
-
     try {
-      await assetBalanceApi.deleteAll();
-      setDbData([]);
-    } catch (err) {
-      setError(getDisplayErrorMessage(err, '削除に失敗しました'));
-    } finally {
-      setDeleting(false);
+      await deleteAllMutation.mutateAsync();
+    } catch {
+      // エラーは deleteAllMutation.error に反映される
     }
-  }, [isAuthenticated]);
+  }, [deleteAllMutation, isAuthenticated]);
+
+  const dbData = useMemo(() => dbQuery.data ?? [], [dbQuery.data]);
+  const queryError = dbQuery.error;
+  const mutationError = bulkCreateMutation.error ?? deleteAllMutation.error;
+  const error = queryError
+    ? getDisplayErrorMessage(queryError, 'データ取得に失敗しました')
+    : mutationError
+      ? getDisplayErrorMessage(mutationError, '操作に失敗しました')
+      : null;
 
   const hasCsvData = csvData.length > 0;
   const hasDbData = useMemo(() => dbData.length > 0, [dbData]);
@@ -140,10 +116,10 @@ export function useAssetBalanceDataSource(
   return {
     dbData,
     csvData,
-    loading,
+    loading: dbQuery.isFetching,
     error,
-    saving,
-    deleting,
+    saving: bulkCreateMutation.isPending,
+    deleting: deleteAllMutation.isPending,
     csvReader,
     hasCsvData,
     hasDbData,

--- a/frontend/src/features/assetBalance/queryKeys.ts
+++ b/frontend/src/features/assetBalance/queryKeys.ts
@@ -1,0 +1,3 @@
+export const assetBalanceQueryKeys = {
+  all: ['assetBalance'] as const,
+};


### PR DESCRIPTION
## 概要
- AssetBalance のデータ同期を TanStack Query ベースに統一
- Receipts の Query 移行後に残っていた手動同期処理を整理
- 保存/削除失敗時のエラー表示を改善

## 主な変更内容
- frontend/src/features/assetBalance/queryKeys.ts を追加
- frontend/src/features/assetBalance/hooks/useAssetBalanceDataSource.ts を Query + Mutation ベースへ移行
- frontend/src/features/assetBalance/hooks/useAssetBalance.ts を Query キャッシュ参照ベースへ移行
- frontend/src/features/receipt/hooks/useReceiptsData.ts で mutation error を UI 表示用エラーに集約

## テスト
- [x] cd frontend && npm run lint
- [x] cd frontend && npm test -- src/pages/__tests__/AssetBalance.test.tsx src/pages/Receipt/__tests__/Dividend.test.tsx src/pages/__tests__/Receipts.test.tsx
- [x] cd frontend && npm run build
- [x] cd frontend && npx tsc --noEmit
