### PR TITLE
fix: UIレビュー運用を run-ui-e2e に統一

### DIFF
--- a/.claude/rules/04-frontend-ui-review.md
+++ b/.claude/rules/04-frontend-ui-review.md
@@ -53,13 +53,12 @@
 | `assetbalance-filter-empty.png` | 絞り込み0件のEmptyState（解除リンク表示） |
 
 ### スクショ取得コマンド（主要ページ）
-認証情報（`frontend/.auth/storage-state.json`）が必要。初回または期限切れ時は `cd frontend && npm run ui:save-auth` で再取得する。
+標準の実行入口はプロジェクトルートの [`scripts/run-ui-e2e.sh`](/home/zaichu/project/shoken-webapp/scripts/run-ui-e2e.sh) とする。認証情報（`frontend/.auth/storage-state.json`）が必要。初回または期限切れ時は `--save-auth` を付けて再取得する。
 
 ```bash
-cd frontend && npm run ui:screenshot:auth
+./scripts/run-ui-e2e.sh --skip-csv
+./scripts/run-ui-e2e.sh --skip-csv --save-auth
 ```
-
-※ `npm run ui:screenshot` は認証情報を読み込まないため使用しない。
 
 ---
 
@@ -83,10 +82,11 @@ CSV アップロード→保存→削除の一連フローを対象とする。E
 | `csv-mutualfund-after-additional-import.png` | 投資信託 - 追加CSV取込後（重複1件スキップ→2件登録） | 2件登録/1件スキップ表示 |
 
 ### スクショ取得コマンド（CSV CRUD）
-前提: ローカル環境が起動中（DB → backend → frontend）、`frontend/.auth/storage-state.json` が保存済み。
+標準の実行入口はプロジェクトルートの [`scripts/run-ui-e2e.sh`](/home/zaichu/project/shoken-webapp/scripts/run-ui-e2e.sh) とする。`frontend/.auth/storage-state.json` が保存済みであること。
 
 ```bash
-cd frontend && npm run ui:screenshot:csv-crud
+./scripts/run-ui-e2e.sh --skip-main
+./scripts/run-ui-e2e.sh --skip-main --save-auth
 ```
 
 ---
@@ -97,10 +97,11 @@ cd frontend && npm run ui:screenshot:csv-crud
 - 本レビューは **8080固定**（`http://127.0.0.1:8080` を使用）
 - **起動順は必ず DB → backend → frontend**（ローカルDB起動後、バックエンド `/health` 応答を確認してからフロントエンドを起動）
 - ローカルDBは `cd backend && make db-up` で起動する（`backend/.env` はローカルDB向け `DATABASE_URL` を使用）
-- まとめて起動する場合は、プロジェクトルートで `./scripts/start-local.sh` を使用する
+- E2E / スクショ取得は `./scripts/run-ui-e2e.sh` を標準入口にする
+- サーバー起動だけ確認したい場合は `./scripts/run-ui-e2e.sh --start-only` を使う
+- まとめて起動するだけなら `./scripts/start-local.sh` も使えるが、レビュー用途では優先しない
 - **ログインは必須**。認証情報は `frontend/.auth/storage-state.json` を使用する
-  - 各 E2E スクリプトは環境変数 `STORAGE_STATE` またはコマンドの `:auth` サフィックスで認証状態を読み込む
-  - 初回保存 / 期限切れ時は `cd frontend && npm run ui:save-auth` で再取得する
+  - 初回保存 / 期限切れ時は `./scripts/run-ui-e2e.sh --save-auth --skip-csv` または `./scripts/run-ui-e2e.sh --save-auth --skip-main` を使う
 - このアプリのレビューは **PC表示前提**（モバイル評価は対象外）
 - スクショは **FHD（1920x1080）** をデフォルトで取得する（4Kが必要な場合は `UI_REVIEW_VIEWPORT=4k` を指定）
 - 開発サーバー運用は以下を厳守する
