### PR TITLE
docs: 開発フローのレビュー責務を明確化

### DIFF
--- a/.claude/rules/00-general.md
+++ b/.claude/rules/00-general.md
@@ -9,11 +9,14 @@
 
 ## 開発フロー（標準）
 
-- 明示的なスキップ指示がない限り、以下を必須フローとする
+- 明示的なスキップ指示がない限り、以下を標準フローとする
 - 実装担当は Claude、レビュー担当は Codex とする
-- 基本の流れは `Claude が作業する → Codex にレビューする`
-- PR作成後は `.claude/skills/pr-review/SKILL.md` に従って Codex レビューを実施する
-- レビュー指摘は Claude が修正し、必要に応じて Codex で再レビューする
+- Claude は実装完了後に PR を作成し、Codex にレビューを依頼する
+- Codex は `.claude/skills/pr-review/SKILL.md` に従って PR をレビューする
+- Codex は PR を承認する前に、要件充足、回帰有無、コード品質、テスト状況を確認する
+- Claude は Codex の指摘に対応し、必要な修正と検証を行う
+- 修正後は Codex が再レビューし、指摘事項の解消を確認する
+- Codex から Claude に修正実装を依頼する場合は `.claude/skills/codex-claude-handoff/SKILL.md` を使用する
 
 ## 出力制約
 


### PR DESCRIPTION
## 概要
開発フローの標準ルールを見直し、Claude と Codex の役割分担を明確化しました。

## 変更種別
- [ ] 新機能
- [ ] バグ修正
- [x] ドキュメント

## 主な変更内容
- 実装完了後の PR 作成とレビュー依頼の流れを明文化
- Codex が承認前に確認すべき観点を明記
- 修正後の再レビュー手順を明文化
- Codex から Claude への修正依頼に codex-claude-handoff skill を参照追加

## テスト
- ドキュメント変更のみのため未実施