### PR TITLE
fix: Receiptsのログアウト時キャッシュ境界を強化

### DIFF
--- a/frontend/src/features/receipt/hooks/__tests__/useReceiptsData.test.ts
+++ b/frontend/src/features/receipt/hooks/__tests__/useReceiptsData.test.ts
@@ -116,5 +116,7 @@ describe('useReceiptsData: 認証境界・キャッシュ境界', () => {
     await waitFor(() => {
       expect(qc.getQueryData(receiptQueryKeys.dividend('user-1'))).toBeUndefined();
     });
+    expect(qc.getQueryData(receiptQueryKeys.domesticstock('user-1'))).toBeUndefined();
+    expect(qc.getQueryData(receiptQueryKeys.mutualfund('user-1'))).toBeUndefined();
   });
 });

--- a/frontend/src/features/receipt/hooks/__tests__/useReceiptsData.test.ts
+++ b/frontend/src/features/receipt/hooks/__tests__/useReceiptsData.test.ts
@@ -1,0 +1,120 @@
+/**
+ * useReceiptsData: 認証境界・キャッシュ境界テスト
+ *
+ * ReceiptsPage を経由しない単独利用として、
+ * 未認証時のフェッチ抑止とログアウト時のキャッシュ削除を検証する
+ */
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { useReceiptsData } from '../useReceiptsData';
+import { receiptQueryKeys } from '../../queryKeys';
+import * as receiptApiModule from '@/features/receipt/api/receiptApi';
+import * as authHook from '@/features/auth/hooks/useAuth';
+
+// ────────────────────────────────────────────────────────
+// モック
+// ────────────────────────────────────────────────────────
+
+vi.mock('@/features/receipt/api/receiptApi', () => ({
+  dividendApi: { list: vi.fn().mockResolvedValue([]) },
+  domesticStockApi: { list: vi.fn().mockResolvedValue([]) },
+  mutualfundApi: { list: vi.fn().mockResolvedValue([]) },
+}));
+
+vi.mock('@/features/receipt/parsers', () => ({
+  transformDBDividend: vi.fn((item: unknown) => item),
+  transformDBDomesticStock: vi.fn((item: unknown) => item),
+  transformDBMutualfund: vi.fn((item: unknown) => item),
+}));
+
+vi.mock('@/features/auth/hooks/useAuth');
+
+type LogoutCallback = () => void;
+type UseAuthReturn = ReturnType<typeof authHook.useAuth>;
+
+function makeAuthMock(opts: {
+  isAuthenticated?: boolean;
+  userId?: string;
+  onLogoutCapture?: (cb: LogoutCallback) => void;
+}): UseAuthReturn {
+  const { isAuthenticated = true, userId = 'user-1', onLogoutCapture } = opts;
+  return {
+    user: isAuthenticated ? { id: userId, email: 'test@example.com' } : null,
+    setUser: vi.fn(),
+    login: vi.fn(),
+    logout: vi.fn().mockResolvedValue(undefined),
+    deleteAccount: vi.fn().mockResolvedValue(undefined),
+    isAuthenticated,
+    isLoading: false,
+    onLogout: (cb: LogoutCallback) => {
+      onLogoutCapture?.(cb);
+      return () => {};
+    },
+  };
+}
+
+function makeWrapper(qc: QueryClient) {
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: qc }, children);
+  }
+  return Wrapper;
+}
+
+// ────────────────────────────────────────────────────────
+// テスト
+// ────────────────────────────────────────────────────────
+
+describe('useReceiptsData: 認証境界・キャッシュ境界', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('未認証時: API フェッチが行われない', async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+
+    vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({ isAuthenticated: false }));
+
+    renderHook(() => useReceiptsData(), { wrapper: makeWrapper(qc) });
+
+    // フェッチされないことを確認（100ms 待って呼ばれていない）
+    await new Promise((r) => setTimeout(r, 100));
+    expect(receiptApiModule.dividendApi.list).not.toHaveBeenCalled();
+    expect(receiptApiModule.domesticStockApi.list).not.toHaveBeenCalled();
+    expect(receiptApiModule.mutualfundApi.list).not.toHaveBeenCalled();
+  });
+
+  it('onLogout コールバック実行で receipts キャッシュが除去される', async () => {
+    let capturedCallback: LogoutCallback | null = null;
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+
+    vi.mocked(authHook.useAuth).mockReturnValue(
+      makeAuthMock({ onLogoutCapture: (cb) => { capturedCallback = cb; } })
+    );
+    vi.mocked(receiptApiModule.dividendApi.list).mockResolvedValue([
+      { id: '1', payment_date: '2023-01-01' } as never,
+    ]);
+
+    renderHook(() => useReceiptsData(), { wrapper: makeWrapper(qc) });
+
+    // キャッシュにデータが入るまで待つ
+    await waitFor(() => {
+      expect(qc.getQueryData(receiptQueryKeys.dividend('user-1'))).toBeDefined();
+    });
+    await waitFor(() => expect(capturedCallback).not.toBeNull());
+
+    act(() => {
+      capturedCallback!();
+      vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({ isAuthenticated: false }));
+    });
+
+    await waitFor(() => {
+      expect(qc.getQueryData(receiptQueryKeys.dividend('user-1'))).toBeUndefined();
+    });
+  });
+});

