### PR TITLE
運用: コミットメッセージ運用を日本語に統一

### DIFF
--- a/.claude/skills/git-pushing/SKILL.md
+++ b/.claude/skills/git-pushing/SKILL.md
@@ -1,34 +1,46 @@
 ---
 name: git-pushing
 description: |
-  変更をステージングし、コミットしてリモートへ push する。
+  変更を選択的にステージングし、コミットしてリモートへ push する。
+  コミット履歴を汚さないため、`git add .` を避けて staged 差分を明示確認してから push する。
   Use when: コミットと push を依頼された時、リモートへ push したいと明示された時、
   または「push して」「commit and push」「push to github」などの表現がある時。
 ---
 
 # Git Push Workflow
 
-Stage all changes, create a conventional commit, and push to the remote branch.
+履歴を汚さないことを最優先に、staged された変更のみをコミットして push する。
 
-## When to Use
+## 必須ルール
 
-Automatically activate when the user:
-- Explicitly asks to push changes ("push this", "commit and push")
-- Mentions saving work to remote ("save to github", "push to remote")
-- Completes a feature and wants to share it
-- Says phrases like "let's push this up" or "commit these changes"
+- `git add .` / `git add -A` を使わない
+- 先に `git add <path>` または `git add -p` で対象変更を絞る
+- コミットメッセージは必ず引数で明示する
+- コミットメッセージの要約・本文は日本語で書く
+- `main` には直接コミットしない
 
 ## Workflow
 
-**ALWAYS use the script** - do NOT use manual git commands:
-
 ```bash
-bash skills/git-pushing/scripts/smart_commit.sh
+# 1) staged 内容を確認
+git status -sb
+git diff --cached
+
+# 2) まだ staged していない場合は対象だけ追加
+git add -p
+
+# 3) コミットして push
+bash .claude/skills/git-pushing/scripts/smart_commit.sh "feat: <変更内容の要約>"
 ```
 
-With custom message:
-```bash
-bash skills/git-pushing/scripts/smart_commit.sh "feat: add feature"
-```
+## マージ後のブランチ削除
 
-Script handles: staging, conventional commit message, Claude footer, push with -u flag.
+マージ済みの作業ブランチは削除する。
+
+```bash
+git switch develop
+git pull --ff-only origin develop
+git branch -d <work-branch>
+git push origin --delete <work-branch>
+git fetch origin --prune
+```

--- a/.claude/skills/git-pushing/scripts/smart_commit.sh
+++ b/.claude/skills/git-pushing/scripts/smart_commit.sh
@@ -1,153 +1,52 @@
 #!/bin/bash
 # Smart Git Commit Script for git-pushing skill
-# Handles staging, commit message generation, and pushing
+# Commits only staged changes and pushes current branch.
 
-set -e  # Exit on error
+set -euo pipefail
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
+usage() {
+    cat <<'USAGE'
+Usage:
+  bash .claude/skills/git-pushing/scripts/smart_commit.sh "type: summary"
 
-# Function to print colored messages
-info() { echo -e "${GREEN}→${NC} $1"; }
-warn() { echo -e "${YELLOW}⚠${NC} $1"; }
-error() { echo -e "${RED}✗${NC} $1" >&2; }
+Notes:
+- Stage only intended files first (git add <path> or git add -p)
+- This script does not run git add automatically
+USAGE
+}
 
