### PR TITLE
refactor: CSV multipart ヘルパーを lib/api/csvHelpers に共通化

### DIFF
--- a/frontend/src/features/assetBalance/api/assetBalanceApi.ts
+++ b/frontend/src/features/assetBalance/api/assetBalanceApi.ts
@@ -1,21 +1,6 @@
 import { apiClient } from '@/lib/api/client';
+import { uploadCsvFile, previewCsvFile } from '@/lib/api/csvHelpers';
 import { AssetBalanceData } from '@/lib/interfaces/assetBalance';
-import type { components } from '@/generated/api';
-
-type CsvPreviewResponse = components['schemas']['CsvPreviewResponse'];
-type CsvUploadResponse = components['schemas']['CsvUploadResponse'];
-
-const uploadCsvFile = (path: string, file: File) => {
-  const formData = new FormData();
-  formData.append('file', file);
-  return apiClient.post<CsvUploadResponse>(path, formData, { withCredentials: true });
-};
-
-const previewCsvFile = (path: string, file: File) => {
-  const formData = new FormData();
-  formData.append('file', file);
-  return apiClient.post<CsvPreviewResponse>(path, formData, { withCredentials: true });
-};
 
 export const assetBalanceApi = {
   list: () =>

--- a/frontend/src/features/receipt/api/receiptApi.ts
+++ b/frontend/src/features/receipt/api/receiptApi.ts
@@ -1,25 +1,8 @@
 import { apiClient } from '@/lib/api/client';
+import { uploadCsvFile, previewCsvFile } from '@/lib/api/csvHelpers';
 import { DividendData } from '@/lib/interfaces/dividend';
 import { DomesticStockData } from '@/lib/interfaces/domesticStock';
 import { MutualfundData } from '@/lib/interfaces/mutualfund';
-import type { components } from '@/generated/api';
-
-// APIレスポンス型（OpenAPI スキーマから生成）
-type CsvUploadResponse = components['schemas']['CsvUploadResponse'];
-type CsvPreviewResponse = components['schemas']['CsvPreviewResponse'];
-
-// CSV ファイルを multipart/form-data で送信
-const uploadCsvFile = (path: string, file: File) => {
-  const formData = new FormData();
-  formData.append('file', file);
-  return apiClient.post<CsvUploadResponse>(path, formData, { withCredentials: true });
-};
-
-const previewCsvFile = (path: string, file: File) => {
-  const formData = new FormData();
-  formData.append('file', file);
-  return apiClient.post<CsvPreviewResponse>(path, formData, { withCredentials: true });
-};
 
 // 配当金API
 export const dividendApi = {
@@ -59,4 +42,3 @@ export const mutualfundApi = {
   deleteAll: async () =>
     apiClient.delete('/mutualfunds/all', { withCredentials: true }),
 };
-

--- a/frontend/src/lib/api/csvHelpers.ts
+++ b/frontend/src/lib/api/csvHelpers.ts
@@ -1,0 +1,17 @@
+import { apiClient } from '@/lib/api/client';
+import type { components } from '@/generated/api';
+
+type CsvUploadResponse = components['schemas']['CsvUploadResponse'];
+type CsvPreviewResponse = components['schemas']['CsvPreviewResponse'];
+
+export const uploadCsvFile = (path: string, file: File) => {
+  const formData = new FormData();
+  formData.append('file', file);
+  return apiClient.post<CsvUploadResponse>(path, formData, { withCredentials: true });
+};
+
+export const previewCsvFile = (path: string, file: File) => {
+  const formData = new FormData();
+  formData.append('file', file);
+  return apiClient.post<CsvPreviewResponse>(path, formData, { withCredentials: true });
+};


### PR DESCRIPTION
## 変更内容

`receiptApi.ts` と `assetBalanceApi.ts` で完全重複していた `uploadCsvFile` / `previewCsvFile` ヘルパー関数を `frontend/src/lib/api/csvHelpers.ts` に抽出。

## テスト結果

- `npm run lint`: 通過
- `npx tsc --noEmit`: 通過
- `npm test`: 42 ファイル 422 テスト通過