### PR TITLE
fix: CsvUploadForm の dead_code clippy エラーを修正

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -26,8 +26,6 @@ jobs:
 
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          cache: false  # キャッシュは下の actions/cache@v4 で管理する（monorepo subdir のため rust-cache が Cargo.toml を見つけられない）
 
       - name: Cache Cargo registry & build
         uses: actions/cache@v4

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false  # キャッシュは下の actions/cache@v4 で管理する（monorepo subdir のため rust-cache が Cargo.toml を見つけられない）
 
       - name: Cache Cargo registry & build
         uses: actions/cache@v4

--- a/backend/src/models/csv_import.rs
+++ b/backend/src/models/csv_import.rs
@@ -2,7 +2,9 @@ use serde::Serialize;
 use utoipa::ToSchema;
 
 /// CSV アップロードのリクエストボディ（multipart/form-data の file フィールド）
+/// OpenAPI スキーマ定義専用の型。実行時に直接参照されないため dead_code を抑制する。
 #[derive(ToSchema)]
+#[allow(dead_code)]
 pub struct CsvUploadForm {
     /// アップロードするCSVファイル（Shift-JIS または UTF-8）
     #[schema(format = Binary)]


### PR DESCRIPTION
## 概要

Backend CI の `Lint (clippy)` が `CsvUploadForm.file` の `dead_code` エラーで失敗していたため修正。

## 変更種別

- [x] バグ修正

## 主な変更内容

- `backend/src/models/csv_import.rs`: `CsvUploadForm` に `#[allow(dead_code)]` を追加
  - `CsvUploadForm` は utoipa の OpenAPI スキーマ定義専用の型
  - 実行時にフィールドが読まれないのは設計上の意図であり、警告を抑制するのが正解
  - `_file` プレフィックス案は OpenAPI フィールド名が変わるため不採用

## 対応しなかったもの

- `setup-rust-toolchain@v1` の `cargo metadata` ノイズ（`Cargo.toml` 不在エラー）は非致命的（step は success 扱い）のため対応しない

## テスト

- [x] `cargo clippy -- -D warnings` pass（ローカル確認済み）
- [x] ビルド確認

対象 CI run: https://github.com/zaichu/shoken-webapp/actions/runs/22531570102