-# Get current branch
+if [ $# -lt 1 ]; then
+    echo "ERROR: commit message is required"
+    usage
+    exit 1
+fi
+
+COMMIT_MSG="$1"
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-info "Current branch: $CURRENT_BRANCH"
 
-# Check if there are changes
-if git diff --quiet && git diff --cached --quiet; then
-    warn "No changes to commit"
-    exit 0
+echo "Current branch: $CURRENT_BRANCH"
+
+if [ "$CURRENT_BRANCH" = "main" ]; then
+    echo "ERROR: direct commits to main are not allowed"
+    exit 1
 fi
 
-# Stage all changes
-info "Staging all changes..."
-git add .
+if git diff --cached --quiet; then
+    echo "ERROR: no staged changes"
+    echo "Stage files explicitly before running this script."
+    exit 1
+fi
 
-# Get staged files for commit message analysis
-STAGED_FILES=$(git diff --cached --name-only)
-DIFF_STAT=$(git diff --cached --stat)
+if ! git diff --quiet; then
+    echo "WARN: unstaged changes remain in working tree"
+fi
 
-# Analyze changes to determine commit type
-determine_commit_type() {
-    local files="$1"
+git commit -m "$COMMIT_MSG"
 
-    # Check for specific patterns
-    if echo "$files" | grep -q "test"; then
-        echo "test"
-    elif echo "$files" | grep -qE "\.(md|txt|rst)$"; then
-        echo "docs"
-    elif echo "$files" | grep -qE "package\.json|requirements\.txt|Cargo\.toml"; then
-        echo "chore"
-    elif git diff --cached | grep -qE "^[\+].*fix|^[\+].*bug"; then
-        echo "fix"
-    elif git diff --cached | grep -qE "^[\+].*refactor"; then
-        echo "refactor"
-    else
-        echo "feat"
-    fi
-}
-
-# Analyze files to determine scope
-determine_scope() {
-    local files="$1"
-
-    # Extract directory or component name
-    local scope=$(echo "$files" | head -1 | cut -d'/' -f1)
-
-    # Check for common patterns
-    if echo "$files" | grep -q "plugin"; then
-        echo "plugin"
-    elif echo "$files" | grep -q "skill"; then
-        echo "skill"
-    elif echo "$files" | grep -q "agent"; then
-        echo "agent"
-    elif [ -n "$scope" ] && [ "$scope" != "." ]; then
-        echo "$scope"
-    else
-        echo ""
-    fi
-}
-
-# Generate commit message if not provided
-if [ -z "$1" ]; then
-    COMMIT_TYPE=$(determine_commit_type "$STAGED_FILES")
-    SCOPE=$(determine_scope "$STAGED_FILES")
-
-    # Count files changed
-    NUM_FILES=$(echo "$STAGED_FILES" | wc -l | xargs)
-
-    # Generate description based on changes
-    if [ "$COMMIT_TYPE" = "docs" ]; then
-        DESCRIPTION="update documentation"
-    elif [ "$COMMIT_TYPE" = "test" ]; then
-        DESCRIPTION="update tests"
-    elif [ "$COMMIT_TYPE" = "chore" ]; then
-        DESCRIPTION="update dependencies"
-    else
-        DESCRIPTION="update $NUM_FILES file(s)"
-    fi
-
-    # Build commit message
-    if [ -n "$SCOPE" ]; then
-        COMMIT_MSG="${COMMIT_TYPE}(${SCOPE}): ${DESCRIPTION}"
-    else
-        COMMIT_MSG="${COMMIT_TYPE}: ${DESCRIPTION}"
-    fi
-
-    info "Generated commit message: $COMMIT_MSG"
+if git rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1; then
+    git push
+    echo "Pushed to upstream of $CURRENT_BRANCH"
 else
-    COMMIT_MSG="$1"
-    info "Using provided message: $COMMIT_MSG"
+    git push -u origin "$CURRENT_BRANCH"
+    echo "Pushed new branch and set upstream: origin/$CURRENT_BRANCH"
 fi
-
-# Create commit with Claude Code footer
-git commit -m "$(cat <<EOF
-${COMMIT_MSG}
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-EOF
-)"
-
-COMMIT_HASH=$(git rev-parse --short HEAD)
-info "Created commit: $COMMIT_HASH"
-
-# Push to remote
-info "Pushing to origin/$CURRENT_BRANCH..."
-
-# Check if branch exists on remote
-if git ls-remote --exit-code --heads origin "$CURRENT_BRANCH" >/dev/null 2>&1; then
-    # Branch exists, just push
-    if git push; then
-        info "Successfully pushed to origin/$CURRENT_BRANCH"
-        echo "$DIFF_STAT"
-    else
-        error "Push failed"
-        exit 1
-    fi
-else
-    # New branch, push with -u
-    if git push -u origin "$CURRENT_BRANCH"; then
-        info "Successfully pushed new branch to origin/$CURRENT_BRANCH"
-        echo "$DIFF_STAT"
-
-        # Check if it's GitHub and show PR link
-        REMOTE_URL=$(git remote get-url origin)
-        if echo "$REMOTE_URL" | grep -q "github.com"; then
-            REPO=$(echo "$REMOTE_URL" | sed -E 's/.*github\.com[:/](.*)\.git/\1/')
-            warn "Create PR: https://github.com/$REPO/pull/new/$CURRENT_BRANCH"
-        fi
-    else
-        error "Push failed"
-        exit 1
-    fi
-fi
-
-exit 0

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -1,51 +1,44 @@
 ---
 name: pr-workflow
 description: |
