### PR TITLE
fix: UIレビュー指摘対応（CSV取込視認性・情報階層・銘柄カード密度）

### DIFF
--- a/frontend/src/components/molecules/PortfolioPieChart/PortfolioPieChart.tsx
+++ b/frontend/src/components/molecules/PortfolioPieChart/PortfolioPieChart.tsx
@@ -158,41 +158,45 @@ export const PortfolioPieChart: React.FC<PortfolioPieChartProps> = ({
                   }}
                 />
               </div>
-              {/* 下段: 詳細情報 */}
-              <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-slate-600">
-                <div className="flex items-center gap-1">
-                  <span className="text-slate-500">コード:</span>
-                  <SecurityCodeLink value={item.securityCode} className="text-xs" />
+              {/* 下段: 詳細情報（取得情報 / 配当情報を2段に分離） */}
+              <div className="mt-1 space-y-1.5 text-xs text-slate-600">
+                <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+                  <div className="flex items-center gap-1">
+                    <span className="text-slate-500">コード:</span>
+                    <SecurityCodeLink value={item.securityCode} className="text-xs" />
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <span className="text-slate-500">取得総額:</span>
+                    <span className="font-medium">{formatCurrency(item.value)}</span>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <span className="text-slate-500">取得単価:</span>
+                    <span className="font-medium">{formatCurrency(item.averagePrice)}</span>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <span className="text-slate-500">数量:</span>
+                    <span className="font-medium">{`${formatNumber(item.shares)}株`}</span>
+                  </div>
                 </div>
-                <div className="flex items-center gap-1">
-                  <span className="text-slate-500">取得単価:</span>
-                  <span className="font-medium">{formatCurrency(item.averagePrice)}</span>
-                </div>
-                <div className="flex items-center gap-1">
-                  <span className="text-slate-500">数量:</span>
-                  <span className="font-medium">{`${formatNumber(item.shares)}株`}</span>
-                </div>
-                <div className="flex items-center gap-1">
-                  <span className="text-slate-500">取得総額:</span>
-                  <span className="font-medium">{formatCurrency(item.value)}</span>
-                </div>
-                <div className="flex items-center gap-1">
-                  <span className="text-slate-500">1株配当:</span>
-                  <span className={`font-medium ${divInfo?.perShare !== null && divInfo?.perShare !== undefined ? 'text-emerald-600' : 'text-slate-500'}`}>
-                    {formatPerShare(divInfo)}
-                  </span>
-                </div>
-                <div className="flex items-center gap-1">
-                  <span className="text-slate-500">年間配当:</span>
-                  <span className={`font-medium ${divInfo?.annual !== null && divInfo?.annual !== undefined ? 'text-emerald-600' : 'text-slate-500'}`}>
-                    {formatAnnual(divInfo)}
-                  </span>
-                </div>
-                <div className="flex items-center gap-1">
-                  <span className="text-slate-500">配当利回り:</span>
-                  <span className={`font-medium ${divInfo?.yieldValue !== null && divInfo?.yieldValue !== undefined ? 'text-emerald-600' : 'text-slate-500'}`}>
-                    {formatYield(divInfo)}
-                  </span>
+                <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-t border-slate-100 pt-1.5">
+                  <div className="flex items-center gap-1">
+                    <span className="text-slate-500">1株配当:</span>
+                    <span className={`font-medium ${divInfo?.perShare !== null && divInfo?.perShare !== undefined ? 'text-emerald-600' : 'text-slate-500'}`}>
+                      {formatPerShare(divInfo)}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <span className="text-slate-500">年間配当:</span>
+                    <span className={`font-medium ${divInfo?.annual !== null && divInfo?.annual !== undefined ? 'text-emerald-600' : 'text-slate-500'}`}>
+                      {formatAnnual(divInfo)}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <span className="text-slate-500">配当利回り:</span>
+                    <span className={`font-medium ${divInfo?.yieldValue !== null && divInfo?.yieldValue !== undefined ? 'text-emerald-600' : 'text-slate-500'}`}>
+                      {formatYield(divInfo)}
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/organisms/ReceiptTable/ReceiptTable.tsx
+++ b/frontend/src/components/organisms/ReceiptTable/ReceiptTable.tsx
@@ -109,9 +109,9 @@ function renderGroupedRows<T extends DataItem, S extends SummaryItem>(
             rawValue: summaryItem[column.key]
         }));
 