--- a/frontend/src/features/receipt/hooks/__tests__/useReceiptsData.test.ts
+++ b/frontend/src/features/receipt/hooks/__tests__/useReceiptsData.test.ts
@@ -80,8 +80,8 @@ describe('useReceiptsData: 認証境界・キャッシュ境界', () => {
 
     renderHook(() => useReceiptsData(), { wrapper: makeWrapper(qc) });
 
-    // フェッチされないことを確認（100ms 待って呼ばれていない）
-    await new Promise((r) => setTimeout(r, 100));
+    // enabled: false のため queryFn は実行されない（非同期キューを flush しても呼ばれない）
+    await act(async () => { await Promise.resolve(); });
     expect(receiptApiModule.dividendApi.list).not.toHaveBeenCalled();
     expect(receiptApiModule.domesticStockApi.list).not.toHaveBeenCalled();
     expect(receiptApiModule.mutualfundApi.list).not.toHaveBeenCalled();

--- a/frontend/src/features/receipt/hooks/useReceiptsData.ts
+++ b/frontend/src/features/receipt/hooks/useReceiptsData.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { dividendApi, domesticStockApi, mutualfundApi } from '../api/receiptApi';
 import {
   parseDividendCsvItem,
@@ -9,9 +9,10 @@ import {
   transformDBDomesticStock,
   transformDBMutualfund,
 } from '../parsers';
-import { receiptQueryKeys } from '../queryKeys';
+import { receiptQueryKeys, clearReceiptsCache } from '../queryKeys';
 import { type ReceiptsType } from '@/pages/receiptsReducer';
 import { getDisplayErrorMessage } from '@/lib/utils/errorHandler';
+import { useAuth } from '@/features/auth/hooks/useAuth';
 
 export interface UseReceiptsDataResult {
   dividendData: ReturnType<typeof transformDBDividend>[];
@@ -34,35 +35,43 @@ interface BulkCreateArgs {
 
 /**
  * 明細データの取得・保存・削除を TanStack Query で管理するフック
+ * ユーザー固有キーでキャッシュを分離し、未認証時はフェッチせず空を返す
  */
-export function useReceiptsData(isAuthenticated: boolean): UseReceiptsDataResult {
+export function useReceiptsData(): UseReceiptsDataResult {
+  const { isAuthenticated, isLoading: authLoading, onLogout, user } = useAuth();
+  const userId = user?.id ?? '';
   const queryClient = useQueryClient();
 
+  // ログアウト時：プレフィックスマッチで全ユーザーキャッシュをクリア
+  useEffect(() => {
+    return onLogout(() => clearReceiptsCache(queryClient));
+  }, [onLogout, queryClient]);
+
   const dividendQuery = useQuery({
-    queryKey: receiptQueryKeys.dividend,
+    queryKey: receiptQueryKeys.dividend(userId),
     queryFn: () =>
       dividendApi.list().then(items =>
         items.map(d => transformDBDividend(d as unknown as Record<string, unknown>))
       ),
-    enabled: isAuthenticated,
+    enabled: isAuthenticated && !authLoading && !!userId,
   });
 
   const domesticstockQuery = useQuery({
-    queryKey: receiptQueryKeys.domesticstock,
+    queryKey: receiptQueryKeys.domesticstock(userId),
     queryFn: () =>
       domesticStockApi.list().then(items =>
         items.map(d => transformDBDomesticStock(d as unknown as Record<string, unknown>))
       ),
-    enabled: isAuthenticated,
+    enabled: isAuthenticated && !authLoading && !!userId,
   });
 
   const mutualfundQuery = useQuery({
-    queryKey: receiptQueryKeys.mutualfund,
+    queryKey: receiptQueryKeys.mutualfund(userId),
     queryFn: () =>
       mutualfundApi.list().then(items =>
         items.map(d => transformDBMutualfund(d as unknown as Record<string, unknown>))
       ),
-    enabled: isAuthenticated,
+    enabled: isAuthenticated && !authLoading && !!userId,
   });
 
   const bulkCreateMutation = useMutation({
@@ -77,7 +86,7 @@ export function useReceiptsData(isAuthenticated: boolean): UseReceiptsDataResult
       }
     },
     onSuccess: (_, { type, onSuccess }) => {
-      queryClient.invalidateQueries({ queryKey: receiptQueryKeys[type] });
+      queryClient.invalidateQueries({ queryKey: receiptQueryKeys[type](userId) });
       onSuccess?.();
     },
   });
@@ -94,14 +103,12 @@ export function useReceiptsData(isAuthenticated: boolean): UseReceiptsDataResult
       }
     },
     onSuccess: (_, type) => {
-      queryClient.setQueryData(receiptQueryKeys[type], []);
+      queryClient.setQueryData(receiptQueryKeys[type](userId), []);
     },
   });
 
   const clearCache = useCallback(() => {
-    queryClient.setQueryData(receiptQueryKeys.dividend, []);
-    queryClient.setQueryData(receiptQueryKeys.domesticstock, []);
-    queryClient.setQueryData(receiptQueryKeys.mutualfund, []);
+    clearReceiptsCache(queryClient);
   }, [queryClient]);
 
   const queryError = dividendQuery.error ?? domesticstockQuery.error ?? mutualfundQuery.error;

--- a/frontend/src/features/receipt/hooks/useReceiptsData.ts
+++ b/frontend/src/features/receipt/hooks/useReceiptsData.ts
@@ -85,8 +85,10 @@ export function useReceiptsData(): UseReceiptsDataResult {
           return mutualfundApi.bulkCreate(csvData.map(parseMutualfundCsvItem));
       }
     },
