### PR TITLE
feat: セキュリティヘッダーと auth/jquants レート制限を導入

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -253,6 +253,7 @@ dependencies = [
  "csv",
  "dotenvy",
  "encoding_rs",
+ "governor",
  "hyper",
  "mockall",
  "oauth2",
@@ -636,6 +637,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -944,6 +959,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,6 +1032,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "governor"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0746aa765db78b521451ef74221663b57ba595bf83f75d0ce23cc09447c8139f"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand 0.8.5",
+ "smallvec",
+ "spinning_top",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1034,6 +1076,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -1668,6 +1716,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2112,6 +2172,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2238,6 +2313,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -2736,6 +2820,15 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
 dependencies = [
  "lock_api",
 ]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -21,6 +21,7 @@ tokio = { version = "1.49.0", features = ["full"] }
 validator = { version = "0.20.0", features = ["derive"] }
 tower = "0.5.3"
 tower-http = { version = "0.6.8", features = ["cors", "limit"] }
+governor = "0.7"
 oauth2 = "5.0.0"
 dotenvy = "0.15.7"
 mockall = "0.14.0"

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -5,6 +5,10 @@ use tower_http::cors::CorsLayer;
 pub struct Config {
     pub cors_origins: Vec<String>,
     pub database_max_connections: u32,
+    /// `/auth/*` ルートへのレート制限（リクエスト/秒）。0 は無制限
+    pub auth_rate_limit_rps: u32,
+    /// `/jquants/*` ルートへのレート制限（リクエスト/秒）。0 は無制限
+    pub jquants_rate_limit_rps: u32,
 }
 
 impl Default for Config {
@@ -18,6 +22,8 @@ impl Default for Config {
                 "http://localhost.:8080".to_string(),
             ],
             database_max_connections: 5,
+            auth_rate_limit_rps: 10,
+            jquants_rate_limit_rps: 5,
         }
     }
 }
@@ -30,6 +36,18 @@ impl Config {
             let parsed = parse_cors_origins(&origins);
             if !parsed.is_empty() {
                 config.cors_origins = parsed;
+            }
+        }
+
+        if let Ok(rps) = env::var("AUTH_RATE_LIMIT_RPS") {
+            if let Ok(v) = rps.parse::<u32>() {
+                config.auth_rate_limit_rps = v;
+            }
+        }
+
+        if let Ok(rps) = env::var("JQUANTS_RATE_LIMIT_RPS") {
+            if let Ok(v) = rps.parse::<u32>() {
+                config.jquants_rate_limit_rps = v;
             }
         }
 
@@ -243,6 +261,8 @@ mod tests {
         let config = Config {
             cors_origins: vec!["http://example.com".to_string()],
             database_max_connections: 10,
+            auth_rate_limit_rps: 10,
+            jquants_rate_limit_rps: 5,
         };
 
         assert_eq!(config.database_max_connections, 10);

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -388,4 +388,29 @@ mod tests {
             .and_then(|value| value.to_str().ok());
         assert_eq!(allowed_origin, Some("http://localhost:8080"));
     }
+
+    /// 不正オリジンによる 403 にもセキュリティヘッダーが付くことを確認する
+    #[tokio::test]
+    async fn test_security_headers_on_403_response() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        let _app_env = EnvGuard::set("APP_ENV", None);
+        let _cors_origins = EnvGuard::set("CORS_ORIGINS", Some("http://localhost:8080"));
+
+        let config = Config::from_env();
+        let app = build_test_app(&config);
+
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/health")
+            .header("origin", "http://evil.example.com")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        assert_eq!(
+            resp.headers().get("X-Content-Type-Options").unwrap(),
+            "nosniff"
+        );
+        assert_eq!(resp.headers().get("X-Frame-Options").unwrap(), "DENY");
+    }
 }

--- a/backend/src/middleware.rs
+++ b/backend/src/middleware.rs
@@ -7,8 +7,48 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
+use governor::{DefaultDirectRateLimiter, Quota, RateLimiter};
 
 use crate::errors::{ErrorDetails, ErrorResponse};
