### PR TITLE
fix: CSV CRUD UIフィードバック改善

### DIFF
--- a/frontend/src/features/assetBalance/hooks/useAssetBalanceDataSource.ts
+++ b/frontend/src/features/assetBalance/hooks/useAssetBalanceDataSource.ts
@@ -72,6 +72,8 @@ export function useAssetBalanceDataSource(): UseAssetBalanceDataSourceResult {
       if (queryClient.getQueryState(key) !== undefined) {
         queryClient.setQueryData(key, []);
       }
+      // 削除後に保存バナーを非表示にする（空データ状態でN件保存済みが残らないよう）
+      setLastSavedCount(null);
     },
   });
 

--- a/frontend/src/features/assetBalance/hooks/useAssetBalanceDataSource.ts
+++ b/frontend/src/features/assetBalance/hooks/useAssetBalanceDataSource.ts
@@ -16,6 +16,7 @@ export interface UseAssetBalanceDataSourceResult {
   saving: boolean;
   deleting: boolean;
   previewing: boolean;
+  lastSavedCount: number | null;
   // フラグ
   hasCsvFile: boolean;
   hasDbData: boolean;
@@ -37,6 +38,7 @@ export function useAssetBalanceDataSource(): UseAssetBalanceDataSourceResult {
 
   const [rawFile, setRawFile] = useState<File | null>(null);
   const [previewRows, setPreviewRows] = useState<AssetBalanceData[]>([]);
+  const [lastSavedCount, setLastSavedCount] = useState<number | null>(null);
 
   const dbQuery = useQuery({
     queryKey: assetBalanceQueryKeys.all(userId),
@@ -54,9 +56,10 @@ export function useAssetBalanceDataSource(): UseAssetBalanceDataSourceResult {
   const uploadCsvMutation = useMutation({
     mutationFn: (file: File) => assetBalanceApi.uploadCsv(file),
     onMutate: () => ({ snapshotUserId: userId }),
-    onSuccess: (_, __, context) => {
+    onSuccess: (data, _, context) => {
       setRawFile(null);
       setPreviewRows([]);
+      setLastSavedCount(data?.inserted ?? null);
       queryClient.invalidateQueries({ queryKey: assetBalanceQueryKeys.all(context?.snapshotUserId ?? userId) });
     },
   });
@@ -77,12 +80,14 @@ export function useAssetBalanceDataSource(): UseAssetBalanceDataSourceResult {
       clearAssetBalanceCache(queryClient);
       setRawFile(null);
       setPreviewRows([]);
+      setLastSavedCount(null);
     });
   }, [onLogout, queryClient]);
 
   const handleFileSelect = useCallback((file: File) => {
     setRawFile(file);
     setPreviewRows([]);
+    setLastSavedCount(null);
     previewMutation.mutate(file);
   }, [previewMutation]);
 
@@ -113,6 +118,7 @@ export function useAssetBalanceDataSource(): UseAssetBalanceDataSourceResult {
     saving: uploadCsvMutation.isPending,
     deleting: deleteAllMutation.isPending,
     previewing: previewMutation.isPending,
+    lastSavedCount,
     hasCsvFile: rawFile !== null,
     hasDbData: dbData.length > 0,
     csvFileName: rawFile?.name ?? null,

--- a/frontend/src/features/receipt/hooks/useReceiptsData.ts
+++ b/frontend/src/features/receipt/hooks/useReceiptsData.ts
@@ -29,7 +29,7 @@ export interface UseReceiptsDataResult {
   previewing: boolean;
   uploadCsv: (args: UploadCsvArgs) => void;
   previewCsv: (args: PreviewCsvArgs) => void;
-  deleteAll: (type: ReceiptsType) => void;
+  deleteAll: (type: ReceiptsType, options?: { onSuccess?: () => void }) => void;
   clearCache: () => void;
 }
 
@@ -178,7 +178,7 @@ export function useReceiptsData(): UseReceiptsDataResult {
     previewing: previewCsvMutation.isPending,
     uploadCsv: uploadCsvMutation.mutate,
     previewCsv: previewCsvMutation.mutate,
-    deleteAll: deleteAllMutation.mutate,
+    deleteAll: (type, options) => deleteAllMutation.mutate(type, { onSuccess: options?.onSuccess }),
     clearCache,
   };
 }

--- a/frontend/src/pages/AssetBalance.tsx
+++ b/frontend/src/pages/AssetBalance.tsx
@@ -73,6 +73,7 @@ export function AssetBalancePage() {
     saving,
     deleting,
     previewing,
+    lastSavedCount,
     hasCsvFile,
     hasDbData,
     csvFileName,
@@ -198,6 +199,15 @@ export function AssetBalancePage() {
               <Alert variant="danger" className="my-3" role="alert" aria-live="assertive">
                 <strong>エラー:</strong> {error}
               </Alert>
+            )}
+
+            {lastSavedCount !== null && (
+              <div className="my-3" role="status" aria-live="polite">
+                <Alert variant="success">
+                  <strong>{lastSavedCount}件保存しました</strong>
+                  <span className="ml-2 text-sm text-secondary">（全件置換）</span>
+                </Alert>
+              </div>
             )}
 
             <div aria-live="polite" aria-atomic="true">

--- a/frontend/src/pages/Receipts.tsx
+++ b/frontend/src/pages/Receipts.tsx
@@ -95,9 +95,10 @@ export function ReceiptsPage() {
   const handleDeleteAll = useCallback(() => {
     if (!isAuthenticated) return;
     dispatch({ type: 'SET_SHOW_DELETE_CONFIRM', payload: false });
-    // 削除完了後にimport resultを非表示にする（削除成功と取込成功の競合を防ぐ）
-    dispatch({ type: 'CLEAR_IMPORT_RESULT', receiptsType });
-    deleteAll(receiptsType);
+    deleteAll(receiptsType, {
+      // 削除成功時のみimport resultをクリア（失敗時は保持）
+      onSuccess: () => dispatch({ type: 'CLEAR_IMPORT_RESULT', receiptsType }),
+    });
   }, [deleteAll, isAuthenticated, receiptsType]);
 
   const hasCsvFile = rawFile !== null;

--- a/frontend/src/pages/Receipts.tsx
+++ b/frontend/src/pages/Receipts.tsx
@@ -95,6 +95,8 @@ export function ReceiptsPage() {
   const handleDeleteAll = useCallback(() => {
     if (!isAuthenticated) return;
     dispatch({ type: 'SET_SHOW_DELETE_CONFIRM', payload: false });
+    // 削除完了後にimport resultを非表示にする（削除成功と取込成功の競合を防ぐ）
+    dispatch({ type: 'CLEAR_IMPORT_RESULT', receiptsType });
     deleteAll(receiptsType);
   }, [deleteAll, isAuthenticated, receiptsType]);
 
@@ -207,11 +209,18 @@ export function ReceiptsPage() {
           return (
             <div className="my-3" role="status" aria-live="polite">
               <Alert variant={hasErrors ? 'warning' : 'success'}>
-                <p>
+                <p className="flex flex-wrap items-baseline gap-x-3">
                   <strong>{importResult.inserted}件登録</strong>
-                  {' / '}
-                  {importResult.skipped}件スキップ
-                  {hasErrors && ` / ${importResult.errors.length}件エラー`}
+                  {importResult.skipped > 0 && (
+                    <span className="text-sm text-secondary">
+                      {importResult.skipped}件スキップ（重複）
+                    </span>
+                  )}
+                  {hasErrors && (
+                    <span className="text-sm text-secondary">
+                      {importResult.errors.length}件エラー
+                    </span>
+                  )}
                 </p>
                 {hasErrors && (
                   <ul className="mt-2 list-disc list-inside text-sm space-y-1">

--- a/frontend/src/pages/receiptsReducer.ts
+++ b/frontend/src/pages/receiptsReducer.ts
@@ -38,6 +38,7 @@ export type ReceiptsAction =
   | { type: 'SET_RAW_FILE'; receiptsType: ReceiptsType; payload: File | null }
   | { type: 'SET_CSV_PREVIEW'; receiptsType: ReceiptsType; payload: CsvPreview | null }
   | { type: 'SET_IMPORT_RESULT'; receiptsType: ReceiptsType; payload: ImportResult }
+  | { type: 'CLEAR_IMPORT_RESULT'; receiptsType: ReceiptsType }
   | { type: 'SET_SHOW_DELETE_CONFIRM'; payload: boolean }
   | { type: 'LOGOUT' };
 
@@ -70,6 +71,11 @@ export function receiptsReducer(state: ReceiptsState, action: ReceiptsAction): R
       return {
         ...state,
         lastImportResults: { ...state.lastImportResults, [action.receiptsType]: action.payload },
+      };
+    case 'CLEAR_IMPORT_RESULT':
+      return {
+        ...state,
+        lastImportResults: { ...state.lastImportResults, [action.receiptsType]: null },
       };
     case 'SET_SHOW_DELETE_CONFIRM':
       return { ...state, showDeleteConfirm: action.payload };


### PR DESCRIPTION
## 変更内容

UIレビュー指摘（高2件・中1件）に対応。

## 高優先度

### 全件削除後のimport resultクリア
- `receiptsReducer` に `CLEAR_IMPORT_RESULT` アクションを追加
- `handleDeleteAll` で削除確認時に該当タブのimport resultをクリア
- 「10件登録」バナーが残ったまま削除後の空テーブルになる競合を解消

### 資産管理の保存完了バナー追加
- `useAssetBalanceDataSource` に `lastSavedCount: number | null` を追加
- `uploadCsvMutation.onSuccess` で `data?.inserted` をキャプチャ
- ファイル選択時・ログアウト時にクリア
- `AssetBalance.tsx` に「N件保存しました（全件置換）」バナーを追加

## 中優先度

### 登録/スキップの視覚的分離
- 登録件数: `<strong>` で強調
- スキップ件数: `text-secondary` + 「（重複）」を明記
- スキップ0件の場合は非表示

## テスト

- lint: pass
- tsc: pass
- 関連テスト（Receipts, AssetBalance, useAssetBalanceDataSource）: 全通過
- build: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)