### PR TITLE
fix: OpenAPIカバレッジ補完とCI型チェック追加

### DIFF
--- a/.claude/rules/00-general.md
+++ b/.claude/rules/00-general.md
@@ -10,8 +10,8 @@
 ## 開発フロー（標準）
 
 - 明示的なスキップ指示がない限り、以下を標準フローとする
-- 実装担当は Claude、レビュー担当は Codex とする
-- Claude は実装完了後に PR を作成し、Codex にレビューを依頼する
+- 実装担当は Claude、レビュー担当は Codex（MCP経由）とする
+- Claude は実装完了後に PR を作成し、Codex の MCP を呼び出してレビューを依頼する
 - Codex は `.claude/skills/pr-review/SKILL.md` に従って PR をレビューする
 - Codex は PR を承認する前に、要件充足、回帰有無、コード品質、テスト状況を確認する
 - Claude は Codex の指摘に対応し、必要な修正と検証を行う

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -58,6 +58,33 @@ jobs:
             exit 1
           fi
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: ${{ github.workspace }}/frontend
+        run: npm ci
+
+      - name: Generate frontend types
+        working-directory: ${{ github.workspace }}/frontend
+        run: npm run generate:types
+
+      - name: Check frontend types are up to date
+        working-directory: ${{ github.workspace }}
+        run: |
+          if ! git diff --exit-code frontend/src/generated/api.ts; then
+            echo "api.ts が古い状態です。npm run generate:types を実行してコミットしてください。"
+            exit 1
+          fi
+
+      - name: TypeScript type check
+        working-directory: ${{ github.workspace }}/frontend
+        run: npx tsc --noEmit
+
   deploy:
     name: Deploy to Fly.io
     needs: test-and-build

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -220,6 +220,16 @@ pub async fn logout(State(state): State<AppState>, jar: CookieJar) -> impl IntoR
 
 /// アカウント削除処理
 /// ユーザーとすべての関連データ（sessions, dividends, domestic_stocks, mutualfunds, asset_balances）を削除
+#[utoipa::path(
+    delete,
+    path = "/auth/delete-account",
+    operation_id = "auth_delete_account",
+    responses(
+        (status = 200, body = MessageResponse),
+        (status = 401, body = ErrorResponse),
+    ),
+    security(("cookieAuth" = []))
+)]
 pub async fn delete_account(
     State(state): State<AppState>,
     jar: CookieJar,

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -227,6 +227,7 @@ pub async fn logout(State(state): State<AppState>, jar: CookieJar) -> impl IntoR
     responses(
         (status = 200, body = MessageResponse),
         (status = 401, body = ErrorResponse),
+        (status = 500, body = ErrorResponse),
     ),
     security(("cookieAuth" = []))
 )]

--- a/backend/src/handlers/jquants.rs
+++ b/backend/src/handlers/jquants.rs
@@ -22,6 +22,8 @@ use axum::{
         (status = 200, body = FinSummaryResponse),
         (status = 400, body = ErrorResponse),
         (status = 401, body = ErrorResponse),
+        (status = 429, body = ErrorResponse),
+        (status = 502, body = ErrorResponse),
     ),
     security(("cookieAuth" = []))
 )]

--- a/backend/src/handlers/jquants.rs
+++ b/backend/src/handlers/jquants.rs
@@ -1,4 +1,4 @@
-use crate::errors::ApiError;
+use crate::errors::{ApiError, ErrorResponse};
 use crate::models::jquants::{FinSummaryQuery, FinSummaryResponse};
 use crate::services::jquants::JQuantsService;
 use crate::state::AppState;