-    onSuccess: (_, { type, onSuccess }) => {
-      queryClient.invalidateQueries({ queryKey: receiptQueryKeys[type](userId) });
+    // mutate 呼び出し時点の userId をスナップショット（ログアウト→再ログイン中の上書き防止）
+    onMutate: () => ({ snapshotUserId: userId }),
+    onSuccess: (_, { type, onSuccess }, context) => {
+      queryClient.invalidateQueries({ queryKey: receiptQueryKeys[type](context?.snapshotUserId ?? userId) });
       onSuccess?.();
     },
   });
@@ -102,8 +104,10 @@ export function useReceiptsData(): UseReceiptsDataResult {
           return mutualfundApi.deleteAll();
       }
     },
-    onSuccess: (_, type) => {
-      queryClient.setQueryData(receiptQueryKeys[type](userId), []);
+    // mutate 呼び出し時点の userId をスナップショット（ログアウト→再ログイン中の上書き防止）
+    onMutate: () => ({ snapshotUserId: userId }),
+    onSuccess: (_, type, context) => {
+      queryClient.setQueryData(receiptQueryKeys[type](context?.snapshotUserId ?? userId), []);
     },
   });
 

--- a/frontend/src/features/receipt/queryKeys.ts
+++ b/frontend/src/features/receipt/queryKeys.ts
@@ -1,7 +1,16 @@
-import { ReceiptsType } from '@/pages/receiptsReducer';
+import type { QueryClient } from '@tanstack/react-query';
 
