### PR TITLE
feat: tower-http TraceLayer と RequestId で可観測性を強化

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3466,6 +3466,8 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -20,7 +20,7 @@ thiserror = "2.0.18"
 tokio = { version = "1.49.0", features = ["full"] }
 validator = { version = "0.20.0", features = ["derive"] }
 tower = "0.5.3"
-tower-http = { version = "0.6.8", features = ["cors", "limit"] }
+tower-http = { version = "0.6.8", features = ["cors", "limit", "trace", "request-id"] }
 governor = "0.7"
 oauth2 = "5.0.0"
 dotenvy = "0.15.7"

--- a/backend/src/middleware.rs
+++ b/backend/src/middleware.rs
@@ -24,10 +24,18 @@ pub struct PathOnlyMakeSpan;
 
 impl<B> MakeSpan<B> for PathOnlyMakeSpan {
     fn make_span(&mut self, request: &AxumRequest<B>) -> tracing::Span {
+        // x-request-id は SetRequestIdLayer より内側で span を作るため、
+        // ここで読んだ値がそのままログ相関 ID として機能する
+        let request_id = request
+            .headers()
+            .get("x-request-id")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("-");
         tracing::debug_span!(
             "http_request",
             method = %request.method(),
             path = request.uri().path(),
+            request_id = request_id,
         )
     }
 }

--- a/backend/src/middleware.rs
+++ b/backend/src/middleware.rs
@@ -9,7 +9,28 @@ use axum::{
 };
 use governor::{DefaultDirectRateLimiter, DefaultKeyedRateLimiter, Quota, RateLimiter};
 
+use axum::http::Request as AxumRequest;
+use tower_http::trace::MakeSpan;
+
 use crate::errors::{ErrorDetails, ErrorResponse};
+
+/// TraceLayer 用スパンメーカー（クエリパラメータを除外）
+///
+/// `TraceLayer::new_for_http()` の既定実装はクエリ文字列込みの URI を記録するため、
+/// OAuth コールバックの `code` / `state` など機密パラメータがログに残る。
+/// このスパンメーカーはパスのみを記録し機密情報の漏洩を防ぐ。
+#[derive(Clone, Copy, Debug)]
+pub struct PathOnlyMakeSpan;
+
+impl<B> MakeSpan<B> for PathOnlyMakeSpan {
+    fn make_span(&mut self, request: &AxumRequest<B>) -> tracing::Span {
+        tracing::debug_span!(
+            "http_request",
+            method = %request.method(),
+            path = request.uri().path(),
+        )
+    }
+}
 
 fn rate_limit_error() -> Response {
     let error_response = ErrorResponse {

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -17,7 +17,7 @@ use crate::{
     handlers,
     middleware::{
         add_security_headers, build_keyed_rate_limiter, build_rate_limiter, keyed_rate_limit,
-        rate_limit, validate_origin,
+        rate_limit, validate_origin, PathOnlyMakeSpan,
     },
     openapi::ApiDoc,
     state::AppState,
@@ -64,8 +64,8 @@ pub fn app_router(state: AppState, config: &Config) -> Router {
         }))
         .layer(RequestBodyLimitLayer::new(REQUEST_BODY_LIMIT))
         .layer(config.build_cors_layer())
-        // リクエストトレース（メソッド/パス/ステータス/レイテンシ）
-        .layer(TraceLayer::new_for_http())
+        // リクエストトレース（パスのみ記録：クエリパラメータの機密情報漏洩を防ぐ）
+        .layer(TraceLayer::new_for_http().make_span_with(PathOnlyMakeSpan))
         // x-request-id をレスポンスに伝播
         .layer(PropagateRequestIdLayer::x_request_id())
         // x-request-id が未設定の場合は UUID v4 を自動付与
@@ -304,5 +304,46 @@ mod tests {
             .unwrap();
         let resp = router.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), axum::http::StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    /// x-request-id がレスポンスに伝播されることを確認
+    #[tokio::test]
+    async fn test_request_id_propagated_to_response() {
+        use axum::{body::Body, http::Request, routing::get, Router};
+        use tower::ServiceExt;
+        use tower_http::request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer};
+
+        let router: Router = Router::new()
+            .route("/health", get(|| async { "OK" }))
+            .layer(PropagateRequestIdLayer::x_request_id())
+            .layer(SetRequestIdLayer::x_request_id(MakeRequestUuid));
+
+        // x-request-id ヘッダーなし → 自動生成されてレスポンスに付与される
+        let req = Request::builder()
+            .method(axum::http::Method::GET)
+            .uri("/health")
+            .body(Body::empty())
+            .unwrap();
+        let resp = router.clone().oneshot(req).await.unwrap();
+        assert!(
+            resp.headers().contains_key("x-request-id"),
+            "x-request-id should be auto-generated"
+        );
+
+        // x-request-id ヘッダーあり → 既存値がそのままレスポンスに伝播される
+        let req = Request::builder()
+            .method(axum::http::Method::GET)
+            .uri("/health")
+            .header("x-request-id", "my-custom-id")
+            .body(Body::empty())
+            .unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.headers()
+                .get("x-request-id")
+                .and_then(|v| v.to_str().ok()),
+            Some("my-custom-id"),
+            "existing x-request-id should be propagated unchanged"
+        );
     }
 }

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -5,7 +5,11 @@ use axum::{
     routing::{delete, get, post},
     Json, Router,
 };
-use tower_http::limit::RequestBodyLimitLayer;
+use tower_http::{
+    limit::RequestBodyLimitLayer,
+    request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer},
+    trace::TraceLayer,
+};
 use utoipa::OpenApi;
 
 use crate::{
@@ -60,6 +64,12 @@ pub fn app_router(state: AppState, config: &Config) -> Router {
         }))
         .layer(RequestBodyLimitLayer::new(REQUEST_BODY_LIMIT))
         .layer(config.build_cors_layer())
+        // リクエストトレース（メソッド/パス/ステータス/レイテンシ）
+        .layer(TraceLayer::new_for_http())
+        // x-request-id をレスポンスに伝播
+        .layer(PropagateRequestIdLayer::x_request_id())
+        // x-request-id が未設定の場合は UUID v4 を自動付与
+        .layer(SetRequestIdLayer::x_request_id(MakeRequestUuid))
         // セキュリティヘッダーは最外層: 403/413 を含む全レスポンスに付与する
         .layer(middleware::from_fn(add_security_headers))
         .with_state(state)


### PR DESCRIPTION
## 変更内容

P1-6: 可観測性基盤の追加

| 機能 | 詳細 |
|---|---|
| `TraceLayer` | リクエスト/レスポンスごとにメソッド・パス・ステータス・レイテンシを DEBUG ログに自動記録 |
| `SetRequestIdLayer` | `x-request-id` ヘッダー未設定時に UUID v4 を自動付与 |
| `PropagateRequestIdLayer` | `x-request-id` をレスポンスヘッダーに伝播（クライアント側でのリクエスト相関に使用可能） |

### ミドルウェア配置

```
request → [security_headers] → [SetRequestId] → [PropagateRequestId] → [TraceLayer] → [CORS] → ...
```

SetRequestId が最外層に近く、TraceLayer は ID 付与後に記録するため、全スパンで x-request-id を参照できる。

## テスト結果

- `cargo fmt --check`: 通過
- `cargo clippy -- -D warnings`: 通過
- `cargo test`: 通過