### PR TITLE
feat: stale_at カラム追加による配当キャッシュ状態管理の単純化

### DIFF
--- a/backend/migrations/0014_add_stale_at_to_dividend_cache.sql
+++ b/backend/migrations/0014_add_stale_at_to_dividend_cache.sql
@@ -6,4 +6,5 @@ UPDATE jquants_dividend_cache
 SET stale_at = fetched_at + INTERVAL '7 days'
 WHERE status IN ('ok', 'zero') AND fetched_at IS NOT NULL;
 
--- error/pending は NULL のまま（is_stale = true = 即再取得対象）
+-- error は NULL のまま（即再取得対象）
+-- pending は NULL のまま（取得中のため再取得対象外）

--- a/backend/migrations/0014_add_stale_at_to_dividend_cache.sql
+++ b/backend/migrations/0014_add_stale_at_to_dividend_cache.sql
@@ -1,0 +1,9 @@
+ALTER TABLE jquants_dividend_cache
+  ADD COLUMN stale_at TIMESTAMPTZ;
+
+-- ok/zero レコードは fetched_at + 7日を設定
+UPDATE jquants_dividend_cache
+SET stale_at = fetched_at + INTERVAL '7 days'
+WHERE status IN ('ok', 'zero') AND fetched_at IS NOT NULL;
+
+-- error/pending は NULL のまま（is_stale = true = 即再取得対象）