-  コミット分割とPR作成のワークフロー。
-  機能ごとにコミットを分け、PRを作成する。
-  Use when: コミット、PR作成、プルリクエストを依頼された時。
+  コミット履歴をきれいに保つための Git ブランチ運用と PR 作成ワークフロー。
+  `main` / `develop` / 短期作業ブランチの役割、コミット分割、PR、マージ後のブランチ削除までを定義する。
+  Use when: ブランチ運用の相談、コミット、PR作成、マージ後のブランチ削除を依頼された時。
 ---
 
 # PR ワークフロー
 
 ## ブランチ戦略
 
-### 基本ルール
-
-- **ブランチは `develop` と `main` のみ**
-- feature ブランチは作成しない
-- 作業は `develop` に直接コミット
-- `main` への反映は **必ず `develop` → `main` の PR 経由**
-
-### 禁止事項
-
-- `main` に直接コミット/マージしない
-- feature ブランチを作成しない
-- `develop` を経由せずに `main` を更新しない
-
-### ワークフロー
-
-```
-1. develop で作業・コミット
-2. develop → main の PR を作成
-3. レビュー・マージ
-```
+- 長期ブランチ
+  - `main`: 本番反映専用。直接コミット禁止。
+  - `develop`: 統合ブランチ。作業ブランチの起点。
+- 短期ブランチ（作業ごとに作成）
+  - `feature/<topic>`
+  - `fix/<topic>`
+  - `refactor/<topic>`
+  - `docs/<topic>`
+  - `chore/<topic>`
+- 短期ブランチはマージ後に必ず削除する（ローカル/リモート）。
 
 ## コミット分割の原則
 
-1. **機能単位で分割** - 1コミット = 1機能
-2. **共通基盤は最初のコミットに含める**
-3. **統合ファイルは最後のコミットに含める**
+1. 1コミット = 1目的（機能・修正・リファクタを混在させない）
+2. `git add .` / `git add -A` は使わず、`git add <path>` または `git add -p` を使う
+3. PR 前に `fixup!` + `rebase -i --autosquash` で不要コミットを整理する
+4. `WIP` のような暫定コミットは push 前に整理する
 
 ## コミットメッセージ形式
 
-```
+```bash
 <種別>: <変更内容の要約>
 
 <詳細説明（任意）>
 
 Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
 ```
+
+- `<変更内容の要約>` と `<詳細説明>` は日本語で記述する
 
 ### 種別
 
@@ -56,51 +49,40 @@ Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
 - `test`: テスト
 - `chore`: ビルド・設定変更
 
-## 分割例（複数機能追加時）
-
-```
-1. 共通基盤 + 機能A
-   - 認証エクストラクター、APIクライアント基盤
-   - 機能A固有ファイル
-
-2. 機能B
-   - 機能B固有ファイル
-
-3. 機能C + 統合
-   - 機能C固有ファイル
-   - main.rs、handlers.rs などの統合ファイル
-```
-
-## コミット手順
+## 標準フロー
 
 ```bash
-# 1. 変更状況確認
-git status
-git diff
+# 1) develop を最新化
+git switch develop
+git pull --ff-only origin develop
 
-# 2. 機能ごとにステージング・コミット
-git add <files>
-git commit -m "$(cat <<'EOF'
-feat: 機能の説明
+# 2) 短期ブランチ作成
+git switch -c feature/<topic>
 