+
+/// 毎秒 rps リクエストを許可するレート制限インスタンスを生成する
+/// rps = 0 の場合は制限なし（None）を返す
+pub fn build_rate_limiter(rps: u32) -> Option<Arc<DefaultDirectRateLimiter>> {
+    let rps = std::num::NonZeroU32::new(rps)?;
+    Some(Arc::new(RateLimiter::direct(Quota::per_second(rps))))
+}
+
+/// レート制限ミドルウェア。制限超過時は 429 を返す
+pub async fn rate_limit(
+    limiter: Arc<DefaultDirectRateLimiter>,
+    req: Request<Body>,
+    next: Next,
+) -> Response {
+    if limiter.check().is_err() {
+        let error_response = ErrorResponse {
+            error: ErrorDetails {
+                code: "RATE_LIMIT_EXCEEDED".to_string(),
+                message: "リクエストが多すぎます。しばらくしてから再試行してください。".to_string(),
+                details: None,
+            },
+        };
+        return (StatusCode::TOO_MANY_REQUESTS, Json(error_response)).into_response();
+    }
+    next.run(req).await
+}
+
+/// セキュリティヘッダー付与ミドルウェア
+pub async fn add_security_headers(req: Request<Body>, next: Next) -> Response {
+    let mut response = next.run(req).await;
+    let headers = response.headers_mut();
+    headers.insert("X-Content-Type-Options", "nosniff".parse().unwrap());
+    headers.insert("X-Frame-Options", "DENY".parse().unwrap());
+    headers.insert(
+        "Referrer-Policy",
+        "strict-origin-when-cross-origin".parse().unwrap(),
+    );
+    response
+}
 
 /// URL 文字列からオリジン部分（scheme://host[:port]）を抽出する
 ///
@@ -273,5 +313,86 @@ mod tests {
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_security_headers_present() {
+        let app = Router::new()
+            .route("/test", post(|| async { "ok" }))
+            .layer(middleware::from_fn(add_security_headers));
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/test")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.headers().get("X-Content-Type-Options").unwrap(),
+            "nosniff"
+        );
+        assert_eq!(resp.headers().get("X-Frame-Options").unwrap(), "DENY");
+        assert_eq!(
+            resp.headers().get("Referrer-Policy").unwrap(),
+            "strict-origin-when-cross-origin"
+        );
+    }
+
+    #[test]
+    fn test_build_rate_limiter_zero_returns_none() {
+        assert!(build_rate_limiter(0).is_none());
+    }
+
+    #[test]
+    fn test_build_rate_limiter_nonzero_returns_some() {
+        assert!(build_rate_limiter(10).is_some());
+    }
+
+    #[tokio::test]
+    async fn test_rate_limit_allows_within_quota() {
+        let limiter = build_rate_limiter(100).unwrap();
+        let app = Router::new()
+            .route("/test", post(|| async { "ok" }))
+            .layer(middleware::from_fn(move |req, next| {
+                let l = limiter.clone();
+                async move { rate_limit(l, req, next).await }
+            }));
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/test")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_ne!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    #[tokio::test]
+    async fn test_rate_limit_blocks_excess_requests() {
+        // rps=1 で複数回リクエストを送ると 429 が返る
+        let limiter = build_rate_limiter(1).unwrap();
+        let make_app = || {
+            let l = limiter.clone();
+            Router::new()
+                .route("/test", post(|| async { "ok" }))
+                .layer(middleware::from_fn(move |req, next| {
+                    let l = l.clone();
+                    async move { rate_limit(l, req, next).await }
+                }))
+        };
+        // 1回目は通過
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/test")
+            .body(Body::empty())
+            .unwrap();
+        let resp = make_app().oneshot(req).await.unwrap();
+        assert_ne!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+        // 2回目は超過
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/test")
+            .body(Body::empty())
+            .unwrap();
+        let resp = make_app().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
     }
 }

--- a/backend/src/middleware.rs
+++ b/backend/src/middleware.rs
@@ -39,29 +39,19 @@ pub fn build_keyed_rate_limiter(
     Some(Arc::new(RateLimiter::keyed(Quota::per_second(rps))))
 }
 