@@ -117,9 +118,20 @@ rm -f .playwright-mcp/*.png
 rm -f .playwright-mcp/csv-*.png
 ```
 
-### 3) スクショを取得（MCPかE2Eのどちらか）
+### 3) スクショを取得（標準は `run-ui-e2e.sh`）
 
-#### A. MCPで取得する場合（主要ページ）
+#### A. 標準フロー
+```bash
+cd /path/to/shoken-webapp
+
+# 主要ページ + CSV CRUD をまとめて取得
+./scripts/run-ui-e2e.sh
+
+# 初回ログイン保存を含める場合
+./scripts/run-ui-e2e.sh --save-auth
+```
+
+#### B. MCPで取得する場合（主要ページ）
 - 先にログインを完了してから開始する
 - `http://127.0.0.1:8080/` に遷移して `home-initial.png` を保存
 - `http://127.0.0.1:8080/search` で `任天堂` を検索し、`search-nintendo-result.png` を保存
@@ -128,13 +140,15 @@ rm -f .playwright-mcp/csv-*.png
 - `http://127.0.0.1:8080/receipts` に遷移し、各タブ/検索状態を操作して取引明細の9枚を保存
 - 設定は `fullPage: true`
 
-#### B. E2Eで取得する場合
+#### C. 個別コマンドで取得する場合
+`run-ui-e2e.sh` の内部動作を切り分けたい場合のみ使う。通常運用ではこの手順を直接叩かない。
+
 ```bash
 set -euo pipefail
 cd /path/to/shoken-webapp
 
 # ログイン状態を保存（初回のみ/期限切れ時）
-# cd frontend && npm run ui:save-auth
+# ./scripts/run-ui-e2e.sh --save-auth --skip-csv
 
 # 先にローカルDBを起動して待機
 (cd backend && make db-up >/tmp/shoken-db.log 2>&1)
@@ -214,6 +228,7 @@ trap cleanup EXIT INT TERM
 ```
 
 ※ `npm run dev` を単独でバックグラウンド起動して放置しないこと（プロセス残留の原因）。
+※ 通常運用は `./scripts/run-ui-e2e.sh` を使うこと。
 
 ### 4) UIレビュー（画像分析）
 
@@ -273,7 +288,7 @@ UIレビューで見つかった改善対応
 - スクショ取得に一部失敗しても、取得できた分でレビューを継続
 - 失敗ファイルは「未取得」と明記
 - CSV CRUD スクショが未取得の場合は「未評価」と明記して task を継続
-- UIレビュー結果は `.playwright-mcp/ui-review-report.md` ではなく `docs/tasks/` の task file に残す
+- UIレビュー結果は `docs/tasks/` の task file に残す
 - task file の命名と運用は `CLAUDE.md` と `docs/tasks/TEMPLATE.md` に従う
 - task は必ず日本語で出力
 - 作業終了時に `8080/8081/8082` の不要プロセスが残っていないことを確認する

--- a/frontend/e2e/ui-screenshots.spec.ts
+++ b/frontend/e2e/ui-screenshots.spec.ts
@@ -7,13 +7,10 @@ import { fileURLToPath } from 'url';
  * UIレビュー用スクリーンショット取得
  *
  * 使用方法:
- * 1. 開発サーバーを起動: npm run dev
- * 2. スクショ取得: npm run ui:screenshot
+ * 1. プロジェクトルートで ./scripts/run-ui-e2e.sh --skip-csv
  *
  * ログインが必要な場合:
- * 1. 手動でブラウザを開きログイン
- * 2. npm run ui:save-auth でログイン状態を保存
- * 3. npm run ui:screenshot:auth で実行
+ * 1. プロジェクトルートで ./scripts/run-ui-e2e.sh --skip-csv --save-auth
  */
 
 const __filename = fileURLToPath(import.meta.url);

--- a/scripts/run-ui-e2e.sh
+++ b/scripts/run-ui-e2e.sh
@@ -2,7 +2,6 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-BACKEND_DIR="$ROOT_DIR/backend"
 FRONTEND_DIR="$ROOT_DIR/frontend"
 
 BACKEND_URL="${BACKEND_URL:-http://127.0.0.1:3001}"
@@ -13,6 +12,7 @@ STORAGE_STATE="${STORAGE_STATE:-$FRONTEND_DIR/.auth/storage-state.json}"
 BACKEND_LOG="${BACKEND_LOG:-/tmp/shoken-backend-e2e.log}"
 FRONTEND_LOG="${FRONTEND_LOG:-/tmp/shoken-frontend-e2e.log}"
 DB_LOG="${DB_LOG:-/tmp/shoken-db-e2e.log}"
+START_LOCAL_LOG="${START_LOCAL_LOG:-/tmp/shoken-start-local-e2e.log}"
 
 RUN_MAIN=1
 RUN_CSV=1
@@ -20,8 +20,8 @@ RUN_SAVE_AUTH=0
 KEEP_RUNNING=0
 START_ONLY=0
 
