### PR TITLE
refactor: Receipts 周辺と PortfolioPieChart のフロントエンド整理

### DIFF
--- a/frontend/src/components/molecules/PortfolioPieChart/PortfolioPieChart.tsx
+++ b/frontend/src/components/molecules/PortfolioPieChart/PortfolioPieChart.tsx
@@ -38,6 +38,141 @@ interface PortfolioPieChartProps {
   dividendStatusMap?: Map<string, DividendStatus>; // 銘柄別取得ステータス
 }
 
+// --- 純粋関数 ---
+
+interface DividendInfoResult {
+  perShare: number | null;
+  annual: number | null;
+  yieldValue: number | null;
+  status: DividendStatus | undefined;
+}
+
+function getDividendInfo(
+  securityCode: string,
+  shares: number,
+  averagePrice: number,
+  dividendPerShareMap: Map<string, number> | undefined,
+  dividendStatusMap: Map<string, DividendStatus> | undefined,
+): DividendInfoResult | null {
+  if (!dividendPerShareMap) return null;
+  const status = dividendStatusMap?.get(securityCode);
+  const perShare = dividendPerShareMap.get(securityCode);
+
+  if (status === 'pending') return { perShare: null, annual: null, yieldValue: null, status };
+  if (status === 'error') return { perShare: null, annual: null, yieldValue: null, status };
+  if (status === 'zero') return { perShare: 0, annual: 0, yieldValue: null, status };
+  if (perShare === undefined) return { perShare: null, annual: null, yieldValue: null, status };
+
+  const annual = perShare * shares;
+  const yieldValue = averagePrice > 0 ? (perShare / averagePrice) * 100 : null;
+  return { perShare, annual, yieldValue, status };
+}
+
+function formatPerShare(divInfo: DividendInfoResult | null): string {
+  if (!divInfo) return '---';
+  if (divInfo.status === 'pending') return '取得中...';
+  if (divInfo.status === 'error') return '取得失敗';
+  if (divInfo.perShare === null) return '---';
+  return formatCurrency(divInfo.perShare);
+}
+
+function formatAnnual(divInfo: DividendInfoResult | null): string {
+  if (!divInfo) return '---';
+  if (divInfo.status === 'pending') return '取得中...';
+  if (divInfo.status === 'error') return '取得失敗';
+  if (divInfo.annual === null) return '---';
+  return formatCurrency(divInfo.annual);
+}
+
+function formatYield(divInfo: DividendInfoResult | null): string {
+  if (!divInfo) return '---';
+  if (divInfo.status === 'pending') return '取得中...';
+  if (divInfo.status === 'error') return '取得失敗';
+  if (divInfo.yieldValue === null) return '---';
+  return formatPercentageValue(divInfo.yieldValue);
+}
+
+// --- サブコンポーネント ---
+
+interface PortfolioItemCardProps {
+  item: ChartDataItem;
+  index: number;
+  dividendPerShareMap?: Map<string, number>;
+  dividendStatusMap?: Map<string, DividendStatus>;
+}
+
+function PortfolioItemCard({ item, index, dividendPerShareMap, dividendStatusMap }: PortfolioItemCardProps) {
+  const divInfo = getDividendInfo(item.securityCode, item.shares, item.averagePrice, dividendPerShareMap, dividendStatusMap);
+  const color = COLORS[index % COLORS.length];
+
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-3">
+      {/* 上段: 銘柄名 + 構成比 */}
+      <div className="flex items-center justify-between gap-2 mb-2">
+        <div className="flex items-center gap-2 min-w-0 flex-1">
+          <span className="h-3 w-3 shrink-0 rounded-sm" style={{ backgroundColor: color }} />
+          <span className="truncate text-sm font-medium text-slate-700" title={item.name}>
+            {item.name}
+          </span>
+        </div>
+        <span className="shrink-0 text-lg font-bold text-slate-800">
+          {item.percentage.toFixed(1)}%
+        </span>
+      </div>
+      {/* 横棒グラフ */}
+      <div className="h-2.5 w-full rounded-full bg-slate-100 mb-2">
+        <div
+          className="h-full rounded-full transition-all duration-300"
+          style={{ width: `${Math.min(item.percentage, 100)}%`, backgroundColor: color }}
+        />
+      </div>
+      {/* 下段: 詳細情報（取得情報 / 配当情報を2段に分離） */}
+      <div className="mt-1 space-y-1.5 text-xs text-slate-600">
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+          <div className="flex items-center gap-1">
+            <span className="text-slate-500">コード:</span>
+            <SecurityCodeLink value={item.securityCode} className="text-xs" />
+          </div>
+          <div className="flex items-center gap-1">
+            <span className="text-slate-500">取得総額:</span>
+            <span className="font-medium">{formatCurrency(item.value)}</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <span className="text-slate-500">取得単価:</span>
+            <span className="font-medium">{formatCurrency(item.averagePrice)}</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <span className="text-slate-500">数量:</span>
+            <span className="font-medium">{`${formatNumber(item.shares)}株`}</span>
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-t border-slate-100 pt-1.5">
+          <div className="flex items-center gap-1">
+            <span className="text-slate-500">1株配当:</span>
+            <span className={`font-medium ${divInfo?.perShare !== null && divInfo?.perShare !== undefined ? 'text-emerald-600' : 'text-slate-500'}`}>
+              {formatPerShare(divInfo)}
+            </span>
+          </div>
+          <div className="flex items-center gap-1">
+            <span className="text-slate-500">年間配当:</span>
+            <span className={`font-medium ${divInfo?.annual !== null && divInfo?.annual !== undefined ? 'text-emerald-600' : 'text-slate-500'}`}>
+              {formatAnnual(divInfo)}
+            </span>
+          </div>
+          <div className="flex items-center gap-1">
+            <span className="text-slate-500">配当利回り:</span>
+            <span className={`font-medium ${divInfo?.yieldValue !== null && divInfo?.yieldValue !== undefined ? 'text-emerald-600' : 'text-slate-500'}`}>
+              {formatYield(divInfo)}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// --- メインコンポーネント ---
+
 /**
  * ポートフォリオ構成比を表示する横棒グラフコンポーネント
  */
@@ -55,18 +190,13 @@ export const PortfolioPieChart: React.FC<PortfolioPieChartProps> = ({
     if (total === 0) return [];
 
     return data
-      .map((item) => ({
-        ...item,
-        percentage: (item.value / total) * 100,
-      }))
+      .map((item) => ({ ...item, percentage: (item.value / total) * 100 }))
       .sort((a, b) => b.percentage - a.percentage);
   }, [data]);
 
   // 表示データ（Top N または全件）
   const displayData = useMemo(() => {
-    if (showAll || chartData.length <= TOP_N) {
-      return chartData;
-    }
+    if (showAll || chartData.length <= TOP_N) return chartData;
     return chartData.slice(0, TOP_N);
   }, [chartData, showAll]);
 
@@ -76,132 +206,23 @@ export const PortfolioPieChart: React.FC<PortfolioPieChartProps> = ({
     return chartData.slice(TOP_N).reduce((sum, item) => sum + item.percentage, 0);
   }, [chartData, showAll]);
 
-  if (chartData.length === 0) {
-    return null;
-  }
+  if (chartData.length === 0) return null;
 
   const remainingCount = chartData.length - TOP_N;
-
-  // 銘柄別の配当情報を計算
-  const getDividendInfo = (securityCode: string, shares: number, averagePrice: number) => {
-    if (!dividendPerShareMap) return null;
-    const status = dividendStatusMap?.get(securityCode);
-    const perShare = dividendPerShareMap.get(securityCode);
-
-    if (status === 'pending') return { perShare: null, annual: null, yieldValue: null, status };
-    if (status === 'error') return { perShare: null, annual: null, yieldValue: null, status };
-    if (status === 'zero') return { perShare: 0, annual: 0, yieldValue: null, status };
-    if (perShare === undefined) return { perShare: null, annual: null, yieldValue: null, status };
-
-    const annual = perShare * shares;
-    const yieldValue = averagePrice > 0 ? (perShare / averagePrice) * 100 : null;
-    return { perShare, annual, yieldValue, status };
-  };
-
-  const formatPerShare = (divInfo: ReturnType<typeof getDividendInfo>) => {
-    if (!divInfo) return '---';
-    if (divInfo.status === 'pending') return '取得中...';
-    if (divInfo.status === 'error') return '取得失敗';
-    if (divInfo.perShare === null) return '---';
-    return formatCurrency(divInfo.perShare);
-  };
-
-  const formatAnnual = (divInfo: ReturnType<typeof getDividendInfo>) => {
-    if (!divInfo) return '---';
-    if (divInfo.status === 'pending') return '取得中...';
-    if (divInfo.status === 'error') return '取得失敗';
-    if (divInfo.annual === null) return '---';
-    return formatCurrency(divInfo.annual);
-  };
-
-  const formatYield = (divInfo: ReturnType<typeof getDividendInfo>) => {
-    if (!divInfo) return '---';
-    if (divInfo.status === 'pending') return '取得中...';
-    if (divInfo.status === 'error') return '取得失敗';
-    if (divInfo.yieldValue === null) return '---';
-    return formatPercentageValue(divInfo.yieldValue);
-  };
 
   return (
     <div className={className} data-testid="portfolio-pie-chart">
       {/* 横棒グラフリスト（2-3列グリッド） */}
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        {displayData.map((item, index) => {
-          const divInfo = getDividendInfo(item.securityCode, item.shares, item.averagePrice);
-          return (
-            <div
-              key={item.securityCode}
-              className="rounded-lg border border-slate-200 bg-white p-3"
-            >
-              {/* 上段: 銘柄名 + 構成比 */}
-              <div className="flex items-center justify-between gap-2 mb-2">
-                <div className="flex items-center gap-2 min-w-0 flex-1">
-                  <span
-                    className="h-3 w-3 shrink-0 rounded-sm"
-                    style={{ backgroundColor: COLORS[index % COLORS.length] }}
-                  />
-                  <span className="truncate text-sm font-medium text-slate-700" title={item.name}>
-                    {item.name}
-                  </span>
-                </div>
-                <span className="shrink-0 text-lg font-bold text-slate-800">
-                  {item.percentage.toFixed(1)}%
-                </span>
-              </div>
-              {/* 横棒グラフ */}
-              <div className="h-2.5 w-full rounded-full bg-slate-100 mb-2">
-                <div
-                  className="h-full rounded-full transition-all duration-300"
-                  style={{
-                    width: `${Math.min(item.percentage, 100)}%`,
-                    backgroundColor: COLORS[index % COLORS.length],
-                  }}
-                />
-              </div>
-              {/* 下段: 詳細情報（取得情報 / 配当情報を2段に分離） */}
-              <div className="mt-1 space-y-1.5 text-xs text-slate-600">
-                <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-                  <div className="flex items-center gap-1">
-                    <span className="text-slate-500">コード:</span>
-                    <SecurityCodeLink value={item.securityCode} className="text-xs" />
-                  </div>
-                  <div className="flex items-center gap-1">
-                    <span className="text-slate-500">取得総額:</span>
-                    <span className="font-medium">{formatCurrency(item.value)}</span>
-                  </div>
-                  <div className="flex items-center gap-1">
-                    <span className="text-slate-500">取得単価:</span>
-                    <span className="font-medium">{formatCurrency(item.averagePrice)}</span>
-                  </div>
-                  <div className="flex items-center gap-1">
-                    <span className="text-slate-500">数量:</span>
-                    <span className="font-medium">{`${formatNumber(item.shares)}株`}</span>
-                  </div>
-                </div>
-                <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-t border-slate-100 pt-1.5">
-                  <div className="flex items-center gap-1">
-                    <span className="text-slate-500">1株配当:</span>
-                    <span className={`font-medium ${divInfo?.perShare !== null && divInfo?.perShare !== undefined ? 'text-emerald-600' : 'text-slate-500'}`}>
-                      {formatPerShare(divInfo)}
-                    </span>
-                  </div>
-                  <div className="flex items-center gap-1">
-                    <span className="text-slate-500">年間配当:</span>
-                    <span className={`font-medium ${divInfo?.annual !== null && divInfo?.annual !== undefined ? 'text-emerald-600' : 'text-slate-500'}`}>
-                      {formatAnnual(divInfo)}
-                    </span>
-                  </div>
-                  <div className="flex items-center gap-1">
-                    <span className="text-slate-500">配当利回り:</span>
-                    <span className={`font-medium ${divInfo?.yieldValue !== null && divInfo?.yieldValue !== undefined ? 'text-emerald-600' : 'text-slate-500'}`}>
-                      {formatYield(divInfo)}
-                    </span>
-                  </div>
-                </div>
-              </div>
-            </div>
-          );
-        })}
+        {displayData.map((item, index) => (
+          <PortfolioItemCard
+            key={item.securityCode}
+            item={item}
+            index={index}
+            dividendPerShareMap={dividendPerShareMap}
+            dividendStatusMap={dividendStatusMap}
+          />
+        ))}
 
         {/* その他（折りたたみ時） */}
         {!showAll && othersPercentage > 0 && (

--- a/frontend/src/hooks/receipt/useReceiptData.ts
+++ b/frontend/src/hooks/receipt/useReceiptData.ts
@@ -1,4 +1,6 @@
 import { useMemo } from 'react';
+import { useReceiptPageState } from './useReceiptPageState';
+import { type FilterConfig } from '@/lib/utils/searchUtils';
 
 /**
  * 受取データの集計用カスタムフック
@@ -8,4 +10,20 @@ export function useReceiptCalculations<T, C>(
   calculateFunction: (data: T[]) => C
 ): C {
   return useMemo(() => calculateFunction(data), [data, calculateFunction]);
+}
+
+/**
+ * 受取明細コンポーネント共通の基盤フック
+ * previewData があればそちらを優先し、ソート・フィルタ状態を一括で返す
+ */
+export function useReceiptBaseData<T>(
+  data: T[],
+  previewData: T[] | undefined,
+  sort: (items: T[]) => T[],
+  filterConfig: FilterConfig<T>,
+) {
+  const displayData = previewData && previewData.length > 0 ? previewData : data;
+  const sortedData = useMemo(() => sort(displayData), [sort, displayData]);
+  const { searchQuery, setSearchQuery, filteredData } = useReceiptPageState(sortedData, filterConfig);
+  return { sortedData, searchQuery, setSearchQuery, filteredData };
 }

--- a/frontend/src/pages/Receipt/Dividend.tsx
+++ b/frontend/src/pages/Receipt/Dividend.tsx
@@ -17,8 +17,7 @@ import {
     SECURITY_CODE_REGEX
 } from '@/lib/utils/formatters';
 import { renderSecurityCode } from '@/components/atoms/SecurityCodeLink';
-import { useReceiptCalculations } from '@/hooks/receipt/useReceiptData';
-import { useReceiptPageState } from '@/hooks/receipt/useReceiptPageState';
+import { useReceiptCalculations, useReceiptBaseData } from '@/hooks/receipt/useReceiptData';
 import {
     createYearOptions,
     createYearMonthOptions,
@@ -31,7 +30,6 @@ import { DividendInfo } from '@/components/molecules/DividendInfo/DividendInfo';
 import { sortDividendBySettlementDate } from '@/features/receipt/parsers';
 import { calculateDividends } from '@/features/receipt/calculations';
 import { reorderColumnsBySearch, ColumnReorderRule } from '@/lib/utils/columnUtils';
-import { useMemo } from 'react';
 
 // コンポーネント外に定数として定義（毎レンダーで新参照が生成されるのを防ぐ）
 const FILTER_CONFIG: FilterConfig<DividendData> = {
@@ -63,9 +61,8 @@ interface DividendProps {
  * 配当金データを表示するコンポーネント
  */
 export const Dividend: React.FC<DividendProps> = ({ data, previewData }) => {
-    const displayData = previewData && previewData.length > 0 ? previewData : data;
-
-    const dividendData = useMemo(() => sortDividendBySettlementDate(displayData), [displayData]);
+    const { sortedData: dividendData, searchQuery, setSearchQuery, filteredData } =
+        useReceiptBaseData(data, previewData, sortDividendBySettlementDate, FILTER_CONFIG);
 
     // 検索カテゴリーの生成
     const searchCategories = {
@@ -75,9 +72,6 @@ export const Dividend: React.FC<DividendProps> = ({ data, previewData }) => {
         years: createYearOptions(dividendData, item => item.settlement_date),
         yearMonths: createYearMonthOptions(dividendData, item => item.settlement_date)
     };
-
-    // 検索クエリに基づくフィルタリング
-    const { searchQuery, setSearchQuery, filteredData } = useReceiptPageState(dividendData, FILTER_CONFIG);
 
     // 表示用の集計（検索前後で同一ロジック: フィルタ後データから計算）
     const calculations = useReceiptCalculations(filteredData, calculateDividends);

--- a/frontend/src/pages/Receipt/DomesticStock.tsx
+++ b/frontend/src/pages/Receipt/DomesticStock.tsx
@@ -13,8 +13,7 @@ import {
     createISODateKey
 } from '@/lib/utils/formatters';
 import { renderSecurityCode } from '@/components/atoms/SecurityCodeLink';
-import { useReceiptCalculations } from '@/hooks/receipt/useReceiptData';
-import { useReceiptPageState } from '@/hooks/receipt/useReceiptPageState';
+import { useReceiptCalculations, useReceiptBaseData } from '@/hooks/receipt/useReceiptData';
 import {
     createYearOptions,
     createYearMonthOptions,
@@ -24,7 +23,6 @@ import {
 import { sortDomesticStockByTradeDate } from '@/features/receipt/parsers';
 import { calculateDailyData, calculateDomesticStock } from '@/features/receipt/calculations';
 import { reorderColumnsBySearch, ColumnReorderRule } from '@/lib/utils/columnUtils';
-import { useMemo } from 'react';
 
 // コンポーネント外に定数として定義（毎レンダーで新参照が生成されるのを防ぐ）
 const FILTER_CONFIG: FilterConfig<DomesticStockData> = {
@@ -53,9 +51,8 @@ interface DomesticStockProps {
  * 国内株式取引データを表示するコンポーネント
  */
 export const DomesticStock: React.FC<DomesticStockProps> = ({ data, previewData }) => {
-    const displayData = previewData && previewData.length > 0 ? previewData : data;
-
-    const domesticStockData = useMemo(() => sortDomesticStockByTradeDate(displayData), [displayData]);
+    const { sortedData: domesticStockData, searchQuery, setSearchQuery, filteredData } =
+        useReceiptBaseData(data, previewData, sortDomesticStockByTradeDate, FILTER_CONFIG);
 
     // 検索カテゴリーの生成
     const searchCategories = {
@@ -64,9 +61,6 @@ export const DomesticStock: React.FC<DomesticStockProps> = ({ data, previewData 
         years: createYearOptions(domesticStockData, item => item.trade_date),
         yearMonths: createYearMonthOptions(domesticStockData, item => item.trade_date)
     };
-
-    // 検索クエリに基づくフィルタリング
-    const { searchQuery, setSearchQuery, filteredData } = useReceiptPageState(domesticStockData, FILTER_CONFIG);
 
     // 日次集計（searchQuery がある場合はフィルタ後データ、ない場合は全データを使用）
     const filteredDailyData = calculateDailyData(searchQuery ? filteredData : domesticStockData);

--- a/frontend/src/pages/Receipt/Mutualfund.tsx
+++ b/frontend/src/pages/Receipt/Mutualfund.tsx
@@ -13,10 +13,8 @@ import {
     formatNumber
 } from '@/lib/utils/formatters';
 import { createYearOptions, FilterConfig } from '@/lib/utils/searchUtils';
-import { useReceiptCalculations } from '@/hooks/receipt/useReceiptData';
-import { useReceiptPageState } from '@/hooks/receipt/useReceiptPageState';
+import { useReceiptCalculations, useReceiptBaseData } from '@/hooks/receipt/useReceiptData';
 import { sortMutualfundByTradeDate } from '@/features/receipt/parsers';
-import { useMemo } from 'react';
 import { calculateMutualfund } from '@/features/receipt/calculations';
 
 // コンポーネント外に定数として定義（毎レンダーで新参照が生成されるのを防ぐ）
@@ -38,18 +36,14 @@ interface MutualfundProps {
  * 投資信託データを表示するコンポーネント
  */
 export const Mutualfund: React.FC<MutualfundProps> = ({ data, previewData }) => {
-    const displayData = previewData && previewData.length > 0 ? previewData : data;
-
-    const mutualfundData = useMemo(() => sortMutualfundByTradeDate(displayData), [displayData]);
+    const { sortedData: mutualfundData, searchQuery, setSearchQuery, filteredData } =
+        useReceiptBaseData(data, previewData, sortMutualfundByTradeDate, FILTER_CONFIG);
 
     // 検索オプションの生成
     const searchCategories = {
         securities: createSearchOptions(mutualfundData, '', 'fund_name', true),
         years: createYearOptions(mutualfundData, item => item.trade_date)
     };
-
-    // 検索クエリに基づくフィルタリング
-    const { searchQuery, setSearchQuery, filteredData } = useReceiptPageState(mutualfundData, FILTER_CONFIG);
 
     // 表示用の集計（検索前後で同一ロジック: フィルタ後データから計算）
     const calculations = useReceiptCalculations(filteredData, calculateMutualfund);

--- a/frontend/src/pages/Receipts.tsx
+++ b/frontend/src/pages/Receipts.tsx
@@ -102,7 +102,7 @@ export function ReceiptsPage() {
   }, [deleteAll, isAuthenticated, receiptsType]);
 
   const hasCsvFile = rawFile !== null;
-  const dbDataCount = (receiptsType === 'dividend' ? dividendData : receiptsType === 'domesticstock' ? domesticstockData : mutualfundData).length;
+  const dbDataCount = { dividend: dividendData, domesticstock: domesticstockData, mutualfund: mutualfundData }[receiptsType].length;
   const hasDbData = dbDataCount > 0;
   const tabName = TAB_LABEL[receiptsType];
   const importResult = lastImportResults[receiptsType];


### PR DESCRIPTION
## Summary
- `useReceiptBaseData` フックを追加し、Dividend/DomesticStock/Mutualfund 共通の 3行パターン（previewData 切替 → sort → useReceiptPageState）を 1 フック呼び出しに集約
- `Receipts.tsx` の `dbDataCount` 三項演算子ネストをマップ参照に置き換え
- `PortfolioPieChart.tsx` の責務を分離:
  - 配当情報計算・整形ヘルパーをモジュールレベルの純粋関数へ抽出
  - アイテムカード表示を `PortfolioItemCard` サブコンポーネントに分割
  - メインコンポーネントがデータ計算と表示の組み立てに集中

## Test plan
- [x] `npx tsc --noEmit` エラーなし
- [x] `npm run lint` warnings 0
- [x] `npm test` 422 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)