-        const summaryBorderClass = summaryIndex > 0 && 'border-t border-slate-200';
-        const summaryLeftClass = cn('bg-slate-50 text-slate-700 font-medium border-l-2 border-slate-400', summaryBorderClass);
-        const summaryValueClass = cn('bg-slate-50 text-slate-700 text-right font-medium', summaryBorderClass);
+        const summaryBorderClass = summaryIndex > 0 && 'border-t-2 border-slate-300';
+        const summaryLeftClass = cn('bg-slate-100 text-slate-800 font-semibold border-l-2 border-slate-500', summaryBorderClass);
+        const summaryValueClass = cn('bg-slate-100 text-slate-800 text-right font-semibold', summaryBorderClass);
 
         return (
             <React.Fragment key={`group-${summaryIndex}`}>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -49,13 +49,13 @@ const FEATURES = [
 export function HomePage() {
   return (
     <Layout>
-      <div className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+      <div className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
         <PageHeader
           title="証券Webへようこそ"
           description="銘柄検索や取引明細の管理ができます。"
         />
 
-        <div className="grid gap-4 md:grid-cols-3">
+        <div className="grid gap-6 md:grid-cols-3">
           {FEATURES.map(({ title, description, detail, to, icon }) => (
             <Link key={to} to={to} className="block group">
               <Card className="h-full transition-shadow hover:shadow-md">
@@ -78,7 +78,7 @@ export function HomePage() {
         </div>
 
         {/* クイックアクション */}
-        <div className="mt-6 pt-4 border-t border-slate-200">
+        <div className="mt-8 pt-5 border-t border-slate-200">
           <h2 className="text-sm font-medium text-slate-500 mb-3">クイックアクション</h2>
           <div className="flex flex-wrap gap-2">
             {QUICK_ACTIONS.map(({ label, to, icon }) => (
@@ -95,7 +95,7 @@ export function HomePage() {
         </div>
 
         {/* はじめかた */}
-        <div className="mt-6 pt-4 border-t border-slate-200">
+        <div className="mt-8 pt-5 border-t border-slate-200">
           <h2 className="text-sm font-medium text-slate-500 mb-3">はじめかた</h2>
           <div className="grid gap-3 sm:grid-cols-3">
             <div className="rounded-lg border border-slate-200 bg-slate-50 p-3">

--- a/frontend/src/pages/Receipt/Dividend.tsx
+++ b/frontend/src/pages/Receipt/Dividend.tsx
@@ -206,11 +206,11 @@ export const Dividend: React.FC<DividendProps> = ({ data, previewData, importRes
     ];
 
     const importNote = importResult && (
-        <div className="mt-1 flex items-center gap-x-2 text-sm text-slate-600">
-            <span>最新取込:</span>
-            <strong>{importResult.inserted}件登録</strong>
+        <div className="mt-1 flex items-center gap-x-2 rounded-md border-l-2 border-primary bg-primary/5 px-3 py-1.5 text-sm">
+            <span className="font-medium text-slate-500">最新取込</span>
+            <strong className="text-slate-900">{importResult.inserted}件登録</strong>
             {importResult.skipped > 0 && (
-                <span className="inline-flex items-center rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-600">
+                <span className="inline-flex items-center rounded-full border border-amber-200 bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-700">
                     {importResult.skipped}件スキップ（重複）
                 </span>
             )}

--- a/frontend/src/pages/Receipt/DomesticStock.tsx
+++ b/frontend/src/pages/Receipt/DomesticStock.tsx
@@ -136,11 +136,11 @@ export const DomesticStock: React.FC<DomesticStockProps> = ({ data, previewData,
     ];
 
     const importNote = importResult && (
-        <div className="mt-1 flex items-center gap-x-2 text-sm text-slate-600">
-            <span>最新取込:</span>
-            <strong>{importResult.inserted}件登録</strong>
+        <div className="mt-1 flex items-center gap-x-2 rounded-md border-l-2 border-primary bg-primary/5 px-3 py-1.5 text-sm">
+            <span className="font-medium text-slate-500">最新取込</span>
+            <strong className="text-slate-900">{importResult.inserted}件登録</strong>
             {importResult.skipped > 0 && (
-                <span className="inline-flex items-center rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-600">
+                <span className="inline-flex items-center rounded-full border border-amber-200 bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-700">
                     {importResult.skipped}件スキップ（重複）
                 </span>
             )}

--- a/frontend/src/pages/Receipt/Mutualfund.tsx
+++ b/frontend/src/pages/Receipt/Mutualfund.tsx
@@ -127,11 +127,11 @@ export const Mutualfund: React.FC<MutualfundProps> = ({ data, previewData, impor
     ];
 
     const importNote = importResult && (
-        <div className="mt-1 flex items-center gap-x-2 text-sm text-slate-600">
-            <span>最新取込:</span>
-            <strong>{importResult.inserted}件登録</strong>
+        <div className="mt-1 flex items-center gap-x-2 rounded-md border-l-2 border-primary bg-primary/5 px-3 py-1.5 text-sm">
+            <span className="font-medium text-slate-500">最新取込</span>
+            <strong className="text-slate-900">{importResult.inserted}件登録</strong>
             {importResult.skipped > 0 && (
-                <span className="inline-flex items-center rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-600">
+                <span className="inline-flex items-center rounded-full border border-amber-200 bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-700">
                     {importResult.skipped}件スキップ（重複）
                 </span>
             )}

--- a/frontend/src/pages/Receipts.tsx
+++ b/frontend/src/pages/Receipts.tsx
@@ -213,7 +213,7 @@ export function ReceiptsPage() {
                 <p className="flex flex-wrap items-center gap-x-2">
                   <strong>{importResult.inserted}件登録</strong>
                   {importResult.skipped > 0 && (
-                    <span className="inline-flex items-center rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-600">
+                    <span className="inline-flex items-center rounded-full border border-amber-200 bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-700">
                       {importResult.skipped}件スキップ（重複）
                     </span>
                   )}

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -79,7 +79,7 @@ export function SearchPage() {
               description="銘柄コード（例：7203）または銘柄名を入力して検索してください。"
               className="py-10"
             />
-            <div className="mt-2 rounded-lg border border-slate-200 bg-slate-50 p-4">
+            <div className="mt-6 rounded-lg border border-slate-200 bg-slate-50 p-4">
               <h3 className="text-sm font-semibold text-slate-600 mb-2">検索のヒント</h3>
               <ul className="space-y-1 text-sm text-slate-500">
                 <li>4桁の銘柄コードで検索できます（例：7203, 9984）</li>


### PR DESCRIPTION
## 概要
UIレビュー指摘（`docs/tasks/chore-ui-review-latest-screenshots.md`）の実装対応。

## 変更内容

### CSV取込後の視認性改善
- `Receipts.tsx`: スキップチップを amber 色（`bg-amber-100 text-amber-700`）に変更し登録件数と視覚的に区別
- `DomesticStock.tsx` / `Dividend.tsx` / `Mutualfund.tsx`: importNote に左ボーダー＋背景色コンテナを追加し、テーブル密度に埋もれにくくした

### ホーム/銘柄検索の情報階層改善
- `Home.tsx`: 外側パディング `p-4` → `p-6`、機能カードグリッド `gap-4` → `gap-6`、セクション間隔 `mt-6` → `mt-8` に拡大
- `Search.tsx`: 検索ヒントと EmptyState の間隔 `mt-2` → `mt-6` に拡大

### 資産管理カード/取引明細の可読性改善
- `PortfolioPieChart.tsx`: 銘柄詳細情報を「取得情報（コード・総額・単価・数量）」と「配当情報（1株・年間・利回り）」の2段に分離
- `ReceiptTable.tsx`: グループサマリー行の背景を `bg-slate-100`、左ボーダーを `border-slate-500`、文字を `font-semibold` に強化

## テスト結果
- `npm run lint`: pass
- `npx tsc --noEmit`: pass
- `npm test`: 42 ファイル all pass
- `npm run build`: pass