### PR TITLE
fix: AssetBalanceのログアウト時キャッシュ境界を強化

### DIFF
--- a/frontend/src/features/assetBalance/hooks/__tests__/useAssetBalance.test.ts
+++ b/frontend/src/features/assetBalance/hooks/__tests__/useAssetBalance.test.ts
@@ -1,0 +1,96 @@
+/**
+ * useAssetBalance: ログアウト時のキャッシュクリアテスト
+ *
+ * AssetBalancePage を経由しない単独利用経路（DividendInfo など）でも
+ * onLogout コールバックが発火した際にキャッシュが除去されることを検証する
+ */
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { useAssetBalance } from '../useAssetBalance';
+import { assetBalanceQueryKeys } from '../../queryKeys';
+import * as assetBalanceApiModule from '@/features/assetBalance/api/assetBalanceApi';
+import * as authHook from '@/features/auth/hooks/useAuth';
+
+// ────────────────────────────────────────────────────────
+// モック
+// ────────────────────────────────────────────────────────
+
+vi.mock('@/features/assetBalance/api/assetBalanceApi', () => ({
+  assetBalanceApi: { list: vi.fn().mockResolvedValue([]) },
+}));
+
+vi.mock('@/features/auth/hooks/useAuth');
+
+type LogoutCallback = () => void;
+type UseAuthReturn = ReturnType<typeof authHook.useAuth>;
+
+function makeAuthMock(opts: {
+  isAuthenticated?: boolean;
+  userId?: string;
+  onLogoutCapture?: (cb: LogoutCallback) => void;
+}): UseAuthReturn {
+  const { isAuthenticated = true, userId = 'user-1', onLogoutCapture } = opts;
+  return {
+    user: isAuthenticated ? { id: userId, email: 'test@example.com' } : null,
+    setUser: vi.fn(),
+    login: vi.fn(),
+    logout: vi.fn().mockResolvedValue(undefined),
+    deleteAccount: vi.fn().mockResolvedValue(undefined),
+    isAuthenticated,
+    isLoading: false,
+    onLogout: (cb: LogoutCallback) => {
+      onLogoutCapture?.(cb);
+      return () => {};
+    },
+  };
+}
+
+function makeWrapper(qc: QueryClient) {
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: qc }, children);
+  }
+  return Wrapper;
+}
+
+// ────────────────────────────────────────────────────────
+// テスト
+// ────────────────────────────────────────────────────────
+
+describe('useAssetBalance: ログアウト時キャッシュクリア', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('onLogout コールバック実行で assetBalance キャッシュが除去される', async () => {
+    let capturedCallback: LogoutCallback | null = null;
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+
+    vi.mocked(authHook.useAuth).mockReturnValue(
+      makeAuthMock({ onLogoutCapture: (cb) => { capturedCallback = cb; } })
+    );
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue([
+      { security_code: '7203', security_name: 'トヨタ自動車', shares: 100 } as never,
+    ]);
+
+    renderHook(() => useAssetBalance(), { wrapper: makeWrapper(qc) });
+
+    // キャッシュにデータが入るまで待つ
+    await waitFor(() => {
+      expect(qc.getQueryData(assetBalanceQueryKeys.all('user-1'))).toBeDefined();
+    });
+    await waitFor(() => expect(capturedCallback).not.toBeNull());
+
+    act(() => {
+      capturedCallback!();
+      vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({ isAuthenticated: false }));
+    });
+
+    await waitFor(() => {
+      expect(qc.getQueryData(assetBalanceQueryKeys.all('user-1'))).toBeUndefined();
+    });
+  });
+});

--- a/frontend/src/features/assetBalance/hooks/useAssetBalance.ts
+++ b/frontend/src/features/assetBalance/hooks/useAssetBalance.ts
@@ -1,9 +1,10 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { AssetBalanceData } from '@/lib/interfaces/assetBalance';
 import { assetBalanceApi } from '@/features/assetBalance/api/assetBalanceApi';
