### PR TITLE
docs: アーキテクチャ / 運用ランブック / テストガイドを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,14 @@ shoken-webapp/
 公開 URL:
 - https://shoken-webapp.vercel.app
 
+## ドキュメント
+
+| ドキュメント | 内容 |
+|---|---|
+| [アーキテクチャ概要](docs/architecture.md) | システム構成・認証フロー・ミドルウェアスタック・CSV設計 |
+| [運用ランブック](docs/runbook.md) | ローカル起動・デプロイ・DBマイグレーション・トラブルシューティング |
+| [テストガイド](docs/testing.md) | フロントエンド・バックエンド・E2Eテストの実行方法と方針 |
+
 ## 補足
 
 - フロントエンド詳細: `frontend/README.md`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -92,7 +92,7 @@ CSV ファイルのアップロードは2段階:
 Client → POST /asset-balances/csv
   → middleware stack
   → handler::asset_balance::upload_csv
-  → services::csv_import::parse_asset_balance_csv
+  → services::csv_import::parse_csv (with parse_asset_balance_row)
   → services::asset_balance::bulk_create (DELETE ALL → INSERT)
   → 200 { inserted, skipped, errors }
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -94,5 +94,5 @@ Client → POST /asset-balances/csv
   → handler::asset_balance::upload_csv
   → services::csv_import::parse_csv (with parse_asset_balance_row)
   → services::asset_balance::bulk_create (DELETE ALL → INSERT)
-  → 200 { inserted, skipped, errors }
+  → 201 { inserted, skipped, errors }
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,98 @@
+# アーキテクチャ概要
+
+## システム構成
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Browser                                                     │
+│  React 19 + TypeScript (Vite)                               │
+│  Vercel でホスティング                                        │
+└───────────────────────────┬─────────────────────────────────┘
+                            │ HTTPS / Axios
+┌───────────────────────────▼─────────────────────────────────┐
+│ Backend API (Fly.io)                                        │
+│  Rust + Axum 0.8                                            │
+│  ├── 認証ミドルウェア（CSRF / レート制限 / セキュリティヘッダー）│
+│  ├── ハンドラー層 (handlers/)                                 │
+│  ├── サービス層 (services/)                                   │
+│  └── SQLx → PostgreSQL (Neon)                               │
+└─────────────────────────────────────────────────────────────┘
+         │                              │
+         │ Google OAuth 2.0            │ J-Quants API
+         ▼                              ▼
+   accounts.google.com          jpx-jquants.com
+```
+
+## ディレクトリ構成
+
+```
+shoken-webapp/
+├── frontend/
+│   ├── src/
+│   │   ├── components/    # Atomic Design (atoms/molecules/organisms/templates)
+│   │   ├── features/      # auth / stock / receipt / assetBalance / jquants
+│   │   ├── hooks/
+│   │   ├── pages/
+│   │   ├── lib/           # api client / csv utils / interfaces / types / utils
+│   │   ├── contexts/
+│   │   ├── routes/
+│   │   └── styles/
+│   └── e2e/               # Playwright E2E テスト
+├── backend/
+│   └── src/
+│       ├── handlers/      # HTTP ハンドラー（ドメイン別）
+│       ├── services/      # ビジネスロジック（CSV パース / DB アクセス）
+│       ├── models/        # データモデル・バリデーション
+│       ├── extractors/    # カスタム Axum エクストラクター
+│       ├── middleware.rs  # 認証・レート制限・セキュリティヘッダー・TraceLayer
+│       ├── routes.rs      # ルーティング定義
+│       ├── config.rs      # 環境変数読み込み
+│       ├── errors.rs      # 統一エラーハンドリング
+│       └── state.rs       # AppState (DB pool / secrets / HTTP client)
+├── docs/                  # 設計・運用ドキュメント
+└── .github/               # CI/CD ワークフロー / Dependabot 設定
+```
+
+## 認証フロー
+
+```
+1. フロント → GET /auth/google
+2. バックエンド → Google OAuth 認証ページへリダイレクト
+3. Google → GET /auth/google/callback?code=...&state=...
+4. バックエンド → セッション Cookie 発行（session_token, Max-Age=7日）
+5. フロント → GET /auth/me でユーザー情報取得
+```
+
+CSRF 対策: `Origin` / `Referer` ヘッダーによるオリジン検証
+
+## セキュリティ層（ミドルウェアスタック）
+
+内側から外側の順:
+
+1. ルートハンドラー
+2. ドメイン別ミドルウェア（keyed レート制限 / global レート制限）
+3. `validate_origin`（CSRF 防止）
+4. `RequestBodyLimitLayer`（10MB 上限）
+5. CORS
+6. `TraceLayer`（リクエストトレース、クエリパラメータ除外）
+7. `PropagateRequestIdLayer`（x-request-id をレスポンスに伝播）
+8. `SetRequestIdLayer`（x-request-id の UUID 自動付与）
+9. `add_security_headers`（最外層: すべてのレスポンスに付与）
+
+## CSV インポート設計
+
+CSV ファイルのアップロードは2段階:
+
+1. **プレビュー** `POST /xxx/csv/preview`: ファイルをパースして行エラー一覧を返す（DB 書き込みなし）
+2. **確定保存** `POST /xxx/csv`: パース + DB 挿入（ON CONFLICT DO NOTHING / occurrence_index）
+
+## データフロー（保有銘柄 CSV の場合）
+
+```
+Client → POST /asset-balances/csv
+  → middleware stack
+  → handler::asset_balance::upload_csv
+  → services::csv_import::parse_asset_balance_csv
+  → services::asset_balance::bulk_create (DELETE ALL → INSERT)
+  → 200 { inserted, skipped, errors }
+```

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -28,8 +28,8 @@ echo "VITE_SHOKEN_WEBAPI_API_URL=http://127.0.0.1:3001" > frontend/.env.developm
 
 | サービス | デプロイ先 | トリガー |
 |---|---|---|
-| フロントエンド | Vercel | main push |
-| バックエンド | Fly.io | main push |
+| フロントエンド | Vercel | main push（Vercel GitHub 連携） |
+| バックエンド | Fly.io | main push（`deploy-backend.yml`） |
 
 ### 手動デプロイ（緊急時）
 
@@ -45,10 +45,10 @@ echo "VITE_SHOKEN_WEBAPI_API_URL=http://127.0.0.1:3001" > frontend/.env.developm
 
 ```bash
 # バックエンド
