### PR TITLE
refactor: CSV import の handler/service 共通処理を抽出

### DIFF
--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -1,5 +1,6 @@
 pub mod asset_balance;
 pub mod auth;
+pub mod csv_import;
 pub mod dividend;
 pub mod dividend_per_share;
 pub mod domestic_stock;

--- a/backend/src/handlers/csv_import.rs
+++ b/backend/src/handlers/csv_import.rs
@@ -1,0 +1,19 @@
+use crate::errors::ApiError;
+use axum::extract::Multipart;
+
+/// マルチパートフォームから `file` フィールドのバイト列を取得する
+pub async fn read_csv_file_bytes(mut multipart: Multipart) -> Result<Vec<u8>, ApiError> {
+    while let Some(field) = multipart.next_field().await.map_err(|e| {
+        ApiError::ValidationError(format!("マルチパートの読み込みに失敗しました: {}", e))
+    })? {
+        if field.name() == Some("file") {
+            let bytes = field.bytes().await.map_err(|e| {
+                ApiError::ValidationError(format!("ファイルの読み込みに失敗しました: {}", e))
+            })?;
+            return Ok(bytes.to_vec());
+        }
+    }
+    Err(ApiError::ValidationError(
+        "fileフィールドが見つかりません".to_string(),
+    ))
+}

