### PR TITLE
docs: Claude の task file 運用を追加

### DIFF
--- a/.claude/rules/00-general.md
+++ b/.claude/rules/00-general.md
@@ -10,6 +10,8 @@
 ## 開発フロー（標準）
 
 - 明示的なスキップ指示がない限り、以下を標準フローとする
+- `docs/tasks/<branch-name>.md` が存在する場合は、作業前に必ず読み、進捗とレビュー指摘を更新する
+- 中規模以上のタスクでは `docs/tasks/TEMPLATE.md` を元に task file を作成する
 - 実装担当は Claude、レビュー担当は Codex（MCP経由）とする
 - Claude は実装完了後に PR を作成し、Codex の MCP を呼び出してレビューを依頼する
 - Codex は `.claude/skills/pr-review/SKILL.md` に従って PR をレビューする

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,14 @@
 - 指示されていない改善・設計提案・リファクタは禁止
 - 情報不足時の質問は1つだけ
 
+## タスク管理
+
+- ブランチ単位の task file は `docs/tasks/<branch-name>.md` を使用する
+- task file が存在する場合は、作業開始前に必ず読む
+- task file が存在する場合は、進捗・受け入れ条件・レビュー指摘を作業に合わせて更新する
+- 新しい中規模以上のタスクでは `docs/tasks/TEMPLATE.md` を元に task file を作成する
+- task file がある場合は、その内容を優先してスコープと非対象を守る
+
 ## 参照ルール
 
 1. `.claude/rules/00-general.md`

--- a/docs/tasks/TEMPLATE.md
+++ b/docs/tasks/TEMPLATE.md
@@ -1,0 +1,58 @@
+# タスクテンプレート
+
+ブランチごとに `docs/tasks/<branch-name>.md` を作成して使用する。
+
+例:
+- `feature/add-login-timeout` -> `docs/tasks/feature-add-login-timeout.md`
+- `fix/openapi-coverage` -> `docs/tasks/fix-openapi-coverage.md`
+
+## タスク名
+
+短い要約を書く。
+
+## 目的
+
+このタスクで達成したいことを 1-3 行で書く。
+
+## スコープ
+
+- やること 1
+- やること 2
+
+## 非対象
+
+- やらないこと 1
+- やらないこと 2
+
+## 受け入れ条件
+
+- [ ] 条件 1
+- [ ] 条件 2
+
+## 変更候補ファイル
+
+- backend/src/...
+- frontend/src/...
+
+## 実行コマンド
+
+- cargo test
+- cargo clippy -- -D warnings
+- npm test
+- npm run build
+
+## 進捗
+
+- [ ] 調査
+- [ ] 実装
+- [ ] テスト
+- [ ] PR 作成
+- [ ] レビュー対応
+
+## レビュー指摘
+
+- 指摘が出たら追記する
+
+## メモ
+
+- 補足事項を書く


### PR DESCRIPTION
## 概要
- Claude の task file 運用をルートガイドに追加
- 全体ルールに task file の読取・更新ルールを追加
- `docs/tasks/TEMPLATE.md` を追加

## テスト
- ドキュメント変更のみのため未実施