-curl https://shoken-webapp-backend.fly.dev/health
+curl https://shoken-backend.fly.dev/health
 
 # ログ確認
-fly logs --app shoken-webapp-backend
+fly logs --app shoken-backend
 ```
 
 ## データベースマイグレーション
@@ -73,7 +73,7 @@ fly secrets set DATABASE_URL="postgresql://..."
 fly secrets set GOOGLE_CLIENT_ID="..."
 fly secrets set GOOGLE_CLIENT_SECRET="..."
 fly secrets set FRONTEND_URL="https://shoken-webapp.vercel.app"
-fly secrets set BACKEND_URL="https://shoken-webapp-backend.fly.dev"
+fly secrets set BACKEND_URL="https://shoken-backend.fly.dev"
 ```
 
 ## セキュリティインシデント対応

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -8,7 +8,7 @@ git clone https://github.com/zaichu/shoken-webapp.git
 cd shoken-webapp
 
 # 2. 環境変数を設定
-cd backend && cp .env.example .env  # DATABASE_URL 等を設定
+(cd backend && cp .env.example .env)  # DATABASE_URL 等を設定
 echo "VITE_SHOKEN_WEBAPI_API_URL=http://127.0.0.1:3001" > frontend/.env.development.local
 
 # 3. 一括起動（推奨）
@@ -35,10 +35,10 @@ echo "VITE_SHOKEN_WEBAPI_API_URL=http://127.0.0.1:3001" > frontend/.env.developm
 
 ```bash
 # バックエンド
-cd backend && make deploy
+(cd backend && make deploy)
 
 # フロントエンド（Vercel CLI）
-cd frontend && vercel --prod
+(cd frontend && vercel --prod)
 ```
 
 ## ヘルスチェック