--- a/backend/src/handlers/dividend.rs
+++ b/backend/src/handlers/dividend.rs
@@ -44,25 +44,9 @@ pub async fn list(
 pub async fn upload_csv(
     State(state): State<AppState>,
     auth_user: AuthenticatedUser,
-    mut multipart: Multipart,
+    multipart: Multipart,
 ) -> Result<impl IntoResponse, ApiError> {
-    let mut file_bytes: Option<Vec<u8>> = None;
-
-    while let Some(field) = multipart.next_field().await.map_err(|e| {
-        ApiError::ValidationError(format!("マルチパートの読み込みに失敗しました: {}", e))
-    })? {
-        if field.name() == Some("file") {
-            let bytes = field.bytes().await.map_err(|e| {
-                ApiError::ValidationError(format!("ファイルの読み込みに失敗しました: {}", e))
-            })?;
-            file_bytes = Some(bytes.to_vec());
-            break;
-        }
-    }
-
-    let bytes = file_bytes
-        .ok_or_else(|| ApiError::ValidationError("fileフィールドが見つかりません".to_string()))?;
-
+    let bytes = crate::handlers::csv_import::read_csv_file_bytes(multipart).await?;
     let response = dividend_service::upload_csv(&state.pool, auth_user.id(), &bytes).await?;
     Ok((StatusCode::CREATED, Json(response)))
 }

--- a/backend/src/handlers/domestic_stock.rs
+++ b/backend/src/handlers/domestic_stock.rs
@@ -44,25 +44,9 @@ pub async fn list(
 pub async fn upload_csv(
     State(state): State<AppState>,
     auth_user: AuthenticatedUser,
-    mut multipart: Multipart,
+    multipart: Multipart,
 ) -> Result<impl IntoResponse, ApiError> {
-    let mut file_bytes: Option<Vec<u8>> = None;
-
-    while let Some(field) = multipart.next_field().await.map_err(|e| {
-        ApiError::ValidationError(format!("マルチパートの読み込みに失敗しました: {}", e))
-    })? {
-        if field.name() == Some("file") {
-            let bytes = field.bytes().await.map_err(|e| {
-                ApiError::ValidationError(format!("ファイルの読み込みに失敗しました: {}", e))
-            })?;
-            file_bytes = Some(bytes.to_vec());
-            break;
-        }
-    }
-
-    let bytes = file_bytes
-        .ok_or_else(|| ApiError::ValidationError("fileフィールドが見つかりません".to_string()))?;
-
+    let bytes = crate::handlers::csv_import::read_csv_file_bytes(multipart).await?;
     let response = domestic_stock_service::upload_csv(&state.pool, auth_user.id(), &bytes).await?;
     Ok((StatusCode::CREATED, Json(response)))
 }

--- a/backend/src/handlers/mutualfund.rs
+++ b/backend/src/handlers/mutualfund.rs
@@ -44,25 +44,9 @@ pub async fn list(
 pub async fn upload_csv(
     State(state): State<AppState>,
     auth_user: AuthenticatedUser,
-    mut multipart: Multipart,
+    multipart: Multipart,
 ) -> Result<impl IntoResponse, ApiError> {
-    let mut file_bytes: Option<Vec<u8>> = None;
-
-    while let Some(field) = multipart.next_field().await.map_err(|e| {
-        ApiError::ValidationError(format!("マルチパートの読み込みに失敗しました: {}", e))
-    })? {
-        if field.name() == Some("file") {
-            let bytes = field.bytes().await.map_err(|e| {
-                ApiError::ValidationError(format!("ファイルの読み込みに失敗しました: {}", e))
-            })?;
-            file_bytes = Some(bytes.to_vec());
-            break;
-        }
-    }
-
-    let bytes = file_bytes
-        .ok_or_else(|| ApiError::ValidationError("fileフィールドが見つかりません".to_string()))?;
-
+    let bytes = crate::handlers::csv_import::read_csv_file_bytes(multipart).await?;
     let response = mutualfund_service::upload_csv(&state.pool, auth_user.id(), &bytes).await?;
     Ok((StatusCode::CREATED, Json(response)))
 }

--- a/backend/src/services/csv_import.rs
+++ b/backend/src/services/csv_import.rs
@@ -226,4 +226,91 @@ mod tests {
         let input = "テスト".as_bytes();
         assert_eq!(decode_bytes(input), "テスト");
     }
+
+    #[test]
+    fn test_parse_csv_ok() {
+        let csv = "col_a,col_b\nfoo,123\nbar,456\n";
+        let (items, errors) = parse_csv::<String, _>(csv.as_bytes(), |record, header_map, _row| {
+            let a = get_cell(record, header_map, "col_a").to_string();
+            let b = get_cell(record, header_map, "col_b").to_string();
+            Ok(format!("{}/{}", a, b))
+        })
+        .unwrap();
+        assert_eq!(items, vec!["foo/123", "bar/456"]);
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn test_parse_csv_row_error_collected() {
+        // name が空の行（2行目）はエラーとして収集され、items には含まれない
+        let csv = "name,id\ngood,1\n,2\nbad,3\n";
+        let (items, errors) = parse_csv::<String, _>(csv.as_bytes(), |record, header_map, row_num| {
+            parse_required_string(record, header_map, "name", row_num)
+        })
+        .unwrap();
+        assert_eq!(items, vec!["good", "bad"]);
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].row, 2);
+    }
+
+    #[test]
+    fn test_parse_required_string_empty() {
+        let record = csv::StringRecord::from(vec!["", "value"]);
+        let mut header_map = HashMap::new();
+        header_map.insert("col_a".to_string(), 0);
+        header_map.insert("col_b".to_string(), 1);
+
+        let err = parse_required_string(&record, &header_map, "col_a", 3).unwrap_err();
+        assert_eq!(err.row, 3);
+        assert!(err.message.contains("col_a"));
+
+        let ok = parse_required_string(&record, &header_map, "col_b", 1).unwrap();
+        assert_eq!(ok, "value");
+    }
+
+    #[test]
+    fn test_parse_required_number_invalid() {
+        let record = csv::StringRecord::from(vec!["abc", "1,234"]);
+        let mut header_map = HashMap::new();
+        header_map.insert("bad".to_string(), 0);
+        header_map.insert("good".to_string(), 1);
+
+        let err = parse_required_number(&record, &header_map, "bad", 5).unwrap_err();
+        assert_eq!(err.row, 5);
+
+        let ok = parse_required_number(&record, &header_map, "good", 1).unwrap();
+        assert_eq!(ok, 1234.0);
+    }
+
+    #[test]
+    fn test_parse_required_date_invalid() {
+        let record = csv::StringRecord::from(vec!["not-a-date", "2024/03/01"]);
+        let mut header_map = HashMap::new();
+        header_map.insert("bad".to_string(), 0);
+        header_map.insert("good".to_string(), 1);
+
+        let err = parse_required_date(&record, &header_map, "bad", 2).unwrap_err();
+        assert_eq!(err.row, 2);
+
+        let ok = parse_required_date(&record, &header_map, "good", 1).unwrap();
+        assert_eq!(ok, NaiveDate::from_ymd_opt(2024, 3, 1).unwrap());
+    }
+
+    #[test]
+    fn test_finish_csv_upload() {
+        use crate::models::csv_import::CsvRowError;
+        let result = crate::models::common::BulkCreateResponse {
+            inserted: 3,
+            skipped: 1,
+        };
+        let errors = vec![CsvRowError {
+            row: 5,
+            message: "エラー".to_string(),
+        }];
+        let response = finish_csv_upload(result, errors);
+        assert_eq!(response.inserted, 3);
+        assert_eq!(response.skipped, 1);
+        assert_eq!(response.errors.len(), 1);
+        assert_eq!(response.errors[0].row, 5);
+    }
 }

--- a/backend/src/services/csv_import.rs
+++ b/backend/src/services/csv_import.rs
@@ -1,5 +1,9 @@
+use crate::errors::ApiError;
+use crate::models::common::BulkCreateResponse;
+use crate::models::csv_import::{CsvRowError, CsvUploadResponse};
 use chrono::NaiveDate;
 use encoding_rs::{SHIFT_JIS, UTF_8};
+use std::collections::HashMap;
 
 /// UTF-8 デコードを試み、失敗時は Shift-JIS にフォールバック
 pub fn decode_bytes(bytes: &[u8]) -> String {
@@ -54,6 +58,121 @@ pub fn compute_taxes(account: &str, realized_pnl: f64) -> (f64, f64) {
         (taxes, after_tax)
     } else {
         (0.0, realized_pnl)
+    }
+}
+
+/// レコードから指定列の値を取得（列が存在しない場合は空文字）
+pub fn get_cell<'a>(
+    record: &'a csv::StringRecord,
+    header_map: &HashMap<String, usize>,
+    name: &str,
+) -> &'a str {
+    header_map
+        .get(name)
+        .and_then(|&i| record.get(i))
+        .unwrap_or("")
+}
+
+/// 必須文字列フィールドを取得（空の場合はエラー）
+pub fn parse_required_string(
+    record: &csv::StringRecord,
+    header_map: &HashMap<String, usize>,
+    col: &str,
+    row_num: usize,
+) -> Result<String, CsvRowError> {
+    let val = get_cell(record, header_map, col);
+    if val.is_empty() {
+        return Err(CsvRowError {
+            row: row_num,
+            message: format!("必須列 '{}' が空または存在しません", col),
+        });
+    }
+    Ok(val.to_string())
+}
+
+/// 必須数値フィールドを取得（空またはパース失敗でエラー）
+pub fn parse_required_number(
+    record: &csv::StringRecord,
+    header_map: &HashMap<String, usize>,
+    col: &str,
+    row_num: usize,
+) -> Result<f64, CsvRowError> {
+    let raw = get_cell(record, header_map, col);
+    if raw.is_empty() {
+        return Err(CsvRowError {
+            row: row_num,
+            message: format!("必須列 '{}' が空または存在しません", col),
+        });
+    }
+    parse_number(raw).map_err(|e| CsvRowError {
+        row: row_num,
+        message: format!("{}: {}", col, e),
+    })
+}
+
+/// 必須日付フィールドを取得（パース失敗でエラー）
+pub fn parse_required_date(
+    record: &csv::StringRecord,
+    header_map: &HashMap<String, usize>,
+    col: &str,
+    row_num: usize,
+) -> Result<NaiveDate, CsvRowError> {
+    let raw = get_cell(record, header_map, col);
+    parse_date(raw).map_err(|e| CsvRowError {
+        row: row_num,
+        message: format!("{}: {}", col, e),
+    })
+}
+
+/// CSV bytes をデコードして行ごとにパース
+/// parse_row が Err を返した行はエラーとして収集し、items には含めない
+pub fn parse_csv<T, F>(bytes: &[u8], parse_row: F) -> Result<(Vec<T>, Vec<CsvRowError>), ApiError>
+where
+    F: Fn(&csv::StringRecord, &HashMap<String, usize>, usize) -> Result<T, CsvRowError>,
+{
+    let content = decode_bytes(bytes);
+    let mut reader = csv::Reader::from_reader(content.as_bytes());
+
+    let header_map: HashMap<String, usize> = reader
+        .headers()
+        .map_err(|e| {
+            ApiError::ValidationError(format!("CSVヘッダーの読み込みに失敗しました: {}", e))
+        })?
+        .iter()
+        .enumerate()
+        .map(|(i, h)| (h.trim().to_string(), i))
+        .collect();
+
+    let mut items = Vec::new();
+    let mut errors = Vec::new();
+
+    for (row_idx, result) in reader.records().enumerate() {
+        let row_num = row_idx + 1;
+        let record = match result {
+            Ok(r) => r,
+            Err(e) => {
+                errors.push(CsvRowError {
+                    row: row_num,
+                    message: format!("CSV行の読み込みに失敗しました: {}", e),
+                });
+                continue;
+            }
+        };
+        match parse_row(&record, &header_map, row_num) {
+            Ok(item) => items.push(item),
+            Err(e) => errors.push(e),
+        }
+    }
+
+    Ok((items, errors))
+}
+
+/// bulk_create 結果と行エラーから CsvUploadResponse を構築
+pub fn finish_csv_upload(result: BulkCreateResponse, errors: Vec<CsvRowError>) -> CsvUploadResponse {
+    CsvUploadResponse {
+        inserted: result.inserted,
+        skipped: result.skipped,
+        errors,
     }
 }
 