+import { useAuth } from '@/features/auth/hooks/useAuth';
 import { normalizeSecurityCode } from '@/lib/utils/formatters';
-import { assetBalanceQueryKeys } from '../queryKeys';
+import { assetBalanceQueryKeys, clearAssetBalanceCache } from '../queryKeys';
 
 export interface UseAssetBalanceReturn {
   assetBalanceData: AssetBalanceData[];
@@ -19,18 +20,30 @@ interface UseAssetBalanceOptions {
 
 /**
  * 保有銘柄データを Query キャッシュから取得するフック
+ * ユーザー固有キーでキャッシュを分離し、未認証時はフェッチせず空配列を返す
  */
 export function useAssetBalance(options: UseAssetBalanceOptions = {}): UseAssetBalanceReturn {
   const { enabled = true } = options;
+  const { isAuthenticated, onLogout, user } = useAuth();
   const queryClient = useQueryClient();
+  const userId = user?.id ?? '';
 
   const query = useQuery({
-    queryKey: assetBalanceQueryKeys.all,
+    queryKey: assetBalanceQueryKeys.all(userId),
     queryFn: () => assetBalanceApi.list(),
-    enabled,
+    enabled: isAuthenticated && !!userId && enabled,
   });
 
-  const assetBalanceData = useMemo(() => query.data ?? [], [query.data]);
+  // ログアウト時：このフックがマウントされている経路でも確実にキャッシュを除去する
+  useEffect(() => {
+    return onLogout(() => clearAssetBalanceCache(queryClient));
+  }, [onLogout, queryClient]);
+
+  // 未認証時はキャッシュに残存データがあっても空を返す
+  const assetBalanceData = useMemo(
+    () => (isAuthenticated ? (query.data ?? []) : []),
+    [isAuthenticated, query.data]
+  );
 
   const getAssetBalanceByCode = useCallback(
     (code: string): AssetBalanceData | undefined => {
@@ -48,8 +61,8 @@ export function useAssetBalance(options: UseAssetBalanceOptions = {}): UseAssetB
   }, [assetBalanceData]);
 
   const refetch = useCallback(async () => {
-    await queryClient.invalidateQueries({ queryKey: assetBalanceQueryKeys.all });
-  }, [queryClient]);
+    await queryClient.invalidateQueries({ queryKey: assetBalanceQueryKeys.all(userId) });
+  }, [queryClient, userId]);
 
   return {
     assetBalanceData,

--- a/frontend/src/features/assetBalance/hooks/useAssetBalanceDataSource.ts
+++ b/frontend/src/features/assetBalance/hooks/useAssetBalanceDataSource.ts
@@ -5,7 +5,7 @@ import { assetBalanceApi } from '@/features/assetBalance/api/assetBalanceApi';
 import { useCSVReader, CSVReaderHook } from '@/hooks/useCSVReader';
 import { useAuth } from '@/features/auth/hooks/useAuth';
 import { getDisplayErrorMessage } from '@/lib/utils/errorHandler';
-import { assetBalanceQueryKeys } from '../queryKeys';
+import { assetBalanceQueryKeys, clearAssetBalanceCache } from '../queryKeys';
 
 export interface UseAssetBalanceDataSourceResult {
   // データ
@@ -29,43 +29,45 @@ export interface UseAssetBalanceDataSourceResult {
 
 /**
  * 保有銘柄データソースを TanStack Query で管理するフック
+ * ユーザー固有クエリキーでキャッシュを分離する
  */
 export function useAssetBalanceDataSource(
   parseCsvItem: (item: Record<string, unknown>) => AssetBalanceData,
   filterCsvItem?: (item: AssetBalanceData) => boolean
 ): UseAssetBalanceDataSourceResult {
-  const { isAuthenticated, isLoading: authLoading, onLogout } = useAuth();
+  const { isAuthenticated, isLoading: authLoading, onLogout, user } = useAuth();
   const queryClient = useQueryClient();
+  const userId = user?.id ?? '';
 
   const [csvData, setCsvData] = useState<Record<string, unknown>[]>([]);
   const csvReader = useCSVReader({ skipHeaderRows: 6 });
 
   const dbQuery = useQuery({
-    queryKey: assetBalanceQueryKeys.all,
+    queryKey: assetBalanceQueryKeys.all(userId),
     queryFn: () => assetBalanceApi.list(),
-    enabled: isAuthenticated && !authLoading,
+    enabled: isAuthenticated && !authLoading && !!userId,
   });
 
   const bulkCreateMutation = useMutation({
     mutationFn: (items: AssetBalanceData[]) => assetBalanceApi.bulkCreate(items),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: assetBalanceQueryKeys.all });
+      queryClient.invalidateQueries({ queryKey: assetBalanceQueryKeys.all(userId) });
     },
   });
 
   const deleteAllMutation = useMutation({
     mutationFn: () => assetBalanceApi.deleteAll(),
     onSuccess: () => {
-      queryClient.setQueryData(assetBalanceQueryKeys.all, []);
+      queryClient.setQueryData(assetBalanceQueryKeys.all(userId), []);
     },
   });
 
-  // ログアウト時にキャッシュと CSV をクリア
+  // ログアウト時：プレフィックスマッチで全ユーザーキャッシュをクリア（他画面からのログアウトにも対応）
   useEffect(() => {
     return onLogout(() => {
+      clearAssetBalanceCache(queryClient);
       setCsvData([]);
       csvReader.reset();
-      queryClient.setQueryData(assetBalanceQueryKeys.all, []);
     });
   }, [onLogout, csvReader, queryClient]);
 

--- a/frontend/src/features/assetBalance/queryKeys.ts
+++ b/frontend/src/features/assetBalance/queryKeys.ts
@@ -1,3 +1,14 @@
+import type { QueryClient } from '@tanstack/react-query';
+
+// ユーザーごとにキャッシュを分離し、別ユーザーへのデータ漏洩を防ぐ
 export const assetBalanceQueryKeys = {
-  all: ['assetBalance'] as const,
+  // ログアウト時の cancelQueries/removeQueries に使うプレフィックスキー
+  prefix: ['assetBalance'] as const,
+  all: (userId: string) => ['assetBalance', userId] as const,
 };
+
+/** ログアウト時の assetBalance キャッシュ全削除（プレフィックスマッチ） */
+export function clearAssetBalanceCache(queryClient: QueryClient): void {
+  queryClient.cancelQueries({ queryKey: assetBalanceQueryKeys.prefix });
+  queryClient.removeQueries({ queryKey: assetBalanceQueryKeys.prefix });
+}

--- a/frontend/src/pages/__tests__/AssetBalancePage.test.tsx
+++ b/frontend/src/pages/__tests__/AssetBalancePage.test.tsx
@@ -1,0 +1,211 @@
+/**
+ * AssetBalancePage の認証境界・キャッシュ境界テスト
+ *
+ * 対象:
+ * - 未認証時: API フェッチ抑制・ログインプロンプト表示
+ * - 認証済み: DB データ取得・全件削除ボタン表示
+ * - ログアウト: onLogout コールバックでキャッシュ除去
+ */
+import React from 'react';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { AssetBalancePage } from '../AssetBalance';
+import { assetBalanceQueryKeys } from '@/features/assetBalance/queryKeys';
+
+// ────────────────────────────────────────────────────────
+// モック定義
+// ────────────────────────────────────────────────────────
+
+vi.mock('@/components/templates/Layout', () => ({
+  Layout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock('@/components/atoms/PageHeader', () => ({
+  PageHeader: ({ title }: { title: string }) => <h1>{title}</h1>,
+}));
+vi.mock('@/components/atoms/Alert', () => ({
+  Alert: ({ children }: { children: React.ReactNode }) => <div role="alert">{children}</div>,
+}));
+vi.mock('@/components/atoms/Spinner', () => ({
+  Spinner: () => <span role="status">loading</span>,
+}));
+vi.mock('@/components/atoms/Button', () => ({
+  Button: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => (
+    <button onClick={onClick}>{children}</button>
+  ),
+}));
+vi.mock('@/components/molecules/CSVFileInput', () => ({
+  CSVFileInput: () => <div data-testid="csv-file-input" />,
+}));
+vi.mock('@/components/molecules/ConfirmDeleteModal/ConfirmDeleteModal', () => ({
+  ConfirmDeleteModal: ({ isOpen, onConfirm }: { isOpen: boolean; onConfirm: () => void }) =>
+    isOpen ? (
+      <button data-testid="confirm-delete" onClick={onConfirm}>削除する</button>
+    ) : null,
+}));
+vi.mock('@/components/organisms/AssetPortfolioSummary', () => ({
+  AssetPortfolioSummary: ({ assetBalanceData }: { assetBalanceData: unknown[] }) => (
+    <div data-testid="portfolio-summary">{assetBalanceData.length}</div>
+  ),
+}));
+vi.mock('@/components/organisms/SearchCard/SearchCard', () => ({
+  SearchCard: () => <div data-testid="search-card" />,
+}));
+
+// AssetBalance API
+import * as assetBalanceApiModule from '@/features/assetBalance/api/assetBalanceApi';
+vi.mock('@/features/assetBalance/api/assetBalanceApi', () => ({
+  assetBalanceApi: {
+    list: vi.fn().mockResolvedValue([]),
+    bulkCreate: vi.fn().mockResolvedValue({ inserted: 0, skipped: 0 }),
+    deleteAll: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+vi.mock('@/features/jquants/hooks/useDividendBatch', () => ({
+  useDividendBatch: vi.fn(() => ({
+    dividendPerShareMap: new Map(),
+    dividendStatusMap: new Map(),
+    fetchedCount: 0,
+    totalCount: 0,
+  })),
+}));
+
+vi.mock('@/hooks/useCSVReader', () => ({
+  useCSVReader: () => ({
+    parseCSV: vi.fn().mockResolvedValue([]),
+    isLoading: false,
+    error: null,
+    fileName: null,
+    resetError: vi.fn(),
+    reset: vi.fn(),
+  }),
+}));
+
+import * as authHook from '@/features/auth/hooks/useAuth';
+vi.mock('@/features/auth/hooks/useAuth');
+
+// ────────────────────────────────────────────────────────
+// ユーティリティ
+// ────────────────────────────────────────────────────────
+
+type LogoutCallback = () => void;
+type UseAuthReturn = ReturnType<typeof authHook.useAuth>;
+
+function makeAuthMock(opts: {
+  isAuthenticated?: boolean;
+  authLoading?: boolean;
+  userId?: string;
+  onLogoutCapture?: (cb: LogoutCallback) => void;
+}): UseAuthReturn {
+  const { isAuthenticated = false, authLoading = false, userId = 'user-1', onLogoutCapture } = opts;
+  return {
+    user: isAuthenticated ? { id: userId, email: 'test@example.com' } : null,
+    setUser: vi.fn(),
+    login: vi.fn(),
+    logout: vi.fn().mockResolvedValue(undefined),
+    deleteAccount: vi.fn().mockResolvedValue(undefined),
+    isAuthenticated,
+    isLoading: authLoading,
+    onLogout: (cb: LogoutCallback) => {
+      onLogoutCapture?.(cb);
+      return () => {};
+    },
+  };
+}
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Infinity },
+    },
+  });
+}
+
+function renderWithQuery(ui: React.ReactElement, qc?: QueryClient) {
+  const client = qc ?? makeQueryClient();
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
+
+// DBデータの型に合わせたモック行
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockDbRow: any = {
+  security_code: '7203',
+  security_name: 'トヨタ自動車',
+  shares: 100,
+  executing_shares: 0,
+  average_purchase_price: 2500,
+  total_purchase_amount: 250000,
+  current_price: 2600,
+  daily_change: 50,
+  market_value: 260000,
+  profit_loss_rate: 4.0,
+};
+
+// ────────────────────────────────────────────────────────
+// テスト
+// ────────────────────────────────────────────────────────
+
+describe('AssetBalancePage 認証境界・キャッシュ境界', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue([]);
+  });
+
+  it('未認証時: ログインプロンプトが表示され API フェッチが行われない', async () => {
+    vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({}));
+
+    renderWithQuery(<AssetBalancePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/ログインが必要です/)).toBeInTheDocument();
+    });
+    expect(assetBalanceApiModule.assetBalanceApi.list).not.toHaveBeenCalled();
+  });
+
+  it('認証済み・DBデータあり: 全件削除ボタンが表示される', async () => {
+    vi.mocked(authHook.useAuth).mockReturnValue(
+      makeAuthMock({ isAuthenticated: true, userId: 'user-1' })
+    );
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue([mockDbRow]);
+
+    renderWithQuery(<AssetBalancePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/全件削除/)).toBeInTheDocument();
+    });
+  });
+
+  it('ログアウト: onLogout コールバック実行でキャッシュが除去される', async () => {
+    let capturedCallback: LogoutCallback | null = null;
+    const qc = makeQueryClient();
+
+    vi.mocked(authHook.useAuth).mockReturnValue(
+      makeAuthMock({
+        isAuthenticated: true,
+        userId: 'user-1',
+        onLogoutCapture: (cb) => { capturedCallback = cb; },
+      })
+    );
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue([mockDbRow]);
+
+    renderWithQuery(<AssetBalancePage />, qc);
+
+    await waitFor(() => expect(capturedCallback).not.toBeNull());
+    await waitFor(() => {
+      expect(screen.getByText(/全件削除/)).toBeInTheDocument();
+    });
+
+    act(() => {
+      // ログアウト: コールバック実行と同時に認証状態を false へ（実際のフローと同順）
+      capturedCallback!();
+      vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({ isAuthenticated: false }));
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText(/全件削除/)).not.toBeInTheDocument();
+    });
+    expect(qc.getQueryData(assetBalanceQueryKeys.all('user-1'))).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## 概要
AssetBalance のログアウト時キャッシュ境界を強化し、利用経路に依存せずにキャッシュを安全に破棄できるようにしました。

