### PR TITLE
chore: CSV CRUDのスクショコマンド名を統一

### DIFF
--- a/.claude/rules/04-frontend-ui-review.md
+++ b/.claude/rules/04-frontend-ui-review.md
@@ -86,7 +86,7 @@ CSV アップロード→保存→削除の一連フローを対象とする。E
 前提: ローカル環境が起動中（DB → backend → frontend）、`frontend/.auth/storage-state.json` が保存済み。
 
 ```bash
-cd frontend && npm run ui:csv-crud:auth
+cd frontend && npm run ui:screenshot:csv-crud
 ```
 
 ---
@@ -209,8 +209,8 @@ trap cleanup EXIT INT TERM
 # 主要ページのスクショ取得
 (cd frontend && npm run ui:screenshot:auth)
 
-# CSV CRUD フローのスクショ取得（任意）
-# (cd frontend && npm run ui:csv-crud:auth)
+# CSV CRUD フローのスクショ取得
+(cd frontend && npm run ui:screenshot:csv-crud)
 ```
 
 ※ `npm run dev` を単独でバックグラウンド起動して放置しないこと（プロセス残留の原因）。

--- a/frontend/e2e/csv-crud.spec.ts
+++ b/frontend/e2e/csv-crud.spec.ts
@@ -2,7 +2,7 @@
  * CSV CRUD E2E テスト
  *
  * 使用方法:
- *   npm run ui:csv-crud:auth
+ *   npm run ui:screenshot:csv-crud
  *
  * 前提:
  *   - ローカル環境が起動中 (DB → backend → frontend)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,8 @@
     "test:watch": "NODE_OPTIONS='--max-old-space-size=8192' vitest --watch",
     "ui:screenshot": "npx playwright test e2e/ui-screenshots.spec.ts",
     "ui:screenshot:auth": "STORAGE_STATE=.auth/storage-state.json npx playwright test e2e/ui-screenshots.spec.ts",
-    "ui:csv-crud:auth": "STORAGE_STATE=.auth/storage-state.json npx playwright test e2e/csv-crud.spec.ts",
+    "ui:screenshot:csv-crud": "STORAGE_STATE=.auth/storage-state.json npx playwright test e2e/csv-crud.spec.ts",
+    "ui:csv-crud:auth": "npm run ui:screenshot:csv-crud",
     "ui:save-auth": "npx tsx e2e/save-auth.spec.ts",
     "generate:types": "npx openapi-typescript ../docs/openapi.json -o src/generated/api.ts"
   },


### PR DESCRIPTION
## 概要
CSV CRUD 用のスクリーンショット取得コマンド名を `ui:screenshot:csv-crud` に統一しました。

## 変更内容
- `frontend/package.json` に `ui:screenshot:csv-crud` を追加
- 既存の `ui:csv-crud:auth` は互換エイリアスとして残し、新コマンドを呼ぶ形に変更
- `frontend/e2e/csv-crud.spec.ts` の使用方法コメントを新コマンド名に更新
- `.claude/rules/04-frontend-ui-review.md` の CSV CRUD スクショ手順を新コマンド名に更新
- CSV CRUD スクショ取得を任意ではなく、UIレビュー手順の標準フローに変更

## テスト
- `cd frontend && npm run ui:screenshot:csv-crud -- --list`