@@ -54,16 +54,14 @@ fly logs --app shoken-webapp-backend
 ## データベースマイグレーション
 
 ```bash
-cd backend
-
 # マイグレーション作成
-sqlx migrate add <migration_name>
+(cd backend && sqlx migrate add <migration_name>)
 
 # マイグレーション実行（起動時に自動実行）
-make run
+(cd backend && make run)
 
 # オフラインモード用 sqlx-data 更新
-make sqlx-prepare
+(cd backend && make sqlx-prepare)
 ```
 
 ## 環境変数（本番）
@@ -86,8 +84,8 @@ fly secrets set BACKEND_URL="https://shoken-webapp-backend.fly.dev"
 脆弱性が発見された場合:
 ```bash
 # 依存関係の脆弱性チェック
-cd backend && cargo audit
-cd frontend && npm audit
+(cd backend && cargo audit)
+(cd frontend && npm audit)
 ```
 
 ## Dependabot PR 対応
@@ -102,21 +100,21 @@ cd frontend && npm audit
 ### DB 接続失敗
 
 ```bash
-cd backend && make db-up  # Docker で PostgreSQL を起動
+(cd backend && make db-up)  # Docker で PostgreSQL を起動
 ```
 
 ### バックエンドビルドエラー
 
 ```bash
-cd backend && cargo check  # コンパイルエラー確認
-cd backend && cargo fmt     # フォーマット修正
+(cd backend && cargo check)  # コンパイルエラー確認
+(cd backend && cargo fmt)    # フォーマット修正
 ```
 
 ### フロントエンドの型エラー
 
 ```bash
-cd frontend && npx tsc --noEmit  # 型エラー確認
-cd frontend && npm run lint      # Lint エラー確認
+(cd frontend && npx tsc --noEmit)  # 型エラー確認
+(cd frontend && npm run lint)      # Lint エラー確認
 ```
 
 ### OpenAPI スキーマと api.ts の不一致

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,126 @@
+# 運用ランブック
+
+## ローカル開発環境の起動
+
+```bash
+# 1. リポジトリをクローン
+git clone https://github.com/zaichu/shoken-webapp.git
+cd shoken-webapp
+
+# 2. 環境変数を設定
+cd backend && cp .env.example .env  # DATABASE_URL 等を設定
+echo "VITE_SHOKEN_WEBAPI_API_URL=http://127.0.0.1:3001" > frontend/.env.development.local
+
+# 3. 一括起動（推奨）
+./scripts/start-local.sh
+```
+
+起動後のアクセス先:
+- フロントエンド: http://127.0.0.1:8080
+- バックエンド: http://127.0.0.1:3001
+- DB: `postgresql://user:password@localhost:5432/shoken_db`
+
+停止: `./scripts/stop-local.sh`
+
+## デプロイ
+
+`main` ブランチへのマージで CI/CD が自動実行されます。
+
+| サービス | デプロイ先 | トリガー |
+|---|---|---|
+| フロントエンド | Vercel | main push |
+| バックエンド | Fly.io | main push |
+
+### 手動デプロイ（緊急時）
+
+```bash
+# バックエンド
+cd backend && make deploy
+
+# フロントエンド（Vercel CLI）
+cd frontend && vercel --prod
+```
+
+## ヘルスチェック
+
+```bash
+# バックエンド
+curl https://shoken-webapp-backend.fly.dev/health
+
+# ログ確認
+fly logs --app shoken-webapp-backend
+```
+
+## データベースマイグレーション
+
+```bash
+cd backend
+
+# マイグレーション作成
+sqlx migrate add <migration_name>
+
+# マイグレーション実行（起動時に自動実行）
+make run
+
+# オフラインモード用 sqlx-data 更新
+make sqlx-prepare
+```
+
+## 環境変数（本番）
+
+Fly.io Secrets で管理:
+
+```bash
+fly secrets set DATABASE_URL="postgresql://..."
+fly secrets set GOOGLE_CLIENT_ID="..."
+fly secrets set GOOGLE_CLIENT_SECRET="..."
+fly secrets set FRONTEND_URL="https://shoken-webapp.vercel.app"
+fly secrets set BACKEND_URL="https://shoken-webapp-backend.fly.dev"
+```
+
+## セキュリティインシデント対応
+
+1. [SECURITY.md](../SECURITY.md) の手順に従って報告を受理
+2. 重大度に応じて 30〜90 日以内に修正
+
+脆弱性が発見された場合:
+```bash
+# 依存関係の脆弱性チェック
+cd backend && cargo audit
+cd frontend && npm audit
+```
+
+## Dependabot PR 対応
+
+毎週月曜日に Dependabot PR が作成されます。
+
+1. CI が green の PR: `gh pr merge <PR番号> --squash --delete-branch`
+2. CI が red の PR: 失敗原因を調査して対応方針を決定（修正 / 保留 / close）
+
+## よくあるトラブル
+
+### DB 接続失敗
+
+```bash
+cd backend && make db-up  # Docker で PostgreSQL を起動
+```
+
+### バックエンドビルドエラー
+
+```bash
+cd backend && cargo check  # コンパイルエラー確認
+cd backend && cargo fmt     # フォーマット修正
+```
+
+### フロントエンドの型エラー
+
+```bash
+cd frontend && npx tsc --noEmit  # 型エラー確認
+cd frontend && npm run lint      # Lint エラー確認
+```
+
+### OpenAPI スキーマと api.ts の不一致
+
+```bash
+bash scripts/check-openapi.sh  # 再生成して差分確認
+```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,117 @@
+# テストガイド
+
+## テスト全体像
+
+| 種別 | 対象 | ツール | 場所 |
+|---|---|---|---|
+| 単体テスト（フロント） | hooks / utils / api | Vitest + RTL | `frontend/src/**/__tests__/` |
+| 単体テスト（バックエンド） | ハンドラー / サービス / ミドルウェア | cargo test | `backend/src/**/tests` |
+| 統合テスト（バックエンド） | DB アクセス（testcontainers） | cargo test | `backend/tests/` |
+| E2E テスト（正常系） | 主要ページ / CSV CRUD | Playwright | `frontend/e2e/` |
+| E2E テスト（失敗系） | API 401 / CSV 行エラー | Playwright + page.route() | `frontend/e2e/error-scenarios.spec.ts` |
+
+## フロントエンドテスト
+
+```bash
+cd frontend
+
+# 全テスト実行
+npm test
+
+# ウォッチモード
+npm run test:watch
+
+# 単一ファイル指定
+npm test -- src/lib/api/__tests__/client.test.ts
+```
+
+### テスト方針
+
+- ユーザー視点で書く: `getByRole` / `getByText` を優先、`data-testid` は最終手段
+- 非同期処理: `waitFor` または `findBy*` を使用
+- テストファイルの配置: 各機能配下の `__tests__/` ディレクトリ
+- フィクスチャ: `__fixtures__/` に配置
+
+## バックエンドテスト
+
+```bash
+cd backend
+
+# 全テスト実行
+cargo test
+
+# lib テストのみ
+cargo test --lib
+
+# 特定モジュールのテスト
+cargo test --lib -- middleware::tests
+
+# Docker が必要な統合テスト（通常は ignore）
+cargo test -- --ignored
+```
+
+### テスト方針
+
+- 単体テスト: `#[cfg(test)] mod tests` を各ファイルの末尾に配置
+- DB が不要なテスト: `connect_pool_lazy` を使用して遅延初期化
+- DB が必要なテスト: testcontainers を使用し `#[ignore = "requires Docker"]` を付与
+- 外部 API 呼び出しテスト: `#[ignore = "requires API key"]` を付与
+
+## E2E テスト
+
+### 前提
+
+1. ローカル環境を起動（DB → バックエンド → フロントエンド の順）
+2. ログイン状態を保存（初回のみ）
+
+```bash
+# 環境起動 + 認証保存 + スクリーンショット取得
+./scripts/run-ui-e2e.sh --save-auth
+
+# 主要ページのみ
+./scripts/run-ui-e2e.sh --skip-csv
+
+# CSV CRUD フローのみ
+./scripts/run-ui-e2e.sh --skip-main
+```
+
+### 失敗系テスト（API モック使用）
+
+```bash
+# フロントエンドサーバーのみ起動でテスト可能
+cd frontend && npm run dev -- --host 127.0.0.1 --port 8080 &
+npx playwright test e2e/error-scenarios.spec.ts
+```
+
+`error-scenarios.spec.ts` は `page.route()` でバックエンド API をモックするため、
+実際のバックエンドサーバーは不要です。
+
+### E2E 用スクリーンショット
+
+スクリーンショットは `.playwright-mcp/` に保存されます（gitignore 対象）。
+
+## CI での実行
+
+GitHub Actions（`.github/workflows/ci.yml`）で以下が自動実行されます:
+
+1. フロント: lint / tsc / test / build
+2. バックエンド: fmt / clippy / test / build
+
+### セキュリティ監査（週次）
+
+`.github/workflows/security-audit.yml` で毎週月曜日に自動実行:
+
+```bash
+cargo audit    # Rust 依存関係の脆弱性
+npm audit --audit-level=high  # npm 依存関係の脆弱性
+```
+
+## テストカバレッジ確認（任意）
+
+```bash
+# バックエンド（tarpaulin 要インストール）
+cd backend && cargo tarpaulin --out Html
+
+# フロントエンド
+cd frontend && npm test -- --coverage
+```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -5,7 +5,7 @@
 | 種別 | 対象 | ツール | 場所 |
 |---|---|---|---|
 | 単体テスト（フロント） | hooks / utils / api | Vitest + RTL | `frontend/src/**/__tests__/` |