@@ -9,6 +9,22 @@ use axum::{
 
 /// 決算サマリーを取得（J-Quants API V2）
 /// V2では fins/statements → fins/summary に変更
+#[utoipa::path(
+    get,
+    path = "/jquants/fins/statements",
+    operation_id = "jquants_fin_summary",
+    params(
+        ("code" = String, Query, description = "銘柄コード"),
+        ("from" = Option<String>, Query, description = "開始日（YYYY-MM-DD）"),
+        ("to" = Option<String>, Query, description = "終了日（YYYY-MM-DD）"),
+    ),
+    responses(
+        (status = 200, body = FinSummaryResponse),
+        (status = 400, body = ErrorResponse),
+        (status = 401, body = ErrorResponse),
+    ),
+    security(("cookieAuth" = []))
+)]
 pub async fn get_fin_summary(
     State(state): State<AppState>,
     Query(params): Query<FinSummaryQuery>,

--- a/backend/src/models/jquants.rs
+++ b/backend/src/models/jquants.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 /// 決算サマリー取得パラメータ（J-Quants API V2）
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct FinSummaryQuery {
     pub code: String,
     pub from: Option<String>,
@@ -10,7 +11,7 @@ pub struct FinSummaryQuery {
 
 /// 決算サマリーレスポンス（J-Quants API V2）
 /// V2では fins/summary を使用し、ルートフィールドは "data"
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct FinSummaryResponse {
     /// 決算サマリーデータの配列（V2では "data" フィールド）
     pub data: Vec<FinSummaryData>,
@@ -21,7 +22,7 @@ pub struct FinSummaryResponse {
 
 /// 決算サマリーデータ（J-Quants API V2）
 /// V2では省略形フィールド名を使用
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct FinSummaryData {
     /// 開示日（DisclosedDate → DiscDate）
     #[serde(rename = "DiscDate")]

--- a/backend/src/openapi.rs
+++ b/backend/src/openapi.rs
@@ -14,6 +14,7 @@ use crate::{
         domestic_stock::{
             BulkCreateDomesticStockRequest, CreateDomesticStockRequest, DomesticStock,
         },
+        jquants::{FinSummaryData, FinSummaryResponse},
         mutualfund::{BulkCreateMutualfundRequest, CreateMutualfundRequest, Mutualfund},
         stock::Stock,
         user::UserResponse,
@@ -39,6 +40,8 @@ use crate::{
         handlers::stock::add_stock_info,
         handlers::auth::get_current_user,
         handlers::auth::logout,
+        handlers::auth::delete_account,
+        handlers::jquants::get_fin_summary,
         handlers::dividend_per_share::batch,
     ),
     components(
@@ -62,6 +65,8 @@ use crate::{
             DividendPerShareBatchRequest,
             DividendPerShareItem,
             DividendPerShareBatchResponse,
+            FinSummaryResponse,
+            FinSummaryData,
             ErrorResponse,
             ErrorDetails,
         )

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -167,6 +167,16 @@
                 }
               }
             }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -599,6 +609,26 @@
             }
           },
           "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "502": {
             "description": "",
             "content": {
               "application/json": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -140,6 +140,42 @@
         ]
       }
     },
+    "/auth/delete-account": {
+      "delete": {
+        "tags": [
+          "handlers::auth"
+        ],
+        "summary": "アカウント削除処理\nユーザーとすべての関連データ（sessions, dividends, domestic_stocks, mutualfunds, asset_balances）を削除",
+        "operationId": "auth_delete_account",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ]
+      }
+    },
     "/auth/logout": {
       "post": {
         "tags": [
@@ -473,6 +509,81 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/BulkCreateResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ]
+      }
+    },
+    "/jquants/fins/statements": {
+      "get": {
+        "tags": [
+          "handlers::jquants"
+        ],
+        "summary": "決算サマリーを取得（J-Quants API V2）\nV2では fins/statements → fins/summary に変更",
+        "operationId": "jquants_fin_summary",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "query",
+            "description": "銘柄コード",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "description": "開始日（YYYY-MM-DD）",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "description": "終了日（YYYY-MM-DD）",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FinSummaryResponse"
                 }
               }
             }