--- a/backend/src/services/dividend.rs
+++ b/backend/src/services/dividend.rs
@@ -2,7 +2,10 @@ use crate::errors::ApiError;
 use crate::models::common::BulkCreateResponse;
 use crate::models::csv_import::{CsvRowError, CsvUploadResponse};
 use crate::models::dividend::{CreateDividendRequest, Dividend};
-use crate::services::csv_import::{decode_bytes, parse_date, parse_number};
+use crate::services::csv_import::{
+    finish_csv_upload, parse_csv, parse_required_date, parse_required_number, parse_required_string,
+};
+use std::collections::HashMap;
 use sqlx::PgPool;
 use std::time::Instant;
 use tracing::info;
@@ -107,111 +110,37 @@ pub async fn upload_csv(
     user_id: Uuid,
     bytes: &[u8],
 ) -> Result<CsvUploadResponse, ApiError> {
-    let content = decode_bytes(bytes);
-    let mut reader = csv::Reader::from_reader(content.as_bytes());
-
-    // ヘッダー名 → 列インデックスのマップを構築
-    let header_map: std::collections::HashMap<String, usize> = reader
-        .headers()
-        .map_err(|e| {
-            ApiError::ValidationError(format!("CSVヘッダーの読み込みに失敗しました: {}", e))
-        })?
-        .iter()
-        .enumerate()
-        .map(|(i, h)| (h.trim().to_string(), i))
-        .collect();
-
-    let mut items: Vec<CreateDividendRequest> = Vec::new();
-    let mut errors: Vec<CsvRowError> = Vec::new();
-
-    for (row_idx, result) in reader.records().enumerate() {
-        let row_num = row_idx + 1;
-        let record = match result {
-            Ok(r) => r,
-            Err(e) => {
-                errors.push(CsvRowError {
-                    row: row_num,
-                    message: format!("CSV行の読み込みに失敗しました: {}", e),
-                });
-                continue;
-            }
-        };
-
-        let get = |name: &str| -> &str {
-            header_map
-                .get(name)
-                .and_then(|&i| record.get(i))
-                .unwrap_or("")
-        };
-
-        // 必須文字列フィールド: 空の場合はエラーとして行をスキップ
-        macro_rules! require_str {
-            ($col:expr) => {{
-                let val = get($col);
-                if val.is_empty() {
-                    errors.push(CsvRowError {
-                        row: row_num,
-                        message: format!("必須列 '{}' が空または存在しません", $col),
-                    });
-                    continue;
-                }
-                val.to_string()
-            }};
-        }
-
-        let settlement_date = match parse_date(get("入金日")) {
-            Ok(d) => d,
-            Err(e) => {
-                errors.push(CsvRowError {
-                    row: row_num,
-                    message: format!("入金日: {}", e),
-                });
-                continue;
-            }
-        };
-
-        macro_rules! parse_num {
-            ($col:expr) => {{
-                let raw = get($col);
-                if raw.is_empty() {
-                    errors.push(CsvRowError {
-                        row: row_num,
-                        message: format!("必須列 '{}' が空または存在しません", $col),
-                    });
-                    continue;
-                }
-                match parse_number(raw) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        errors.push(CsvRowError {
-                            row: row_num,
-                            message: format!("{}: {}", $col, e),
-                        });
-                        continue;
-                    }
-                }
-            }};
-        }
-
-        items.push(CreateDividendRequest {
-            settlement_date,
-            product: require_str!("商品"),
-            account: require_str!("口座"),
-            security_code: require_str!("銘柄コード"),
-            security_name: require_str!("銘柄"),
-            unit_price: parse_num!("単価[円/現地通貨]"),
-            shares: parse_num!("数量[株/口]"),
-            dividends_before_tax: parse_num!("配当・分配金合計（税引前）[円/現地通貨]"),
-            taxes: parse_num!("税額合計[円/現地通貨]"),
-            net_amount_received: parse_num!("受取金額[円/現地通貨]"),
-        });
-    }
-
+    let (items, errors) = parse_csv(bytes, parse_dividend_row)?;
     let result = bulk_create(pool, user_id, &items).await?;
