### PR TITLE
docs: pr workflowをmain起点のfeature運用に更新

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,25 +1,34 @@
 ---
 name: pr-review
 description: |
-  Claude の実装完了後に、Codex へコードレビューを依頼する運用を標準化する。
-  Use when: 「PRレビューをCodexに回したい」「Claude作業後のレビュー依頼文を作りたい」
-  「Claude→Codexレビュー運用にしたい」と依頼された時。
+  Claude の実装完了後に、発行済みPRを自動検出してレビュー開始する運用を標準化する。
+  Use when: 「PRレビューを開始したい」「Claude作業後にそのままレビューしたい」
+  「レビュー依頼文を作りたい」と依頼された時。
 ---
 
 # PR Review Handoff
 
 ## Overview
-Claude が実装を終えたら、このスキルでレビュー材料を固定フォーマットに整理し、Codex へレビュー依頼する。  
-Codex は findings first で重大度順レビューを返す前提で依頼文を作成する。
+Claude が実装を終えたら、このスキルで `gh` から発行済み PR を自動検出し、
+差分と検証結果を集めて **そのままレビューを開始** する。
+
+依頼文作成モードは補助機能として残し、
+ユーザーが「依頼文を作って」と明示した場合のみ使う。
 
 ## Workflow
 
-1. 実装完了状態を確定する。
+1. レビュー対象PRを自動検出する。
+- `git branch --show-current` で現在ブランチを確認する。
+- まず `gh pr list --state open --head <current-branch>` で open PR を探す。
+- 見つからない場合のみ `gh pr list --state open --base main --limit 30` を確認し、候補PRを特定する。
+- それでも見つからない場合は、ユーザーに PR 番号 or URL を確認する。
+
+2. 実装完了状態を確定する。
 - `git status -sb` で差分が意図どおりか確認する。
 - レビュー対象コミット/差分を特定する。
-- PR がある場合は PR 番号と URL を控える。
+- PR 番号と URL を確定する。
 
-2. レビュー材料を収集する。
+3. レビュー材料を収集する。
 - 必ず以下を取得する。
   - `git diff --name-status`
   - `git diff --stat`
@@ -27,35 +36,41 @@ Codex は findings first で重大度順レビューを返す前提で依頼文�
 - PR がある場合は以下も取得する。
   - `gh pr view <PR番号> --json number,title,url,body`
   - `gh pr view <PR番号> --comments`
-- PR がない場合は `main...develop` の差分を明記する。
+- PR がない場合は `main...<current-branch>` の差分を明記する。
 
-3. 検証結果を確定する。
+4. 検証結果を確定する。
 - 変更範囲に応じて `lint` / `test` / `build` を実行する。
 - 実行コマンドと結果（pass/fail）をそのまま記録する。
 - 失敗していても隠さず依頼文に含める。
 
-4. Codex への依頼文を作成する。
+5. レビューを実行する（デフォルト）。
+- findings first で重大度順に出す。
+- `path:line` を付ける。
+- 期待フォーマット:
+  1. Findings（重大度順、`path:line` 付き）
+  2. Open questions / assumptions
+  3. 修正方針サマリー（短く）
+
+6. 依頼文作成モード（明示要求時のみ）。
 - `references/codex-review-request-template.md` を読み、必須項目を埋める。
 - 曖昧語を使わない。
 - レビュー観点（バグ、回帰、テスト不足、設計リスク）を明示する。
 
-5. Codex レビュー結果を取り込む。
+7. レビュー結果を取り込む。
 - 指摘を重大度順に処理する。
 - 修正後に同じ検証コマンドを再実行する。
 - 必要に応じて再レビューを Codex に依頼する。
 
 ## Review Request Rules
-- Codex への依頼文には必ず対象範囲を入れる。
-  - PR URL または比較範囲（例: `main...develop`）
-- Codex への依頼文には必ず検証結果を入れる。
+- レビュー結果には必ず対象範囲を入れる。
+  - PR URL または比較範囲（例: `main...fix/asset-balance-lock-test`）
+- レビュー結果には必ず検証結果を入れる。
   - 実行したコマンドと pass/fail
-- Codex への依頼文には必ず期待する出力形式を入れる。
-  - findings first
-  - 重大度順
-  - ファイルパスと行番号
+- findings first / 重大度順 / ファイルパスと行番号を必須とする。
 
 ## Output
-Codex へ渡す最終依頼文を Markdown で返す。
+- デフォルト: レビュー結果（findings first）。
+- 例外: ユーザーが依頼文作成を明示した場合のみ、Codex へ渡す依頼文を Markdown で返す。
 
 ## Reference
 - 依頼テンプレートは `references/codex-review-request-template.md` を使う。

--- a/.claude/skills/pr-review/references/codex-review-request-template.md
+++ b/.claude/skills/pr-review/references/codex-review-request-template.md
@@ -8,7 +8,7 @@
 
 ## 対象
 - PR: <PR URL または PR 番号>
-- 比較範囲: <例: main...develop>
+- 比較範囲: <例: main...fix/asset-balance-lock-test>
 - 対象コミット: <最新コミットSHA>
 
 ## 変更ファイル