-BACK_PID=""
-FRONT_PID=""
+START_LOCAL_PID=""
+STARTED_STACK=0
 
 usage() {
   cat <<EOF
@@ -50,87 +50,88 @@ cleanup() {
     return 0
   fi
 
-  if [[ -n "$FRONT_PID" ]] && kill -0 "$FRONT_PID" >/dev/null 2>&1; then
-    kill "$FRONT_PID" >/dev/null 2>&1 || true
+  if [[ "$STARTED_STACK" -eq 1 ]]; then
+    if [[ -n "$START_LOCAL_PID" ]] && kill -0 "$START_LOCAL_PID" >/dev/null 2>&1; then
+      kill "$START_LOCAL_PID" >/dev/null 2>&1 || true
+      wait "$START_LOCAL_PID" >/dev/null 2>&1 || true
+    else
+      "$ROOT_DIR/scripts/stop-local.sh" --keep-db >/dev/null 2>&1 || true
+    fi
   fi
-  if [[ -n "$BACK_PID" ]] && kill -0 "$BACK_PID" >/dev/null 2>&1; then
-    kill "$BACK_PID" >/dev/null 2>&1 || true
+}
+
+print_log_tail() {
+  local label="$1"
+  local path="$2"
+
+  if [[ -f "$path" ]]; then
+    echo "--- $label: $path ---" >&2
+    tail -n 80 "$path" >&2 || true
   fi
 }
 
-wait_for_http_ok() {
-  local url="$1"
-  local label="$2"
-  local retries="${3:-120}"
-  local interval="${4:-0.5}"
+ensure_stack() {
+  echo "1/2 Ensuring local stack..."
 
-  for _ in $(seq 1 "$retries"); do
-    if curl -sSf "$url" >/dev/null 2>&1; then
-      return 0
-    fi
-    sleep "$interval"
-  done
-
-  echo "$label did not become ready: $url" >&2
-  return 1
-}
-
-ensure_db() {
-  echo "1/4 Ensuring local PostgreSQL..."
-  (cd "$BACKEND_DIR" && make db-up >"$DB_LOG" 2>&1)
-
-  for i in $(seq 1 120); do
-    if (cd "$BACKEND_DIR" && docker compose -f docker-compose.yml exec -T postgres pg_isready -U user -d shoken_db >/dev/null 2>&1); then
-      return 0
-    fi
-    sleep 0.5
-    if [[ "$i" -eq 120 ]]; then
-      echo "Local DB did not become ready." >&2
-      tail -n 80 "$DB_LOG" >&2 || true
-      exit 1
-    fi
-  done
-}
-
-ensure_backend() {
-  echo "2/4 Ensuring backend..."
-  if curl -sSf "$BACKEND_URL/health" >/dev/null 2>&1; then
+  if curl -sSf "$BACKEND_URL/health" >/dev/null 2>&1 && curl -sSf "$FRONTEND_URL/" >/dev/null 2>&1; then
     echo "  Reusing backend: $BACKEND_URL"
-    return 0
-  fi
-
-  (cd "$BACKEND_DIR" && make run >"$BACKEND_LOG" 2>&1) &
-  BACK_PID=$!
-
-  if ! wait_for_http_ok "$BACKEND_URL/health" "Backend" 120 0.5; then
-    tail -n 80 "$BACKEND_LOG" >&2 || true
-    exit 1
-  fi
-}
-
-ensure_frontend() {
-  echo "3/4 Ensuring frontend..."
-  if curl -sSf "$FRONTEND_URL/" >/dev/null 2>&1; then
     echo "  Reusing frontend: $FRONTEND_URL"
     return 0
   fi
 
-  (
-    cd "$FRONTEND_DIR"
-    VITE_SHOKEN_WEBAPI_API_URL="$BACKEND_URL" \
-      npm run dev -- --host 127.0.0.1 --port "$FRONTEND_PORT" --strictPort >"$FRONTEND_LOG" 2>&1
-  ) &
-  FRONT_PID=$!
+  "$ROOT_DIR/scripts/stop-local.sh" --keep-db >/dev/null 2>&1 || true
 
-  if ! wait_for_http_ok "$FRONTEND_URL/" "Frontend" 120 0.5; then
-    tail -n 80 "$FRONTEND_LOG" >&2 || true
-    exit 1
+  if [[ "$KEEP_RUNNING" -eq 1 || "$START_ONLY" -eq 1 ]]; then
+    nohup env \
+      BACKEND_URL="$BACKEND_URL" \
+      FRONTEND_URL="$FRONTEND_URL" \
+      FRONTEND_PORT="$FRONTEND_PORT" \
+      BACKEND_LOG="$BACKEND_LOG" \
+      FRONTEND_LOG="$FRONTEND_LOG" \
+      DB_LOG="$DB_LOG" \
+      "$ROOT_DIR/scripts/start-local.sh" >"$START_LOCAL_LOG" 2>&1 &
+  else
+    env \
+      BACKEND_URL="$BACKEND_URL" \
+      FRONTEND_URL="$FRONTEND_URL" \
+      FRONTEND_PORT="$FRONTEND_PORT" \
+      BACKEND_LOG="$BACKEND_LOG" \
+      FRONTEND_LOG="$FRONTEND_LOG" \
+      DB_LOG="$DB_LOG" \
+      "$ROOT_DIR/scripts/start-local.sh" >"$START_LOCAL_LOG" 2>&1 &
   fi
+  START_LOCAL_PID=$!
+  STARTED_STACK=1
+
+  for _ in $(seq 1 120); do
+    if curl -sSf "$BACKEND_URL/health" >/dev/null 2>&1 && curl -sSf "$FRONTEND_URL/" >/dev/null 2>&1; then
+      return 0
+    fi
+
+    if ! kill -0 "$START_LOCAL_PID" >/dev/null 2>&1; then
+      echo "start-local.sh exited before services became ready." >&2
+      print_log_tail "start-local" "$START_LOCAL_LOG"
+      print_log_tail "db" "$DB_LOG"
+      print_log_tail "backend" "$BACKEND_LOG"
+      print_log_tail "frontend" "$FRONTEND_LOG"
+      exit 1
+    fi
+
+    sleep 0.5
+  done
+
+  echo "Local stack did not become ready." >&2
+  print_log_tail "start-local" "$START_LOCAL_LOG"
+  print_log_tail "db" "$DB_LOG"
+  print_log_tail "backend" "$BACKEND_LOG"
+  print_log_tail "frontend" "$FRONTEND_LOG"
+  exit 1
 }
 
 ensure_storage_state() {
+  echo "2/2 Ensuring auth state..."
+
   if [[ "$RUN_SAVE_AUTH" -eq 1 ]]; then
-    echo "4/4 Saving auth state..."
     (cd "$FRONTEND_DIR" && npm run ui:save-auth)
     return 0
   fi
@@ -193,20 +194,21 @@ fi
 
 trap cleanup EXIT INT TERM
 
-ensure_db
-ensure_backend
-ensure_frontend
+ensure_stack
+if [[ "$START_ONLY" -eq 1 ]]; then
+  echo "Ready:"
+  echo "  Backend  : $BACKEND_URL"
+  echo "  Frontend : $FRONTEND_URL"
+  echo "Start only mode completed."
+  exit 0
+fi
+
 ensure_storage_state
 
 echo "Ready:"
 echo "  Backend  : $BACKEND_URL"
 echo "  Frontend : $FRONTEND_URL"
 echo "  Screens  : $ROOT_DIR/.playwright-mcp"
-
-if [[ "$START_ONLY" -eq 1 ]]; then
-  echo "Start only mode completed."
-  exit 0
-fi
 
 if [[ "$RUN_MAIN" -eq 1 ]]; then
   run_main_screenshots

--- a/scripts/run-ui-e2e.sh
+++ b/scripts/run-ui-e2e.sh
@@ -70,10 +70,15 @@ print_log_tail() {
   fi
 }
 
+http_ok() {
+  local url="$1"
+  curl -sSf --connect-timeout 1 --max-time 2 "$url" >/dev/null 2>&1
+}
+
 ensure_stack() {
   echo "1/2 Ensuring local stack..."
 
-  if curl -sSf "$BACKEND_URL/health" >/dev/null 2>&1 && curl -sSf "$FRONTEND_URL/" >/dev/null 2>&1; then
+  if http_ok "$BACKEND_URL/health" && http_ok "$FRONTEND_URL/"; then
     echo "  Reusing backend: $BACKEND_URL"
     echo "  Reusing frontend: $FRONTEND_URL"
     return 0
@@ -104,10 +109,6 @@ ensure_stack() {
   STARTED_STACK=1
 
   for _ in $(seq 1 120); do
-    if curl -sSf "$BACKEND_URL/health" >/dev/null 2>&1 && curl -sSf "$FRONTEND_URL/" >/dev/null 2>&1; then
-      return 0
-    fi
-
     if ! kill -0 "$START_LOCAL_PID" >/dev/null 2>&1; then
       echo "start-local.sh exited before services became ready." >&2
       print_log_tail "start-local" "$START_LOCAL_LOG"
@@ -115,6 +116,10 @@ ensure_stack() {
       print_log_tail "backend" "$BACKEND_LOG"
       print_log_tail "frontend" "$FRONTEND_LOG"
       exit 1
+    fi
+
+    if http_ok "$BACKEND_URL/health" && http_ok "$FRONTEND_URL/"; then
+      return 0
     fi
 
     sleep 0.5


### PR DESCRIPTION
## 概要
- run-ui-e2e.sh の readiness probe に timeout を追加
- UIレビュー用ルールを run-ui-e2e.sh 前提に更新
- ui-screenshots.spec.ts の実行コメントも run-ui-e2e.sh 前提に整理

## テスト
- bash -n scripts/run-ui-e2e.sh
- ./scripts/run-ui-e2e.sh --start-only