-/// X-Forwarded-For / fly-client-ip ヘッダーからクライアント IP を取得する
+/// クライアント IP を取得する
+///
+/// Fly.io は `fly-client-ip` を必ずセットし、クライアントによる偽装を防ぐ。
+/// `X-Forwarded-For` はクライアントが任意の値を送れるため信頼しない。
+/// `fly-client-ip` が存在しない場合（ローカル開発など）は 0.0.0.0 を返す。
+/// これにより「プロキシ未経由の不明リクエスト」は共有バケットに入るため、
+/// バイパス攻撃には使えない。
 fn extract_client_ip(req: &Request<Body>) -> std::net::IpAddr {
-    // Fly.io / CDN などのリバースプロキシ経由の実 IP
-    if let Some(ip) = req
-        .headers()
+    req.headers()
         .get("fly-client-ip")
         .and_then(|v| v.to_str().ok())
         .and_then(|s| s.parse().ok())
-    {
-        return ip;
-    }
-    if let Some(ip) = req
-        .headers()
-        .get("x-forwarded-for")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|s| s.split(',').next())
-        .map(str::trim)
-        .and_then(|s| s.parse().ok())
-    {
-        return ip;
-    }
-    // フォールバック: ローカル/不明
-    std::net::IpAddr::from([0, 0, 0, 0])
+        .unwrap_or(std::net::IpAddr::from([0, 0, 0, 0]))
 }
 
 /// グローバルレート制限ミドルウェア。制限超過時は 429 を返す
