### PR TITLE
refactor: Receipt3ページからuseMemo/useCallbackを除去（React Compiler対応）

### DIFF
--- a/frontend/src/pages/Receipt/Dividend.tsx
+++ b/frontend/src/pages/Receipt/Dividend.tsx
@@ -1,7 +1,7 @@
 import { ReceiptTemplate } from '@/components/templates/ReceiptTemplate';
 import { ReceiptHeader } from '@/components/molecules/ReceiptHeader/ReceiptHeader';
 import { ReceiptTable } from '@/components/organisms/ReceiptTable/ReceiptTable';
-import React, { useMemo, useCallback } from 'react';
+import React from 'react';
 import { DividendData } from '@/lib/interfaces/dividend';
 import { TableColumnConfig, SummaryColumnConfig } from '@/lib/interfaces/receipt';
 import {
@@ -44,16 +44,16 @@ export const Dividend: React.FC<DividendProps> = ({ csvData }) => {
     const dividendData = useReceiptData(csvData, parseDividendCsvItem, sortDividendBySettlementDate);
 
     // 検索カテゴリーの生成
-    const searchCategories = useMemo(() => ({
+    const searchCategories = {
         securities: createSearchOptions(dividendData, 'security_code', 'security_name', true),
         products: getUniqueValues(dividendData, item => item.product),
         accounts: getUniqueValues(dividendData, item => item.account),
         years: createYearOptions(dividendData, item => item.settlement_date),
         yearMonths: createYearMonthOptions(dividendData, item => item.settlement_date)
-    }), [dividendData]);
+    };
 
     // フィルタ設定
-    const filterConfig: FilterConfig<DividendData> = useMemo(() => ({
+    const filterConfig: FilterConfig<DividendData> = {
         stringFields: [
             item => item.security_code,
             item => item.security_name,
@@ -71,7 +71,7 @@ export const Dividend: React.FC<DividendProps> = ({ csvData }) => {
             item => item.taxes,
             item => item.net_amount_received,
         ],
-    }), []);
+    };
 
     // 検索クエリに基づくフィルタリング
     const { searchQuery, setSearchQuery, filteredData } = useReceiptPageState(dividendData, filterConfig);
@@ -80,7 +80,7 @@ export const Dividend: React.FC<DividendProps> = ({ csvData }) => {
     const calculations = useReceiptCalculations(filteredData, calculateDividends);
 
     // グループキーの取得（検索タイプに応じて動的に変更）
-    const getGroupKey = useCallback((item: DividendData): string => {
+    const getGroupKey = (item: DividendData): string => {
         if (!searchQuery) {
             return createYearMonthKey(item.settlement_date);
         }
@@ -115,17 +115,17 @@ export const Dividend: React.FC<DividendProps> = ({ csvData }) => {
 
         // デフォルトは年月でグループ化
         return createYearMonthKey(item.settlement_date);
-    }, [searchQuery]);
+    };
 
     // サマリーデータの集計
-    const summary = useMemo(() => groupAndSummarizeData(
+    const summary = groupAndSummarizeData(
         filteredData,
         getGroupKey,
         ['dividends_before_tax', 'taxes', 'net_amount_received']
-    ), [filteredData, getGroupKey]);
+    );
 
     // 銘柄名検索時に銘柄コードを補完
-    const searchSecurityCode = useMemo(() => {
+    const searchSecurityCode = (() => {
         if (!searchQuery) return '';
         const normalizedQuery = searchQuery.toLowerCase();
         const labelMatch = searchQuery.match(/^\\s*([0-9A-Za-z]+)\\s*[:：]/);
@@ -137,12 +137,10 @@ export const Dividend: React.FC<DividendProps> = ({ csvData }) => {
             item.security_name.toLowerCase() === normalizedQuery
         );
         return matchedItem?.security_code || '';
-    }, [filteredData, searchQuery]);
+    })();
 
     // 銘柄コード検索かどうかを判定（配当シミュレーション表示の条件）
-    const isSecurityCodeSearch = useMemo(() => {
-        return !!searchSecurityCode && SECURITY_CODE_REGEX.test(searchSecurityCode);
-    }, [searchSecurityCode]);
+    const isSecurityCodeSearch = !!searchSecurityCode && SECURITY_CODE_REGEX.test(searchSecurityCode);
 
     // ヘッダー項目の定義
     const allHeaderItems = [
@@ -173,7 +171,7 @@ export const Dividend: React.FC<DividendProps> = ({ csvData }) => {
     const headerItems = isSecurityCodeSearch ? [] : allHeaderItems;
 
     // テーブルカラムの定義（検索タイプに応じて表示順序を調整）
-    const baseColumns: TableColumnConfig[] = useMemo(() => ([
+    const baseColumns: TableColumnConfig[] = [
         { key: 'settlement_date', header: '入金日', width: '90px', format: formatJPDate },
         { key: 'product', header: '商品', width: '80px' },
         { key: 'account', header: '口座', width: '70px' },
@@ -184,19 +182,16 @@ export const Dividend: React.FC<DividendProps> = ({ csvData }) => {
         { key: 'dividends_before_tax', header: '配当金', width: '90px', textAlign: 'right', format: formatCurrency },
         { key: 'taxes', header: '税額', width: '70px', textAlign: 'right', format: formatCurrency },
         { key: 'net_amount_received', header: '受取額', width: '90px', textAlign: 'right', format: formatCurrency },
-    ]), []);
+    ];
 
     // 列の前面配置ルール（商品 > 口座の優先順）
-    const columnRules: ColumnReorderRule<DividendData>[] = useMemo(() => [
+    const columnRules: ColumnReorderRule<DividendData>[] = [
         { columnKey: 'product', match: (item, q) => item.product.toLowerCase().includes(q) },
         { columnKey: 'account', match: (item, q) => item.account.toLowerCase().includes(q) },
-    ], []);
+    ];
 
     // 検索タイプに応じて重要なカラムを前面に配置
-    const columns = useMemo(
-        () => reorderColumnsBySearch(baseColumns, filteredData, searchQuery, columnRules, 1),
-        [baseColumns, filteredData, searchQuery, columnRules]
-    );
+    const columns = reorderColumnsBySearch(baseColumns, filteredData, searchQuery, columnRules, 1);
 
     // サマリーカラムの定義
     const summaryColumns: SummaryColumnConfig[] = [

--- a/frontend/src/pages/Receipt/Dividend.tsx
+++ b/frontend/src/pages/Receipt/Dividend.tsx
@@ -31,6 +31,27 @@ import { parseDividendCsvItem, sortDividendBySettlementDate } from '@/features/r
 import { calculateDividends } from '@/features/receipt/calculations';
 import { reorderColumnsBySearch, ColumnReorderRule } from '@/lib/utils/columnUtils';
 
+// コンポーネント外に定数として定義（毎レンダーで新参照が生成されるのを防ぐ）
+const FILTER_CONFIG: FilterConfig<DividendData> = {
+    stringFields: [
+        item => item.security_code,
+        item => item.security_name,
+        item => item.product,
+        item => item.account,
+    ],
+    dateField: item => item.settlement_date,
+    yearSearch: true,
+    yearMonthSearch: true,
+    dateSearch: true,
+    amountFields: [
+        item => item.unit_price,
+        item => item.shares,
+        item => item.dividends_before_tax,
+        item => item.taxes,
+        item => item.net_amount_received,
+    ],
+};
+
 interface DividendProps {
     csvData: Record<string, unknown>[];
 }
@@ -52,29 +73,8 @@ export const Dividend: React.FC<DividendProps> = ({ csvData }) => {
         yearMonths: createYearMonthOptions(dividendData, item => item.settlement_date)
     };
 
-    // フィルタ設定
-    const filterConfig: FilterConfig<DividendData> = {
-        stringFields: [
-            item => item.security_code,
-            item => item.security_name,
-            item => item.product,
-            item => item.account,
-        ],
-        dateField: item => item.settlement_date,
-        yearSearch: true,
-        yearMonthSearch: true,
-        dateSearch: true,
-        amountFields: [
-            item => item.unit_price,
-            item => item.shares,
-            item => item.dividends_before_tax,
-            item => item.taxes,
-            item => item.net_amount_received,
-        ],
-    };
-
     // 検索クエリに基づくフィルタリング
-    const { searchQuery, setSearchQuery, filteredData } = useReceiptPageState(dividendData, filterConfig);
+    const { searchQuery, setSearchQuery, filteredData } = useReceiptPageState(dividendData, FILTER_CONFIG);
 
     // 表示用の集計（検索前後で同一ロジック: フィルタ後データから計算）
     const calculations = useReceiptCalculations(filteredData, calculateDividends);

--- a/frontend/src/pages/Receipt/DomesticStock.tsx
+++ b/frontend/src/pages/Receipt/DomesticStock.tsx
@@ -1,7 +1,7 @@
 import { ReceiptTemplate } from '@/components/templates/ReceiptTemplate';
 import { ReceiptHeader } from '@/components/molecules/ReceiptHeader/ReceiptHeader';
 import { ReceiptTable } from '@/components/organisms/ReceiptTable/ReceiptTable';
-import React, { useMemo, useCallback } from 'react';
+import React from 'react';
 import { DomesticStockData } from '@/lib/interfaces/domesticStock';
 import { TableColumnConfig, SummaryColumnConfig } from '@/lib/interfaces/receipt';
 import { createSearchOptions } from '@/lib/utils/dataTransformer';
@@ -37,18 +37,18 @@ export const DomesticStock: React.FC<DomesticStockProps> = ({ csvData }) => {
     const domesticStockData = useReceiptData(csvData, parseDomesticStockCsvItem, sortDomesticStockByTradeDate);
 
     // 日次データの集計（全データ）
-    const dailyData = useMemo(() => calculateDailyData(domesticStockData), [domesticStockData]);
+    const dailyData = calculateDailyData(domesticStockData);
 
     // 検索カテゴリーの生成
-    const searchCategories = useMemo(() => ({
+    const searchCategories = {
         securities: createSearchOptions(domesticStockData, 'security_code', 'security_name', true),
         accounts: getUniqueValues(domesticStockData, item => item.account),
         years: createYearOptions(domesticStockData, item => item.trade_date),
         yearMonths: createYearMonthOptions(domesticStockData, item => item.trade_date)
-    }), [domesticStockData]);
+    };
 
     // フィルタ設定
-    const filterConfig: FilterConfig<DomesticStockData> = useMemo(() => ({
+    const filterConfig: FilterConfig<DomesticStockData> = {
         stringFields: [
             item => item.security_code,
             item => item.security_name,
@@ -63,24 +63,19 @@ export const DomesticStock: React.FC<DomesticStockProps> = ({ csvData }) => {
             item => item.purchase_price,
             item => item.realized_profit_and_loss,
         ],
-    }), []);
+    };
 
     // 検索クエリに基づくフィルタリング
     const { searchQuery, setSearchQuery, filteredData } = useReceiptPageState(domesticStockData, filterConfig);
 
     // フィルタ後の日次集計
-    const filteredDailyData = useMemo(
-        () => (searchQuery ? calculateDailyData(filteredData) : dailyData),
-        [dailyData, filteredData, searchQuery]
-    );
+    const filteredDailyData = searchQuery ? calculateDailyData(filteredData) : dailyData;
 
     // 表示用の集計（検索前後で同一ロジック: フィルタ後データから計算）
     const calculations = useReceiptCalculations(filteredDailyData, calculateDomesticStock);
 
     // グループキーの取得
-    const getGroupKey = useCallback((item: DomesticStockData): string => {
-        return createISODateKey(item.trade_date);
-    }, []);
+    const getGroupKey = (item: DomesticStockData): string => createISODateKey(item.trade_date);
 
     // ヘッダー項目の定義
     const headerItems = [
@@ -109,7 +104,7 @@ export const DomesticStock: React.FC<DomesticStockProps> = ({ csvData }) => {
 
     // テーブルカラムの定義（検索タイプに応じて表示順序を調整）
     // サマリーと一致するよう、最後の3カラムは「実現損益」「税額」「税引後」にする
-    const baseColumns: TableColumnConfig[] = useMemo(() => ([
+    const baseColumns: TableColumnConfig[] = [
         { key: 'trade_date', header: '約定日', width: '90px', format: formatJPDate },
         { key: 'security_code', header: '銘柄コード', width: '80px', textAlign: 'center', format: renderSecurityCode },
         { key: 'security_name', header: '銘柄名', width: '180px' },
@@ -121,18 +116,15 @@ export const DomesticStock: React.FC<DomesticStockProps> = ({ csvData }) => {
         { key: 'realized_profit_and_loss', header: '損益', width: '90px', textAlign: 'right', format: formatCurrency },
         { key: 'taxes', header: '税額', width: '70px', textAlign: 'right', format: formatCurrency },
         { key: 'realized_profit_and_loss_after_tax', header: '税引後', width: '90px', textAlign: 'right', format: formatCurrency },
-    ]), []);
+    ];
 
     // 列の前面配置ルール（口座のみ）
-    const columnRules: ColumnReorderRule<DomesticStockData>[] = useMemo(() => [
+    const columnRules: ColumnReorderRule<DomesticStockData>[] = [
         { columnKey: 'account', match: (item, q) => item.account.toLowerCase().includes(q) },
-    ], []);
+    ];
 
     // 検索タイプに応じて重要なカラムを前面に配置（日付・コードの2列固定）
-    const columns = useMemo(
-        () => reorderColumnsBySearch(baseColumns, filteredData, searchQuery, columnRules, 2),
-        [baseColumns, filteredData, searchQuery, columnRules]
-    );
+    const columns = reorderColumnsBySearch(baseColumns, filteredData, searchQuery, columnRules, 2);
 
     // サマリーカラムの定義（最後の3カラムと一致）
     const summaryColumns: SummaryColumnConfig[] = [

--- a/frontend/src/pages/Receipt/DomesticStock.tsx
+++ b/frontend/src/pages/Receipt/DomesticStock.tsx
@@ -24,6 +24,24 @@ import { parseDomesticStockCsvItem, sortDomesticStockByTradeDate } from '@/featu
 import { calculateDailyData, calculateDomesticStock } from '@/features/receipt/calculations';
 import { reorderColumnsBySearch, ColumnReorderRule } from '@/lib/utils/columnUtils';
 
+// コンポーネント外に定数として定義（毎レンダーで新参照が生成されるのを防ぐ）
+const FILTER_CONFIG: FilterConfig<DomesticStockData> = {
+    stringFields: [
+        item => item.security_code,
+        item => item.security_name,
+        item => item.account,
+    ],
+    dateField: item => item.trade_date,
+    yearSearch: true,
+    amountFields: [
+        item => item.shares,
+        item => item.asked_price,
+        item => item.proceeds,
+        item => item.purchase_price,
+        item => item.realized_profit_and_loss,
+    ],
+};
+
 interface DomesticStockProps {
     csvData: Record<string, unknown>[];
 }
@@ -36,9 +54,6 @@ export const DomesticStock: React.FC<DomesticStockProps> = ({ csvData }) => {
     // CSVデータを国内株式データ形式に変換
     const domesticStockData = useReceiptData(csvData, parseDomesticStockCsvItem, sortDomesticStockByTradeDate);
 
-    // 日次データの集計（全データ）
-    const dailyData = calculateDailyData(domesticStockData);
-
     // 検索カテゴリーの生成
     const searchCategories = {
         securities: createSearchOptions(domesticStockData, 'security_code', 'security_name', true),
@@ -47,29 +62,11 @@ export const DomesticStock: React.FC<DomesticStockProps> = ({ csvData }) => {
         yearMonths: createYearMonthOptions(domesticStockData, item => item.trade_date)
     };
 
-    // フィルタ設定
-    const filterConfig: FilterConfig<DomesticStockData> = {
-        stringFields: [
-            item => item.security_code,
-            item => item.security_name,
-            item => item.account,
-        ],
-        dateField: item => item.trade_date,
-        yearSearch: true,
-        amountFields: [
-            item => item.shares,
-            item => item.asked_price,
-            item => item.proceeds,
-            item => item.purchase_price,
-            item => item.realized_profit_and_loss,
-        ],
-    };
-
     // 検索クエリに基づくフィルタリング
-    const { searchQuery, setSearchQuery, filteredData } = useReceiptPageState(domesticStockData, filterConfig);
+    const { searchQuery, setSearchQuery, filteredData } = useReceiptPageState(domesticStockData, FILTER_CONFIG);
 
-    // フィルタ後の日次集計
-    const filteredDailyData = searchQuery ? calculateDailyData(filteredData) : dailyData;
+    // 日次集計（searchQuery がある場合はフィルタ後データ、ない場合は全データを使用）
+    const filteredDailyData = calculateDailyData(searchQuery ? filteredData : domesticStockData);
 
     // 表示用の集計（検索前後で同一ロジック: フィルタ後データから計算）
     const calculations = useReceiptCalculations(filteredDailyData, calculateDomesticStock);

--- a/frontend/src/pages/Receipt/Mutualfund.tsx
+++ b/frontend/src/pages/Receipt/Mutualfund.tsx
@@ -1,7 +1,7 @@
 import { ReceiptTemplate } from '@/components/templates/ReceiptTemplate';
 import { ReceiptHeader } from '@/components/molecules/ReceiptHeader/ReceiptHeader';
 import { ReceiptTable } from '@/components/organisms/ReceiptTable/ReceiptTable';
-import React, { useMemo, useCallback } from 'react';
+import React from 'react';
 import { MutualfundData } from '@/lib/interfaces/mutualfund';
 import { TableColumnConfig, SummaryColumnConfig } from '@/lib/interfaces/receipt';
 import { createSearchOptions, groupAndSummarizeData } from '@/lib/utils/dataTransformer';
@@ -29,23 +29,21 @@ export const Mutualfund: React.FC<MutualfundProps> = ({ csvData }) => {
     // CSVデータを投資信託データ形式に変換
     const mutualfundData = useReceiptData(csvData, parseMutualfundCsvItem, sortMutualfundByTradeDate);
 
-    /**
-     * 検索オプションの生成
-     */
-    const searchCategories = useMemo(() => ({
+    // 検索オプションの生成
+    const searchCategories = {
         securities: createSearchOptions(mutualfundData, '', 'fund_name', true),
         years: createYearOptions(mutualfundData, item => item.trade_date)
-    }), [mutualfundData]);
+    };
 
     // フィルタ設定
-    const filterConfig: FilterConfig<MutualfundData> = useMemo(() => ({
+    const filterConfig: FilterConfig<MutualfundData> = {
         stringFields: [
             item => item.fund_name,
             item => item.account,
         ],
         dateField: item => item.trade_date,
         yearSearch: true,
-    }), []);
+    };
 
     // 検索クエリに基づくフィルタリング
     const { searchQuery, setSearchQuery, filteredData } = useReceiptPageState(mutualfundData, filterConfig);
@@ -53,11 +51,9 @@ export const Mutualfund: React.FC<MutualfundProps> = ({ csvData }) => {
     // 表示用の集計（検索前後で同一ロジック: フィルタ後データから計算）
     const calculations = useReceiptCalculations(filteredData, calculateMutualfund);
 
-    /**
-     * グループキーの取得（日付文字列：年月）
-     * ファンド名検索時は元データの正式表記を使用
-     */
-    const getGroupKey = useCallback((item: MutualfundData): string => {
+    // グループキーの取得（日付文字列：年月）
+    // ファンド名検索時は元データの正式表記を使用
+    const getGroupKey = (item: MutualfundData): string => {
         if (searchQuery) {
             // ファンド名検索の場合は元データの表記を使用（小文字化しない）
             const query = searchQuery.toLowerCase();
@@ -68,20 +64,16 @@ export const Mutualfund: React.FC<MutualfundProps> = ({ csvData }) => {
             return createYearMonthKey(item.trade_date);
         }
         return createYearMonthKey(item.trade_date);
-    }, [searchQuery]);
+    };
 
-    /**
-     * サマリーデータの集計
-     */
-    const summary = useMemo(() => groupAndSummarizeData(
+    // サマリーデータの集計
+    const summary = groupAndSummarizeData(
         filteredData,
         getGroupKey,
         ['cancellation_amount_yen', 'realized_profit_and_loss', 'taxes', 'realized_profit_and_loss_after_tax']
-    ), [filteredData, getGroupKey]);
+    );
 
-    /**
-     * ヘッダー項目の定義
-     */
+    // ヘッダー項目の定義
     const headerItems = [
         {
             title: '実現損益',
@@ -106,10 +98,8 @@ export const Mutualfund: React.FC<MutualfundProps> = ({ csvData }) => {
         }
     ];
 
-    /**
-     * テーブルカラムの定義（列幅を明示的に設定して右端切れを防止）
-     */
-    const columns: TableColumnConfig[] = useMemo(() => ([
+    // テーブルカラムの定義（列幅を明示的に設定して右端切れを防止）
+    const columns: TableColumnConfig[] = [
         { key: 'trade_date', header: '約定日', width: '90px', format: formatJPDate },
         { key: 'settlement_date', header: '受渡日', width: '90px', format: formatJPDate },
         { key: 'fund_name', header: 'ファンド名', width: '200px' },
@@ -122,11 +112,9 @@ export const Mutualfund: React.FC<MutualfundProps> = ({ csvData }) => {
         { key: 'realized_profit_and_loss', header: '実現損益', width: '90px', textAlign: 'right', format: formatCurrency },
         { key: 'taxes', header: '税額', width: '70px', textAlign: 'right', format: formatCurrency },
         { key: 'realized_profit_and_loss_after_tax', header: '税引損益', width: '90px', textAlign: 'right', format: formatCurrency },
-    ]), []);
+    ];
 
-    /**
-     * サマリーカラムの定義（ヘッダーと同じ項目: 実現損益、税額、税引後）
-     */
+    // サマリーカラムの定義（ヘッダーと同じ項目: 実現損益、税額、税引後）
     const summaryColumns: SummaryColumnConfig[] = [
         { key: 'realized_profit_and_loss', textAlign: 'right', format: formatCurrency },
         { key: 'taxes', textAlign: 'right', format: formatCurrency },

--- a/frontend/src/pages/Receipt/Mutualfund.tsx
+++ b/frontend/src/pages/Receipt/Mutualfund.tsx
@@ -17,6 +17,16 @@ import { useReceiptPageState } from '@/hooks/receipt/useReceiptPageState';
 import { parseMutualfundCsvItem, sortMutualfundByTradeDate } from '@/features/receipt/parsers';
 import { calculateMutualfund } from '@/features/receipt/calculations';
 
+// コンポーネント外に定数として定義（毎レンダーで新参照が生成されるのを防ぐ）
+const FILTER_CONFIG: FilterConfig<MutualfundData> = {
+    stringFields: [
+        item => item.fund_name,
+        item => item.account,
+    ],
+    dateField: item => item.trade_date,
+    yearSearch: true,
+};
+
 interface MutualfundProps {
     csvData: Record<string, unknown>[];
 }
@@ -35,18 +45,8 @@ export const Mutualfund: React.FC<MutualfundProps> = ({ csvData }) => {
         years: createYearOptions(mutualfundData, item => item.trade_date)
     };
 
-    // フィルタ設定
-    const filterConfig: FilterConfig<MutualfundData> = {
-        stringFields: [
-            item => item.fund_name,
-            item => item.account,
-        ],
-        dateField: item => item.trade_date,
-        yearSearch: true,
-    };
-
     // 検索クエリに基づくフィルタリング
-    const { searchQuery, setSearchQuery, filteredData } = useReceiptPageState(mutualfundData, filterConfig);
+    const { searchQuery, setSearchQuery, filteredData } = useReceiptPageState(mutualfundData, FILTER_CONFIG);
 
     // 表示用の集計（検索前後で同一ロジック: フィルタ後データから計算）
     const calculations = useReceiptCalculations(filteredData, calculateMutualfund);


### PR DESCRIPTION
## 概要

React Compiler が自動メモ化するため、Dividend / DomesticStock / Mutualfund の
useMemo・useCallback ラッパーを削除し、あわせて Codex レビュー指摘も対応。

## 変更種別
- [x] リファクタリング

## 主な変更内容

| 対象 | 変更内容 |
|------|----------|
| `Dividend.tsx` / `DomesticStock.tsx` / `Mutualfund.tsx` | useMemo/useCallback を除去（計25箇所）。React Compiler が自動最適化 |
| 同上 3ファイル | filterConfig をモジュールスコープ定数（FILTER_CONFIG）に移動。毎レンダーの新参照生成を防止し useReceiptPageState 内の filteredData 再計算を抑制 |
| `DomesticStock.tsx` | dailyData の二重計算を解消。`calculateDailyData(searchQuery ? filteredData : domesticStockData)` に統合 |

## テスト
- [x] `npm run lint` — クリーン
- [x] `npx tsc --noEmit` — クリーン
- [x] `npm test --run` — 416/423 passed
- [x] Codex レビュー — LGTM