### PR TITLE
refactor: CSV サービス層の delete_all を shared ヘルパーに集約

### DIFF
--- a/backend/src/services.rs
+++ b/backend/src/services.rs
@@ -7,4 +7,5 @@ pub mod dividend_cache;
 pub mod domestic_stock;
 pub mod jquants;
 pub mod mutualfund;
+pub mod shared;
 pub mod stock;

--- a/backend/src/services/asset_balance.rs
+++ b/backend/src/services/asset_balance.rs
@@ -220,13 +220,8 @@ fn parse_asset_balance_row(
 
 /// 認証ユーザーの保有銘柄を全削除
 pub async fn delete_all(pool: &PgPool, user_id: Uuid) -> Result<u64, ApiError> {
-    crate::services::shared::delete_all_for_user(
-        pool,
-        user_id,
-        "asset_balances",
-        "asset_balance",
-    )
-    .await
+    crate::services::shared::delete_all_for_user(pool, user_id, "asset_balances", "asset_balance")
+        .await
 }
 
 #[cfg(test)]

--- a/backend/src/services/asset_balance.rs
+++ b/backend/src/services/asset_balance.rs
@@ -220,15 +220,13 @@ fn parse_asset_balance_row(
 
 /// 認証ユーザーの保有銘柄を全削除
 pub async fn delete_all(pool: &PgPool, user_id: Uuid) -> Result<u64, ApiError> {
-    info!("[asset_balance.delete_all] リクエスト受信");
-    let result = sqlx::query("DELETE FROM asset_balances WHERE user_id = $1")
-        .bind(user_id)
-        .execute(pool)
-        .await?;
-
-    let deleted = result.rows_affected();
-    info!("[asset_balance.delete_all] 完了: {}件削除", deleted);
-    Ok(deleted)
+    crate::services::shared::delete_all_for_user(
+        pool,
+        user_id,
+        "asset_balances",
+        "asset_balance",
+    )
+    .await
 }
 
 #[cfg(test)]

--- a/backend/src/services/dividend.rs
+++ b/backend/src/services/dividend.rs
@@ -152,13 +152,5 @@ fn parse_dividend_row(
 
 /// 認証ユーザーの配当金を全削除
 pub async fn delete_all(pool: &PgPool, user_id: Uuid) -> Result<u64, ApiError> {
-    info!("[dividend.delete_all] リクエスト受信");
-    let result = sqlx::query("DELETE FROM dividends WHERE user_id = $1")
-        .bind(user_id)
-        .execute(pool)
-        .await?;
-
-    let deleted = result.rows_affected();
-    info!("[dividend.delete_all] 完了: {}件削除", deleted);
-    Ok(deleted)
+    crate::services::shared::delete_all_for_user(pool, user_id, "dividends", "dividend").await
 }

--- a/backend/src/services/domestic_stock.rs
+++ b/backend/src/services/domestic_stock.rs
@@ -214,13 +214,8 @@ fn parse_domestic_stock_row(
 
 /// 認証ユーザーの国内株式取引を全削除
 pub async fn delete_all(pool: &PgPool, user_id: Uuid) -> Result<u64, ApiError> {
-    crate::services::shared::delete_all_for_user(
-        pool,
-        user_id,
-        "domestic_stocks",
-        "domestic_stock",
-    )
-    .await
+    crate::services::shared::delete_all_for_user(pool, user_id, "domestic_stocks", "domestic_stock")
+        .await
 }
 
 #[cfg(test)]

--- a/backend/src/services/domestic_stock.rs
+++ b/backend/src/services/domestic_stock.rs
@@ -214,15 +214,13 @@ fn parse_domestic_stock_row(
 
 /// 認証ユーザーの国内株式取引を全削除
 pub async fn delete_all(pool: &PgPool, user_id: Uuid) -> Result<u64, ApiError> {
-    info!("[domestic_stock.delete_all] リクエスト受信");
-    let result = sqlx::query("DELETE FROM domestic_stocks WHERE user_id = $1")
-        .bind(user_id)
-        .execute(pool)
-        .await?;
-
-    let deleted = result.rows_affected();
-    info!("[domestic_stock.delete_all] 完了: {}件削除", deleted);
-    Ok(deleted)
+    crate::services::shared::delete_all_for_user(
+        pool,
+        user_id,
+        "domestic_stocks",
+        "domestic_stock",
+    )
+    .await
 }
 
 #[cfg(test)]

--- a/backend/src/services/mutualfund.rs
+++ b/backend/src/services/mutualfund.rs
@@ -189,13 +189,5 @@ fn parse_mutualfund_row(
 
 /// 認証ユーザーの投資信託を全削除
 pub async fn delete_all(pool: &PgPool, user_id: Uuid) -> Result<u64, ApiError> {
-    info!("[mutualfund.delete_all] リクエスト受信");
-    let result = sqlx::query("DELETE FROM mutualfunds WHERE user_id = $1")
-        .bind(user_id)
-        .execute(pool)
-        .await?;
-
-    let deleted = result.rows_affected();
-    info!("[mutualfund.delete_all] 完了: {}件削除", deleted);
-    Ok(deleted)
+    crate::services::shared::delete_all_for_user(pool, user_id, "mutualfunds", "mutualfund").await
 }

--- a/backend/src/services/shared.rs
+++ b/backend/src/services/shared.rs
@@ -1,0 +1,22 @@
+use crate::errors::ApiError;
+use sqlx::PgPool;
+use tracing::info;
+use uuid::Uuid;
+
+/// ユーザーに紐づく全レコードを削除する共通実装。
+/// テーブル名は呼び出し元がリテラルで指定するため SQL インジェクションの危険はない。
+pub async fn delete_all_for_user(
+    pool: &PgPool,
+    user_id: Uuid,
+    table_name: &'static str,
+    domain: &'static str,
+) -> Result<u64, ApiError> {
+    info!("[{}.delete_all] リクエスト受信", domain);
+    let result = sqlx::query(&format!("DELETE FROM {} WHERE user_id = $1", table_name))
+        .bind(user_id)
+        .execute(pool)
+        .await?;
+    let deleted = result.rows_affected();
+    info!("[{}.delete_all] 完了: {}件削除", domain, deleted);
+    Ok(deleted)
+}


### PR DESCRIPTION
## 概要

4ドメインの CSV サービスで完全同一だった \`delete_all\` 実装（計44行）を共通化。

## 変更内容

- \`services/shared.rs\` を新規作成し \`delete_all_for_user\` を実装
- \`dividend\` / \`domestic_stock\` / \`mutualfund\` / \`asset_balance\` の各 \`delete_all\` が共通関数を呼び出す形に変更

## テスト結果

- \`cargo clippy --all-targets -- -D warnings\` → 警告 0
- \`cargo test\` → 132 pass（5 ignored）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized deletion logic across multiple backend services to reduce duplication and improve maintainability and logging consistency.
  * Services now delegate record-deletion work to a shared utility.
  * No changes to public function signatures or runtime behavior—end-user experience remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->