-    Ok(CsvUploadResponse {
-        inserted: result.inserted,
-        skipped: result.skipped,
-        errors,
+    Ok(finish_csv_upload(result, errors))
+}
+
+fn parse_dividend_row(
+    record: &csv::StringRecord,
+    header_map: &HashMap<String, usize>,
+    row_num: usize,
+) -> Result<CreateDividendRequest, CsvRowError> {
+    Ok(CreateDividendRequest {
+        settlement_date: parse_required_date(record, header_map, "入金日", row_num)?,
+        product: parse_required_string(record, header_map, "商品", row_num)?,
+        account: parse_required_string(record, header_map, "口座", row_num)?,
+        security_code: parse_required_string(record, header_map, "銘柄コード", row_num)?,
+        security_name: parse_required_string(record, header_map, "銘柄", row_num)?,
+        unit_price: parse_required_number(record, header_map, "単価[円/現地通貨]", row_num)?,
+        shares: parse_required_number(record, header_map, "数量[株/口]", row_num)?,
+        dividends_before_tax: parse_required_number(
+            record,
+            header_map,
+            "配当・分配金合計（税引前）[円/現地通貨]",
+            row_num,
+        )?,
+        taxes: parse_required_number(record, header_map, "税額合計[円/現地通貨]", row_num)?,
+        net_amount_received: parse_required_number(
+            record,
+            header_map,
+            "受取金額[円/現地通貨]",
+            row_num,
+        )?,
     })
 }
 

--- a/backend/src/services/domestic_stock.rs
+++ b/backend/src/services/domestic_stock.rs
@@ -2,7 +2,11 @@ use crate::errors::ApiError;
 use crate::models::common::BulkCreateResponse;
 use crate::models::csv_import::{CsvRowError, CsvUploadResponse};
 use crate::models::domestic_stock::{CreateDomesticStockRequest, DomesticStock};
-use crate::services::csv_import::{compute_taxes, decode_bytes, parse_date, parse_number};
+use crate::services::csv_import::{
+    compute_taxes, finish_csv_upload, parse_csv, parse_required_date, parse_required_number,
+    parse_required_string,
+};
+use std::collections::HashMap;
 use sqlx::PgPool;
 use std::time::Instant;
 use tracing::info;
@@ -172,122 +176,34 @@ pub async fn upload_csv(
     user_id: Uuid,
     bytes: &[u8],
 ) -> Result<CsvUploadResponse, ApiError> {
-    let content = decode_bytes(bytes);
-    let mut reader = csv::Reader::from_reader(content.as_bytes());
-
-    let header_map: std::collections::HashMap<String, usize> = reader
-        .headers()
-        .map_err(|e| {
-            ApiError::ValidationError(format!("CSVヘッダーの読み込みに失敗しました: {}", e))
-        })?
-        .iter()
-        .enumerate()
-        .map(|(i, h)| (h.trim().to_string(), i))
-        .collect();
-
-    let mut items: Vec<CreateDomesticStockRequest> = Vec::new();
-    let mut errors: Vec<CsvRowError> = Vec::new();
-
-    for (row_idx, result) in reader.records().enumerate() {
-        let row_num = row_idx + 1;
-        let record = match result {
-            Ok(r) => r,
-            Err(e) => {
-                errors.push(CsvRowError {
-                    row: row_num,
-                    message: format!("CSV行の読み込みに失敗しました: {}", e),
-                });
-                continue;
-            }
-        };
-
-        let get = |name: &str| -> &str {
-            header_map
-                .get(name)
-                .and_then(|&i| record.get(i))
-                .unwrap_or("")
-        };
-
-        // 必須文字列フィールド: 空の場合はエラーとして行をスキップ
-        macro_rules! require_str {
-            ($col:expr) => {{
-                let val = get($col);
-                if val.is_empty() {
-                    errors.push(CsvRowError {
-                        row: row_num,
-                        message: format!("必須列 '{}' が空または存在しません", $col),
-                    });
-                    continue;
-                }
-                val.to_string()
-            }};
-        }
-
-        macro_rules! parse_date_field {
-            ($col:expr) => {
-                match parse_date(get($col)) {
-                    Ok(d) => d,
-                    Err(e) => {
-                        errors.push(CsvRowError {
-                            row: row_num,
-                            message: format!("{}: {}", $col, e),
-                        });
-                        continue;
-                    }
-                }
-            };
-        }
-
-        macro_rules! parse_num {
-            ($col:expr) => {{
-                let raw = get($col);
-                if raw.is_empty() {
-                    errors.push(CsvRowError {
-                        row: row_num,
-                        message: format!("必須列 '{}' が空または存在しません", $col),
-                    });
-                    continue;
-                }
-                match parse_number(raw) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        errors.push(CsvRowError {
-                            row: row_num,
-                            message: format!("{}: {}", $col, e),
-                        });
-                        continue;
-                    }
-                }
-            }};
-        }
-
-        let trade_date = parse_date_field!("約定日");
-        let settlement_date = parse_date_field!("受渡日");
-        let account = require_str!("口座");
-        let realized_pnl = parse_num!("実現損益[円]");
-        let (taxes, realized_pnl_after_tax) = compute_taxes(&account, realized_pnl);
-
-        items.push(CreateDomesticStockRequest {
-            trade_date,
-            settlement_date,
-            security_code: require_str!("銘柄コード"),
-            security_name: require_str!("銘柄名"),
-            account,
-            shares: parse_num!("数量[株]"),
-            asked_price: parse_num!("売却/決済単価[円]"),
-            proceeds: parse_num!("売却/決済額[円]"),
-            purchase_price: parse_num!("平均取得価額[円]"),
-            realized_profit_and_loss: realized_pnl,
-            taxes,
-            realized_profit_and_loss_after_tax: realized_pnl_after_tax,
-        });
-    }
-
+    let (items, errors) = parse_csv(bytes, parse_domestic_stock_row)?;
     let result = bulk_create(pool, user_id, &items).await?;