## 変更種別
- [ ] 新機能
- [x] バグ修正
- [x] リファクタリング
- [x] テスト追加

## 主な変更内容
- `assetBalance` の Query Key をユーザー単位 (`['assetBalance', userId]`) に変更
- ログアウト時キャッシュ削除処理を `clearAssetBalanceCache` として `frontend/src/features/assetBalance/queryKeys.ts` に集約
- `useAssetBalance` / `useAssetBalanceDataSource` の両方から共通キャッシュ削除関数を利用
- 未認証時は `useAssetBalance` が常に空配列を返すよう明示
- 認証境界・キャッシュ境界のテストを追加
  - `frontend/src/pages/__tests__/AssetBalancePage.test.tsx`
  - `frontend/src/features/assetBalance/hooks/__tests__/useAssetBalance.test.ts`

## テスト
- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npx tsc --noEmit`
- [x] `cd frontend && npm test -- src/features/assetBalance/hooks/__tests__/useAssetBalance.test.ts src/pages/__tests__/AssetBalancePage.test.tsx src/pages/Receipt/__tests__/Dividend.test.tsx src/pages/__tests__/AssetBalance.test.tsx`

補足: テストは全て pass。`AssetBalance.test.tsx` 実行時に Suspense 関連の `act(...)` 警告が stderr に出ますが、失敗はしていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