@@ -1376,6 +1487,780 @@
         "properties": {
           "error": {
             "$ref": "#/components/schemas/ErrorDetails"
+          }
+        }
+      },
+      "FinSummaryData": {
+        "type": "object",
+        "description": "決算サマリーデータ（J-Quants API V2）\nV2では省略形フィールド名を使用",
+        "required": [
+          "DiscDate",
+          "Code",
+          "DocType"
+        ],
+        "properties": {
+          "AvgSh": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "期中平均株式数"
+          },
+          "BPS": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "1株当たり純資産"
+          },
+          "CFF": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "財務活動によるキャッシュフロー"
+          },
+          "CFI": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "投資活動によるキャッシュフロー"
+          },
+          "CFO": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "営業活動によるキャッシュフロー"
+          },
+          "CashEq": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "現金及び現金同等物の期末残高"
+          },
+          "ChgAccStd": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "会計基準の改正に伴う変更"
+          },
+          "ChgEstimate": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "会計上の見積りの変更"
+          },
+          "ChgOther": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "会計基準の改正以外の変更"
+          },
+          "Code": {
+            "type": "string",
+            "description": "銘柄コード（LocalCode → Code）"
+          },
+          "CurFYEn": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "当会計年度終了日"
+          },
+          "CurFYSt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "当会計年度開始日"
+          },
+          "CurPerEn": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "当期終了日"
+          },
+          "CurPerSt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "当期開始日"
+          },
+          "CurPerType": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "当期種別"
+          },
+          "DEPS": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "希薄化後1株当たり当期純利益"
+          },
+          "DiscDate": {
+            "type": "string",
+            "description": "開示日（DisclosedDate → DiscDate）"
+          },
+          "DiscNo": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "開示番号"
+          },
+          "DiscTime": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "開示時刻"
+          },
+          "Div1Q": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "1株当たり配当金（第1四半期末）実績"
+          },
+          "Div2Q": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "1株当たり配当金（第2四半期末）実績"
+          },
+          "Div3Q": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "1株当たり配当金（第3四半期末）実績"
+          },
+          "DivAnn": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "1株当たり年間配当金実績"
+          },
+          "DivFY": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "1株当たり配当金（期末）実績"
+          },
+          "DivTotalAnn": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "年間配当支払総額実績"
+          },
+          "DivUnit": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "1口当たり分配金（REIT）"
+          },
+          "DocType": {
+            "type": "string",
+            "description": "書類種別"
+          },
+          "EPS": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "1株当たり当期純利益"
+          },
+          "Eq": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "純資産"
+          },
+          "EqAR": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "自己資本比率"
+          },
+          "FDiv1Q": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "1株当たり配当金（第1四半期末）予想"
+          },
+          "FDiv2Q": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "1株当たり配当金（第2四半期末）予想"
+          },
+          "FDiv3Q": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "1株当たり配当金（第3四半期末）予想"
+          },
+          "FDivAnn": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "1株当たり年間配当金予想（今期）"
+          },
+          "FDivFY": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "1株当たり配当金（期末）予想"
+          },
+          "FDivTotalAnn": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "年間配当支払総額予想"
+          },
+          "FDivUnit": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "1口当たり分配金（REIT）予想"
+          },
+          "FEPS": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "1株当たり当期純利益予想（通期）"
+          },
+          "FEPS2Q": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "1株当たり当期純利益予想（第2四半期）"
+          },
+          "FNCEPS": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "1株当たり当期純利益予想（通期・個別）"
+          },
+          "FNCEPS2Q": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "1株当たり当期純利益予想（第2四半期・個別）"
+          },
+          "FNCNP": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "当期純利益予想（通期・個別）"
+          },
+          "FNCNP2Q": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "当期純利益予想（第2四半期・個別）"
+          },
+          "FNCOP": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "営業利益予想（通期・個別）"
+          },
+          "FNCOP2Q": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "営業利益予想（第2四半期・個別）"
+          },
+          "FNCOdP": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "経常利益予想（通期・個別）"
+          },
+          "FNCOdP2Q": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "経常利益予想（第2四半期・個別）"
+          },
+          "FNCSales": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "売上高予想（通期・個別）"
+          },
+          "FNCSales2Q": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "売上高予想（第2四半期・個別）"
+          },
+          "FNP": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "当期純利益予想（通期）"
+          },
+          "FNP2Q": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "当期純利益予想（第2四半期）"
+          },
+          "FOP": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "営業利益予想（通期）"
+          },
+          "FOP2Q": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "営業利益予想（第2四半期）"
+          },
+          "FOdP": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "経常利益予想（通期）"
+          },
+          "FOdP2Q": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "経常利益予想（第2四半期）"
+          },
+          "FPayoutRatioAnn": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "配当性向予想"
+          },
+          "FSales": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "売上高予想（通期）"
+          },
+          "FSales2Q": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "売上高予想（第2四半期）"
+          },
+          "MatChgSub": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "重要な子会社の異動"
+          },
+          "NCBPS": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "1株当たり純資産（個別）"
+          },
+          "NCEPS": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "1株当たり当期純利益（個別）"
+          },
+          "NCEq": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "純資産（個別）"
+          },
+          "NCEqAR": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "自己資本比率（個別）"
+          },
+          "NCNP": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "当期純利益（個別）"
+          },
+          "NCOP": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "営業利益（個別）"
+          },
+          "NCOdP": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "経常利益（個別）"
+          },
+          "NCSales": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "売上高（個別）"
+          },
+          "NCTA": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "総資産（個別）"
+          },
+          "NP": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "当期純利益"
+          },
+          "NxFDiv1Q": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "1株当たり配当金（第1四半期末）来期予想"
+          },
+          "NxFDiv2Q": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "1株当たり配当金（第2四半期末）来期予想"
+          },
+          "NxFDiv3Q": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "1株当たり配当金（第3四半期末）来期予想"
+          },
+          "NxFDivAnn": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "1株当たり年間配当金来期予想"
+          },
+          "NxFDivFY": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "1株当たり配当金（期末）来期予想"
+          },
+          "NxFDivUnit": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "1口当たり分配金（REIT）来期予想"
+          },
+          "NxFEPS": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "1株当たり当期純利益来期予想（通期）"
+          },
+          "NxFEPS2Q": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "1株当たり当期純利益来期予想（第2四半期）"
+          },
+          "NxFNCEPS": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "1株当たり当期純利益来期予想（通期・個別）"
+          },
+          "NxFNCEPS2Q": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "1株当たり当期純利益来期予想（第2四半期・個別）"
+          },
+          "NxFNCNP": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "当期純利益来期予想（通期・個別）"
+          },
+          "NxFNCNP2Q": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "当期純利益来期予想（第2四半期・個別）"
+          },
+          "NxFNCOP": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "営業利益来期予想（通期・個別）"
+          },
+          "NxFNCOP2Q": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "営業利益来期予想（第2四半期・個別）"
+          },
+          "NxFNCOdP": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "経常利益来期予想（通期・個別）"
+          },
+          "NxFNCOdP2Q": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "経常利益来期予想（第2四半期・個別）"
+          },
+          "NxFNCSales": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "売上高来期予想（通期・個別）"
+          },
+          "NxFNCSales2Q": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "売上高来期予想（第2四半期・個別）"
+          },
+          "NxFNp": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "当期純利益来期予想（通期）"
+          },
+          "NxFNp2Q": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "当期純利益来期予想（第2四半期）"
+          },
+          "NxFOP": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "営業利益来期予想（通期）"
+          },
+          "NxFOP2Q": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "営業利益来期予想（第2四半期）"
+          },
+          "NxFOdP": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "経常利益来期予想（通期）"
+          },
+          "NxFOdP2Q": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "経常利益来期予想（第2四半期）"
+          },
+          "NxFPayoutRatioAnn": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "配当性向来期予想"
+          },
+          "NxFSales": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "売上高来期予想（通期）"
+          },
+          "NxFSales2Q": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "売上高来期予想（第2四半期）"
+          },
+          "NxtFYEn": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "翌会計年度終了日"
+          },
+          "NxtFYSt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "翌会計年度開始日"
+          },
+          "OP": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "営業利益"
+          },
+          "OdP": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "経常利益"
+          },
+          "PayoutRatioAnn": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "配当性向実績"
+          },
+          "Restatement": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "修正再表示"
+          },
+          "Sales": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "売上高"
+          },
+          "ShOutFY": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "発行済株式数（期末・自己株式を含む）"
+          },
+          "SigChgInC": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "連結範囲の重要な変更"
+          },
+          "TA": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "総資産"
+          },
+          "TrShFY": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "自己株式数（期末）"
+          }
+        }
+      },
+      "FinSummaryResponse": {
+        "type": "object",
+        "description": "決算サマリーレスポンス（J-Quants API V2）\nV2では fins/summary を使用し、ルートフィールドは \"data\"",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FinSummaryData"
+            },
+            "description": "決算サマリーデータの配列（V2では \"data\" フィールド）"
+          },
+          "pagination_key": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "ページネーションキー（データが大量の場合に設定される）"
           }
         }
       },

