### PR TITLE
chore: E2E CI自動実行とViteブラウザ自動オープン抑制

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -42,3 +42,17 @@ jobs:
         run: npm run build
         env:
           VITE_SHOKEN_WEBAPI_API_URL: https://example.com
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+
+      - name: Run E2E tests (CI mode)
+        run: npm run test:e2e:ci
+
+      - name: Upload E2E artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/
+          retention-days: 7

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "ui:screenshot:csv-crud": "STORAGE_STATE=.auth/storage-state.json npx playwright test e2e/csv-crud.spec.ts",
     "ui:csv-crud:auth": "npm run ui:screenshot:csv-crud",
     "ui:save-auth": "npx tsx e2e/save-auth.spec.ts",
+    "test:e2e:ci": "npx playwright test --config playwright.ci.config.ts",
     "generate:types": "npx openapi-typescript ../docs/openapi.json -o src/generated/api.ts"
   },
   "dependencies": {

--- a/frontend/playwright.ci.config.ts
+++ b/frontend/playwright.ci.config.ts
@@ -1,0 +1,40 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * CI 用 Playwright 設定
+ *
+ * - Vite dev server を自動起動
+ * - error-scenarios.spec.ts のみ実行（API モックのため認証不要）
+ * - 失敗時に trace / screenshot / HTML レポートを保存
+ */
+export default defineConfig({
+  testDir: './e2e',
+  testMatch: ['**/error-scenarios.spec.ts'],
+  fullyParallel: false,
+  forbidOnly: true,
+  retries: 1,
+  workers: 1,
+  reporter: [['html', { open: 'never', outputFolder: 'playwright-report' }], ['list']],
+  use: {
+    baseURL: 'http://127.0.0.1:8080',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npx vite --host 127.0.0.1 --port 8080 --strictPort',
+    url: 'http://127.0.0.1:8080',
+    reuseExistingServer: false,
+    timeout: 60_000,
+    env: {
+      // バックエンドは page.route() でモックするため実際に接続しない
+      VITE_SHOKEN_WEBAPI_API_URL: 'http://localhost:3001',
+      PLAYWRIGHT_TEST: '1',
+    },
+  },
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   base: '/',
   server: {
     port: 8080,
-    open: true,
+    open: !process.env.CI && !process.env.PLAYWRIGHT_TEST,
   },
   build: {
     outDir: 'dist',


### PR DESCRIPTION
## 概要

- E2E テストを CI（GitHub Actions）で自動実行できるようにした
- Vite 起動時に CI/E2E 環境でブラウザタブが開かないように修正

## 変更内容

- `frontend/playwright.ci.config.ts`: CI用Playwright設定を新規追加（Vite dev server自動起動、`error-scenarios.spec.ts`のみ実行）
- `frontend/vite.config.ts`: `open: !process.env.CI && !process.env.PLAYWRIGHT_TEST` に変更
- `frontend/package.json`: `test:e2e:ci` スクリプトを追加
- `.github/workflows/deploy-frontend.yml`: Playwrightブラウザインストール・E2E実行・アーティファクト保存ステップを追加

## テスト結果

```
Running 3 tests using 1 worker
  ✓  1 › 配当金一覧取得が 401 のときエラー Alert が表示される
  ✓  2 › 資産管理一覧取得が 401 のときエラー Alert が表示される
  ✓  3 › CSV プレビューで行エラーが返ったとき warning Alert に一覧表示される
3 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)