+// ユーザーごとにキャッシュを分離し、別ユーザーへのデータ漏洩を防ぐ
 export const receiptQueryKeys = {
-  dividend: ['receipts', 'dividend'] as const,
-  domesticstock: ['receipts', 'domesticstock'] as const,
-  mutualfund: ['receipts', 'mutualfund'] as const,
-} satisfies Record<ReceiptsType, readonly string[]>;
+  // ログアウト時の cancelQueries/removeQueries に使うプレフィックスキー
+  prefix: ['receipts'] as const,
+  dividend: (userId: string) => ['receipts', userId, 'dividend'] as const,
+  domesticstock: (userId: string) => ['receipts', userId, 'domesticstock'] as const,
+  mutualfund: (userId: string) => ['receipts', userId, 'mutualfund'] as const,
+};
+
+/** ログアウト時の receipts キャッシュ全削除（プレフィックスマッチ） */
+export function clearReceiptsCache(queryClient: QueryClient): void {
+  queryClient.cancelQueries({ queryKey: receiptQueryKeys.prefix });
+  queryClient.removeQueries({ queryKey: receiptQueryKeys.prefix });
+}

--- a/frontend/src/pages/Receipts.tsx
+++ b/frontend/src/pages/Receipts.tsx
@@ -48,7 +48,7 @@ export function ReceiptsPage() {
     bulkCreate,
     deleteAll,
     clearCache,
-  } = useReceiptsData(isAuthenticated && !authLoading);
+  } = useReceiptsData();
 
   // ログアウト時に CSV データと Query キャッシュをクリア
   useEffect(() => {

--- a/frontend/src/pages/Receipts.tsx
+++ b/frontend/src/pages/Receipts.tsx
@@ -47,16 +47,14 @@ export function ReceiptsPage() {
     deleting,
     bulkCreate,
     deleteAll,
-    clearCache,
   } = useReceiptsData();
 
-  // ログアウト時に CSV データと Query キャッシュをクリア
+  // ログアウト時に CSV データをクリア（Query キャッシュは useReceiptsData が内部処理）
   useEffect(() => {
     return onLogout(() => {
       dispatch({ type: 'LOGOUT' });
-      clearCache();
     });
-  }, [onLogout, clearCache]);
+  }, [onLogout]);
 
   // ランタイムデータマッピング（switch削減用）
   const runtimeDataMap = useMemo(() => ({

--- a/frontend/src/pages/__tests__/Receipts.test.tsx
+++ b/frontend/src/pages/__tests__/Receipts.test.tsx
@@ -14,6 +14,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { receiptsReducer, initialState } from '../receiptsReducer';
 import type { ReceiptsState } from '../receiptsReducer';
 import { ReceiptsPage } from '../Receipts';
+import { receiptQueryKeys } from '@/features/receipt/queryKeys';
 
 // ────────────────────────────────────────────────────────
 // モック定義
@@ -142,12 +143,13 @@ type UseAuthReturn = ReturnType<typeof authHook.useAuth>;
 
 function makeAuthMock(opts: {
   isAuthenticated?: boolean;
+  userId?: string;
   authLoading?: boolean;
   onLogoutCapture?: (cb: LogoutCallback) => void;
 }): UseAuthReturn {
-  const { isAuthenticated = false, authLoading = false, onLogoutCapture } = opts;
+  const { isAuthenticated = false, userId = 'user-1', authLoading = false, onLogoutCapture } = opts;
   return {
-    user: null,
+    user: isAuthenticated ? { id: userId, email: 'test@example.com' } : null,
     setUser: vi.fn(),
     login: vi.fn(),
     logout: vi.fn().mockResolvedValue(undefined),
@@ -360,8 +362,9 @@ describe('ReceiptsPage', () => {
     });
   });
 
-  it('ログアウト: onLogout コールバック実行で csvData / dbData がクリアされる', async () => {
+  it('ログアウト: onLogout コールバック実行で csvData / dbData がクリアされ Query キャッシュが除去される', async () => {
     let capturedLogoutCallback: LogoutCallback | null = null;
+    const qc = makeQueryClient();
 
     vi.mocked(authHook.useAuth).mockReturnValue(
       makeAuthMock({
@@ -376,7 +379,7 @@ describe('ReceiptsPage', () => {
     vi.mocked(receiptApi.domesticStockApi.list).mockResolvedValue([]);
     vi.mocked(receiptApi.mutualfundApi.list).mockResolvedValue([]);
 
-    renderWithQuery(<ReceiptsPage />);
+    renderWithQuery(<ReceiptsPage />, qc);
 
     await waitFor(() => expect(capturedLogoutCallback).not.toBeNull());
 
@@ -388,10 +391,14 @@ describe('ReceiptsPage', () => {
       expect(screen.getByText(/全件削除/)).toBeInTheDocument();
     });
 
-    act(() => { capturedLogoutCallback!(); });
+    act(() => {
+      capturedLogoutCallback!();
+      vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({ isAuthenticated: false }));
+    });
 
     await waitFor(() => {
       expect(screen.queryByText(/全件削除/)).not.toBeInTheDocument();
     });
+    expect(qc.getQueryData(receiptQueryKeys.dividend('user-1'))).toBeUndefined();
   });
 });

--- a/frontend/src/pages/__tests__/Receipts.test.tsx
+++ b/frontend/src/pages/__tests__/Receipts.test.tsx
@@ -363,13 +363,14 @@ describe('ReceiptsPage', () => {
   });
 
   it('ログアウト: onLogout コールバック実行で csvData / dbData がクリアされ Query キャッシュが除去される', async () => {
-    let capturedLogoutCallback: LogoutCallback | null = null;
+    // AuthContext は複数コールバックをすべて発火する。配列で収集して一括発火することで実際の動作を再現する
+    const capturedCallbacks: LogoutCallback[] = [];
     const qc = makeQueryClient();
 
     vi.mocked(authHook.useAuth).mockReturnValue(
       makeAuthMock({
         isAuthenticated: true,
-        onLogoutCapture: (cb) => { capturedLogoutCallback = cb; },
+        onLogoutCapture: (cb) => { capturedCallbacks.push(cb); },
       })
     );
 
@@ -381,7 +382,7 @@ describe('ReceiptsPage', () => {
 
     renderWithQuery(<ReceiptsPage />, qc);
 
-    await waitFor(() => expect(capturedLogoutCallback).not.toBeNull());
+    await waitFor(() => expect(capturedCallbacks.length).toBeGreaterThan(0));
 
     await waitFor(() => {
       expect(screen.queryByRole('status')).not.toBeInTheDocument();
@@ -392,7 +393,7 @@ describe('ReceiptsPage', () => {
     });
 
     act(() => {
-      capturedLogoutCallback!();
+      capturedCallbacks.forEach(cb => cb());
       vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({ isAuthenticated: false }));
     });
 

--- a/frontend/src/pages/__tests__/Receipts.test.tsx
+++ b/frontend/src/pages/__tests__/Receipts.test.tsx
@@ -400,5 +400,7 @@ describe('ReceiptsPage', () => {
       expect(screen.queryByText(/全件削除/)).not.toBeInTheDocument();
     });
     expect(qc.getQueryData(receiptQueryKeys.dividend('user-1'))).toBeUndefined();
+    expect(qc.getQueryData(receiptQueryKeys.domesticstock('user-1'))).toBeUndefined();
+    expect(qc.getQueryData(receiptQueryKeys.mutualfund('user-1'))).toBeUndefined();
   });
 });


### PR DESCRIPTION
## 概要
Receipts の TanStack Query キャッシュをユーザー単位で分離し、ログアウト時にプレフィックス一致で確実にキャッシュを破棄するようにしました。

## 変更種別
- [ ] 新機能
- [x] バグ修正
- [x] リファクタリング
- [x] テスト追加

## 主な変更内容
- `frontend/src/features/receipt/queryKeys.ts`
  - `receiptQueryKeys` を `userId` を含むキーへ変更
  - `clearReceiptsCache(queryClient)` を追加（`cancelQueries + removeQueries`）
- `frontend/src/features/receipt/hooks/useReceiptsData.ts`
  - `useAuth` を利用し、`enabled` を `isAuthenticated && !authLoading && !!userId` に変更
  - `invalidateQueries/setQueryData` をユーザー単位キーに統一
  - `onLogout` で `clearReceiptsCache` を呼ぶように変更
- `frontend/src/pages/Receipts.tsx`
  - `useReceiptsData(isAuthenticated && !authLoading)` を `useReceiptsData()` に変更
- テスト更新
  - `frontend/src/pages/__tests__/Receipts.test.tsx` にキャッシュ削除アサーションを追加
  - `frontend/src/features/receipt/hooks/__tests__/useReceiptsData.test.ts` を新規追加（未認証フェッチ抑止・ログアウト時キャッシュ削除）

## テスト
- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npx tsc --noEmit`
- [x] `cd frontend && npm test -- src/pages/__tests__/Receipts.test.tsx src/pages/Receipt/__tests__/Dividend.test.tsx src/features/receipt/hooks/__tests__/useReceiptsData.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
