### PR TITLE
chore: アクセシビリティ監査（axe-core）を導入し WCAG 重大違反を修正

### DIFF
--- a/.claude/rules/00-general.md
+++ b/.claude/rules/00-general.md
@@ -14,8 +14,8 @@
 - 中規模以上のタスクでは `docs/tasks/TEMPLATE.md` を元に task file を作成する
 - task file はローカルの一時ファイルとして扱い、ユーザー明示指示がない限りコミット・PR に含めない
 - task 完了時または作業中止時には、対応する task file を削除する
-- 実装担当は Claude、レビュー担当は Codex（MCP経由）とする
-- Claude は実装完了後に PR を作成し、Codex の MCP を呼び出してレビューを依頼する
+- 実装担当は Claude、レビュー担当は Codex（CLI経由）とする
+- Claude は実装完了後に PR を作成し、Codex CLI を呼び出してレビューを依頼する
 - Codex は `.claude/skills/pr-review/SKILL.md` に従って PR をレビューする
 - Codex は PR を承認する前に、要件充足、回帰有無、コード品質、テスト状況を確認する
 - Claude は Codex の指摘に対応し、必要な修正と検証を行う

--- a/frontend/e2e/a11y.spec.ts
+++ b/frontend/e2e/a11y.spec.ts
@@ -18,7 +18,7 @@ const ROUTES = {
   domesticStocks: /\/domestic-stocks$/,
   mutualfunds: /\/mutualfunds$/,
   assetBalances: /\/asset-balances$/,
-  stock: /\/stock\//,
+  stock: /\/stock\/[^/]+$/,
 };
 
 async function setupAuthMocks(page: import('@playwright/test').Page) {

--- a/frontend/e2e/a11y.spec.ts
+++ b/frontend/e2e/a11y.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * アクセシビリティ監査 E2E テスト（API モック使用）
+ *
+ * @axe-core/playwright を使用して主要ページの WCAG 違反を検出する。
+ * page.route() でバックエンド API をモックし、認証なしで実行可能。
+ *
+ * 使用方法:
+ *   cd frontend && npx playwright test e2e/a11y.spec.ts --config playwright.ci.config.ts
+ */
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+const MOCK_USER = { id: 1, email: 'test@example.com', name: 'テストユーザー' };
+
+const ROUTES = {
+  authMe: /\/auth\/me$/,
+  dividends: /\/dividends$/,
+  domesticStocks: /\/domestic-stocks$/,
+  mutualfunds: /\/mutualfunds$/,
+  assetBalances: /\/asset-balances$/,
+  stock: /\/stock\//,
+};
+
+async function setupAuthMocks(page: import('@playwright/test').Page) {
+  await page.route(ROUTES.authMe, (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(MOCK_USER) }),
+  );
+  await page.route(ROUTES.dividends, (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+  );
+  await page.route(ROUTES.domesticStocks, (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+  );
+  await page.route(ROUTES.mutualfunds, (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+  );
+  await page.route(ROUTES.assetBalances, (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+  );
+}
+
+// WCAG2AA の critical/serious 違反のみチェックする
+function buildAxe(page: import('@playwright/test').Page) {
+  return new AxeBuilder({ page })
+    .withTags(['wcag2a', 'wcag2aa'])
+    .options({ runOnly: { type: 'tag', values: ['wcag2a', 'wcag2aa'] } });
+}
+
+test('ホームページに重大な WCAG 違反がない', async ({ page }) => {
+  await setupAuthMocks(page);
+  await page.goto('/');
+  await page.waitForLoadState('networkidle');
+
+  const results = await buildAxe(page).analyze();
+  const critical = results.violations.filter((v) => v.impact === 'critical' || v.impact === 'serious');
+
+  expect(
+    critical,
+    critical.map((v) => `[${v.impact}] ${v.id}: ${v.description}`).join('\n'),
+  ).toHaveLength(0);
+});
+
+test('銘柄検索ページに重大な WCAG 違反がない', async ({ page }) => {
+  await setupAuthMocks(page);
+  await page.route(ROUTES.stock, (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+  );
+  await page.goto('/search');
+  await page.waitForLoadState('networkidle');
+
+  const results = await buildAxe(page).analyze();
+  const critical = results.violations.filter((v) => v.impact === 'critical' || v.impact === 'serious');
+
+  expect(
+    critical,
+    critical.map((v) => `[${v.impact}] ${v.id}: ${v.description}`).join('\n'),
+  ).toHaveLength(0);
+});
+
+test('資産管理ページに重大な WCAG 違反がない', async ({ page }) => {
+  await setupAuthMocks(page);
+  await page.goto('/assetbalance');
+  await page.waitForLoadState('networkidle');
+
+  const results = await buildAxe(page).analyze();
+  const critical = results.violations.filter((v) => v.impact === 'critical' || v.impact === 'serious');
+
+  expect(
+    critical,
+    critical.map((v) => `[${v.impact}] ${v.id}: ${v.description}`).join('\n'),
+  ).toHaveLength(0);
+});
+
+test('取引明細ページに重大な WCAG 違反がない', async ({ page }) => {
+  await setupAuthMocks(page);
+  await page.goto('/receipts');
+  await page.waitForLoadState('networkidle');
+
+  const results = await buildAxe(page).analyze();
+  const critical = results.violations.filter((v) => v.impact === 'critical' || v.impact === 'serious');
+
+  expect(
+    critical,
+    critical.map((v) => `[${v.impact}] ${v.id}: ${v.description}`).join('\n'),
+  ).toHaveLength(0);
+});

--- a/frontend/e2e/a11y.spec.ts
+++ b/frontend/e2e/a11y.spec.ts
@@ -91,16 +91,27 @@ test('資産管理ページに重大な WCAG 違反がない', async ({ page }) 
   ).toHaveLength(0);
 });
 
-test('取引明細ページに重大な WCAG 違反がない', async ({ page }) => {
+test('取引明細ページに重大な WCAG 違反がない（全タブ）', async ({ page }) => {
   await setupAuthMocks(page);
   await page.goto('/receipts');
   await page.waitForLoadState('networkidle');
 
-  const results = await buildAxe(page).analyze();
-  const critical = results.violations.filter((v) => v.impact === 'critical' || v.impact === 'serious');
+  const tabs = [
+    { label: '配当金', selector: 'button[role="tab"][id="tab-dividend"]' },
+    { label: '国内株式', selector: 'button[role="tab"][id="tab-domesticstock"]' },
+    { label: '投資信託', selector: 'button[role="tab"][id="tab-mutualfund"]' },
+  ];
 
-  expect(
-    critical,
-    critical.map((v) => `[${v.impact}] ${v.id}: ${v.description}`).join('\n'),
-  ).toHaveLength(0);
+  for (const tab of tabs) {
+    await page.click(tab.selector);
+    await page.waitForLoadState('networkidle');
+
+    const results = await buildAxe(page).analyze();
+    const critical = results.violations.filter((v) => v.impact === 'critical' || v.impact === 'serious');
+
+    expect(
+      critical,
+      `[${tab.label}タブ] ` + critical.map((v) => `[${v.impact}] ${v.id}: ${v.description}`).join('\n'),
+    ).toHaveLength(0);
+  }
 });

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "tailwindcss": "^4.2.1"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.1",
         "@eslint/js": "9.39.2",
         "@playwright/test": "^1.58.2",
         "@testing-library/jest-dom": "6.9.1",
@@ -117,6 +118,19 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.1.tgz",
+      "integrity": "sha512-mKEfoUIB1MkVTht0BGZFXtSAEKXMJoDkyV5YZ9jbBmZCcWDz71tegNsdTkIN8zc/yMi5Gm2kx7Z5YQ9PfWNAWw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -3118,6 +3132,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
+      "integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/axios": {
@@ -6294,6 +6318,7 @@
       "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "tailwindcss": "^4.2.1"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.1",
     "@eslint/js": "9.39.2",
     "@playwright/test": "^1.58.2",
     "@testing-library/jest-dom": "6.9.1",

--- a/frontend/playwright.ci.config.ts
+++ b/frontend/playwright.ci.config.ts
@@ -9,7 +9,7 @@ import { defineConfig, devices } from '@playwright/test';
  */
 export default defineConfig({
   testDir: './e2e',
-  testMatch: ['**/error-scenarios.spec.ts'],
+  testMatch: ['**/error-scenarios.spec.ts', '**/a11y.spec.ts'],
   fullyParallel: false,
   forbidOnly: true,
   retries: 1,

--- a/frontend/src/components/molecules/CSVFileInput.tsx
+++ b/frontend/src/components/molecules/CSVFileInput.tsx
@@ -50,6 +50,7 @@ export function CSVFileInput({ onFileSelect, selectedFileName = '', disabled = f
         placeholder="ファイル未選択"
         value={selectedFileName}
         disabled={disabled}
+        aria-label="選択されたファイル名"
       />
     </div>
   );

--- a/frontend/src/pages/Receipts.tsx
+++ b/frontend/src/pages/Receipts.tsx
@@ -116,8 +116,8 @@ export function ReceiptsPage() {
         title="取引明細"
         description="配当金・国内株式・投資信託の取引明細を管理します。"
       />
-      <nav className="border-b border-slate-200 no-print">
-        <div className="flex flex-wrap gap-1">
+      <nav className="border-b border-slate-200 no-print" aria-label="取引明細タブ">
+        <div className="flex flex-wrap gap-1" role="tablist">
           {(['dividend', 'domesticstock', 'mutualfund'] as const).map((tab) => {
             const isActive = receiptsType === tab;
             return (
@@ -132,6 +132,7 @@ export function ReceiptsPage() {
                 type="button"
                 role="tab"
                 aria-selected={isActive}
+                aria-controls={`tabpanel-${tab}`}
               >
                 {TAB_LABEL[tab]}
               </button>
@@ -250,24 +251,30 @@ export function ReceiptsPage() {
         {/* ローディング完了後のみコンテンツを表示（0円集計との同時表示を防止） */}
         {!authLoading && !dbLoading && (
           <>
-            {receiptsType === 'dividend' && (
-              <Dividend
-                data={dividendData}
-                previewData={csvPreview?.rows?.map(r => transformDBDividend(r))}
-              />
-            )}
-            {receiptsType === 'domesticstock' && (
-              <DomesticStock
-                data={domesticstockData}
-                previewData={csvPreview?.rows?.map(r => transformDBDomesticStock(r))}
-              />
-            )}
-            {receiptsType === 'mutualfund' && (
-              <Mutualfund
-                data={mutualfundData}
-                previewData={csvPreview?.rows?.map(r => transformDBMutualfund(r))}
-              />
-            )}
+            <div id="tabpanel-dividend" role="tabpanel" hidden={receiptsType !== 'dividend'}>
+              {receiptsType === 'dividend' && (
+                <Dividend
+                  data={dividendData}
+                  previewData={csvPreview?.rows?.map(r => transformDBDividend(r))}
+                />
+              )}
+            </div>
+            <div id="tabpanel-domesticstock" role="tabpanel" hidden={receiptsType !== 'domesticstock'}>
+              {receiptsType === 'domesticstock' && (
+                <DomesticStock
+                  data={domesticstockData}
+                  previewData={csvPreview?.rows?.map(r => transformDBDomesticStock(r))}
+                />
+              )}
+            </div>
+            <div id="tabpanel-mutualfund" role="tabpanel" hidden={receiptsType !== 'mutualfund'}>
+              {receiptsType === 'mutualfund' && (
+                <Mutualfund
+                  data={mutualfundData}
+                  previewData={csvPreview?.rows?.map(r => transformDBMutualfund(r))}
+                />
+              )}
+            </div>
           </>
         )}
 

--- a/frontend/src/pages/Receipts.tsx
+++ b/frontend/src/pages/Receipts.tsx
@@ -25,6 +25,9 @@ const TAB_LABEL: Record<ReceiptsType, string> = {
   mutualfund: '投資信託',
 };
 
+// タブ一覧（順序固定）
+const TABS = ['dividend', 'domesticstock', 'mutualfund'] as const;
+
 /**
  * 明細種類ごとにCSVデータを管理するページコンポーネント
  */
@@ -107,8 +110,6 @@ export function ReceiptsPage() {
   const tabName = TAB_LABEL[receiptsType];
   const importResult = lastImportResults[receiptsType];
 
-  // タブ一覧（順序を固定して矢印キーナビゲーションに使用）
-  const TABS = ['dividend', 'domesticstock', 'mutualfund'] as const;
   const tablistRef = useRef<HTMLDivElement>(null);
 
   // 矢印キーでのタブ切り替え（roving tabIndex パターン）

--- a/frontend/src/pages/Receipts.tsx
+++ b/frontend/src/pages/Receipts.tsx
@@ -1,4 +1,4 @@
-import { useReducer, useEffect, useCallback } from 'react';
+import { useReducer, useEffect, useCallback, useRef } from 'react';
 import { Layout } from '../components/templates/Layout';
 import { PageHeader } from '../components/atoms/PageHeader';
 import { CSVFileInput } from '../components/molecules/CSVFileInput';
@@ -106,6 +106,31 @@ export function ReceiptsPage() {
   const hasDbData = dbDataCount > 0;
   const tabName = TAB_LABEL[receiptsType];
   const importResult = lastImportResults[receiptsType];
+
+  // タブ一覧（順序を固定して矢印キーナビゲーションに使用）
+  const TABS = ['dividend', 'domesticstock', 'mutualfund'] as const;
+  const tablistRef = useRef<HTMLDivElement>(null);
+
+  // 矢印キーでのタブ切り替え（roving tabIndex パターン）
+  const handleTabKeyDown = useCallback((e: React.KeyboardEvent<HTMLButtonElement>) => {
+    const currentIndex = TABS.indexOf(receiptsType);
+    let nextIndex: number | null = null;
+    if (e.key === 'ArrowRight') {
+      nextIndex = (currentIndex + 1) % TABS.length;
+    } else if (e.key === 'ArrowLeft') {
+      nextIndex = (currentIndex - 1 + TABS.length) % TABS.length;
+    } else if (e.key === 'Home') {
+      nextIndex = 0;
+    } else if (e.key === 'End') {
+      nextIndex = TABS.length - 1;
+    }
+    if (nextIndex !== null) {
+      e.preventDefault();
+      dispatch({ type: 'SET_RECEIPTS_TYPE', payload: TABS[nextIndex] });
+      const buttons = tablistRef.current?.querySelectorAll<HTMLButtonElement>('[role="tab"]');
+      buttons?.[nextIndex]?.focus();
+    }
+  }, [receiptsType, dispatch]);
   const saveLabel = csvPreview
     ? `${csvPreview.validRows}件 追加で保存`
     : '追加で保存';
@@ -117,8 +142,8 @@ export function ReceiptsPage() {
         description="配当金・国内株式・投資信託の取引明細を管理します。"
       />
       <nav className="border-b border-slate-200 no-print" aria-label="取引明細タブ">
-        <div className="flex flex-wrap gap-1" role="tablist">
-          {(['dividend', 'domesticstock', 'mutualfund'] as const).map((tab) => {
+        <div className="flex flex-wrap gap-1" role="tablist" ref={tablistRef}>
+          {TABS.map((tab) => {
             const isActive = receiptsType === tab;
             return (
               <button
@@ -129,10 +154,12 @@ export function ReceiptsPage() {
                     : 'border-transparent text-slate-600 hover:text-slate-900 hover:border-slate-300'
                 }`}
                 onClick={() => dispatch({ type: 'SET_RECEIPTS_TYPE', payload: tab })}
+                onKeyDown={handleTabKeyDown}
                 type="button"
                 role="tab"
                 aria-selected={isActive}
                 aria-controls={`tabpanel-${tab}`}
+                tabIndex={isActive ? 0 : -1}
               >
                 {TAB_LABEL[tab]}
               </button>

--- a/frontend/src/pages/Receipts.tsx
+++ b/frontend/src/pages/Receipts.tsx
@@ -149,6 +149,7 @@ export function ReceiptsPage() {
             return (
               <button
                 key={tab}
+                id={`tab-${tab}`}
                 className={`px-4 py-3 text-sm font-medium transition-colors border-b-2 -mb-px ${
                   isActive
                     ? 'border-primary text-primary bg-white'
@@ -279,7 +280,7 @@ export function ReceiptsPage() {
         {/* ローディング完了後のみコンテンツを表示（0円集計との同時表示を防止） */}
         {!authLoading && !dbLoading && (
           <>
-            <div id="tabpanel-dividend" role="tabpanel" hidden={receiptsType !== 'dividend'}>
+            <div id="tabpanel-dividend" role="tabpanel" aria-labelledby="tab-dividend" hidden={receiptsType !== 'dividend'}>
               {receiptsType === 'dividend' && (
                 <Dividend
                   data={dividendData}
@@ -287,7 +288,7 @@ export function ReceiptsPage() {
                 />
               )}
             </div>
-            <div id="tabpanel-domesticstock" role="tabpanel" hidden={receiptsType !== 'domesticstock'}>
+            <div id="tabpanel-domesticstock" role="tabpanel" aria-labelledby="tab-domesticstock" hidden={receiptsType !== 'domesticstock'}>
               {receiptsType === 'domesticstock' && (
                 <DomesticStock
                   data={domesticstockData}
@@ -295,7 +296,7 @@ export function ReceiptsPage() {
                 />
               )}
             </div>
-            <div id="tabpanel-mutualfund" role="tabpanel" hidden={receiptsType !== 'mutualfund'}>
+            <div id="tabpanel-mutualfund" role="tabpanel" aria-labelledby="tab-mutualfund" hidden={receiptsType !== 'mutualfund'}>
               {receiptsType === 'mutualfund' && (
                 <Mutualfund
                   data={mutualfundData}


### PR DESCRIPTION
## 概要

- `@axe-core/playwright` を導入し、主要4ページの WCAG 2A/2AA 自動監査を E2E テストとして追加
- CI（`playwright.ci.config.ts`）で自動実行されるよう設定
- 監査で検出した取引明細ページの WCAG 重大違反（`aria-required-parent`・`aria-valid-attr-value`）を修正

## 変更詳細

### アクセシビリティ監査テスト
- `frontend/e2e/a11y.spec.ts` 新規作成（ホーム・銘柄検索・資産管理・取引明細）
- API モックで認証不要（CI 実行可能）
- `critical` / `serious` 違反のみチェック

### WCAG 違反修正（`frontend/src/pages/Receipts.tsx`）
- タブコンテナ div に `role="tablist"` を追加
- 各タブボタンに `aria-controls="tabpanel-{type}"` を追加
- 各タブコンテンツを `role="tabpanel"` + `id="tabpanel-{type}"` + `hidden` で囲む

### その他
- `.claude/rules/00-general.md`: Codex 連携を MCP から CLI に変更

## テスト結果

```
4 passed (a11y.spec.ts)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)