--- a/frontend/src/generated/api.ts
+++ b/frontend/src/generated/api.ts
@@ -970,6 +970,14 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
         };
     };
     auth_logout: {
@@ -1268,6 +1276,22 @@ export interface operations {
                 };
             };
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            502: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/generated/api.ts
+++ b/frontend/src/generated/api.ts
@@ -55,6 +55,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/auth/delete-account": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * アカウント削除処理
+         *     ユーザーとすべての関連データ（sessions, dividends, domestic_stocks, mutualfunds, asset_balances）を削除
+         */
+        delete: operations["auth_delete_account"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/auth/logout": {
         parameters: {
             query?: never;
@@ -202,6 +222,26 @@ export interface paths {
         put?: never;
         /** 国内株式取引を一括追加（全件挿入） */
         post: operations["domestic_stock_bulk_create"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/jquants/fins/statements": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 決算サマリーを取得（J-Quants API V2）
+         *     V2では fins/statements → fins/summary に変更
+         */
+        get: operations["jquants_fin_summary"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -517,6 +557,236 @@ export interface components {
         ErrorResponse: {
             error: components["schemas"]["ErrorDetails"];
         };
+        /**
+         * @description 決算サマリーデータ（J-Quants API V2）
+         *     V2では省略形フィールド名を使用
+         */
+        FinSummaryData: {
+            /** @description 期中平均株式数 */
+            AvgSh?: string | null;
+            /** @description 1株当たり純資産 */
+            BPS?: string | null;
+            /** @description 財務活動によるキャッシュフロー */
+            CFF?: string | null;
+            /** @description 投資活動によるキャッシュフロー */
+            CFI?: string | null;
+            /** @description 営業活動によるキャッシュフロー */
+            CFO?: string | null;
+            /** @description 現金及び現金同等物の期末残高 */
+            CashEq?: string | null;
+            /** @description 会計基準の改正に伴う変更 */
+            ChgAccStd?: string | null;
+            /** @description 会計上の見積りの変更 */
+            ChgEstimate?: string | null;
+            /** @description 会計基準の改正以外の変更 */
+            ChgOther?: string | null;
+            /** @description 銘柄コード（LocalCode → Code） */
+            Code: string;
+            /** @description 当会計年度終了日 */
+            CurFYEn?: string | null;
+            /** @description 当会計年度開始日 */
+            CurFYSt?: string | null;
+            /** @description 当期終了日 */
+            CurPerEn?: string | null;
+            /** @description 当期開始日 */
+            CurPerSt?: string | null;
+            /** @description 当期種別 */
+            CurPerType?: string | null;
+            /** @description 希薄化後1株当たり当期純利益 */
+            DEPS?: string | null;
+            /** @description 開示日（DisclosedDate → DiscDate） */
+            DiscDate: string;
+            /** @description 開示番号 */
+            DiscNo?: string | null;
+            /** @description 開示時刻 */
+            DiscTime?: string | null;
+            /** @description 1株当たり配当金（第1四半期末）実績 */
+            Div1Q?: string | null;
+            /** @description 1株当たり配当金（第2四半期末）実績 */
+            Div2Q?: string | null;
+            /** @description 1株当たり配当金（第3四半期末）実績 */
+            Div3Q?: string | null;
+            /** @description 1株当たり年間配当金実績 */
+            DivAnn?: string | null;
+            /** @description 1株当たり配当金（期末）実績 */
+            DivFY?: string | null;
+            /** @description 年間配当支払総額実績 */
+            DivTotalAnn?: string | null;
+            /** @description 1口当たり分配金（REIT） */
+            DivUnit?: string | null;
+            /** @description 書類種別 */
+            DocType: string;
+            /** @description 1株当たり当期純利益 */
+            EPS?: string | null;
+            /** @description 純資産 */
+            Eq?: string | null;
+            /** @description 自己資本比率 */
+            EqAR?: string | null;
+            /** @description 1株当たり配当金（第1四半期末）予想 */
+            FDiv1Q?: string | null;
+            /** @description 1株当たり配当金（第2四半期末）予想 */
+            FDiv2Q?: string | null;
+            /** @description 1株当たり配当金（第3四半期末）予想 */
+            FDiv3Q?: string | null;
+            /** @description 1株当たり年間配当金予想（今期） */
+            FDivAnn?: string | null;
+            /** @description 1株当たり配当金（期末）予想 */
+            FDivFY?: string | null;
+            /** @description 年間配当支払総額予想 */
+            FDivTotalAnn?: string | null;
+            /** @description 1口当たり分配金（REIT）予想 */
+            FDivUnit?: string | null;
+            /** @description 1株当たり当期純利益予想（通期） */
+            FEPS?: string | null;
+            /** @description 1株当たり当期純利益予想（第2四半期） */
+            FEPS2Q?: string | null;
+            /** @description 1株当たり当期純利益予想（通期・個別） */
+            FNCEPS?: string | null;
+            /** @description 1株当たり当期純利益予想（第2四半期・個別） */
+            FNCEPS2Q?: string | null;
+            /** @description 当期純利益予想（通期・個別） */
+            FNCNP?: string | null;
+            /** @description 当期純利益予想（第2四半期・個別） */
+            FNCNP2Q?: string | null;
+            /** @description 営業利益予想（通期・個別） */
+            FNCOP?: string | null;
+            /** @description 営業利益予想（第2四半期・個別） */
+            FNCOP2Q?: string | null;
+            /** @description 経常利益予想（通期・個別） */
+            FNCOdP?: string | null;
+            /** @description 経常利益予想（第2四半期・個別） */
+            FNCOdP2Q?: string | null;
+            /** @description 売上高予想（通期・個別） */
+            FNCSales?: string | null;
+            /** @description 売上高予想（第2四半期・個別） */
+            FNCSales2Q?: string | null;
+            /** @description 当期純利益予想（通期） */
+            FNP?: string | null;
+            /** @description 当期純利益予想（第2四半期） */
+            FNP2Q?: string | null;
+            /** @description 営業利益予想（通期） */
+            FOP?: string | null;
+            /** @description 営業利益予想（第2四半期） */
+            FOP2Q?: string | null;
+            /** @description 経常利益予想（通期） */
+            FOdP?: string | null;
+            /** @description 経常利益予想（第2四半期） */
+            FOdP2Q?: string | null;
+            /** @description 配当性向予想 */
+            FPayoutRatioAnn?: string | null;
+            /** @description 売上高予想（通期） */
+            FSales?: string | null;
+            /** @description 売上高予想（第2四半期） */
+            FSales2Q?: string | null;
+            /** @description 重要な子会社の異動 */
+            MatChgSub?: string | null;
+            /** @description 1株当たり純資産（個別） */
+            NCBPS?: string | null;
+            /** @description 1株当たり当期純利益（個別） */
+            NCEPS?: string | null;
+            /** @description 純資産（個別） */
+            NCEq?: string | null;
+            /** @description 自己資本比率（個別） */
+            NCEqAR?: string | null;
+            /** @description 当期純利益（個別） */
+            NCNP?: string | null;
+            /** @description 営業利益（個別） */
+            NCOP?: string | null;
+            /** @description 経常利益（個別） */
+            NCOdP?: string | null;
+            /** @description 売上高（個別） */
+            NCSales?: string | null;
+            /** @description 総資産（個別） */
+            NCTA?: string | null;
+            /** @description 当期純利益 */
+            NP?: string | null;
+            /** @description 1株当たり配当金（第1四半期末）来期予想 */
+            NxFDiv1Q?: string | null;
+            /** @description 1株当たり配当金（第2四半期末）来期予想 */
+            NxFDiv2Q?: string | null;
+            /** @description 1株当たり配当金（第3四半期末）来期予想 */
+            NxFDiv3Q?: string | null;
+            /** @description 1株当たり年間配当金来期予想 */
+            NxFDivAnn?: string | null;
+            /** @description 1株当たり配当金（期末）来期予想 */
+            NxFDivFY?: string | null;
+            /** @description 1口当たり分配金（REIT）来期予想 */
+            NxFDivUnit?: string | null;
+            /** @description 1株当たり当期純利益来期予想（通期） */
+            NxFEPS?: string | null;
+            /** @description 1株当たり当期純利益来期予想（第2四半期） */
+            NxFEPS2Q?: string | null;
+            /** @description 1株当たり当期純利益来期予想（通期・個別） */
+            NxFNCEPS?: string | null;
+            /** @description 1株当たり当期純利益来期予想（第2四半期・個別） */
+            NxFNCEPS2Q?: string | null;
+            /** @description 当期純利益来期予想（通期・個別） */
+            NxFNCNP?: string | null;
+            /** @description 当期純利益来期予想（第2四半期・個別） */
+            NxFNCNP2Q?: string | null;
+            /** @description 営業利益来期予想（通期・個別） */
+            NxFNCOP?: string | null;
+            /** @description 営業利益来期予想（第2四半期・個別） */
+            NxFNCOP2Q?: string | null;
+            /** @description 経常利益来期予想（通期・個別） */
+            NxFNCOdP?: string | null;
+            /** @description 経常利益来期予想（第2四半期・個別） */
+            NxFNCOdP2Q?: string | null;
+            /** @description 売上高来期予想（通期・個別） */
+            NxFNCSales?: string | null;
+            /** @description 売上高来期予想（第2四半期・個別） */
+            NxFNCSales2Q?: string | null;
+            /** @description 当期純利益来期予想（通期） */
+            NxFNp?: string | null;
+            /** @description 当期純利益来期予想（第2四半期） */
+            NxFNp2Q?: string | null;
+            /** @description 営業利益来期予想（通期） */
+            NxFOP?: string | null;
+            /** @description 営業利益来期予想（第2四半期） */
+            NxFOP2Q?: string | null;
+            /** @description 経常利益来期予想（通期） */
+            NxFOdP?: string | null;
+            /** @description 経常利益来期予想（第2四半期） */
+            NxFOdP2Q?: string | null;
+            /** @description 配当性向来期予想 */
+            NxFPayoutRatioAnn?: string | null;
+            /** @description 売上高来期予想（通期） */
+            NxFSales?: string | null;
+            /** @description 売上高来期予想（第2四半期） */
+            NxFSales2Q?: string | null;
+            /** @description 翌会計年度終了日 */
+            NxtFYEn?: string | null;
+            /** @description 翌会計年度開始日 */
+            NxtFYSt?: string | null;
+            /** @description 営業利益 */
+            OP?: string | null;
+            /** @description 経常利益 */
+            OdP?: string | null;
+            /** @description 配当性向実績 */
+            PayoutRatioAnn?: string | null;
+            /** @description 修正再表示 */
+            Restatement?: string | null;
+            /** @description 売上高 */
+            Sales?: string | null;
+            /** @description 発行済株式数（期末・自己株式を含む） */
+            ShOutFY?: string | null;
+            /** @description 連結範囲の重要な変更 */
+            SigChgInC?: string | null;
+            /** @description 総資産 */
+            TA?: string | null;
+            /** @description 自己株式数（期末） */
+            TrShFY?: string | null;
+        };
+        /**
+         * @description 決算サマリーレスポンス（J-Quants API V2）
+         *     V2では fins/summary を使用し、ルートフィールドは "data"
+         */
+        FinSummaryResponse: {
+            /** @description 決算サマリーデータの配列（V2では "data" フィールド） */
+            data: components["schemas"]["FinSummaryData"][];
+            /** @description ページネーションキー（データが大量の場合に設定される） */
+            pagination_key?: string | null;
+        };
         /** @description メッセージレスポンス（削除・ログアウト等） */
         MessageResponse: {
             message: string;
@@ -663,6 +933,33 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    auth_delete_account: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MessageResponse"];
                 };
             };
             401: {
@@ -918,6 +1215,48 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["BulkCreateResponse"];
+                };
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    jquants_fin_summary: {
+        parameters: {
+            query: {
+                /** @description 銘柄コード */
+                code: string;
+                /** @description 開始日（YYYY-MM-DD） */
+                from?: string;
+                /** @description 終了日（YYYY-MM-DD） */
+                to?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FinSummaryResponse"];
                 };
             };
             400: {


### PR DESCRIPTION
## 変更内容

Codex レビュー指摘（Medium 2件）への対応。

### 指摘1: CI でフロント生成型の更新漏れを検知できない

`deploy-backend.yml` に以下を追加:
- Node.js セットアップ（v22）
- `npm ci` でフロント依存インストール
- `npm run generate:types` でフロント型再生成
- `git diff --exit-code frontend/src/generated/api.ts` で差分チェック
- `npx tsc --noEmit` で型チェック

### 指摘2: OpenAPI カバレッジ不完全

以下を追加収録:
- `GET /jquants/fins/statements` — FinSummaryResponse を返す J-Quants エンドポイント
- `DELETE /auth/delete-account` — アカウント削除エンドポイント

除外継続（計画書通り）:
- `GET /auth/google`, `GET /auth/google/callback` — OAuth リダイレクトのため

### 生成ファイル更新
- `docs/openapi.json` — 再生成（operationId 19件）
- `frontend/src/generated/api.ts` — 再生成

## テスト結果

- `cargo clippy -- -D warnings`: OK
- `cargo test`: OK（DB依存テストはignore）
- `npm run generate:types`: OK
- `npx tsc --noEmit`: OK