### PR TITLE
fix: 取引明細UIの3点改善（EmptyState・スキップチップ・取込件数表示）

### DIFF
--- a/frontend/src/pages/Receipt/Dividend.tsx
+++ b/frontend/src/pages/Receipt/Dividend.tsx
@@ -2,7 +2,6 @@ import { ReceiptTemplate } from '@/components/templates/ReceiptTemplate';
 import { ReceiptHeader } from '@/components/molecules/ReceiptHeader/ReceiptHeader';
 import { ReceiptTable } from '@/components/organisms/ReceiptTable/ReceiptTable';
 import { EmptyState } from '@/components/atoms/EmptyState';
-import { Card, CardBody } from '@/components/atoms/Card';
 import React from 'react';
 import { DividendData } from '@/lib/interfaces/dividend';
 import type { ImportResult } from '@/pages/receiptsReducer';
@@ -206,19 +205,6 @@ export const Dividend: React.FC<DividendProps> = ({ data, previewData, importRes
         { key: 'net_amount_received', textAlign: 'right', format: formatCurrency },
     ];
 
-    if (dividendData.length === 0) {
-        return (
-            <Card>
-                <CardBody>
-                    <EmptyState
-                        title="データがありません"
-                        description="CSVファイルをアップロードして配当金の取引明細を追加してください"
-                    />
-                </CardBody>
-            </Card>
-        );
-    }
-
     const importNote = importResult && (
         <div className="mt-1 flex items-center gap-x-2 text-sm text-slate-600">
             <span>最新取込:</span>
@@ -256,13 +242,20 @@ export const Dividend: React.FC<DividendProps> = ({ data, previewData, importRes
             onSearch={(query: string) => setSearchQuery(query)}
             searchCategories={searchCategories}
         >
-            <ReceiptTable
-                data={filteredData}
-                summary={summary}
-                columns={columns}
-                summaryColumns={summaryColumns}
-                getGroupKey={getGroupKey}
-            />
+            {dividendData.length === 0 ? (
+                <EmptyState
+                    title="データがありません"
+                    description="CSVファイルをアップロードして配当金の取引明細を追加してください"
+                />
+            ) : (
+                <ReceiptTable
+                    data={filteredData}
+                    summary={summary}
+                    columns={columns}
+                    summaryColumns={summaryColumns}
+                    getGroupKey={getGroupKey}
+                />
+            )}
         </ReceiptTemplate>
     );
 };

--- a/frontend/src/pages/Receipt/Dividend.tsx
+++ b/frontend/src/pages/Receipt/Dividend.tsx
@@ -1,8 +1,11 @@
 import { ReceiptTemplate } from '@/components/templates/ReceiptTemplate';
 import { ReceiptHeader } from '@/components/molecules/ReceiptHeader/ReceiptHeader';
 import { ReceiptTable } from '@/components/organisms/ReceiptTable/ReceiptTable';
+import { EmptyState } from '@/components/atoms/EmptyState';
+import { Card, CardBody } from '@/components/atoms/Card';
 import React from 'react';
 import { DividendData } from '@/lib/interfaces/dividend';
+import type { ImportResult } from '@/pages/receiptsReducer';
 import { TableColumnConfig, SummaryColumnConfig } from '@/lib/interfaces/receipt';
 import {
     createSearchOptions,
@@ -56,12 +59,13 @@ const FILTER_CONFIG: FilterConfig<DividendData> = {
 interface DividendProps {
     data: DividendData[];
     previewData?: DividendData[];
+    importResult?: ImportResult | null;
 }
 
 /**
  * 配当金データを表示するコンポーネント
  */
-export const Dividend: React.FC<DividendProps> = ({ data, previewData }) => {
+export const Dividend: React.FC<DividendProps> = ({ data, previewData, importResult }) => {
     const displayData = previewData && previewData.length > 0 ? previewData : data;
 
     const dividendData = useMemo(() => sortDividendBySettlementDate(displayData), [displayData]);
@@ -202,24 +206,52 @@ export const Dividend: React.FC<DividendProps> = ({ data, previewData }) => {
         { key: 'net_amount_received', textAlign: 'right', format: formatCurrency },
     ];
 
+    if (dividendData.length === 0) {
+        return (
+            <Card>
+                <CardBody>
+                    <EmptyState
+                        title="データがありません"
+                        description="CSVファイルをアップロードして配当金の取引明細を追加してください"
+                    />
+                </CardBody>
+            </Card>
+        );
+    }
+
+    const importNote = importResult && (
+        <div className="mt-1 flex items-center gap-x-2 text-sm text-slate-600">
+            <span>最新取込:</span>
+            <strong>{importResult.inserted}件登録</strong>
+            {importResult.skipped > 0 && (
+                <span className="inline-flex items-center rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-600">
+                    {importResult.skipped}件スキップ（重複）
+                </span>
+            )}
+        </div>
+    );
+
     return (
         <ReceiptTemplate
             title="配当金"
             header={
-                <ReceiptHeader
-                    items={headerItems}
-                    title={isSecurityCodeSearch ? "集計情報 / 銘柄詳細" : "集計情報"}
-                    collapsible={isSecurityCodeSearch}
-                >
-                    {isSecurityCodeSearch && (
-                        <DividendInfo
-                            searchQuery={searchQuery}
-                            securityCode={searchSecurityCode}
-                            summary={summary}
-                            embedded
-                        />
-                    )}
-                </ReceiptHeader>
+                <>
+                    <ReceiptHeader
+                        items={headerItems}
+                        title={isSecurityCodeSearch ? "集計情報 / 銘柄詳細" : "集計情報"}
+                        collapsible={isSecurityCodeSearch}
+                    >
+                        {isSecurityCodeSearch && (
+                            <DividendInfo
+                                searchQuery={searchQuery}
+                                securityCode={searchSecurityCode}
+                                summary={summary}
+                                embedded
+                            />
+                        )}
+                    </ReceiptHeader>
+                    {importNote}
+                </>
             }
             onSearch={(query: string) => setSearchQuery(query)}
             searchCategories={searchCategories}

--- a/frontend/src/pages/Receipt/DomesticStock.tsx
+++ b/frontend/src/pages/Receipt/DomesticStock.tsx
@@ -2,7 +2,6 @@ import { ReceiptTemplate } from '@/components/templates/ReceiptTemplate';
 import { ReceiptHeader } from '@/components/molecules/ReceiptHeader/ReceiptHeader';
 import { ReceiptTable } from '@/components/organisms/ReceiptTable/ReceiptTable';
 import { EmptyState } from '@/components/atoms/EmptyState';
-import { Card, CardBody } from '@/components/atoms/Card';
 import React from 'react';
 import { DomesticStockData } from '@/lib/interfaces/domesticStock';
 import type { ImportResult } from '@/pages/receiptsReducer';
@@ -136,19 +135,6 @@ export const DomesticStock: React.FC<DomesticStockProps> = ({ data, previewData,
         { key: 'total_realized_profit_and_loss_after_tax', textAlign: 'right', format: formatCurrency },
     ];
 
-    if (domesticStockData.length === 0) {
-        return (
-            <Card>
-                <CardBody>
-                    <EmptyState
-                        title="データがありません"
-                        description="CSVファイルをアップロードして国内株式の取引明細を追加してください"
-                    />
-                </CardBody>
-            </Card>
-        );
-    }
-
     const importNote = importResult && (
         <div className="mt-1 flex items-center gap-x-2 text-sm text-slate-600">
             <span>最新取込:</span>
@@ -168,13 +154,20 @@ export const DomesticStock: React.FC<DomesticStockProps> = ({ data, previewData,
             onSearch={(query: string) => setSearchQuery(query)}
             searchCategories={searchCategories}
         >
-            <ReceiptTable
-                data={filteredData}
-                summary={filteredDailyData}
-                columns={columns}
-                summaryColumns={summaryColumns}
-                getGroupKey={getGroupKey}
-            />
+            {domesticStockData.length === 0 ? (
+                <EmptyState
+                    title="データがありません"
+                    description="CSVファイルをアップロードして国内株式の取引明細を追加してください"
+                />
+            ) : (
+                <ReceiptTable
+                    data={filteredData}
+                    summary={filteredDailyData}
+                    columns={columns}
+                    summaryColumns={summaryColumns}
+                    getGroupKey={getGroupKey}
+                />
+            )}
         </ReceiptTemplate>
     );
 };

--- a/frontend/src/pages/Receipt/DomesticStock.tsx
+++ b/frontend/src/pages/Receipt/DomesticStock.tsx
@@ -1,8 +1,11 @@
 import { ReceiptTemplate } from '@/components/templates/ReceiptTemplate';
 import { ReceiptHeader } from '@/components/molecules/ReceiptHeader/ReceiptHeader';
 import { ReceiptTable } from '@/components/organisms/ReceiptTable/ReceiptTable';
+import { EmptyState } from '@/components/atoms/EmptyState';
+import { Card, CardBody } from '@/components/atoms/Card';
 import React from 'react';
 import { DomesticStockData } from '@/lib/interfaces/domesticStock';
+import type { ImportResult } from '@/pages/receiptsReducer';
 import { TableColumnConfig, SummaryColumnConfig } from '@/lib/interfaces/receipt';
 import { createSearchOptions } from '@/lib/utils/dataTransformer';
 import {
@@ -46,12 +49,13 @@ const FILTER_CONFIG: FilterConfig<DomesticStockData> = {
 interface DomesticStockProps {
     data: DomesticStockData[];
     previewData?: DomesticStockData[];
+    importResult?: ImportResult | null;
 }
 
 /**
  * 国内株式取引データを表示するコンポーネント
  */
-export const DomesticStock: React.FC<DomesticStockProps> = ({ data, previewData }) => {
+export const DomesticStock: React.FC<DomesticStockProps> = ({ data, previewData, importResult }) => {
     const displayData = previewData && previewData.length > 0 ? previewData : data;
 
     const domesticStockData = useMemo(() => sortDomesticStockByTradeDate(displayData), [displayData]);
@@ -132,10 +136,35 @@ export const DomesticStock: React.FC<DomesticStockProps> = ({ data, previewData 
         { key: 'total_realized_profit_and_loss_after_tax', textAlign: 'right', format: formatCurrency },
     ];
 
+    if (domesticStockData.length === 0) {
+        return (
+            <Card>
+                <CardBody>
+                    <EmptyState
+                        title="データがありません"
+                        description="CSVファイルをアップロードして国内株式の取引明細を追加してください"
+                    />
+                </CardBody>
+            </Card>
+        );
+    }
+
+    const importNote = importResult && (
+        <div className="mt-1 flex items-center gap-x-2 text-sm text-slate-600">
+            <span>最新取込:</span>
+            <strong>{importResult.inserted}件登録</strong>
+            {importResult.skipped > 0 && (
+                <span className="inline-flex items-center rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-600">
+                    {importResult.skipped}件スキップ（重複）
+                </span>
+            )}
+        </div>
+    );
+
     return (
         <ReceiptTemplate
             title="国内株式"
-            header={<ReceiptHeader items={headerItems} />}
+            header={<><ReceiptHeader items={headerItems} />{importNote}</>}
             onSearch={(query: string) => setSearchQuery(query)}
             searchCategories={searchCategories}
         >

--- a/frontend/src/pages/Receipt/Mutualfund.tsx
+++ b/frontend/src/pages/Receipt/Mutualfund.tsx
@@ -2,7 +2,6 @@ import { ReceiptTemplate } from '@/components/templates/ReceiptTemplate';
 import { ReceiptHeader } from '@/components/molecules/ReceiptHeader/ReceiptHeader';
 import { ReceiptTable } from '@/components/organisms/ReceiptTable/ReceiptTable';
 import { EmptyState } from '@/components/atoms/EmptyState';
-import { Card, CardBody } from '@/components/atoms/Card';
 import React from 'react';
 import { MutualfundData } from '@/lib/interfaces/mutualfund';
 import type { ImportResult } from '@/pages/receiptsReducer';
@@ -127,19 +126,6 @@ export const Mutualfund: React.FC<MutualfundProps> = ({ data, previewData, impor
         { key: 'realized_profit_and_loss_after_tax', textAlign: 'right', format: formatCurrency },
     ];
 
-    if (mutualfundData.length === 0) {
-        return (
-            <Card>
-                <CardBody>
-                    <EmptyState
-                        title="データがありません"
-                        description="CSVファイルをアップロードして投資信託の取引明細を追加してください"
-                    />
-                </CardBody>
-            </Card>
-        );
-    }
-
     const importNote = importResult && (
         <div className="mt-1 flex items-center gap-x-2 text-sm text-slate-600">
             <span>最新取込:</span>
@@ -159,13 +145,20 @@ export const Mutualfund: React.FC<MutualfundProps> = ({ data, previewData, impor
             onSearch={(query: string) => setSearchQuery(query)}
             searchCategories={searchCategories}
         >
-            <ReceiptTable
-                data={filteredData}
-                summary={summary}
-                columns={columns}
-                summaryColumns={summaryColumns}
-                getGroupKey={getGroupKey}
-            />
+            {mutualfundData.length === 0 ? (
+                <EmptyState
+                    title="データがありません"
+                    description="CSVファイルをアップロードして投資信託の取引明細を追加してください"
+                />
+            ) : (
+                <ReceiptTable
+                    data={filteredData}
+                    summary={summary}
+                    columns={columns}
+                    summaryColumns={summaryColumns}
+                    getGroupKey={getGroupKey}
+                />
+            )}
         </ReceiptTemplate>
     );
 };

--- a/frontend/src/pages/Receipt/Mutualfund.tsx
+++ b/frontend/src/pages/Receipt/Mutualfund.tsx
@@ -1,8 +1,11 @@
 import { ReceiptTemplate } from '@/components/templates/ReceiptTemplate';
 import { ReceiptHeader } from '@/components/molecules/ReceiptHeader/ReceiptHeader';
 import { ReceiptTable } from '@/components/organisms/ReceiptTable/ReceiptTable';
+import { EmptyState } from '@/components/atoms/EmptyState';
+import { Card, CardBody } from '@/components/atoms/Card';
 import React from 'react';
 import { MutualfundData } from '@/lib/interfaces/mutualfund';
+import type { ImportResult } from '@/pages/receiptsReducer';
 import { TableColumnConfig, SummaryColumnConfig } from '@/lib/interfaces/receipt';
 import { createSearchOptions, groupAndSummarizeData } from '@/lib/utils/dataTransformer';
 import {
@@ -31,12 +34,13 @@ const FILTER_CONFIG: FilterConfig<MutualfundData> = {
 interface MutualfundProps {
     data: MutualfundData[];
     previewData?: MutualfundData[];
+    importResult?: ImportResult | null;
 }
 
 /**
  * 投資信託データを表示するコンポーネント
  */
-export const Mutualfund: React.FC<MutualfundProps> = ({ data, previewData }) => {
+export const Mutualfund: React.FC<MutualfundProps> = ({ data, previewData, importResult }) => {
     const displayData = previewData && previewData.length > 0 ? previewData : data;
 
     const mutualfundData = useMemo(() => sortMutualfundByTradeDate(displayData), [displayData]);
@@ -123,10 +127,35 @@ export const Mutualfund: React.FC<MutualfundProps> = ({ data, previewData }) => 
         { key: 'realized_profit_and_loss_after_tax', textAlign: 'right', format: formatCurrency },
     ];
 
+    if (mutualfundData.length === 0) {
+        return (
+            <Card>
+                <CardBody>
+                    <EmptyState
+                        title="データがありません"
+                        description="CSVファイルをアップロードして投資信託の取引明細を追加してください"
+                    />
+                </CardBody>
+            </Card>
+        );
+    }
+
+    const importNote = importResult && (
+        <div className="mt-1 flex items-center gap-x-2 text-sm text-slate-600">
+            <span>最新取込:</span>
+            <strong>{importResult.inserted}件登録</strong>
+            {importResult.skipped > 0 && (
+                <span className="inline-flex items-center rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-600">
+                    {importResult.skipped}件スキップ（重複）
+                </span>
+            )}
+        </div>
+    );
+
     return (
         <ReceiptTemplate
             title="投資信託"
-            header={<ReceiptHeader items={headerItems} />}
+            header={<><ReceiptHeader items={headerItems} />{importNote}</>}
             onSearch={(query: string) => setSearchQuery(query)}
             searchCategories={searchCategories}
         >

--- a/frontend/src/pages/Receipt/__tests__/Dividend.test.tsx
+++ b/frontend/src/pages/Receipt/__tests__/Dividend.test.tsx
@@ -219,16 +219,10 @@ describe('Dividend', () => {
         });
     });
 
-    it('空のデータでもエラーが発生しない', () => {
+    it('空のデータでEmptyStateが表示される', () => {
         render(<Dividend data={[]} />);
 
-        // タイトルは表示される（テーブルヘッダーにも「配当金」があるためgetAllByTextを使用）
-        const titleElements = screen.getAllByText('配当金');
-        expect(titleElements.length).toBeGreaterThan(0);
-
-        // 集計情報はゼロで表示される
-        const summaryElements = screen.getAllByText('配当金');
-        expect(summaryElements.length).toBeGreaterThan(0);
+        expect(screen.getByText('データがありません')).toBeInTheDocument();
     });
 
     it('数値フォーマットが正しく適用される', () => {

--- a/frontend/src/pages/Receipt/__tests__/DomesticStock.test.tsx
+++ b/frontend/src/pages/Receipt/__tests__/DomesticStock.test.tsx
@@ -135,12 +135,10 @@ describe('DomesticStock', () => {
         }, waitOpts);
     }, 20000);
 
-    it('空のデータでもエラーが発生しない', () => {
+    it('空のデータでEmptyStateが表示される', () => {
         render(<DomesticStock data={[]} />);
 
-        // 集計情報はゼロで表示される（複数要素がある場合を考慮）
-        const summaryElements = screen.getAllByText('実現損益');
-        expect(summaryElements.length).toBeGreaterThan(0);
+        expect(screen.getByText('データがありません')).toBeInTheDocument();
     });
 
     it('数値フォーマットが正しく適用される', () => {

--- a/frontend/src/pages/Receipt/__tests__/Mutualfund.test.tsx
+++ b/frontend/src/pages/Receipt/__tests__/Mutualfund.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import { Mutualfund } from '../Mutualfund';
+
+// React Router DOM のモック
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+  useLocation: () => ({ pathname: '/' }),
+}));
+
+// React Query のモック
+vi.mock('@tanstack/react-query', () => ({
+  QueryClient: vi.fn(() => ({
+    setQueryData: vi.fn(),
+    getQueryData: vi.fn(),
+  })),
+  QueryClientProvider: ({ children }: { children: React.ReactNode }) => children,
+  useQuery: () => ({
+    data: null,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+describe('Mutualfund', () => {
+    const mockData = [
+        {
+            trade_date: new Date('2023-01-15'),
+            settlement_date: new Date('2023-01-18'),
+            fund_name: 'テストファンドA',
+            dividends: '0',
+            account: '特定',
+            shares: 10000,
+            exchange_rate: 1,
+            cancellation_unit_price_yen: 15000,
+            cancellation_amount_yen: 150000000,
+            average_acquisition_price_yen: 12000,
+            realized_profit_and_loss: 30000000,
+            taxes: 6123000,
+            realized_profit_and_loss_after_tax: 23877000,
+        },
+    ];
+
+    it('空のデータでEmptyStateが表示される', () => {
+        render(<Mutualfund data={[]} />);
+
+        expect(screen.getByText('データがありません')).toBeInTheDocument();
+    });
+
+    it('空データ時もReceiptTemplateが維持される', () => {
+        const { container } = render(<Mutualfund data={[]} />);
+
+        // ReceiptTemplate の receipt-container が存在する（テンプレート全体が維持されている）
+        expect(container.querySelector('[data-testid="receipt-container"]')).toBeInTheDocument();
+    });
+
+    it('データがある場合にテーブルヘッダーが表示される', () => {
+        render(<Mutualfund data={mockData} />);
+
+        expect(screen.getByText('約定日')).toBeInTheDocument();
+        expect(screen.getByText('ファンド名')).toBeInTheDocument();
+    });
+});

--- a/frontend/src/pages/Receipts.tsx
+++ b/frontend/src/pages/Receipts.tsx
@@ -210,10 +210,10 @@ export function ReceiptsPage() {
           return (
             <div className="my-3" role="status" aria-live="polite">
               <Alert variant={hasErrors ? 'warning' : 'success'}>
-                <p className="flex flex-wrap items-baseline gap-x-3">
+                <p className="flex flex-wrap items-center gap-x-2">
                   <strong>{importResult.inserted}件登録</strong>
                   {importResult.skipped > 0 && (
-                    <span className="text-sm text-secondary">
+                    <span className="inline-flex items-center rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-600">
                       {importResult.skipped}件スキップ（重複）
                     </span>
                   )}
@@ -254,18 +254,21 @@ export function ReceiptsPage() {
               <Dividend
                 data={dividendData}
                 previewData={csvPreview?.rows?.map(r => transformDBDividend(r))}
+                importResult={importResult}
               />
             )}
             {receiptsType === 'domesticstock' && (
               <DomesticStock
                 data={domesticstockData}
                 previewData={csvPreview?.rows?.map(r => transformDBDomesticStock(r))}
+                importResult={importResult}
               />
             )}
             {receiptsType === 'mutualfund' && (
               <Mutualfund
                 data={mutualfundData}
                 previewData={csvPreview?.rows?.map(r => transformDBMutualfund(r))}
+                importResult={importResult}
               />
             )}
           </>

--- a/scripts/run-ui-e2e.sh
+++ b/scripts/run-ui-e2e.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BACKEND_DIR="$ROOT_DIR/backend"
+FRONTEND_DIR="$ROOT_DIR/frontend"
+
+BACKEND_URL="${BACKEND_URL:-http://127.0.0.1:3001}"
+FRONTEND_URL="${FRONTEND_URL:-http://127.0.0.1:8080}"
+FRONTEND_PORT="${FRONTEND_PORT:-8080}"
+STORAGE_STATE="${STORAGE_STATE:-$FRONTEND_DIR/.auth/storage-state.json}"
+
+BACKEND_LOG="${BACKEND_LOG:-/tmp/shoken-backend-e2e.log}"
+FRONTEND_LOG="${FRONTEND_LOG:-/tmp/shoken-frontend-e2e.log}"
+DB_LOG="${DB_LOG:-/tmp/shoken-db-e2e.log}"
+
+RUN_MAIN=1
+RUN_CSV=1
+RUN_SAVE_AUTH=0
+KEEP_RUNNING=0
+START_ONLY=0
+
+BACK_PID=""
+FRONT_PID=""
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [options]
+
+フロントエンド / バックエンドを起動または再利用し、
+主要ページのスクショと CSV CRUD の Playwright をまとめて実行します。
+
+Options:
+  --skip-main     主要ページスクショ (npm run ui:screenshot:auth) をスキップ
+  --skip-csv      CSV CRUD スクショ (npm run ui:screenshot:csv-crud) をスキップ
+  --save-auth     実行前に npm run ui:save-auth を実行
+  --start-only    サーバー起動 / 再利用だけ行って終了
+  --keep-running  実行後も、このスクリプトが起動した backend / frontend を止めない
+  --help          このヘルプを表示
+
+Examples:
+  $(basename "$0")
+  $(basename "$0") --skip-csv
+  $(basename "$0") --save-auth --keep-running
+EOF
+}
+
+cleanup() {
+  if [[ "$KEEP_RUNNING" -eq 1 ]]; then
+    return 0
+  fi
+
+  if [[ -n "$FRONT_PID" ]] && kill -0 "$FRONT_PID" >/dev/null 2>&1; then
+    kill "$FRONT_PID" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "$BACK_PID" ]] && kill -0 "$BACK_PID" >/dev/null 2>&1; then
+    kill "$BACK_PID" >/dev/null 2>&1 || true
+  fi
+}
+
+wait_for_http_ok() {
+  local url="$1"
+  local label="$2"
+  local retries="${3:-120}"
+  local interval="${4:-0.5}"
+
+  for _ in $(seq 1 "$retries"); do
+    if curl -sSf "$url" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep "$interval"
+  done
+
+  echo "$label did not become ready: $url" >&2
+  return 1
+}
+
+ensure_db() {
+  echo "1/4 Ensuring local PostgreSQL..."
+  (cd "$BACKEND_DIR" && make db-up >"$DB_LOG" 2>&1)
+
+  for i in $(seq 1 120); do
+    if (cd "$BACKEND_DIR" && docker compose -f docker-compose.yml exec -T postgres pg_isready -U user -d shoken_db >/dev/null 2>&1); then
+      return 0
+    fi
+    sleep 0.5
+    if [[ "$i" -eq 120 ]]; then
+      echo "Local DB did not become ready." >&2
+      tail -n 80 "$DB_LOG" >&2 || true
+      exit 1
+    fi
+  done
+}
+
+ensure_backend() {
+  echo "2/4 Ensuring backend..."
+  if curl -sSf "$BACKEND_URL/health" >/dev/null 2>&1; then
+    echo "  Reusing backend: $BACKEND_URL"
+    return 0
+  fi
+
+  (cd "$BACKEND_DIR" && make run >"$BACKEND_LOG" 2>&1) &
+  BACK_PID=$!
+
+  if ! wait_for_http_ok "$BACKEND_URL/health" "Backend" 120 0.5; then
+    tail -n 80 "$BACKEND_LOG" >&2 || true
+    exit 1
+  fi
+}
+
+ensure_frontend() {
+  echo "3/4 Ensuring frontend..."
+  if curl -sSf "$FRONTEND_URL/" >/dev/null 2>&1; then
+    echo "  Reusing frontend: $FRONTEND_URL"
+    return 0
+  fi
+
+  (
+    cd "$FRONTEND_DIR"
+    VITE_SHOKEN_WEBAPI_API_URL="$BACKEND_URL" \
+      npm run dev -- --host 127.0.0.1 --port "$FRONTEND_PORT" --strictPort >"$FRONTEND_LOG" 2>&1
+  ) &
+  FRONT_PID=$!
+
+  if ! wait_for_http_ok "$FRONTEND_URL/" "Frontend" 120 0.5; then
+    tail -n 80 "$FRONTEND_LOG" >&2 || true
+    exit 1
+  fi
+}
+
+ensure_storage_state() {
+  if [[ "$RUN_SAVE_AUTH" -eq 1 ]]; then
+    echo "4/4 Saving auth state..."
+    (cd "$FRONTEND_DIR" && npm run ui:save-auth)
+    return 0
+  fi
+
+  if [[ ! -f "$STORAGE_STATE" ]]; then
+    echo "storage state not found: $STORAGE_STATE" >&2
+    echo "Run with --save-auth or create frontend/.auth/storage-state.json first." >&2
+    exit 1
+  fi
+}
+
+run_main_screenshots() {
+  echo "Running main page screenshots..."
+  (cd "$FRONTEND_DIR" && npm run ui:screenshot:auth)
+}
+
+run_csv_screenshots() {
+  echo "Running CSV CRUD screenshots..."
+  (cd "$FRONTEND_DIR" && npm run ui:screenshot:csv-crud)
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skip-main)
+      RUN_MAIN=0
+      shift
+      ;;
+    --skip-csv)
+      RUN_CSV=0
+      shift
+      ;;
+    --save-auth)
+      RUN_SAVE_AUTH=1
+      shift
+      ;;
+    --keep-running)
+      KEEP_RUNNING=1
+      shift
+      ;;
+    --start-only)
+      START_ONLY=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "$RUN_MAIN" -eq 0 && "$RUN_CSV" -eq 0 && "$START_ONLY" -eq 0 ]]; then
+  echo "Nothing to run. Remove --skip-main/--skip-csv or use --start-only." >&2
+  exit 1
+fi
+
+trap cleanup EXIT INT TERM
+
+ensure_db
+ensure_backend
+ensure_frontend
+ensure_storage_state
+
+echo "Ready:"
+echo "  Backend  : $BACKEND_URL"
+echo "  Frontend : $FRONTEND_URL"
+echo "  Screens  : $ROOT_DIR/.playwright-mcp"
+
+if [[ "$START_ONLY" -eq 1 ]]; then
+  echo "Start only mode completed."
+  exit 0
+fi
+
+if [[ "$RUN_MAIN" -eq 1 ]]; then
+  run_main_screenshots
+fi
+
+if [[ "$RUN_CSV" -eq 1 ]]; then
+  run_csv_screenshots
+fi
+
+echo "Completed."


### PR DESCRIPTION
## 概要

UIレビュー指摘（中優先度）3点の対応と、ローカルで E2E / スクショ取得をまとめて回すバッチ追加。

## 変更内容

1. **空データ時のEmptyState表示**（DomesticStock / Dividend / Mutualfund）
   - データが0件の場合、ReceiptTemplate を維持したまま EmptyState を表示

2. **スキップ件数のチップ表示**（Receipts.tsx）
   - 重複スキップ件数をバッジ風の chip スタイルで表示
   - `inline-flex rounded-full bg-slate-100` スタイルを適用

3. **取込件数サマリーの永続表示**（DomesticStock / Dividend / Mutualfund）
   - `importResult` prop を各タブコンポーネントに追加
   - タブヘッダーに「最新取込: N件登録 / M件スキップ」を常時表示

4. **UI E2E 実行バッチ追加**
   - `scripts/run-ui-e2e.sh` を追加
   - DB / backend / frontend の起動または再利用、認証状態確認、主要ページスクショ、CSV CRUD スクショを一括実行可能

## テスト

- `cd frontend && npm run lint`
- `cd frontend && npx tsc --noEmit`
- `cd frontend && npm test`
- `cd frontend && npm run build`
- `bash -n scripts/run-ui-e2e.sh`
- `./scripts/run-ui-e2e.sh --help`
