### PR TITLE
fix: Origin検証をConfig.cors_originsと統一しOAuthエラー詳細の外部露出を修正

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -315,8 +315,10 @@ mod tests {
     async fn test_validate_origin_respects_cors_origins_env() {
         let _lock = ENV_MUTEX.lock().unwrap();
         let _app_env = EnvGuard::set("APP_ENV", None);
-        let _cors_origins =
-            EnvGuard::set("CORS_ORIGINS", Some("http://custom-origin.example.com:8080"));
+        let _cors_origins = EnvGuard::set(
+            "CORS_ORIGINS",
+            Some("http://custom-origin.example.com:8080"),
+        );
 
         let config = Config::from_env();
         let app = build_test_app(&config);

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -153,7 +153,7 @@ mod tests {
     use crate::{routes::app_router, state::AppState};
     use axum::{
         body::Body,
-        http::{header::ACCESS_CONTROL_ALLOW_ORIGIN, Method, Request},
+        http::{header::ACCESS_CONTROL_ALLOW_ORIGIN, Method, Request, StatusCode},
         Router,
     };
     use reqwest::Client;
@@ -307,6 +307,47 @@ mod tests {
             .get(ACCESS_CONTROL_ALLOW_ORIGIN)
             .and_then(|value| value.to_str().ok());
         assert_eq!(allowed_origin, None);
+    }
+
+    /// CORS_ORIGINS で設定したオリジンが validate_origin ミドルウェアにも反映されることを確認する
+    /// （POST リクエストに対して Config::cors_origins と validate_origin が同一リストを参照する）
+    #[tokio::test]
+    async fn test_validate_origin_respects_cors_origins_env() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        let _app_env = EnvGuard::set("APP_ENV", None);
+        let _cors_origins =
+            EnvGuard::set("CORS_ORIGINS", Some("http://custom-origin.example.com:8080"));
+
+        let config = Config::from_env();
+        let app = build_test_app(&config);
+
+        // 許可オリジンからの POST → 通過（/health は GET のみだが validate_origin のチェックが目的）
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/health")
+            .header("origin", "http://custom-origin.example.com:8080")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_ne!(
+            resp.status(),
+            StatusCode::FORBIDDEN,
+            "許可されたカスタムオリジンは通過すべき"
+        );
+
+        // 許可されていないオリジンからの POST → 403
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/health")
+            .header("origin", "http://disallowed-origin.example.com")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::FORBIDDEN,
+            "許可されていないオリジンは拒否すべき"
+        );
     }
 
     #[tokio::test]

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -124,7 +124,10 @@ pub async fn google_callback(
         .exchange_code(AuthorizationCode::new(query.code))
         .request_async(&http_client)
         .await
-        .map_err(|e| ApiError::ApiError(format!("トークン交換エラー: {:?}", e)))?;
+        .map_err(|e| {
+            tracing::error!("OAuth token exchange error: {:?}", e);
+            ApiError::OAuthError(e.to_string())
+        })?;
 
     let access_token = token_result.access_token().secret();
 

--- a/backend/src/middleware.rs
+++ b/backend/src/middleware.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use axum::{
     body::Body,
     http::{Method, Request, StatusCode},
@@ -10,8 +12,13 @@ use crate::errors::{ErrorDetails, ErrorResponse};
 
 /// Origin検証ミドルウェア（CSRF対策）
 /// POST/PUT/DELETE リクエストに対して Origin ヘッダーを検証し、
-/// 許可されたオリジンからのリクエストのみ通過させる
-pub async fn validate_origin(request: Request<Body>, next: Next) -> Response {
+/// 許可されたオリジンからのリクエストのみ通過させる。
+/// allowed_origins は Config::cors_origins と一致させる。
+pub async fn validate_origin(
+    allowed_origins: Arc<Vec<String>>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
     let method = request.method().clone();
 
     // GET/HEAD/OPTIONS はスキップ
@@ -26,17 +33,8 @@ pub async fn validate_origin(request: Request<Body>, next: Next) -> Response {
         .and_then(|v| v.to_str().ok())
         .map(|s| s.to_string());
 
-    // 許可されたオリジンリスト
-    let allowed_origins = [
-        "https://shoken-webapp.vercel.app",
-        "http://localhost:8080",
-        "http://127.0.0.1:8080",
-        "http://[::1]:8080",
-        "http://localhost.:8080",
-    ];
-
     match origin {
-        Some(ref o) if allowed_origins.contains(&o.as_str()) => {
+        Some(ref o) if allowed_origins.iter().any(|a| a == o) => {
             // 許可されたオリジン → 通過
             next.run(request).await
         }
@@ -67,9 +65,19 @@ mod tests {
     use tower::ServiceExt;
 
     fn test_app() -> Router {
+        let allowed_origins = Arc::new(vec![
+            "https://shoken-webapp.vercel.app".to_string(),
+            "http://localhost:8080".to_string(),
+            "http://127.0.0.1:8080".to_string(),
+            "http://[::1]:8080".to_string(),
+            "http://localhost.:8080".to_string(),
+        ]);
         Router::new()
             .route("/test", post(|| async { "ok" }))
-            .layer(middleware::from_fn(validate_origin))
+            .layer(middleware::from_fn(move |req, next| {
+                let origins = allowed_origins.clone();
+                async move { validate_origin(origins, req, next).await }
+            }))
     }
 
     #[tokio::test]
@@ -126,9 +134,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_with_disallowed_origin() {
+        let allowed_origins = Arc::new(vec!["http://localhost:8080".to_string()]);
         let app = Router::new()
             .route("/test", axum::routing::delete(|| async { "ok" }))
-            .layer(middleware::from_fn(validate_origin));
+            .layer(middleware::from_fn(move |req, next| {
+                let origins = allowed_origins.clone();
+                async move { validate_origin(origins, req, next).await }
+            }));
 
         let req = Request::builder()
             .method(Method::DELETE)

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use axum::{
     middleware,
     routing::{delete, get, post},
@@ -14,6 +16,7 @@ use crate::{
 const REQUEST_BODY_LIMIT: usize = 10 * 1024 * 1024;
 
 pub fn app_router(state: AppState, config: &Config) -> Router {
+    let allowed_origins = Arc::new(config.cors_origins.clone());
     Router::new()
         .merge(stock_routes())
         .merge(jquants_routes())
@@ -28,7 +31,10 @@ pub fn app_router(state: AppState, config: &Config) -> Router {
             "/api-docs/openapi.json",
             get(|| async { Json(ApiDoc::openapi()) }),
         )
-        .layer(middleware::from_fn(validate_origin))
+        .layer(middleware::from_fn(move |req, next| {
+            let origins = allowed_origins.clone();
+            async move { validate_origin(origins, req, next).await }
+        }))
         .layer(RequestBodyLimitLayer::new(REQUEST_BODY_LIMIT))
         .layer(config.build_cors_layer())
         .with_state(state)


### PR DESCRIPTION
## 概要

セキュリティレビュー（`docs/tasks/chore-security-review-20260305.md`）で検出した問題2件を修正。

## 変更内容

### 高: Origin検証と CORS 設定の乖離

**問題**: `middleware.rs` の `validate_origin` が許可オリジンをハードコードしており、`config.rs` の `CORS_ORIGINS` 環境変数による動的設定が反映されなかった。

**修正**:
- `validate_origin(allowed_origins: Arc<Vec<String>>, ...)` に変更
- `routes.rs` で `Config::cors_origins` から生成した `Arc<Vec<String>>` をクロージャ経由で渡す
- これにより CORS 設定と Origin 検証が常に同一のオリジンリストを参照する

### 中: OAuth token exchange エラー詳細の外部露出

**問題**: `handlers/auth.rs:127` で `ApiError::ApiError(format!("トークン交換エラー: {:?}", e))` を使用しており、`ApiError::ApiError` は `msg` を `message` フィールドに直接載せるため OAuth エラー詳細が API レスポンスに含まれる可能性があった。

**修正**:
- `ApiError::OAuthError` に変更（`details: None`、`"Authentication error"` のみ返す）
- エラー詳細は `tracing::error!` でサーバーログにのみ出力

## テスト結果

- `cargo fmt` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo test` ✅ (middleware/config/errors 全 22 テスト通過)

🤖 Generated with [Claude Code](https://claude.com/claude-code)