@@ -37,4 +37,3 @@
 2. Open questions / assumptions
 3. 修正方針サマリー（短く）
 ```
-

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -16,6 +16,7 @@ description: |
 - 1タスク = 1ブランチ（例: `fix/asset-balance-lock-test`）
 - PR は **feature ブランチ → `main`**
 - `develop` は既定の開発ブランチとして使わない（必要時のみ検証用に限定）
+- マージ完了後は feature ブランチをローカル/リモートとも削除する
 
 ### 禁止事項
 
@@ -23,6 +24,7 @@ description: |
 - `develop` への直接コミットを日常運用にしない
 - 長期間の `develop` 集約後に巨大な `develop -> main` PR を作らない
 - feature ブランチで `merge` を多用しない（`rebase` で履歴を保つ）
+- マージ済みブランチを放置しない
 
 ### ワークフロー
 
@@ -32,6 +34,7 @@ description: |
 3. feature ブランチで作業・コミット
 4. feature → main の PR を作成
 5. レビュー後に squash merge
+6. マージ済み feature ブランチを削除
 ```
 
 ### 開始手順（毎回）
@@ -72,6 +75,26 @@ git rebase -i origin/main
 # 5. プッシュして PR 作成（base は main）
 git push -u origin <type>/<short-topic>
 gh pr create --base main --head <type>/<short-topic>
+```
+
+### マージ後クリーンアップ（必須）
+
+```bash
+# 1. PRを squash merge し、リモートブランチを削除
+gh pr merge <PR番号 or PR URL> --squash --delete-branch
+
+# 2. main を最新化
+git checkout main
+git pull origin main
+
+# 3. ローカルの作業ブランチを削除
+git branch -d <type>/<short-topic>
+```
+
+`gh` で削除できなかった場合のみ、リモートは手動削除する。
+
+```bash
+git push origin --delete <type>/<short-topic>
 ```
 
 ## コミット分割の原則

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -12,23 +12,66 @@ description: |
 
 ### 基本ルール
 
-- **ブランチは `develop` と `main` のみ**
-- feature ブランチは作成しない
-- 作業は `develop` に直接コミット
-- `main` への反映は **必ず `develop` → `main` の PR 経由**
+- **`main` を常に最新化し、作業は短命 feature ブランチで行う**
+- 1タスク = 1ブランチ（例: `fix/asset-balance-lock-test`）
+- PR は **feature ブランチ → `main`**
+- `develop` は既定の開発ブランチとして使わない（必要時のみ検証用に限定）
 
 ### 禁止事項
 
 - `main` に直接コミット/マージしない
-- feature ブランチを作成しない
-- `develop` を経由せずに `main` を更新しない
+- `develop` への直接コミットを日常運用にしない
+- 長期間の `develop` 集約後に巨大な `develop -> main` PR を作らない
+- feature ブランチで `merge` を多用しない（`rebase` で履歴を保つ）
 
 ### ワークフロー
 
 ```
-1. develop で作業・コミット
-2. develop → main の PR を作成
-3. レビュー・マージ
+1. main を最新化
+2. feature ブランチ作成
+3. feature ブランチで作業・コミット
+4. feature → main の PR を作成
+5. レビュー後に squash merge
+```
+
+### 開始手順（毎回）
+
+```bash
+git checkout main
+git pull origin main
+git switch -c <type>/<short-topic>
+```
+
+### PR前の整形（必須）
+
+```bash
+# feature ブランチを main に追従
+git fetch origin
+git rebase origin/main
+
+# 必要ならコミット統合（fixup/squash）
+git rebase -i origin/main
+```
+
+### 既存 `develop` からクリーンブランチへ載せ替える手順
+
+```bash
+# 1. main を最新化
+git checkout main
+git pull origin main
+
+# 2. 新しい feature ブランチを作る
+git switch -c <type>/<short-topic>
+
+# 3. develop の必要コミットだけを順に取り込む
+git cherry-pick <commit1> <commit2> <commit3>
+
+# 4. 競合解消後に履歴整形
+git rebase -i origin/main
+
+# 5. プッシュして PR 作成（base は main）
+git push -u origin <type>/<short-topic>
+gh pr create --base main --head <type>/<short-topic>
 ```
 
 ## コミット分割の原則
@@ -97,7 +140,7 @@ EOF
 
 ```bash
 # 1. プッシュ
-git push origin <branch>
+git push -u origin <branch>
 
 # 2. PR作成
 gh pr create --base main --head <branch> --title "タイトル" --body "$(cat <<'EOF'
@@ -142,3 +185,4 @@ EOF
 - ユーザーが明示的に依頼しない限りコミット・PRを作成しない
 - `git add -A` は避け、ファイルを個別に追加
 - 機密ファイル（.env等）をコミットしない
+- PRは小さく保つ（目安: 1目的、レビュー可能な差分量）


### PR DESCRIPTION
## 概要
- pr-workflowをmain起点+短命feature運用へ更新
- pr-reviewの比較範囲例をfeatureブランチ運用に更新
- マージ後ブランチ削除ルールを追加