### PR TITLE
docs: task file を一時メモ運用に整理する

### DIFF
--- a/.claude/rules/00-general.md
+++ b/.claude/rules/00-general.md
@@ -12,6 +12,8 @@
 - 明示的なスキップ指示がない限り、以下を標準フローとする
 - `docs/tasks/<branch-name>.md` が存在する場合は、作業前に必ず読み、進捗とレビュー指摘を更新する
 - 中規模以上のタスクでは `docs/tasks/TEMPLATE.md` を元に task file を作成する
+- task file はローカルの一時ファイルとして扱い、ユーザー明示指示がない限りコミット・PR に含めない
+- task 完了時または作業中止時には、対応する task file を削除する
 - 実装担当は Claude、レビュー担当は Codex（MCP経由）とする
 - Claude は実装完了後に PR を作成し、Codex の MCP を呼び出してレビューを依頼する
 - Codex は `.claude/skills/pr-review/SKILL.md` に従って PR をレビューする

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ Secrets*.toml
 CLAUDE.local.md
 backend/CLAUDE.local.md
 frontend/CLAUDE.local.md
+docs/tasks/*.md
+!docs/tasks/TEMPLATE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,10 +20,12 @@
 ## タスク管理
 
 - ブランチ単位の task file は `docs/tasks/<branch-name>.md` を使用する
+- task file はローカルの一時メモとして扱い、ユーザーの明示指示がない限りコミットや PR に含めない
 - task file が存在する場合は、作業開始前に必ず読む
 - task file が存在する場合は、進捗・受け入れ条件・レビュー指摘を作業に合わせて更新する
 - 新しい中規模以上のタスクでは `docs/tasks/TEMPLATE.md` を元に task file を作成する
 - task file がある場合は、その内容を優先してスコープと非対象を守る
+- task 完了時または作業中止時には、対応する task file を削除する
 
 ## 参照ルール
 

--- a/docs/tasks/TEMPLATE.md
+++ b/docs/tasks/TEMPLATE.md
@@ -1,6 +1,8 @@
 # タスクテンプレート
 
 ブランチごとに `docs/tasks/<branch-name>.md` を作成して使用する。
+共通のテスト・レビュー・PR フローは `CLAUDE.md` / `.claude/rules/*.md` に従い、ここにはタスク固有の差分だけを書く。
+task file はローカルの一時メモであり、作業完了または中止時に削除する。
 
 例:
 - `feature/add-login-timeout` -> `docs/tasks/feature-add-login-timeout.md`
@@ -26,20 +28,19 @@
 
 ## 受け入れ条件
 
-- [ ] 条件 1
-- [ ] 条件 2
+- [ ] このタスク固有の完了条件 1
+- [ ] このタスク固有の完了条件 2
 
 ## 変更候補ファイル
 
 - backend/src/...
 - frontend/src/...
 
-## 実行コマンド
+## タスク固有コマンド（任意）
 
-- cargo test
-- cargo clippy -- -D warnings
-- npm test
-- npm run build
+- `cargo run --bin generate_openapi`
+- `npm run generate:types`
+- 手動確認の手順があれば追記する
 
 ## 進捗
 
@@ -55,4 +56,5 @@
 
 ## メモ
 
-- 補足事項を書く
+- 共通ルールに書いてある内容は繰り返さない
+- 補足事項だけを書く


### PR DESCRIPTION
## 概要
- task file をローカルの一時メモとして扱う運用に変更
- 共通ルールに task file を commit / PR に含めないことを明記
- `docs/tasks/*.md` を ignore し、`TEMPLATE.md` だけ追跡対象に維持

## テスト
- ドキュメント・gitignore 変更のみのため未実施
