### PR TITLE
fix: 取引明細コンポーネントの重複importNote表示を削除

### DIFF
--- a/frontend/src/pages/Receipt/Dividend.tsx
+++ b/frontend/src/pages/Receipt/Dividend.tsx
@@ -4,7 +4,6 @@ import { ReceiptTable } from '@/components/organisms/ReceiptTable/ReceiptTable';
 import { EmptyState } from '@/components/atoms/EmptyState';
 import React from 'react';
 import { DividendData } from '@/lib/interfaces/dividend';
-import type { ImportResult } from '@/pages/receiptsReducer';
 import { TableColumnConfig, SummaryColumnConfig } from '@/lib/interfaces/receipt';
 import {
     createSearchOptions,
@@ -58,13 +57,12 @@ const FILTER_CONFIG: FilterConfig<DividendData> = {
 interface DividendProps {
     data: DividendData[];
     previewData?: DividendData[];
-    importResult?: ImportResult | null;
 }
 
 /**
  * 配当金データを表示するコンポーネント
  */
-export const Dividend: React.FC<DividendProps> = ({ data, previewData, importResult }) => {
+export const Dividend: React.FC<DividendProps> = ({ data, previewData }) => {
     const displayData = previewData && previewData.length > 0 ? previewData : data;
 
     const dividendData = useMemo(() => sortDividendBySettlementDate(displayData), [displayData]);
@@ -205,39 +203,24 @@ export const Dividend: React.FC<DividendProps> = ({ data, previewData, importRes
         { key: 'net_amount_received', textAlign: 'right', format: formatCurrency },
     ];
 
-    const importNote = importResult && (
-        <div className="mt-1 flex items-center gap-x-2 rounded-md border-l-2 border-primary bg-primary/5 px-3 py-1.5 text-sm">
-            <span className="font-medium text-slate-500">最新取込</span>
-            <strong className="text-slate-900">{importResult.inserted}件登録</strong>
-            {importResult.skipped > 0 && (
-                <span className="inline-flex items-center rounded-full border border-amber-200 bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-700">
-                    {importResult.skipped}件スキップ（重複）
-                </span>
-            )}
-        </div>
-    );
-
     return (
         <ReceiptTemplate
             title="配当金"
             header={
-                <>
-                    <ReceiptHeader
-                        items={headerItems}
-                        title={isSecurityCodeSearch ? "集計情報 / 銘柄詳細" : "集計情報"}
-                        collapsible={isSecurityCodeSearch}
-                    >
-                        {isSecurityCodeSearch && (
-                            <DividendInfo
-                                searchQuery={searchQuery}
-                                securityCode={searchSecurityCode}
-                                summary={summary}
-                                embedded
-                            />
-                        )}
-                    </ReceiptHeader>
-                    {importNote}
-                </>
+                <ReceiptHeader
+                    items={headerItems}
+                    title={isSecurityCodeSearch ? "集計情報 / 銘柄詳細" : "集計情報"}
+                    collapsible={isSecurityCodeSearch}
+                >
+                    {isSecurityCodeSearch && (
+                        <DividendInfo
+                            searchQuery={searchQuery}
+                            securityCode={searchSecurityCode}
+                            summary={summary}
+                            embedded
+                        />
+                    )}
+                </ReceiptHeader>
             }
             onSearch={(query: string) => setSearchQuery(query)}
             searchCategories={searchCategories}

--- a/frontend/src/pages/Receipt/DomesticStock.tsx
+++ b/frontend/src/pages/Receipt/DomesticStock.tsx
@@ -4,7 +4,6 @@ import { ReceiptTable } from '@/components/organisms/ReceiptTable/ReceiptTable';
 import { EmptyState } from '@/components/atoms/EmptyState';
 import React from 'react';
 import { DomesticStockData } from '@/lib/interfaces/domesticStock';
-import type { ImportResult } from '@/pages/receiptsReducer';
 import { TableColumnConfig, SummaryColumnConfig } from '@/lib/interfaces/receipt';
 import { createSearchOptions } from '@/lib/utils/dataTransformer';
 import {
@@ -48,13 +47,12 @@ const FILTER_CONFIG: FilterConfig<DomesticStockData> = {
 interface DomesticStockProps {
     data: DomesticStockData[];
     previewData?: DomesticStockData[];
-    importResult?: ImportResult | null;
 }
 
 /**
  * 国内株式取引データを表示するコンポーネント
  */
-export const DomesticStock: React.FC<DomesticStockProps> = ({ data, previewData, importResult }) => {
+export const DomesticStock: React.FC<DomesticStockProps> = ({ data, previewData }) => {
     const displayData = previewData && previewData.length > 0 ? previewData : data;
 
     const domesticStockData = useMemo(() => sortDomesticStockByTradeDate(displayData), [displayData]);
@@ -135,22 +133,10 @@ export const DomesticStock: React.FC<DomesticStockProps> = ({ data, previewData,
         { key: 'total_realized_profit_and_loss_after_tax', textAlign: 'right', format: formatCurrency },
     ];
 
-    const importNote = importResult && (
-        <div className="mt-1 flex items-center gap-x-2 rounded-md border-l-2 border-primary bg-primary/5 px-3 py-1.5 text-sm">
-            <span className="font-medium text-slate-500">最新取込</span>
-            <strong className="text-slate-900">{importResult.inserted}件登録</strong>
-            {importResult.skipped > 0 && (
-                <span className="inline-flex items-center rounded-full border border-amber-200 bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-700">
-                    {importResult.skipped}件スキップ（重複）
-                </span>
-            )}
-        </div>
-    );
-
     return (
         <ReceiptTemplate
             title="国内株式"
-            header={<><ReceiptHeader items={headerItems} />{importNote}</>}
+            header={<ReceiptHeader items={headerItems} />}
             onSearch={(query: string) => setSearchQuery(query)}
             searchCategories={searchCategories}
         >

--- a/frontend/src/pages/Receipt/Mutualfund.tsx
+++ b/frontend/src/pages/Receipt/Mutualfund.tsx
@@ -4,7 +4,6 @@ import { ReceiptTable } from '@/components/organisms/ReceiptTable/ReceiptTable';
 import { EmptyState } from '@/components/atoms/EmptyState';
 import React from 'react';
 import { MutualfundData } from '@/lib/interfaces/mutualfund';
-import type { ImportResult } from '@/pages/receiptsReducer';
 import { TableColumnConfig, SummaryColumnConfig } from '@/lib/interfaces/receipt';
 import { createSearchOptions, groupAndSummarizeData } from '@/lib/utils/dataTransformer';
 import {
@@ -33,13 +32,12 @@ const FILTER_CONFIG: FilterConfig<MutualfundData> = {
 interface MutualfundProps {
     data: MutualfundData[];
     previewData?: MutualfundData[];
-    importResult?: ImportResult | null;
 }
 
 /**
  * 投資信託データを表示するコンポーネント
  */
-export const Mutualfund: React.FC<MutualfundProps> = ({ data, previewData, importResult }) => {
+export const Mutualfund: React.FC<MutualfundProps> = ({ data, previewData }) => {
     const displayData = previewData && previewData.length > 0 ? previewData : data;
 
     const mutualfundData = useMemo(() => sortMutualfundByTradeDate(displayData), [displayData]);
@@ -126,22 +124,10 @@ export const Mutualfund: React.FC<MutualfundProps> = ({ data, previewData, impor
         { key: 'realized_profit_and_loss_after_tax', textAlign: 'right', format: formatCurrency },
     ];
 
-    const importNote = importResult && (
-        <div className="mt-1 flex items-center gap-x-2 rounded-md border-l-2 border-primary bg-primary/5 px-3 py-1.5 text-sm">
-            <span className="font-medium text-slate-500">最新取込</span>
-            <strong className="text-slate-900">{importResult.inserted}件登録</strong>
-            {importResult.skipped > 0 && (
-                <span className="inline-flex items-center rounded-full border border-amber-200 bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-700">
-                    {importResult.skipped}件スキップ（重複）
-                </span>
-            )}
-        </div>
-    );
-
     return (
         <ReceiptTemplate
             title="投資信託"
-            header={<><ReceiptHeader items={headerItems} />{importNote}</>}
+            header={<ReceiptHeader items={headerItems} />}
             onSearch={(query: string) => setSearchQuery(query)}
             searchCategories={searchCategories}
         >

--- a/frontend/src/pages/Receipts.tsx
+++ b/frontend/src/pages/Receipts.tsx
@@ -254,21 +254,18 @@ export function ReceiptsPage() {
               <Dividend
                 data={dividendData}
                 previewData={csvPreview?.rows?.map(r => transformDBDividend(r))}
-                importResult={importResult}
               />
             )}
             {receiptsType === 'domesticstock' && (
               <DomesticStock
                 data={domesticstockData}
                 previewData={csvPreview?.rows?.map(r => transformDBDomesticStock(r))}
-                importResult={importResult}
               />
             )}
             {receiptsType === 'mutualfund' && (
               <Mutualfund
                 data={mutualfundData}
                 previewData={csvPreview?.rows?.map(r => transformDBMutualfund(r))}
-                importResult={importResult}
               />
             )}
           </>

--- a/frontend/src/pages/__tests__/Receipts.test.tsx
+++ b/frontend/src/pages/__tests__/Receipts.test.tsx
@@ -306,6 +306,41 @@ describe('ReceiptsPage', () => {
     }, waitOpts);
   }, 20000);
 
+  it('取込結果: importResult は Receipts.tsx の Alert 1箇所だけに表示される（子コンポーネントに重複なし）', async () => {
+    vi.mocked(authHook.useAuth).mockReturnValue(
+      makeAuthMock({ isAuthenticated: true })
+    );
+    vi.mocked(receiptApi.dividendApi.list).mockResolvedValue([]);
+    vi.mocked(receiptApi.domesticStockApi.list).mockResolvedValue([]);
+    vi.mocked(receiptApi.mutualfundApi.list).mockResolvedValue([]);
+    vi.mocked(receiptApi.dividendApi.uploadCsv).mockResolvedValue({ inserted: 3, skipped: 2, errors: [] });
+
+    renderWithQuery(<ReceiptsPage />);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    }, waitOpts);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('csv-file-input'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /追加で保存/ })).toBeInTheDocument();
+    }, waitOpts);
+
+    await user.click(screen.getByRole('button', { name: /追加で保存/ }));
+
+    await waitFor(() => {
+      expect(receiptApi.dividendApi.uploadCsv).toHaveBeenCalled();
+    }, waitOpts);
+
+    // 「3件登録」という strong テキストは親 Alert に 1 つだけ存在する
+    await waitFor(() => {
+      const matches = screen.getAllByText(/3件登録/);
+      expect(matches).toHaveLength(1);
+    }, waitOpts);
+  }, 20000);
+
   it('全削除: 確認モーダル経由で deleteAll API が呼ばれデータがクリアされる', async () => {
     vi.mocked(authHook.useAuth).mockReturnValue(
       makeAuthMock({ isAuthenticated: true })

--- a/frontend/src/pages/__tests__/Receipts.test.tsx
+++ b/frontend/src/pages/__tests__/Receipts.test.tsx
@@ -71,20 +71,29 @@ vi.mock('@/components/molecules/ConfirmDeleteModal/ConfirmDeleteModal', () => ({
     ) : null,
 }));
 
-// 子コンポーネント: data の長さだけ確認できる最小表示
+// 子コンポーネント: data の長さ確認 + importResult が渡された場合は表示（回帰検知用）
 vi.mock('@/pages/Receipt/Dividend', () => ({
-  Dividend: ({ data }: { data: unknown[] }) => (
-    <div data-testid="dividend-view">{data.length}</div>
+  Dividend: ({ data, importResult }: { data: unknown[]; importResult?: { inserted: number } }) => (
+    <div data-testid="dividend-view">
+      {data.length}
+      {importResult && <strong>{importResult.inserted}件登録</strong>}
+    </div>
   ),
 }));
 vi.mock('@/pages/Receipt/DomesticStock', () => ({
-  DomesticStock: ({ data }: { data: unknown[] }) => (
-    <div data-testid="domesticstock-view">{data.length}</div>
+  DomesticStock: ({ data, importResult }: { data: unknown[]; importResult?: { inserted: number } }) => (
+    <div data-testid="domesticstock-view">
+      {data.length}
+      {importResult && <strong>{importResult.inserted}件登録</strong>}
+    </div>
   ),
 }));
 vi.mock('@/pages/Receipt/Mutualfund', () => ({
-  Mutualfund: ({ data }: { data: unknown[] }) => (
-    <div data-testid="mutualfund-view">{data.length}</div>
+  Mutualfund: ({ data, importResult }: { data: unknown[]; importResult?: { inserted: number } }) => (
+    <div data-testid="mutualfund-view">
+      {data.length}
+      {importResult && <strong>{importResult.inserted}件登録</strong>}
+    </div>
   ),
 }));
 


### PR DESCRIPTION
## 概要

各取引明細タブ（配当金・国内株式・投資信託）コンポーネント内の `importNote` 表示を削除し、
`Receipts.tsx` の Alert 表示に一本化した。

## 変更内容

- `Dividend.tsx` / `DomesticStock.tsx` / `Mutualfund.tsx` から `importResult` prop・`importNote` const を削除
- `Receipts.tsx` から各コンポーネントへの `importResult={importResult}` prop 渡しを削除

## テスト結果

- `npm run lint` ✅
- `npx tsc --noEmit` ✅
- `npm test` ✅ (42 files, 421 tests passed)
- E2E (ui-screenshots.spec.ts) ✅ (13/13 passed)
- E2E (csv-crud.spec.ts) ✅ (4/4 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)