-| 単体テスト（バックエンド） | ハンドラー / サービス / ミドルウェア | cargo test | `backend/src/**/tests` |
+| 単体テスト（バックエンド） | ハンドラー / サービス / ミドルウェア | cargo test | 各ファイル末尾の `#[cfg(test)] mod tests` |
 | 統合テスト（バックエンド） | DB アクセス（testcontainers） | cargo test | `backend/tests/` |
 | E2E テスト（正常系） | 主要ページ / CSV CRUD | Playwright | `frontend/e2e/` |
 | E2E テスト（失敗系） | API 401 / CSV 行エラー | Playwright + page.route() | `frontend/e2e/error-scenarios.spec.ts` |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -80,7 +80,7 @@ cargo test -- --ignored
 ```bash
 # フロントエンドサーバーのみ起動でテスト可能
 cd frontend && npm run dev -- --host 127.0.0.1 --port 8080 &
-npx playwright test e2e/error-scenarios.spec.ts
+cd frontend && npx playwright test e2e/error-scenarios.spec.ts
 ```
 
 `error-scenarios.spec.ts` は `page.route()` でバックエンド API をモックするため、
@@ -92,10 +92,12 @@ npx playwright test e2e/error-scenarios.spec.ts
 
 ## CI での実行
 
-GitHub Actions（`.github/workflows/ci.yml`）で以下が自動実行されます:
+GitHub Actions で以下が自動実行されます（PR 時）:
 
