### PR TITLE
fix: エラー時に既存の配当情報を保持するよう修正

### DIFF
--- a/backend/src/services/dividend_cache.rs
+++ b/backend/src/services/dividend_cache.rs
@@ -251,10 +251,9 @@ async fn update_cache_error(pool: &PgPool, code: &str, error_msg: &str) -> Resul
             (security_code, dividend_per_share, status, error_message, source, updated_at)
         VALUES ($1, NULL, 'error', $2, 'jquants', NOW())
         ON CONFLICT (security_code) DO UPDATE
-            SET dividend_per_share = NULL,
-                status             = 'error',
-                error_message      = EXCLUDED.error_message,
-                updated_at         = NOW()
+            SET status        = 'error',
+                error_message = EXCLUDED.error_message,
+                updated_at    = NOW()
         "#,
     )
     .bind(code)


### PR DESCRIPTION
## 概要
RateLimit等でJ-Quants APIエラーが発生した場合、既存の正常なキャッシュデータが消える問題を修正。

## 変更内容
- `update_cache_error` のUPSERT: `dividend_per_share = NULL` の上書きを削除
- エラー時は `status` と `error_message` のみ更新し、既存の配当情報を保持する

## テスト
- [x] `make check` 通過