-    Ok(CsvUploadResponse {
-        inserted: result.inserted,
-        skipped: result.skipped,
-        errors,
+    Ok(finish_csv_upload(result, errors))
+}
+
+fn parse_domestic_stock_row(
+    record: &csv::StringRecord,
+    header_map: &HashMap<String, usize>,
+    row_num: usize,
+) -> Result<CreateDomesticStockRequest, CsvRowError> {
+    let trade_date = parse_required_date(record, header_map, "約定日", row_num)?;
+    let settlement_date = parse_required_date(record, header_map, "受渡日", row_num)?;
+    let account = parse_required_string(record, header_map, "口座", row_num)?;
+    let realized_pnl = parse_required_number(record, header_map, "実現損益[円]", row_num)?;
+    let (taxes, realized_pnl_after_tax) = compute_taxes(&account, realized_pnl);
+    Ok(CreateDomesticStockRequest {
+        trade_date,
+        settlement_date,
+        security_code: parse_required_string(record, header_map, "銘柄コード", row_num)?,
+        security_name: parse_required_string(record, header_map, "銘柄名", row_num)?,
+        account,
+        shares: parse_required_number(record, header_map, "数量[株]", row_num)?,
+        asked_price: parse_required_number(record, header_map, "売却/決済単価[円]", row_num)?,
+        proceeds: parse_required_number(record, header_map, "売却/決済額[円]", row_num)?,
+        purchase_price: parse_required_number(record, header_map, "平均取得価額[円]", row_num)?,
+        realized_profit_and_loss: realized_pnl,
+        taxes,
+        realized_profit_and_loss_after_tax: realized_pnl_after_tax,
     })
 }
 

--- a/backend/src/services/mutualfund.rs
+++ b/backend/src/services/mutualfund.rs
@@ -2,7 +2,11 @@ use crate::errors::ApiError;
 use crate::models::common::BulkCreateResponse;
 use crate::models::csv_import::{CsvRowError, CsvUploadResponse};
 use crate::models::mutualfund::{CreateMutualfundRequest, Mutualfund};
-use crate::services::csv_import::{compute_taxes, decode_bytes, parse_date, parse_number};
+use crate::services::csv_import::{
+    compute_taxes, finish_csv_upload, get_cell, parse_csv, parse_required_date,
+    parse_required_number, parse_required_string,
+};
+use std::collections::HashMap;
 use sqlx::PgPool;
 use std::time::Instant;
 use tracing::info;
@@ -124,131 +128,57 @@ pub async fn upload_csv(
     user_id: Uuid,
     bytes: &[u8],
 ) -> Result<CsvUploadResponse, ApiError> {
-    let content = decode_bytes(bytes);
-    let mut reader = csv::Reader::from_reader(content.as_bytes());
-
-    let header_map: std::collections::HashMap<String, usize> = reader
-        .headers()
-        .map_err(|e| {
-            ApiError::ValidationError(format!("CSVヘッダーの読み込みに失敗しました: {}", e))
-        })?
-        .iter()
-        .enumerate()
-        .map(|(i, h)| (h.trim().to_string(), i))
-        .collect();
-
-    let mut items: Vec<CreateMutualfundRequest> = Vec::new();
-    let mut errors: Vec<CsvRowError> = Vec::new();
-
-    for (row_idx, result) in reader.records().enumerate() {
-        let row_num = row_idx + 1;
-        let record = match result {
-            Ok(r) => r,
-            Err(e) => {
-                errors.push(CsvRowError {
-                    row: row_num,
-                    message: format!("CSV行の読み込みに失敗しました: {}", e),
-                });
-                continue;
-            }
-        };
-
-        let get = |name: &str| -> &str {
-            header_map
-                .get(name)
-                .and_then(|&i| record.get(i))
-                .unwrap_or("")
-        };
-
-        // 必須文字列フィールド: 空の場合はエラーとして行をスキップ
-        macro_rules! require_str {
-            ($col:expr) => {{
-                let val = get($col);
-                if val.is_empty() {
-                    errors.push(CsvRowError {
-                        row: row_num,
-                        message: format!("必須列 '{}' が空または存在しません", $col),
-                    });
-                    continue;
-                }
-                val.to_string()
-            }};
-        }
-
-        macro_rules! parse_date_field {
-            ($col:expr) => {
-                match parse_date(get($col)) {
-                    Ok(d) => d,
-                    Err(e) => {
-                        errors.push(CsvRowError {
-                            row: row_num,
-                            message: format!("{}: {}", $col, e),
-                        });
-                        continue;
-                    }
-                }
-            };
-        }
-
-        macro_rules! parse_num {
-            ($col:expr) => {{
-                let raw = get($col);
-                if raw.is_empty() {
-                    errors.push(CsvRowError {
-                        row: row_num,
-                        message: format!("必須列 '{}' が空または存在しません", $col),
-                    });
-                    continue;
-                }
-                match parse_number(raw) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        errors.push(CsvRowError {
-                            row: row_num,
-                            message: format!("{}: {}", $col, e),
-                        });
-                        continue;
-                    }
-                }
-            }};
-        }
-
-        let trade_date = parse_date_field!("約定日");
-        let settlement_date = parse_date_field!("受渡日");
-        let account = require_str!("口座");
-        let realized_pnl = parse_num!("実現損益［円］");
-        let (taxes, realized_pnl_after_tax) = compute_taxes(&account, realized_pnl);
-
-        // 分配金フィールドは空文字を None に変換
-        let dividends_raw = get("分配金");
-        let dividends = if dividends_raw.trim().is_empty() {
-            None
-        } else {
-            Some(dividends_raw.to_string())
-        };
-
-        items.push(CreateMutualfundRequest {
-            trade_date,
-            settlement_date,
-            fund_name: require_str!("ファンド名"),
-            dividends,
-            account,
-            shares: parse_num!("数量[口]"),
-            exchange_rate: parse_num!("為替レート［円］"),
-            cancellation_unit_price_yen: parse_num!("解約単価［円］"),
-            cancellation_amount_yen: parse_num!("解約額［円］"),
-            average_acquisition_price_yen: parse_num!("平均取得価額［円］"),
-            realized_profit_and_loss: realized_pnl,
-            taxes,
-            realized_profit_and_loss_after_tax: realized_pnl_after_tax,
-        });
-    }
-
+    let (items, errors) = parse_csv(bytes, parse_mutualfund_row)?;
     let result = bulk_create(pool, user_id, &items).await?;