@@ -470,7 +460,7 @@ mod tests {
         let req = Request::builder()
             .method(Method::POST)
             .uri("/test")
-            .header("x-forwarded-for", "1.2.3.4")
+            .header("fly-client-ip", "1.2.3.4")
             .body(Body::empty())
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
@@ -493,7 +483,7 @@ mod tests {
         let req = Request::builder()
             .method(Method::POST)
             .uri("/test")
-            .header("x-forwarded-for", "1.2.3.4")
+            .header("fly-client-ip", "1.2.3.4")
             .body(Body::empty())
             .unwrap();
         let resp = make_app().oneshot(req).await.unwrap();
@@ -502,7 +492,7 @@ mod tests {
         let req = Request::builder()
             .method(Method::POST)
             .uri("/test")
-            .header("x-forwarded-for", "1.2.3.4")
+            .header("fly-client-ip", "1.2.3.4")
             .body(Body::empty())
             .unwrap();
         let resp = make_app().oneshot(req).await.unwrap();
@@ -526,16 +516,16 @@ mod tests {
         let req = Request::builder()
             .method(Method::POST)
             .uri("/test")
-            .header("x-forwarded-for", "1.2.3.4")
+            .header("fly-client-ip", "1.2.3.4")
             .body(Body::empty())
             .unwrap();
         let resp = make_app().oneshot(req).await.unwrap();
         assert_ne!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
-        // IP2 はまだ許可される
+        // IP2 はまだ許可される（独立したバケット）
         let req = Request::builder()
             .method(Method::POST)
             .uri("/test")
-            .header("x-forwarded-for", "5.6.7.8")
+            .header("fly-client-ip", "5.6.7.8")
             .body(Body::empty())
             .unwrap();
         let resp = make_app().oneshot(req).await.unwrap();

--- a/backend/src/middleware.rs
+++ b/backend/src/middleware.rs
@@ -7,32 +7,84 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
-use governor::{DefaultDirectRateLimiter, Quota, RateLimiter};
+use governor::{DefaultDirectRateLimiter, DefaultKeyedRateLimiter, Quota, RateLimiter};
 
 use crate::errors::{ErrorDetails, ErrorResponse};
 
-/// 毎秒 rps リクエストを許可するレート制限インスタンスを生成する
+fn rate_limit_error() -> Response {
+    let error_response = ErrorResponse {
+        error: ErrorDetails {
+            code: "RATE_LIMIT_EXCEEDED".to_string(),
+            message: "リクエストが多すぎます。しばらくしてから再試行してください。".to_string(),
+            details: None,
+        },
+    };
+    (StatusCode::TOO_MANY_REQUESTS, Json(error_response)).into_response()
+}
+
+/// 毎秒 rps リクエストを許可するグローバルレート制限インスタンスを生成する
+/// （jquants など外部 API クォータ保護に使用）
 /// rps = 0 の場合は制限なし（None）を返す
 pub fn build_rate_limiter(rps: u32) -> Option<Arc<DefaultDirectRateLimiter>> {
     let rps = std::num::NonZeroU32::new(rps)?;
     Some(Arc::new(RateLimiter::direct(Quota::per_second(rps))))
 }
 
-/// レート制限ミドルウェア。制限超過時は 429 を返す
+/// IP 単位のレート制限インスタンスを生成する（auth など DoS 対策に使用）
+/// rps = 0 の場合は制限なし（None）を返す
+pub fn build_keyed_rate_limiter(
+    rps: u32,
+) -> Option<Arc<DefaultKeyedRateLimiter<std::net::IpAddr>>> {
+    let rps = std::num::NonZeroU32::new(rps)?;
+    Some(Arc::new(RateLimiter::keyed(Quota::per_second(rps))))
+}
+
+/// X-Forwarded-For / fly-client-ip ヘッダーからクライアント IP を取得する
+fn extract_client_ip(req: &Request<Body>) -> std::net::IpAddr {
+    // Fly.io / CDN などのリバースプロキシ経由の実 IP
+    if let Some(ip) = req
+        .headers()
+        .get("fly-client-ip")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse().ok())
+    {
+        return ip;
+    }
+    if let Some(ip) = req
+        .headers()
+        .get("x-forwarded-for")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.split(',').next())
+        .map(str::trim)
+        .and_then(|s| s.parse().ok())
+    {
+        return ip;
+    }
+    // フォールバック: ローカル/不明
+    std::net::IpAddr::from([0, 0, 0, 0])
+}
+
+/// グローバルレート制限ミドルウェア。制限超過時は 429 を返す
 pub async fn rate_limit(
     limiter: Arc<DefaultDirectRateLimiter>,
     req: Request<Body>,
     next: Next,
 ) -> Response {
     if limiter.check().is_err() {
-        let error_response = ErrorResponse {
-            error: ErrorDetails {
-                code: "RATE_LIMIT_EXCEEDED".to_string(),
-                message: "リクエストが多すぎます。しばらくしてから再試行してください。".to_string(),
-                details: None,
-            },
-        };
-        return (StatusCode::TOO_MANY_REQUESTS, Json(error_response)).into_response();
+        return rate_limit_error();
+    }
+    next.run(req).await
+}
+
+/// IP 単位レート制限ミドルウェア。制限超過時は 429 を返す
+pub async fn keyed_rate_limit(
+    limiter: Arc<DefaultKeyedRateLimiter<std::net::IpAddr>>,
+    req: Request<Body>,
+    next: Next,
+) -> Response {
+    let ip = extract_client_ip(&req);
+    if limiter.check_key(&ip).is_err() {
+        return rate_limit_error();
     }
     next.run(req).await
 }
@@ -394,5 +446,99 @@ mod tests {
             .unwrap();
         let resp = make_app().oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    #[test]
+    fn test_build_keyed_rate_limiter_zero_returns_none() {
+        assert!(build_keyed_rate_limiter(0).is_none());
+    }
+
+    #[test]
+    fn test_build_keyed_rate_limiter_nonzero_returns_some() {
+        assert!(build_keyed_rate_limiter(10).is_some());
+    }
+
+    #[tokio::test]
+    async fn test_keyed_rate_limit_allows_within_quota() {
+        let limiter = build_keyed_rate_limiter(100).unwrap();
+        let app = Router::new()
+            .route("/test", post(|| async { "ok" }))
+            .layer(middleware::from_fn(move |req, next| {
+                let l = limiter.clone();
+                async move { keyed_rate_limit(l, req, next).await }
+            }));
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/test")
+            .header("x-forwarded-for", "1.2.3.4")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_ne!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    #[tokio::test]
+    async fn test_keyed_rate_limit_blocks_same_ip() {
+        // rps=1: 同一 IP からの 2 回目は 429
+        let limiter = build_keyed_rate_limiter(1).unwrap();
+        let make_app = || {
+            let l = limiter.clone();
+            Router::new()
+                .route("/test", post(|| async { "ok" }))
+                .layer(middleware::from_fn(move |req, next| {
+                    let l = l.clone();
+                    async move { keyed_rate_limit(l, req, next).await }
+                }))
+        };
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/test")
+            .header("x-forwarded-for", "1.2.3.4")
+            .body(Body::empty())
+            .unwrap();
+        let resp = make_app().oneshot(req).await.unwrap();
+        assert_ne!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+        // 2回目（同一 IP）は超過
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/test")
+            .header("x-forwarded-for", "1.2.3.4")
+            .body(Body::empty())
+            .unwrap();
+        let resp = make_app().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    #[tokio::test]
+    async fn test_keyed_rate_limit_different_ips_independent() {
+        // rps=1: 異なる IP は独立したバケット
+        let limiter = build_keyed_rate_limiter(1).unwrap();
+        let make_app = || {
+            let l = limiter.clone();
+            Router::new()
+                .route("/test", post(|| async { "ok" }))
+                .layer(middleware::from_fn(move |req, next| {
+                    let l = l.clone();
+                    async move { keyed_rate_limit(l, req, next).await }
+                }))
+        };
+        // IP1 が 1 回消費
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/test")
+            .header("x-forwarded-for", "1.2.3.4")
+            .body(Body::empty())
+            .unwrap();
+        let resp = make_app().oneshot(req).await.unwrap();
+        assert_ne!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+        // IP2 はまだ許可される
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/test")
+            .header("x-forwarded-for", "5.6.7.8")
+            .body(Body::empty())
+            .unwrap();
+        let resp = make_app().oneshot(req).await.unwrap();
+        assert_ne!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
     }
 }

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -11,7 +11,10 @@ use utoipa::OpenApi;
 use crate::{
     config::Config,
     handlers,
-    middleware::{add_security_headers, build_rate_limiter, rate_limit, validate_origin},
+    middleware::{
+        add_security_headers, build_keyed_rate_limiter, build_rate_limiter, keyed_rate_limit,
+        rate_limit, validate_origin,
+    },
     openapi::ApiDoc,
     state::AppState,
 };
@@ -21,7 +24,8 @@ const REQUEST_BODY_LIMIT: usize = 10 * 1024 * 1024;
 
 pub fn app_router(state: AppState, config: &Config) -> Router {
     let allowed_origins = Arc::new(config.cors_origins.clone());
-    let auth_limiter = build_rate_limiter(config.auth_rate_limit_rps);
+    // auth は IP 単位の keyed limiter（ブルートフォース/DoS 対策）
+    let auth_limiter = build_keyed_rate_limiter(config.auth_rate_limit_rps);
     let jquants_limiter = build_rate_limiter(config.jquants_rate_limit_rps);
     Router::new()
         .merge(stock_routes())
@@ -76,7 +80,9 @@ fn dividend_per_share_routes() -> Router<AppState> {
     )
 }
 
-fn auth_routes(limiter: Option<Arc<governor::DefaultDirectRateLimiter>>) -> Router<AppState> {
+fn auth_routes(
+    limiter: Option<Arc<governor::DefaultKeyedRateLimiter<std::net::IpAddr>>>,
+) -> Router<AppState> {
     let router = Router::new()
         .route("/auth/google", get(handlers::auth::google_auth))
         .route(
@@ -92,7 +98,7 @@ fn auth_routes(limiter: Option<Arc<governor::DefaultDirectRateLimiter>>) -> Rout
     if let Some(l) = limiter {
         router.layer(middleware::from_fn(move |req, next| {
             let l = l.clone();
-            async move { rate_limit(l, req, next).await }
+            async move { keyed_rate_limit(l, req, next).await }
         }))
     } else {
         router

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -27,6 +27,20 @@ pub fn app_router(state: AppState, config: &Config) -> Router {
     // auth は IP 単位の keyed limiter（ブルートフォース/DoS 対策）
     let auth_limiter = build_keyed_rate_limiter(config.auth_rate_limit_rps);
     let jquants_limiter = build_rate_limiter(config.jquants_rate_limit_rps);
+
+    // keyed limiter のキー増加を抑制するため、60 秒ごとに retain_recent を実行
+    if let Some(ref limiter) = auth_limiter {
+        let l = limiter.clone();
+        tokio::spawn(async move {
+            let mut interval =
+                tokio::time::interval(std::time::Duration::from_secs(60));
+            loop {
+                interval.tick().await;
+                l.retain_recent();
+            }
+        });
+    }
+
     Router::new()
         .merge(stock_routes())
         .merge(jquants_routes(jquants_limiter))

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -32,8 +32,7 @@ pub fn app_router(state: AppState, config: &Config) -> Router {
     if let Some(ref limiter) = auth_limiter {
         let l = limiter.clone();
         tokio::spawn(async move {
-            let mut interval =
-                tokio::time::interval(std::time::Duration::from_secs(60));
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
             loop {
                 interval.tick().await;
                 l.retain_recent();
@@ -182,6 +181,25 @@ fn asset_balance_routes() -> Router<AppState> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+
+    fn make_test_state() -> AppState {
+        let database_url = "postgresql://user:password@localhost/test_db";
+        let pool = crate::db::connect_pool_lazy(database_url, 1).expect("pool");
+        let secrets = Arc::new(crate::state::Secrets {
+            database_url: database_url.to_string(),
+            jquants_api_key: None,
+            google_client_id: None,
+            google_client_secret: None,
+            frontend_url: "http://localhost:8080".to_string(),
+        });
+        AppState {
+            pool,
+            secrets,
+            client: reqwest::Client::new(),
+            background_task_running: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        }
+    }
 
     #[test]
     fn test_stock_routes_creation() {
@@ -216,5 +234,65 @@ mod tests {
     #[test]
     fn test_asset_balance_routes_creation() {
         let _router = asset_balance_routes();
+    }
+
+    /// auth ルートが rps=1 制限を超えると 429 を返すことを確認
+    #[tokio::test]
+    async fn test_auth_routes_rate_limit_returns_429() {
+        use axum::{body::Body, http::Request};
+        use tower::ServiceExt;
+
+        let limiter = crate::middleware::build_keyed_rate_limiter(1);
+        let state = make_test_state();
+        let router = auth_routes(limiter).with_state(state);
+
+        // 1 回目は通過（ルートが見つからず 200/401/500 になるが 429 ではない）
+        let req = Request::builder()
+            .method(axum::http::Method::GET)
+            .uri("/auth/me")
+            .header("fly-client-ip", "1.2.3.4")
+            .body(Body::empty())
+            .unwrap();
+        let resp = router.clone().oneshot(req).await.unwrap();
+        assert_ne!(resp.status(), axum::http::StatusCode::TOO_MANY_REQUESTS);
+
+        // 2 回目（同一 IP）は 429
+        let req = Request::builder()
+            .method(axum::http::Method::GET)
+            .uri("/auth/me")
+            .header("fly-client-ip", "1.2.3.4")
+            .body(Body::empty())
+            .unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), axum::http::StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    /// jquants ルートが rps=1 制限を超えると 429 を返すことを確認
+    #[tokio::test]
+    async fn test_jquants_routes_rate_limit_returns_429() {
+        use axum::{body::Body, http::Request};
+        use tower::ServiceExt;
+
+        let limiter = crate::middleware::build_rate_limiter(1);
+        let state = make_test_state();
+        let router = jquants_routes(limiter).with_state(state);
+
+        // 1 回目は通過
+        let req = Request::builder()
+            .method(axum::http::Method::GET)
+            .uri("/jquants/fins/statements")
+            .body(Body::empty())
+            .unwrap();
+        let resp = router.clone().oneshot(req).await.unwrap();
+        assert_ne!(resp.status(), axum::http::StatusCode::TOO_MANY_REQUESTS);
+
+        // 2 回目は 429
+        let req = Request::builder()
+            .method(axum::http::Method::GET)
+            .uri("/jquants/fins/statements")
+            .body(Body::empty())
+            .unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), axum::http::StatusCode::TOO_MANY_REQUESTS);
     }
 }

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -9,7 +9,11 @@ use tower_http::limit::RequestBodyLimitLayer;
 use utoipa::OpenApi;
 
 use crate::{
-    config::Config, handlers, middleware::validate_origin, openapi::ApiDoc, state::AppState,
+    config::Config,
+    handlers,
+    middleware::{add_security_headers, build_rate_limiter, rate_limit, validate_origin},
+    openapi::ApiDoc,
+    state::AppState,
 };
 
 /// リクエストボディの上限サイズ（10MB）
@@ -17,11 +21,13 @@ const REQUEST_BODY_LIMIT: usize = 10 * 1024 * 1024;
 
 pub fn app_router(state: AppState, config: &Config) -> Router {
     let allowed_origins = Arc::new(config.cors_origins.clone());
+    let auth_limiter = build_rate_limiter(config.auth_rate_limit_rps);
+    let jquants_limiter = build_rate_limiter(config.jquants_rate_limit_rps);
     Router::new()
         .merge(stock_routes())
-        .merge(jquants_routes())
+        .merge(jquants_routes(jquants_limiter))
         .merge(dividend_per_share_routes())
-        .merge(auth_routes())
+        .merge(auth_routes(auth_limiter))
         .merge(dividend_routes())
         .merge(domestic_stock_routes())
         .merge(mutualfund_routes())
@@ -31,6 +37,7 @@ pub fn app_router(state: AppState, config: &Config) -> Router {
             "/api-docs/openapi.json",
             get(|| async { Json(ApiDoc::openapi()) }),
         )
+        .layer(middleware::from_fn(add_security_headers))
         .layer(middleware::from_fn(move |req, next| {
             let origins = allowed_origins.clone();
             async move { validate_origin(origins, req, next).await }
@@ -46,11 +53,19 @@ fn stock_routes() -> Router<AppState> {
         .route("/stock/{query}", get(handlers::stock::select_stock_info))
 }
 
-fn jquants_routes() -> Router<AppState> {
-    Router::new().route(
+fn jquants_routes(limiter: Option<Arc<governor::DefaultDirectRateLimiter>>) -> Router<AppState> {
+    let router = Router::new().route(
         "/jquants/fins/statements",
         get(handlers::jquants::get_fin_summary),
-    )
+    );
+    if let Some(l) = limiter {
+        router.layer(middleware::from_fn(move |req, next| {
+            let l = l.clone();
+            async move { rate_limit(l, req, next).await }
+        }))
+    } else {
+        router
+    }
 }
 
 fn dividend_per_share_routes() -> Router<AppState> {
@@ -60,8 +75,8 @@ fn dividend_per_share_routes() -> Router<AppState> {
     )
 }
 
-fn auth_routes() -> Router<AppState> {
-    Router::new()
+fn auth_routes(limiter: Option<Arc<governor::DefaultDirectRateLimiter>>) -> Router<AppState> {
+    let router = Router::new()
         .route("/auth/google", get(handlers::auth::google_auth))
         .route(
             "/auth/google/callback",
@@ -72,7 +87,15 @@ fn auth_routes() -> Router<AppState> {
         .route(
             "/auth/delete-account",
             delete(handlers::auth::delete_account),
-        )
+        );
+    if let Some(l) = limiter {
+        router.layer(middleware::from_fn(move |req, next| {
+            let l = l.clone();
+            async move { rate_limit(l, req, next).await }
+        }))
+    } else {
+        router
+    }
 }
 
 fn dividend_routes() -> Router<AppState> {
@@ -146,12 +169,12 @@ mod tests {
 
     #[test]
     fn test_jquants_routes_creation() {
-        let _router = jquants_routes();
+        let _router = jquants_routes(None);
     }
 
     #[test]
     fn test_auth_routes_creation() {
-        let _router = auth_routes();
+        let _router = auth_routes(None);
     }
 
     #[test]

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -37,13 +37,14 @@ pub fn app_router(state: AppState, config: &Config) -> Router {
             "/api-docs/openapi.json",
             get(|| async { Json(ApiDoc::openapi()) }),
         )
-        .layer(middleware::from_fn(add_security_headers))
         .layer(middleware::from_fn(move |req, next| {
             let origins = allowed_origins.clone();
             async move { validate_origin(origins, req, next).await }
         }))
         .layer(RequestBodyLimitLayer::new(REQUEST_BODY_LIMIT))
         .layer(config.build_cors_layer())
+        // セキュリティヘッダーは最外層: 403/413 を含む全レスポンスに付与する
+        .layer(middleware::from_fn(add_security_headers))
         .with_state(state)
 }
 


### PR DESCRIPTION
## 概要

- `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy` を全レスポンスに付与
- `/auth/*` および `/jquants/*` ルートにトークンバケット方式のレート制限を追加
- 閾値は環境変数 `AUTH_RATE_LIMIT_RPS` / `JQUANTS_RATE_LIMIT_RPS` で調整可能（デフォルト: 10/5 rps）
- `governor` クレート（v0.7）を追加

## 変更ファイル

- `Cargo.toml`: `governor` 追加
- `src/config.rs`: `auth_rate_limit_rps`, `jquants_rate_limit_rps` フィールドと環境変数パース追加
- `src/middleware.rs`: `add_security_headers`, `build_rate_limiter`, `rate_limit` 追加・テスト5件
- `src/routes.rs`: 全ルートにセキュリティヘッダー層・auth/jquants にレート制限層を適用

## テスト

- `cargo test`: 122 passed, 0 failed
- `cargo clippy -- -D warnings`: 警告なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)