-1. フロント: lint / tsc / test / build
-2. バックエンド: fmt / clippy / test / build
+| ワークフロー | ファイル | ステップ |
+|---|---|---|
+| フロント | `deploy-frontend.yml` | lint / test / build |
+| バックエンド | `deploy-backend.yml` | clippy / test / check / OpenAPI 同期確認 / tsc |
 
 ### セキュリティ監査（週次）
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -112,8 +112,8 @@ npm audit --audit-level=high  # npm 依存関係の脆弱性
 
 ```bash
 # バックエンド（tarpaulin 要インストール）
-cd backend && cargo tarpaulin --out Html
+(cd backend && cargo tarpaulin --out Html)
 
 # フロントエンド
-cd frontend && npm test -- --coverage
+(cd frontend && npm test -- --coverage)
 ```


### PR DESCRIPTION
## 概要

新規参画者が手順を辿れるようにドキュメントを整備しました。

- `docs/architecture.md`: システム構成・認証フロー・ミドルウェアスタック・CSV設計
- `docs/runbook.md`: ローカル起動・デプロイ・DB マイグレーション・Dependabot 対応・トラブルシューティング
- `docs/testing.md`: フロントエンド / バックエンド / E2E テストの実行方法と方針
- `README.md`: ドキュメントテーブルを追加

## テスト

- ドキュメントのみの変更のためコード変更なし
- README のリンク先が正しいことを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)