### PR TITLE
fix: Receiptsのlogout競合でdeleteAll後のキャッシュ再生成を防止

### DIFF
--- a/frontend/src/features/receipt/hooks/__tests__/useReceiptsData.test.ts
+++ b/frontend/src/features/receipt/hooks/__tests__/useReceiptsData.test.ts
@@ -18,9 +18,9 @@ import * as authHook from '@/features/auth/hooks/useAuth';
 // ────────────────────────────────────────────────────────
 
 vi.mock('@/features/receipt/api/receiptApi', () => ({
-  dividendApi: { list: vi.fn().mockResolvedValue([]) },
-  domesticStockApi: { list: vi.fn().mockResolvedValue([]) },
-  mutualfundApi: { list: vi.fn().mockResolvedValue([]) },
+  dividendApi: { list: vi.fn().mockResolvedValue([]), deleteAll: vi.fn().mockResolvedValue({}) },
+  domesticStockApi: { list: vi.fn().mockResolvedValue([]), deleteAll: vi.fn().mockResolvedValue({}) },
+  mutualfundApi: { list: vi.fn().mockResolvedValue([]), deleteAll: vi.fn().mockResolvedValue({}) },
 }));
 
 vi.mock('@/features/receipt/parsers', () => ({
@@ -85,6 +85,54 @@ describe('useReceiptsData: 認証境界・キャッシュ境界', () => {
     expect(receiptApiModule.dividendApi.list).not.toHaveBeenCalled();
     expect(receiptApiModule.domesticStockApi.list).not.toHaveBeenCalled();
     expect(receiptApiModule.mutualfundApi.list).not.toHaveBeenCalled();
+  });
+
+  it('deleteAll 実行中ログアウト: mutation 完了後もキャッシュが再生成されない', async () => {
+    // deleteAll の完了を手動制御するための Promise
+    let resolveDeleteAll!: () => void;
+    vi.mocked(receiptApiModule.dividendApi.deleteAll).mockReturnValue(
+      new Promise<void>((resolve) => { resolveDeleteAll = resolve; }) as never
+    );
+
+    const capturedCallbacks: LogoutCallback[] = [];
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+
+    vi.mocked(authHook.useAuth).mockReturnValue(
+      makeAuthMock({ onLogoutCapture: (cb) => { capturedCallbacks.push(cb); } })
+    );
+    vi.mocked(receiptApiModule.dividendApi.list).mockResolvedValue([
+      { id: '1', payment_date: '2023-01-01' } as never,
+    ]);
+
+    const { result } = renderHook(() => useReceiptsData(), { wrapper: makeWrapper(qc) });
+
+    // データがキャッシュに入り、onLogout が登録されるまで待つ
+    await waitFor(() => {
+      expect(qc.getQueryData(receiptQueryKeys.dividend('user-1'))).toBeDefined();
+    });
+    await waitFor(() => expect(capturedCallbacks.length).toBeGreaterThan(0));
+
+    // deleteAll を開始（まだ完了しない）
+    act(() => { result.current.deleteAll('dividend'); });
+
+    // ログアウト実行（キャッシュをクリア）
+    act(() => {
+      capturedCallbacks.forEach(cb => cb());
+      vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({ isAuthenticated: false }));
+    });
+
+    // キャッシュがクリアされたことを確認
+    await waitFor(() => {
+      expect(qc.getQueryData(receiptQueryKeys.dividend('user-1'))).toBeUndefined();
+    });
+
+    // deleteAll を完了させる（onSuccess が setQueryData を試みる）
+    await act(async () => { resolveDeleteAll(); });
+
+    // getQueryState ガードにより キャッシュが再生成されていないことを確認
+    expect(qc.getQueryData(receiptQueryKeys.dividend('user-1'))).toBeUndefined();
   });
 
   it('onLogout コールバック実行で receipts キャッシュが除去される', async () => {

--- a/frontend/src/features/receipt/hooks/useReceiptsData.ts
+++ b/frontend/src/features/receipt/hooks/useReceiptsData.ts
@@ -107,7 +107,11 @@ export function useReceiptsData(): UseReceiptsDataResult {
     // mutate 呼び出し時点の userId をスナップショット（ログアウト→再ログイン中の上書き防止）
     onMutate: () => ({ snapshotUserId: userId }),
     onSuccess: (_, type, context) => {
-      queryClient.setQueryData(receiptQueryKeys[type](context?.snapshotUserId ?? userId), []);
+      const key = receiptQueryKeys[type](context?.snapshotUserId ?? userId);
+      // ログアウト等で clearReceiptsCache が先行しキャッシュが消えている場合は再生成しない
+      if (queryClient.getQueryState(key) !== undefined) {
+        queryClient.setQueryData(key, []);
+      }
     },
   });
 


### PR DESCRIPTION
## 概要
Receipts の `deleteAll` 実行中にログアウトした場合、mutation 完了時の `setQueryData([])` でキャッシュが再生成される競合を防止しました。

## 変更種別
- [ ] 新機能
- [x] バグ修正
- [ ] リファクタリング
- [x] テスト追加

## 主な変更内容
- `useReceiptsData` の `deleteAllMutation.onSuccess` で `queryClient.getQueryState(key)` を確認し、
  既に `clearReceiptsCache` で削除済みのキーは `setQueryData` しないように変更
- `useReceiptsData.test.ts` に「deleteAll 実行中ログアウト後、mutation 完了してもキャッシュが再生成されない」回帰テストを追加

## テスト
- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npx tsc --noEmit`
- [x] `cd frontend && npm test -- src/features/receipt/hooks/__tests__/useReceiptsData.test.ts src/pages/__tests__/Receipts.test.tsx`
- [x] `cd frontend && npm run build`

🤖 Generated with Codex