### PR TITLE
fix: 資産管理ページから配当取得進捗バッジを削除

### DIFF
--- a/frontend/src/pages/AssetBalance.tsx
+++ b/frontend/src/pages/AssetBalance.tsx
@@ -134,7 +134,7 @@ export function AssetBalancePage() {
     () => (saving || loading) ? [] : assetBalanceData.map(item => item.security_code),
     [saving, loading, assetBalanceData]
   );
-  const { dividendPerShareMap, dividendStatusMap, fetchedCount, totalCount: dividendTotalCount } = useDividendBatch(securityCodes, isAuthenticated);
+  const { dividendPerShareMap, dividendStatusMap } = useDividendBatch(securityCodes, isAuthenticated);
 
   // 検索オプションの生成
   const searchCategories = useMemo(() => ({
@@ -263,12 +263,6 @@ export function AssetBalancePage() {
               />
             )}
 
-            {/* 配当取得進捗バッジ */}
-            {dividendTotalCount > 0 && fetchedCount < dividendTotalCount && (
-              <div className="mb-2 text-xs text-slate-500" role="status" aria-live="polite">
-                配当情報 {fetchedCount}/{dividendTotalCount} 件 取得済み（取得中...）
-              </div>
-            )}
 
             {/* ローディング完了後に表示（空データでもEmptyStateを表示） */}
             {!loading && !csvReader.isLoading && (

--- a/frontend/src/pages/AssetBalance.tsx
+++ b/frontend/src/pages/AssetBalance.tsx
@@ -128,8 +128,6 @@ export function AssetBalancePage() {
 
   // J-Quants APIから1株配当を一括取得
   // saving または loading 中は securityCodes を空にして dividend の state をリセットする
-  // （save後に csvData がクリアされ、invalidateQueries による再フェッチ完了前に dbData が旧件数に戻ることで
-  //   "X/旧件数" が表示されるのを防ぐ）
   const securityCodes = useMemo(
     () => (saving || loading) ? [] : assetBalanceData.map(item => item.security_code),
     [saving, loading, assetBalanceData]


### PR DESCRIPTION
## 概要
資産管理ページで表示されていた「配当情報 X/Y 件 取得済み（取得中...）」バッジを削除する。

## 変更種別
- [ ] 新機能
- [x] バグ修正 / UI改善

## 主な変更内容
- `AssetBalance.tsx` から配当取得進捗バッジの表示ロジックを削除
- `useDividendBatch` の戻り値から不要な `fetchedCount` / `totalCount` の destructuring を除去

## テスト
- [x] lint 通過
- [x] tsc 通過
- [x] テスト通過