### PR TITLE
fix: 取引明細空データ時の集計ヘッダー非表示とホーム/検索の下余白解消

### DIFF
--- a/frontend/src/components/templates/Layout.tsx
+++ b/frontend/src/components/templates/Layout.tsx
@@ -10,7 +10,7 @@ export function Layout({ children }: LayoutProps) {
     <div className="min-h-screen flex flex-col bg-slate-50">
       <Header />
 
-      <main className="mx-auto w-full max-w-[1440px] px-4 sm:px-5 lg:px-6 py-4 flex-1">
+      <main className="mx-auto w-full max-w-[1440px] px-4 sm:px-5 lg:px-6 py-4 flex-1 flex flex-col">
         {children}
       </main>
 

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -49,7 +49,7 @@ const FEATURES = [
 export function HomePage() {
   return (
     <Layout>
-      <div className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+      <div className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm flex-1">
         <PageHeader
           title="証券Webへようこそ"
           description="銘柄検索や取引明細の管理ができます。"

--- a/frontend/src/pages/Receipt/Dividend.tsx
+++ b/frontend/src/pages/Receipt/Dividend.tsx
@@ -206,7 +206,7 @@ export const Dividend: React.FC<DividendProps> = ({ data, previewData }) => {
     return (
         <ReceiptTemplate
             title="配当金"
-            header={
+            header={dividendData.length > 0 ? (
                 <ReceiptHeader
                     items={headerItems}
                     title={isSecurityCodeSearch ? "集計情報 / 銘柄詳細" : "集計情報"}
@@ -221,7 +221,7 @@ export const Dividend: React.FC<DividendProps> = ({ data, previewData }) => {
                         />
                     )}
                 </ReceiptHeader>
-            }
+            ) : undefined}
             onSearch={(query: string) => setSearchQuery(query)}
             searchCategories={searchCategories}
         >

--- a/frontend/src/pages/Receipt/DomesticStock.tsx
+++ b/frontend/src/pages/Receipt/DomesticStock.tsx
@@ -136,7 +136,7 @@ export const DomesticStock: React.FC<DomesticStockProps> = ({ data, previewData 
     return (
         <ReceiptTemplate
             title="国内株式"
-            header={<ReceiptHeader items={headerItems} />}
+            header={domesticStockData.length > 0 ? <ReceiptHeader items={headerItems} /> : undefined}
             onSearch={(query: string) => setSearchQuery(query)}
             searchCategories={searchCategories}
         >

--- a/frontend/src/pages/Receipt/Mutualfund.tsx
+++ b/frontend/src/pages/Receipt/Mutualfund.tsx
@@ -127,7 +127,7 @@ export const Mutualfund: React.FC<MutualfundProps> = ({ data, previewData }) => 
     return (
         <ReceiptTemplate
             title="投資信託"
-            header={<ReceiptHeader items={headerItems} />}
+            header={mutualfundData.length > 0 ? <ReceiptHeader items={headerItems} /> : undefined}
             onSearch={(query: string) => setSearchQuery(query)}
             searchCategories={searchCategories}
         >

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -39,7 +39,7 @@ export function SearchPage() {
 
   return (
     <Layout>
-      <div>
+      <div className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm flex-1">
         <PageHeader
           title="銘柄検索"
           description="銘柄コードまたは銘柄名を入力して株式情報を検索できます。"


### PR DESCRIPTION
## 概要

UIレビュー指摘（`docs/tasks/chore-ui-review-20260305.md`）に基づく改善。

## 変更内容

**取引明細 - 空データ時の集計ヘッダー非表示**
- データ0件時に ¥0/¥0/¥0 の集計ヘッダーを表示していた問題を修正
- `DomesticStock.tsx` / `Dividend.tsx` / `Mutualfund.tsx`: データが存在する場合のみ `ReceiptHeader` を表示

**ホーム/銘柄検索 - 下余白解消**
- `Layout.tsx`: main に `flex flex-col` を追加
- `Home.tsx` / `Search.tsx`: 外枠コンテナに `flex-1` を付与し、ビューポート全体を白背景で満たす

## テスト結果

- `npm run lint` ✅
- `npx tsc --noEmit` ✅
- `npm test` ✅ (42 files, 422 passed)
- E2E (ui-screenshots.spec.ts) ✅ 13/13
- E2E (csv-crud.spec.ts) ✅ 4/4

🤖 Generated with [Claude Code](https://claude.com/claude-code)