--- a/backend/src/models/dividend_cache.rs
+++ b/backend/src/models/dividend_cache.rs
@@ -22,7 +22,7 @@ pub struct DividendCache {
     /// ok: 有配当、zero: ゼロ配当、error: 取得失敗、pending: 未取得/更新待ち
     pub status: String,
     pub fetched_at: Option<DateTime<Utc>>,
-    /// TTL期限。この時刻を過ぎると再取得対象（NULL = 即再取得対象）
+    /// TTL期限。この時刻を過ぎると再取得対象（NULL かつ pending 以外 = 即再取得対象）
     pub stale_at: Option<DateTime<Utc>>,
     pub source: String,
     pub created_at: DateTime<Utc>,

--- a/backend/src/models/dividend_cache.rs
+++ b/backend/src/models/dividend_cache.rs
@@ -6,15 +6,15 @@ use validator::Validate;
 
 /// 配当キャッシュレコード
 ///
-/// status × stale_at 整合ルール
-/// | status  | stale_at         | 意味               | 再取得? |
-/// |---------|------------------|--------------------|---------|
-/// | pending | NULL             | 初回取得中         | No      |
-/// | ok      | future           | 有効データ         | No      |
-/// | ok      | NULL / past      | stale（再取得待ち）| Yes     |
-/// | zero    | future           | 配当なし（有効）   | No      |
-/// | zero    | NULL / past      | stale（再取得待ち）| Yes     |
-/// | error   | NULL（即再取得） | エラー             | Yes     |
+/// status × stale_at 整合ルール（is_stale / 再取得対象の判定基準）
+/// | status  | stale_at    | is_stale | 再取得? | 理由                         |
+/// |---------|-------------|----------|---------|------------------------------|
+/// | pending | NULL        | false    | No      | 取得中のため再取得しない     |
+/// | ok      | future      | false    | No      | 有効データ                   |
+/// | ok      | NULL / past | true     | Yes     | stale（再取得待ち）          |
+/// | zero    | future      | false    | No      | 配当なし（有効）             |
+/// | zero    | NULL / past | true     | Yes     | stale（再取得待ち）          |
+/// | error   | NULL        | true     | Yes     | 即再取得対象                 |
 #[derive(Debug, Clone, Serialize, FromRow)]
 pub struct DividendCache {
     pub security_code: String,

--- a/backend/src/models/dividend_cache.rs
+++ b/backend/src/models/dividend_cache.rs
@@ -5,6 +5,16 @@ use utoipa::ToSchema;
 use validator::Validate;
 
 /// 配当キャッシュレコード
+///
+/// status × stale_at 整合ルール
+/// | status  | stale_at         | 意味               | 再取得? |
+/// |---------|------------------|--------------------|---------|
+/// | pending | NULL             | 初回取得中         | No      |
+/// | ok      | future           | 有効データ         | No      |
+/// | ok      | NULL / past      | stale（再取得待ち）| Yes     |
+/// | zero    | future           | 配当なし（有効）   | No      |
+/// | zero    | NULL / past      | stale（再取得待ち）| Yes     |
+/// | error   | NULL（即再取得） | エラー             | Yes     |
 #[derive(Debug, Clone, Serialize, FromRow)]
 pub struct DividendCache {
     pub security_code: String,
@@ -12,6 +22,8 @@ pub struct DividendCache {
     /// ok: 有配当、zero: ゼロ配当、error: 取得失敗、pending: 未取得/更新待ち
     pub status: String,
     pub fetched_at: Option<DateTime<Utc>>,
+    /// TTL期限。この時刻を過ぎると再取得対象（NULL = 即再取得対象）
+    pub stale_at: Option<DateTime<Utc>>,
     pub source: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
@@ -41,5 +53,3 @@ pub struct DividendPerShareBatchResponse {
     pub items: Vec<DividendPerShareItem>,
 }
 
-/// キャッシュのTTL（日数）
-pub const CACHE_TTL_DAYS: i64 = 7;

--- a/backend/src/services/dividend_cache.rs
+++ b/backend/src/services/dividend_cache.rs
@@ -1,5 +1,5 @@
 use crate::errors::ApiError;
-use crate::models::dividend_cache::{DividendCache, DividendPerShareItem, CACHE_TTL_DAYS};
+use crate::models::dividend_cache::{DividendCache, DividendPerShareItem};
 use crate::models::jquants::FinSummaryData;
 use crate::services::jquants::JQuantsService;
 use chrono::Utc;
@@ -26,7 +26,7 @@ pub async fn get_batch(
     // DB からキャッシュを一括取得
     let cached: Vec<DividendCache> = sqlx::query_as::<_, DividendCache>(
         r#"
-        SELECT security_code, dividend_per_share, status, fetched_at, source,
+        SELECT security_code, dividend_per_share, status, fetched_at, stale_at, source,
                created_at, updated_at
         FROM jquants_dividend_cache
         WHERE security_code = ANY($1)
@@ -37,7 +37,6 @@ pub async fn get_batch(
     .await?;
 
     let now = Utc::now();
-    let ttl_threshold = now - chrono::Duration::days(CACHE_TTL_DAYS);
 
     // コードをキーにしてキャッシュをマップ化
     let cache_map: std::collections::HashMap<&str, &DividendCache> = cached
@@ -53,8 +52,8 @@ pub async fn get_batch(
         .map(|code| {
             if let Some(cached_item) = cache_map.get(code.as_str()) {
                 let is_stale = cached_item
-                    .fetched_at
-                    .map(|t| t < ttl_threshold)
+                    .stale_at
+                    .map(|t| t < now)
                     .unwrap_or(true);
                 if is_stale && cached_item.status != "pending" {
                     refresh_codes.push(code.clone());
@@ -210,12 +209,13 @@ async fn fetch_and_cache(
     sqlx::query(
         r#"
         INSERT INTO jquants_dividend_cache
-            (security_code, dividend_per_share, status, fetched_at, source, updated_at)
-        VALUES ($1, $2, $3, NOW(), 'jquants', NOW())
+            (security_code, dividend_per_share, status, fetched_at, stale_at, source, updated_at)
+        VALUES ($1, $2, $3, NOW(), NOW() + INTERVAL '7 days', 'jquants', NOW())
         ON CONFLICT (security_code) DO UPDATE
             SET dividend_per_share = EXCLUDED.dividend_per_share,
                 status             = EXCLUDED.status,
                 fetched_at         = EXCLUDED.fetched_at,
+                stale_at           = NOW() + INTERVAL '7 days',
                 source             = EXCLUDED.source,
                 error_message      = NULL,
                 updated_at         = NOW()
@@ -248,11 +248,12 @@ async fn update_cache_error(pool: &PgPool, code: &str, error_msg: &str) -> Resul
     sqlx::query(
         r#"
         INSERT INTO jquants_dividend_cache
-            (security_code, dividend_per_share, status, error_message, source, updated_at)
-        VALUES ($1, NULL, 'error', $2, 'jquants', NOW())
+            (security_code, dividend_per_share, status, error_message, stale_at, source, updated_at)
+        VALUES ($1, NULL, 'error', $2, NULL, 'jquants', NOW())
         ON CONFLICT (security_code) DO UPDATE
             SET status        = 'error',
                 error_message = EXCLUDED.error_message,
+                stale_at      = NULL,
                 updated_at    = NOW()
         "#,
     )
@@ -382,8 +383,4 @@ mod tests {
         assert_eq!(val, Some(60.0));
     }
 
-    #[test]
-    fn test_cache_ttl_constant() {
-        assert_eq!(CACHE_TTL_DAYS, 7);
-    }
 }

--- a/backend/src/services/dividend_cache.rs
+++ b/backend/src/services/dividend_cache.rs
@@ -2,7 +2,7 @@ use crate::errors::ApiError;
 use crate::models::dividend_cache::{DividendCache, DividendPerShareItem};
 use crate::models::jquants::FinSummaryData;
 use crate::services::jquants::JQuantsService;
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use reqwest::Client;
 use sqlx::PgPool;
 use std::sync::{
@@ -51,11 +51,8 @@ pub async fn get_batch(
         .iter()
         .map(|code| {
             if let Some(cached_item) = cache_map.get(code.as_str()) {
-                let is_stale = cached_item
-                    .stale_at
-                    .map(|t| t < now)
-                    .unwrap_or(true);
-                if is_stale && cached_item.status != "pending" {
+                let is_stale = compute_is_stale(&cached_item.status, cached_item.stale_at, now);
+                if is_stale {
                     refresh_codes.push(code.clone());
                 }
                 DividendPerShareItem {
@@ -265,6 +262,14 @@ async fn update_cache_error(pool: &PgPool, code: &str, error_msg: &str) -> Resul
     Ok(())
 }
 
+/// キャッシュエントリの is_stale を判定する
+///
+/// pending は取得中のため stale_at が NULL でも is_stale = false とする。
+/// それ以外は stale_at が NULL または過去なら is_stale = true。
+fn compute_is_stale(status: &str, stale_at: Option<DateTime<Utc>>, now: DateTime<Utc>) -> bool {
+    status != "pending" && stale_at.map(|t| t < now).unwrap_or(true)
+}
+
 /// 決算サマリーから1株配当を抽出する
 /// 優先順位: 来期予想(NxFDivAnn) > 今期予想(FDivAnn) > 実績(DivAnn)
 fn extract_dividend(data: &[FinSummaryData]) -> (Option<f64>, String) {
@@ -370,6 +375,43 @@ mod tests {
         let (val, status) = extract_dividend(&[]);
         assert_eq!(val, Some(0.0));
         assert_eq!(status, "zero");
+    }
+
+    #[test]
+    fn test_compute_is_stale_pending_null_is_false() {
+        // pending は stale_at=NULL でも is_stale=false（取得中のため）
+        let now = Utc::now();
+        assert!(!compute_is_stale("pending", None, now));
+    }
+
+    #[test]
+    fn test_compute_is_stale_error_null_is_true() {
+        // error は stale_at=NULL → 即再取得対象
+        let now = Utc::now();
+        assert!(compute_is_stale("error", None, now));
+    }
+
+    #[test]
+    fn test_compute_is_stale_ok_past_is_true() {
+        // ok で stale_at が過去 → stale
+        let now = Utc::now();
+        let past = now - chrono::Duration::hours(1);
+        assert!(compute_is_stale("ok", Some(past), now));
+    }
+
+    #[test]
+    fn test_compute_is_stale_ok_future_is_false() {
+        // ok で stale_at が未来 → 有効
+        let now = Utc::now();
+        let future = now + chrono::Duration::days(7);
+        assert!(!compute_is_stale("ok", Some(future), now));
+    }
+
+    #[test]
+    fn test_compute_is_stale_ok_null_is_true() {
+        // ok で stale_at=NULL → stale
+        let now = Utc::now();
+        assert!(compute_is_stale("ok", None, now));
     }
 
     #[test]


### PR DESCRIPTION
## 概要

`jquants_dividend_cache` テーブルに `stale_at` カラムを追加し、TTL判定をアプリ層からDB値に統一した。

## 変更種別
- [x] 新機能
- [ ] バグ修正
- [ ] リファクタリング

## 主な変更内容

- **マイグレーション**: `stale_at TIMESTAMPTZ` カラムを追加。既存の ok/zero レコードには `fetched_at + 7日` を設定
- **モデル**: `DividendCache` に `stale_at` フィールドを追加。`status × stale_at` 整合ルールをコメントで明文化
- **サービス**: `is_stale` 判定を `fetched_at + CACHE_TTL_DAYS` 計算から `stale_at < now` に変更
- **fetch_and_cache**: ON CONFLICT 節に `stale_at = NOW() + 7日` を追加
- **update_cache_error**: ON CONFLICT 節に `stale_at = NULL` を追加（エラー時は即再取得対象）
- `CACHE_TTL_DAYS` 定数と関連テストを削除

## テスト

- [x] `cargo clippy -- -D warnings` 通過
- [x] `cargo test` 通過（84テスト）
- [x] `npx tsc --noEmit` 通過