-- 変更点1
-- 変更点2
+# 3) 変更を目的単位でコミット
+git add -p
+git commit -m "feat: <変更内容の要約>"
 
-Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
-EOF
-)"
+# 4) リモートへ push
+git push -u origin feature/<topic>
+```
 
-# 3. 繰り返し
+## 履歴整理（PR前）
+
+```bash
+# 直近コミットを fixup として積む例
+git commit --fixup <target-commit-hash>
+
+# develop 基準で自動 squash/fixup
+git rebase -i --autosquash origin/develop
 ```
 
 ## PR作成手順
 
-```bash
-# 1. プッシュ
-git push origin <branch>
+作業ブランチは `develop` 向けに PR を作成する。
 
-# 2. PR作成
-gh pr create --base main --head <branch> --title "タイトル" --body "$(cat <<'EOF'
+```bash
+gh pr create --base develop --head <work-branch> --title "タイトル" --body "$(cat <<'EOF_BODY'
 ## 概要
 変更内容の説明
 
@@ -115,30 +97,32 @@ gh pr create --base main --head <branch> --title "タイトル" --body "$(cat <<
 ## テスト
 - [x] テスト実行確認
 - [x] ビルド確認
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-EOF
+EOF_BODY
 )"
 ```
 
-## よくあるパターン
+`develop` から `main` への反映は、別 PR（`base=main`, `head=develop`）で実施する。
 
-### Skills + 機能追加
-```
-1. feat: Agent Skills を追加
-2. feat: 機能AのDB取込機能を追加
-3. feat: 機能BのDB取込機能を追加
-4. feat: 機能CのDB取込機能を追加
+## マージ方式
+
+- 作業ブランチ -> `develop`: `Squash and merge` を推奨（1タスク1コミット化）
+- `develop` -> `main`: `Rebase and merge`（または `--ff-only` マージ）で直線履歴を維持
+
+## ブランチ削除（マージ後）
+
+```bash
+# 例: feature/login-timeout-fix を削除
+git switch develop
+git pull --ff-only origin develop
+git branch -d feature/login-timeout-fix
+git push origin --delete feature/login-timeout-fix
+git fetch origin --prune
 ```
 
-### リファクタリング + 機能追加
-```
-1. refactor: 共通処理を抽出
-2. feat: 新機能を追加
-```
+## 禁止事項
 
-## 注意事項
-
-- ユーザーが明示的に依頼しない限りコミット・PRを作成しない
-- `git add -A` は避け、ファイルを個別に追加
-- 機密ファイル（.env等）をコミットしない
+- `main` への直接コミット
+- `develop` への直接コミット（緊急時の明示指示を除く）
+- `git add .` / `git add -A`
+- `git branch -D` での強制削除（未マージ削除が必要な場合はユーザー明示指示時のみ）
+- ユーザーが明示的に依頼していないコミット・PR作成

--- a/README.md
+++ b/README.md
@@ -230,6 +230,15 @@ shoken-webapp/
 └── .github/workflows/
 ```
 
+## Git ブランチ運用
+
+- 長期ブランチは `main` と `develop` のみ
+- 作業は必ず `develop` から短期ブランチを切って行う（例: `feature/<topic>`, `fix/<topic>`）
+- `main` へ直接コミットしない
+- `git add .` / `git add -A` は避け、`git add <path>` または `git add -p` でコミット範囲を明示する
+- 作業ブランチの PR マージ後は、ローカル・リモートの両方からブランチを削除する
+- `develop` から `main` へは PR 経由で反映する
+
 ## デプロイ
 
 - Frontend: Vercel


### PR DESCRIPTION
## 概要
- コミット履歴を整える運用方針に合わせて skills を更新しました

## 変更内容
- `pr-workflow` に日本語コミットメッセージルールを追加
- `git-pushing` に日本語コミットメッセージルールを追加
- `git-pushing` の手順例を日本語要約に更新
- README に Git ブランチ運用方針を追記

## テスト
- `bash -n .claude/skills/git-pushing/scripts/smart_commit.sh`
- `smart_commit.sh` の引数なし/未staged時のガード動作確認