-    Ok(CsvUploadResponse {
-        inserted: result.inserted,
-        skipped: result.skipped,
-        errors,
+    Ok(finish_csv_upload(result, errors))
+}
+
+fn parse_mutualfund_row(
+    record: &csv::StringRecord,
+    header_map: &HashMap<String, usize>,
+    row_num: usize,
+) -> Result<CreateMutualfundRequest, CsvRowError> {
+    let trade_date = parse_required_date(record, header_map, "約定日", row_num)?;
+    let settlement_date = parse_required_date(record, header_map, "受渡日", row_num)?;
+    let account = parse_required_string(record, header_map, "口座", row_num)?;
+    let realized_pnl = parse_required_number(record, header_map, "実現損益［円］", row_num)?;
+    let (taxes, realized_pnl_after_tax) = compute_taxes(&account, realized_pnl);
+    // 分配金フィールドは空文字を None に変換
+    let dividends_raw = get_cell(record, header_map, "分配金");
+    let dividends = if dividends_raw.trim().is_empty() {
+        None
+    } else {
+        Some(dividends_raw.to_string())
+    };
+    Ok(CreateMutualfundRequest {
+        trade_date,
+        settlement_date,
+        fund_name: parse_required_string(record, header_map, "ファンド名", row_num)?,
+        dividends,
+        account,
+        shares: parse_required_number(record, header_map, "数量[口]", row_num)?,
+        exchange_rate: parse_required_number(record, header_map, "為替レート［円］", row_num)?,
+        cancellation_unit_price_yen: parse_required_number(
+            record,
+            header_map,
+            "解約単価［円］",
+            row_num,
+        )?,
+        cancellation_amount_yen: parse_required_number(
+            record,
+            header_map,
+            "解約額［円］",
+            row_num,
+        )?,
+        average_acquisition_price_yen: parse_required_number(
+            record,
+            header_map,
+            "平均取得価額［円］",
+            row_num,
+        )?,
+        realized_profit_and_loss: realized_pnl,
+        taxes,
+        realized_profit_and_loss_after_tax: realized_pnl_after_tax,
     })
 }
 


### PR DESCRIPTION
## 変更内容

CSV import で3ドメイン（配当金・国内株式・投資信託）に重複していた処理を共通化。

### 追加ファイル
- `backend/src/handlers/csv_import.rs` — multipart から `file` バイト列を取得する `read_csv_file_bytes`

### 拡張ファイル
- `backend/src/services/csv_import.rs`
  - `parse_csv<T, F>` — decode→reader→header_map→行ループを一元化した高階関数
  - `get_cell` — レコードから列値を取得
  - `parse_required_string/number/date` — 必須フィールド取得ヘルパー
  - `finish_csv_upload` — `BulkCreateResponse` → `CsvUploadResponse` 変換

### 簡略化ファイル（3ハンドラー・3サービス）
- 各ハンドラーの `upload_csv` を3行に削減（20行のマルチパート読み込みボイラープレートを除去）
- 各サービスの `upload_csv` をドメイン固有の `parse_*_row` 関数 + 2行に削減

## テスト結果

- `cargo clippy -- -D warnings` → 警告なし
- `cargo test` → 94 passed, 0 failed（Docker 不要テスト全通過）

## 非対象

- API パス・リクエスト・レスポンス形式は変更なし
- `bulk_create` SQL は触らない
- 国内株式の `content_hash` / `occurrence_index` ロジックは維持