### PR TITLE
fix: f64 → rust_decimal::Decimal へ移行し金額計算の精度を修正

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3,6 +3,17 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,6 +50,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "astral-tokio-tar"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,7 +90,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -84,7 +101,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -192,7 +209,7 @@ checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -211,6 +228,8 @@ dependencies = [
  "mockall",
  "oauth2",
  "reqwest",
+ "rust_decimal",
+ "rust_decimal_macros",
  "serde",
  "serde_json",
  "sqlx",
@@ -255,6 +274,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
 ]
 
 [[package]]
@@ -344,10 +375,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
+dependencies = [
+ "borsh-derive",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0686c856aa6aac0c4498f936d7d6a02df690f614c03e4d906d1018062b5c5e2c"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "byteorder"
@@ -550,7 +626,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -564,7 +640,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -575,7 +651,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -586,7 +662,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -644,7 +720,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -836,6 +912,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -902,7 +984,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1037,6 +1119,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1638,7 +1723,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1835,7 +1920,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1907,7 +1992,7 @@ dependencies = [
  "regex",
  "regex-syntax",
  "structmeta",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1948,7 +2033,7 @@ checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2059,7 +2144,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -2081,7 +2175,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2113,7 +2207,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2123,6 +2217,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2215,6 +2329,12 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -2319,7 +2439,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2350,6 +2470,15 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
 
 [[package]]
 name = "reqwest"
@@ -2410,6 +2539,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2427,6 +2585,32 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61f703d19852dbf87cbc513643fa81428361eb6940f1ac14fd58155d295a3eb0"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.5",
+ "rkyv",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "rust_decimal_macros"
+version = "1.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74a5a6f027e892c7a035c6fddb50435a1fbf5a734ffc0c2a9fed4d0221440519"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2557,6 +2741,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2612,7 +2802,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2647,7 +2837,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2690,7 +2880,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2749,6 +2939,12 @@ dependencies = [
  "digest",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -2841,6 +3037,7 @@ dependencies = [
  "native-tls",
  "once_cell",
  "percent-encoding",
+ "rust_decimal",
  "serde",
  "serde_json",
  "sha2",
@@ -2863,7 +3060,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2886,7 +3083,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn",
+ "syn 2.0.117",
  "tokio",
  "url",
 ]
@@ -2923,6 +3120,7 @@ dependencies = [
  "percent-encoding",
  "rand 0.8.5",
  "rsa",
+ "rust_decimal",
  "serde",
  "sha1",
  "sha2",
@@ -2962,6 +3160,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "rand 0.8.5",
+ "rust_decimal",
  "serde",
  "serde_json",
  "sha2",
@@ -3032,7 +3231,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3043,7 +3242,7 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3051,6 +3250,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -3080,7 +3290,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3103,6 +3313,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -3188,7 +3404,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3199,7 +3415,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3292,7 +3508,7 @@ checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3348,6 +3564,36 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.0.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.4+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
+dependencies = [
+ "indexmap 2.13.0",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.9+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -3462,7 +3708,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3641,7 +3887,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn",
+ "syn 2.0.117",
  "uuid",
 ]
 
@@ -3684,7 +3930,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3790,7 +4036,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -3919,7 +4165,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3930,7 +4176,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4191,6 +4437,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4220,7 +4475,7 @@ dependencies = [
  "heck",
  "indexmap 2.13.0",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -4236,7 +4491,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -4285,6 +4540,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4313,7 +4577,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -4334,7 +4598,7 @@ checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4354,7 +4618,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -4394,7 +4658,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2599,6 +2599,7 @@ dependencies = [
  "num-traits",
  "rand 0.8.5",
  "rkyv",
+ "ryu",
  "serde",
  "serde_json",
 ]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -10,11 +10,14 @@ axum-extra = { version = "0.12", features = ["cookie"] }
 chrono = { version = "0.4.44", features = ["serde"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
+rust_decimal = { version = "1", features = ["serde-float"] }
+rust_decimal_macros = "1"
 sqlx = { version = "0.8.6", features = [
     "runtime-tokio-native-tls",
     "postgres",
     "chrono",
     "uuid",
+    "rust_decimal",
 ] }
 thiserror = "2.0.18"
 tokio = { version = "1.50.0", features = ["full"] }

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -9,8 +9,8 @@ encoding_rs = "0.8"
 axum-extra = { version = "0.12", features = ["cookie"] }
 chrono = { version = "0.4.44", features = ["serde"] }
 serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
-rust_decimal = { version = "1", features = ["serde-float"] }
+serde_json = { version = "1.0.149", features = ["arbitrary_precision"] }
+rust_decimal = { version = "1", features = ["serde-float", "serde-arbitrary-precision"] }
 rust_decimal_macros = "1"
 sqlx = { version = "0.8.6", features = [
     "runtime-tokio-native-tls",

--- a/backend/migrations/0016_alter_money_columns_to_numeric.sql
+++ b/backend/migrations/0016_alter_money_columns_to_numeric.sql
@@ -1,39 +1,41 @@
--- dividends テーブル: DOUBLE PRECISION → NUMERIC(18,6)
+-- dividends テーブル: DOUBLE PRECISION → NUMERIC（無制限精度）
+-- NUMERIC(18,6) ではなく NUMERIC にすることで ::text 変換時に trailing zeros が付かず
+-- INSERT 時の content_hash と一致する表現を保証する
 ALTER TABLE dividends
-    ALTER COLUMN unit_price              TYPE NUMERIC(18,6) USING unit_price::NUMERIC,
-    ALTER COLUMN shares                  TYPE NUMERIC(18,6) USING shares::NUMERIC,
-    ALTER COLUMN dividends_before_tax    TYPE NUMERIC(18,6) USING dividends_before_tax::NUMERIC,
-    ALTER COLUMN taxes                   TYPE NUMERIC(18,6) USING taxes::NUMERIC,
-    ALTER COLUMN net_amount_received     TYPE NUMERIC(18,6) USING net_amount_received::NUMERIC;
+    ALTER COLUMN unit_price              TYPE NUMERIC USING unit_price::NUMERIC,
+    ALTER COLUMN shares                  TYPE NUMERIC USING shares::NUMERIC,
+    ALTER COLUMN dividends_before_tax    TYPE NUMERIC USING dividends_before_tax::NUMERIC,
+    ALTER COLUMN taxes                   TYPE NUMERIC USING taxes::NUMERIC,
+    ALTER COLUMN net_amount_received     TYPE NUMERIC USING net_amount_received::NUMERIC;
 
--- domestic_stocks テーブル: DOUBLE PRECISION → NUMERIC(18,6)
+-- domestic_stocks テーブル: DOUBLE PRECISION → NUMERIC
 ALTER TABLE domestic_stocks
-    ALTER COLUMN shares                              TYPE NUMERIC(18,6) USING shares::NUMERIC,
-    ALTER COLUMN asked_price                         TYPE NUMERIC(18,6) USING asked_price::NUMERIC,
-    ALTER COLUMN proceeds                            TYPE NUMERIC(18,6) USING proceeds::NUMERIC,
-    ALTER COLUMN purchase_price                      TYPE NUMERIC(18,6) USING purchase_price::NUMERIC,
-    ALTER COLUMN realized_profit_and_loss            TYPE NUMERIC(18,6) USING realized_profit_and_loss::NUMERIC,
-    ALTER COLUMN taxes                               TYPE NUMERIC(18,6) USING taxes::NUMERIC,
-    ALTER COLUMN realized_profit_and_loss_after_tax  TYPE NUMERIC(18,6) USING realized_profit_and_loss_after_tax::NUMERIC;
+    ALTER COLUMN shares                              TYPE NUMERIC USING shares::NUMERIC,
+    ALTER COLUMN asked_price                         TYPE NUMERIC USING asked_price::NUMERIC,
+    ALTER COLUMN proceeds                            TYPE NUMERIC USING proceeds::NUMERIC,
+    ALTER COLUMN purchase_price                      TYPE NUMERIC USING purchase_price::NUMERIC,
+    ALTER COLUMN realized_profit_and_loss            TYPE NUMERIC USING realized_profit_and_loss::NUMERIC,
+    ALTER COLUMN taxes                               TYPE NUMERIC USING taxes::NUMERIC,
+    ALTER COLUMN realized_profit_and_loss_after_tax  TYPE NUMERIC USING realized_profit_and_loss_after_tax::NUMERIC;
 
--- mutualfunds テーブル: DOUBLE PRECISION → NUMERIC(18,6)
+-- mutualfunds テーブル: DOUBLE PRECISION → NUMERIC
 ALTER TABLE mutualfunds
-    ALTER COLUMN shares                              TYPE NUMERIC(18,6) USING shares::NUMERIC,
-    ALTER COLUMN exchange_rate                       TYPE NUMERIC(18,6) USING exchange_rate::NUMERIC,
-    ALTER COLUMN cancellation_unit_price_yen         TYPE NUMERIC(18,6) USING cancellation_unit_price_yen::NUMERIC,
-    ALTER COLUMN cancellation_amount_yen             TYPE NUMERIC(18,6) USING cancellation_amount_yen::NUMERIC,
-    ALTER COLUMN average_acquisition_price_yen       TYPE NUMERIC(18,6) USING average_acquisition_price_yen::NUMERIC,
-    ALTER COLUMN realized_profit_and_loss            TYPE NUMERIC(18,6) USING realized_profit_and_loss::NUMERIC,
-    ALTER COLUMN taxes                               TYPE NUMERIC(18,6) USING taxes::NUMERIC,
-    ALTER COLUMN realized_profit_and_loss_after_tax  TYPE NUMERIC(18,6) USING realized_profit_and_loss_after_tax::NUMERIC;
+    ALTER COLUMN shares                              TYPE NUMERIC USING shares::NUMERIC,
+    ALTER COLUMN exchange_rate                       TYPE NUMERIC USING exchange_rate::NUMERIC,
+    ALTER COLUMN cancellation_unit_price_yen         TYPE NUMERIC USING cancellation_unit_price_yen::NUMERIC,
+    ALTER COLUMN cancellation_amount_yen             TYPE NUMERIC USING cancellation_amount_yen::NUMERIC,
+    ALTER COLUMN average_acquisition_price_yen       TYPE NUMERIC USING average_acquisition_price_yen::NUMERIC,
+    ALTER COLUMN realized_profit_and_loss            TYPE NUMERIC USING realized_profit_and_loss::NUMERIC,
+    ALTER COLUMN taxes                               TYPE NUMERIC USING taxes::NUMERIC,
+    ALTER COLUMN realized_profit_and_loss_after_tax  TYPE NUMERIC USING realized_profit_and_loss_after_tax::NUMERIC;
 
--- asset_balances テーブル: DOUBLE PRECISION → NUMERIC(18,6)
+-- asset_balances テーブル: DOUBLE PRECISION → NUMERIC
 ALTER TABLE asset_balances
-    ALTER COLUMN shares                  TYPE NUMERIC(18,6) USING shares::NUMERIC,
-    ALTER COLUMN executing_shares        TYPE NUMERIC(18,6) USING executing_shares::NUMERIC,
-    ALTER COLUMN average_purchase_price  TYPE NUMERIC(18,6) USING average_purchase_price::NUMERIC,
-    ALTER COLUMN total_purchase_amount   TYPE NUMERIC(18,6) USING total_purchase_amount::NUMERIC,
-    ALTER COLUMN current_price           TYPE NUMERIC(18,6) USING current_price::NUMERIC,
-    ALTER COLUMN daily_change            TYPE NUMERIC(18,6) USING daily_change::NUMERIC,
-    ALTER COLUMN market_value            TYPE NUMERIC(18,6) USING market_value::NUMERIC,
-    ALTER COLUMN profit_loss_rate        TYPE NUMERIC(18,6) USING profit_loss_rate::NUMERIC;
+    ALTER COLUMN shares                  TYPE NUMERIC USING shares::NUMERIC,
+    ALTER COLUMN executing_shares        TYPE NUMERIC USING executing_shares::NUMERIC,
+    ALTER COLUMN average_purchase_price  TYPE NUMERIC USING average_purchase_price::NUMERIC,
+    ALTER COLUMN total_purchase_amount   TYPE NUMERIC USING total_purchase_amount::NUMERIC,
+    ALTER COLUMN current_price           TYPE NUMERIC USING current_price::NUMERIC,
+    ALTER COLUMN daily_change            TYPE NUMERIC USING daily_change::NUMERIC,
+    ALTER COLUMN market_value            TYPE NUMERIC USING market_value::NUMERIC,
+    ALTER COLUMN profit_loss_rate        TYPE NUMERIC USING profit_loss_rate::NUMERIC;

--- a/backend/migrations/0016_alter_money_columns_to_numeric.sql
+++ b/backend/migrations/0016_alter_money_columns_to_numeric.sql
@@ -1,0 +1,39 @@
+-- dividends テーブル: DOUBLE PRECISION → NUMERIC(18,6)
+ALTER TABLE dividends
+    ALTER COLUMN unit_price              TYPE NUMERIC(18,6) USING unit_price::NUMERIC,
+    ALTER COLUMN shares                  TYPE NUMERIC(18,6) USING shares::NUMERIC,
+    ALTER COLUMN dividends_before_tax    TYPE NUMERIC(18,6) USING dividends_before_tax::NUMERIC,
+    ALTER COLUMN taxes                   TYPE NUMERIC(18,6) USING taxes::NUMERIC,
+    ALTER COLUMN net_amount_received     TYPE NUMERIC(18,6) USING net_amount_received::NUMERIC;
+
+-- domestic_stocks テーブル: DOUBLE PRECISION → NUMERIC(18,6)
+ALTER TABLE domestic_stocks
+    ALTER COLUMN shares                              TYPE NUMERIC(18,6) USING shares::NUMERIC,
+    ALTER COLUMN asked_price                         TYPE NUMERIC(18,6) USING asked_price::NUMERIC,
+    ALTER COLUMN proceeds                            TYPE NUMERIC(18,6) USING proceeds::NUMERIC,
+    ALTER COLUMN purchase_price                      TYPE NUMERIC(18,6) USING purchase_price::NUMERIC,
+    ALTER COLUMN realized_profit_and_loss            TYPE NUMERIC(18,6) USING realized_profit_and_loss::NUMERIC,
+    ALTER COLUMN taxes                               TYPE NUMERIC(18,6) USING taxes::NUMERIC,
+    ALTER COLUMN realized_profit_and_loss_after_tax  TYPE NUMERIC(18,6) USING realized_profit_and_loss_after_tax::NUMERIC;
+
+-- mutualfunds テーブル: DOUBLE PRECISION → NUMERIC(18,6)
+ALTER TABLE mutualfunds
+    ALTER COLUMN shares                              TYPE NUMERIC(18,6) USING shares::NUMERIC,
+    ALTER COLUMN exchange_rate                       TYPE NUMERIC(18,6) USING exchange_rate::NUMERIC,
+    ALTER COLUMN cancellation_unit_price_yen         TYPE NUMERIC(18,6) USING cancellation_unit_price_yen::NUMERIC,
+    ALTER COLUMN cancellation_amount_yen             TYPE NUMERIC(18,6) USING cancellation_amount_yen::NUMERIC,
+    ALTER COLUMN average_acquisition_price_yen       TYPE NUMERIC(18,6) USING average_acquisition_price_yen::NUMERIC,
+    ALTER COLUMN realized_profit_and_loss            TYPE NUMERIC(18,6) USING realized_profit_and_loss::NUMERIC,
+    ALTER COLUMN taxes                               TYPE NUMERIC(18,6) USING taxes::NUMERIC,
+    ALTER COLUMN realized_profit_and_loss_after_tax  TYPE NUMERIC(18,6) USING realized_profit_and_loss_after_tax::NUMERIC;
+
+-- asset_balances テーブル: DOUBLE PRECISION → NUMERIC(18,6)
+ALTER TABLE asset_balances
+    ALTER COLUMN shares                  TYPE NUMERIC(18,6) USING shares::NUMERIC,
+    ALTER COLUMN executing_shares        TYPE NUMERIC(18,6) USING executing_shares::NUMERIC,
+    ALTER COLUMN average_purchase_price  TYPE NUMERIC(18,6) USING average_purchase_price::NUMERIC,
+    ALTER COLUMN total_purchase_amount   TYPE NUMERIC(18,6) USING total_purchase_amount::NUMERIC,
+    ALTER COLUMN current_price           TYPE NUMERIC(18,6) USING current_price::NUMERIC,
+    ALTER COLUMN daily_change            TYPE NUMERIC(18,6) USING daily_change::NUMERIC,
+    ALTER COLUMN market_value            TYPE NUMERIC(18,6) USING market_value::NUMERIC,
+    ALTER COLUMN profit_loss_rate        TYPE NUMERIC(18,6) USING profit_loss_rate::NUMERIC;

--- a/backend/migrations/0017_recalculate_domestic_stocks_content_hash.sql
+++ b/backend/migrations/0017_recalculate_domestic_stocks_content_hash.sql
@@ -8,13 +8,15 @@
 
 DROP INDEX IF EXISTS idx_domestic_stocks_hash_occurrence;
 
+-- trim_scale() で trailing zeros を除去し、parse_number().normalize() と同一の表現でハッシュを作る
+-- (例: 1.0 → 1、1.10 → 1.1) ※ trim_scale は PostgreSQL 13+
 UPDATE domestic_stocks
 SET content_hash = md5(
     trade_date::text || '|' || settlement_date::text || '|' ||
     security_code || '|' || security_name || '|' || account || '|' ||
-    shares::text || '|' || asked_price::text || '|' || proceeds::text || '|' ||
-    purchase_price::text || '|' || realized_profit_and_loss::text || '|' ||
-    taxes::text || '|' || realized_profit_and_loss_after_tax::text
+    trim_scale(shares)::text || '|' || trim_scale(asked_price)::text || '|' || trim_scale(proceeds)::text || '|' ||
+    trim_scale(purchase_price)::text || '|' || trim_scale(realized_profit_and_loss)::text || '|' ||
+    trim_scale(taxes)::text || '|' || trim_scale(realized_profit_and_loss_after_tax)::text
 );
 
 -- occurrence_index を新しい content_hash に合わせて再計算

--- a/backend/migrations/0017_recalculate_domestic_stocks_content_hash.sql
+++ b/backend/migrations/0017_recalculate_domestic_stocks_content_hash.sql
@@ -1,0 +1,26 @@
+-- 0016 で DOUBLE PRECISION → NUMERIC(18,6) に変換後、
+-- content_hash が float8::text 前提で作られた値のままになるため再計算する
+-- 同一表現（numeric::text）でハッシュを作り直すことで新規 insert との互換性を回復する
+
+UPDATE domestic_stocks
+SET content_hash = md5(
+    trade_date::text || '|' || settlement_date::text || '|' ||
+    security_code || '|' || security_name || '|' || account || '|' ||
+    shares::text || '|' || asked_price::text || '|' || proceeds::text || '|' ||
+    purchase_price::text || '|' || realized_profit_and_loss::text || '|' ||
+    taxes::text || '|' || realized_profit_and_loss_after_tax::text
+);
+
+-- occurrence_index を新しい content_hash に合わせて再計算
+WITH ranked AS (
+    SELECT id,
+           ROW_NUMBER() OVER (
+               PARTITION BY user_id, content_hash
+               ORDER BY created_at, id
+           ) AS rn
+    FROM domestic_stocks
+)
+UPDATE domestic_stocks d
+SET occurrence_index = ranked.rn
+FROM ranked
+WHERE d.id = ranked.id;

--- a/backend/migrations/0017_recalculate_domestic_stocks_content_hash.sql
+++ b/backend/migrations/0017_recalculate_domestic_stocks_content_hash.sql
@@ -1,6 +1,12 @@
--- 0016 で DOUBLE PRECISION → NUMERIC(18,6) に変換後、
+-- 0016 で DOUBLE PRECISION → NUMERIC に変換後、
 -- content_hash が float8::text 前提で作られた値のままになるため再計算する
 -- 同一表現（numeric::text）でハッシュを作り直すことで新規 insert との互換性を回復する
+--
+-- ユニークインデックス (user_id, content_hash, occurrence_index) が存在するため、
+-- content_hash 更新 → occurrence_index 更新の過渡状態でキー衝突が起きないよう
+-- インデックスを DROP してから再計算し、最後に RECREATE する
+
+DROP INDEX IF EXISTS idx_domestic_stocks_hash_occurrence;
 
 UPDATE domestic_stocks
 SET content_hash = md5(
@@ -24,3 +30,6 @@ UPDATE domestic_stocks d
 SET occurrence_index = ranked.rn
 FROM ranked
 WHERE d.id = ranked.id;
+
+CREATE UNIQUE INDEX idx_domestic_stocks_hash_occurrence
+    ON domestic_stocks (user_id, content_hash, occurrence_index);

--- a/backend/src/models/asset_balance.rs
+++ b/backend/src/models/asset_balance.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use utoipa::ToSchema;
@@ -14,14 +15,22 @@ pub struct AssetBalance {
     pub user_id: Uuid,
     pub security_code: String,
     pub security_name: String,
-    pub shares: f64,
-    pub executing_shares: f64,
-    pub average_purchase_price: f64,
-    pub total_purchase_amount: f64,
-    pub current_price: f64,
-    pub daily_change: f64,
-    pub market_value: f64,
-    pub profit_loss_rate: f64,
+    #[schema(value_type = f64)]
+    pub shares: Decimal,
+    #[schema(value_type = f64)]
+    pub executing_shares: Decimal,
+    #[schema(value_type = f64)]
+    pub average_purchase_price: Decimal,
+    #[schema(value_type = f64)]
+    pub total_purchase_amount: Decimal,
+    #[schema(value_type = f64)]
+    pub current_price: Decimal,
+    #[schema(value_type = f64)]
+    pub daily_change: Decimal,
+    #[schema(value_type = f64)]
+    pub market_value: Decimal,
+    #[schema(value_type = f64)]
+    pub profit_loss_rate: Decimal,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -33,14 +42,22 @@ pub struct CreateAssetBalanceRequest {
     pub security_code: String,
     #[validate(length(min = 1, max = 200))]
     pub security_name: String,
-    pub shares: f64,
-    pub executing_shares: f64,
-    pub average_purchase_price: f64,
-    pub total_purchase_amount: f64,
-    pub current_price: f64,
-    pub daily_change: f64,
-    pub market_value: f64,
-    pub profit_loss_rate: f64,
+    #[schema(value_type = f64)]
+    pub shares: Decimal,
+    #[schema(value_type = f64)]
+    pub executing_shares: Decimal,
+    #[schema(value_type = f64)]
+    pub average_purchase_price: Decimal,
+    #[schema(value_type = f64)]
+    pub total_purchase_amount: Decimal,
+    #[schema(value_type = f64)]
+    pub current_price: Decimal,
+    #[schema(value_type = f64)]
+    pub daily_change: Decimal,
+    #[schema(value_type = f64)]
+    pub market_value: Decimal,
+    #[schema(value_type = f64)]
+    pub profit_loss_rate: Decimal,
 }
 
 /// 保有銘柄一括作成リクエスト
@@ -53,20 +70,21 @@ pub struct BulkCreateAssetBalanceRequest {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rust_decimal_macros::dec;
 
     #[test]
     fn test_create_asset_balance_request_validation() {
         let request = CreateAssetBalanceRequest {
             security_code: "1234".to_string(),
             security_name: "テスト株式会社".to_string(),
-            shares: 100.0,
-            executing_shares: 0.0,
-            average_purchase_price: 1500.0,
-            total_purchase_amount: 150000.0,
-            current_price: 1600.0,
-            daily_change: 10.0,
-            market_value: 160000.0,
-            profit_loss_rate: 6.67,
+            shares: dec!(100),
+            executing_shares: dec!(0),
+            average_purchase_price: dec!(1500),
+            total_purchase_amount: dec!(150000),
+            current_price: dec!(1600),
+            daily_change: dec!(10),
+            market_value: dec!(160000),
+            profit_loss_rate: dec!(6.67),
         };
 
         assert!(request.validate().is_ok());

--- a/backend/src/models/dividend.rs
+++ b/backend/src/models/dividend.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, NaiveDate, Utc};
+use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use utoipa::ToSchema;
@@ -17,11 +18,16 @@ pub struct Dividend {
     pub account: String,
     pub security_code: String,
     pub security_name: String,
-    pub unit_price: f64,
-    pub shares: f64,
-    pub dividends_before_tax: f64,
-    pub taxes: f64,
-    pub net_amount_received: f64,
+    #[schema(value_type = f64)]
+    pub unit_price: Decimal,
+    #[schema(value_type = f64)]
+    pub shares: Decimal,
+    #[schema(value_type = f64)]
+    pub dividends_before_tax: Decimal,
+    #[schema(value_type = f64)]
+    pub taxes: Decimal,
+    #[schema(value_type = f64)]
+    pub net_amount_received: Decimal,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -38,16 +44,22 @@ pub struct CreateDividendRequest {
     pub security_code: String,
     #[validate(length(min = 1, max = 200))]
     pub security_name: String,
-    pub unit_price: f64,
-    pub shares: f64,
-    pub dividends_before_tax: f64,
-    pub taxes: f64,
-    pub net_amount_received: f64,
+    #[schema(value_type = f64)]
+    pub unit_price: Decimal,
+    #[schema(value_type = f64)]
+    pub shares: Decimal,
+    #[schema(value_type = f64)]
+    pub dividends_before_tax: Decimal,
+    #[schema(value_type = f64)]
+    pub taxes: Decimal,
+    #[schema(value_type = f64)]
+    pub net_amount_received: Decimal,
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rust_decimal_macros::dec;
 
     #[test]
     fn test_create_dividend_request_validation() {
@@ -57,11 +69,11 @@ mod tests {
             account: "特定".to_string(),
             security_code: "1234".to_string(),
             security_name: "テスト株式会社".to_string(),
-            unit_price: 100.0,
-            shares: 100.0,
-            dividends_before_tax: 1000.0,
-            taxes: 200.0,
-            net_amount_received: 800.0,
+            unit_price: dec!(100),
+            shares: dec!(100),
+            dividends_before_tax: dec!(1000),
+            taxes: dec!(200),
+            net_amount_received: dec!(800),
         };
 
         assert!(request.validate().is_ok());

--- a/backend/src/models/domestic_stock.rs
+++ b/backend/src/models/domestic_stock.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, NaiveDate, Utc};
+use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use utoipa::ToSchema;
@@ -17,13 +18,20 @@ pub struct DomesticStock {
     pub security_code: String,
     pub security_name: String,
     pub account: String,
-    pub shares: f64,
-    pub asked_price: f64,
-    pub proceeds: f64,
-    pub purchase_price: f64,
-    pub realized_profit_and_loss: f64,
-    pub taxes: f64,
-    pub realized_profit_and_loss_after_tax: f64,
+    #[schema(value_type = f64)]
+    pub shares: Decimal,
+    #[schema(value_type = f64)]
+    pub asked_price: Decimal,
+    #[schema(value_type = f64)]
+    pub proceeds: Decimal,
+    #[schema(value_type = f64)]
+    pub purchase_price: Decimal,
+    #[schema(value_type = f64)]
+    pub realized_profit_and_loss: Decimal,
+    #[schema(value_type = f64)]
+    pub taxes: Decimal,
+    #[schema(value_type = f64)]
+    pub realized_profit_and_loss_after_tax: Decimal,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -39,18 +47,26 @@ pub struct CreateDomesticStockRequest {
     pub security_name: String,
     #[validate(length(min = 1, max = 100))]
     pub account: String,
-    pub shares: f64,
-    pub asked_price: f64,
-    pub proceeds: f64,
-    pub purchase_price: f64,
-    pub realized_profit_and_loss: f64,
-    pub taxes: f64,
-    pub realized_profit_and_loss_after_tax: f64,
+    #[schema(value_type = f64)]
+    pub shares: Decimal,
+    #[schema(value_type = f64)]
+    pub asked_price: Decimal,
+    #[schema(value_type = f64)]
+    pub proceeds: Decimal,
+    #[schema(value_type = f64)]
+    pub purchase_price: Decimal,
+    #[schema(value_type = f64)]
+    pub realized_profit_and_loss: Decimal,
+    #[schema(value_type = f64)]
+    pub taxes: Decimal,
+    #[schema(value_type = f64)]
+    pub realized_profit_and_loss_after_tax: Decimal,
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rust_decimal_macros::dec;
 
     #[test]
     fn test_create_domestic_stock_request_validation() {
@@ -60,13 +76,13 @@ mod tests {
             security_code: "1234".to_string(),
             security_name: "テスト株式会社".to_string(),
             account: "特定".to_string(),
-            shares: 100.0,
-            asked_price: 1500.0,
-            proceeds: 150000.0,
-            purchase_price: 1400.0,
-            realized_profit_and_loss: 10000.0,
-            taxes: 2000.0,
-            realized_profit_and_loss_after_tax: 8000.0,
+            shares: dec!(100),
+            asked_price: dec!(1500),
+            proceeds: dec!(150000),
+            purchase_price: dec!(1400),
+            realized_profit_and_loss: dec!(10000),
+            taxes: dec!(2000),
+            realized_profit_and_loss_after_tax: dec!(8000),
         };
 
         assert!(request.validate().is_ok());

--- a/backend/src/models/mutualfund.rs
+++ b/backend/src/models/mutualfund.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, NaiveDate, Utc};
+use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use utoipa::ToSchema;
@@ -17,14 +18,22 @@ pub struct Mutualfund {
     pub fund_name: String,
     pub dividends: Option<String>,
     pub account: String,
-    pub shares: f64,
-    pub exchange_rate: f64,
-    pub cancellation_unit_price_yen: f64,
-    pub cancellation_amount_yen: f64,
-    pub average_acquisition_price_yen: f64,
-    pub realized_profit_and_loss: f64,
-    pub taxes: f64,
-    pub realized_profit_and_loss_after_tax: f64,
+    #[schema(value_type = f64)]
+    pub shares: Decimal,
+    #[schema(value_type = f64)]
+    pub exchange_rate: Decimal,
+    #[schema(value_type = f64)]
+    pub cancellation_unit_price_yen: Decimal,
+    #[schema(value_type = f64)]
+    pub cancellation_amount_yen: Decimal,
+    #[schema(value_type = f64)]
+    pub average_acquisition_price_yen: Decimal,
+    #[schema(value_type = f64)]
+    pub realized_profit_and_loss: Decimal,
+    #[schema(value_type = f64)]
+    pub taxes: Decimal,
+    #[schema(value_type = f64)]
+    pub realized_profit_and_loss_after_tax: Decimal,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -40,19 +49,28 @@ pub struct CreateMutualfundRequest {
     pub dividends: Option<String>,
     #[validate(length(min = 1, max = 100))]
     pub account: String,
-    pub shares: f64,
-    pub exchange_rate: f64,
-    pub cancellation_unit_price_yen: f64,
-    pub cancellation_amount_yen: f64,
-    pub average_acquisition_price_yen: f64,
-    pub realized_profit_and_loss: f64,
-    pub taxes: f64,
-    pub realized_profit_and_loss_after_tax: f64,
+    #[schema(value_type = f64)]
+    pub shares: Decimal,
+    #[schema(value_type = f64)]
+    pub exchange_rate: Decimal,
+    #[schema(value_type = f64)]
+    pub cancellation_unit_price_yen: Decimal,
+    #[schema(value_type = f64)]
+    pub cancellation_amount_yen: Decimal,
+    #[schema(value_type = f64)]
+    pub average_acquisition_price_yen: Decimal,
+    #[schema(value_type = f64)]
+    pub realized_profit_and_loss: Decimal,
+    #[schema(value_type = f64)]
+    pub taxes: Decimal,
+    #[schema(value_type = f64)]
+    pub realized_profit_and_loss_after_tax: Decimal,
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rust_decimal_macros::dec;
 
     #[test]
     fn test_create_mutualfund_request_validation() {
@@ -62,14 +80,14 @@ mod tests {
             fund_name: "テストファンド".to_string(),
             dividends: Some("再投資型".to_string()),
             account: "特定".to_string(),
-            shares: 10000.0,
-            exchange_rate: 1.0,
-            cancellation_unit_price_yen: 15000.0,
-            cancellation_amount_yen: 150000.0,
-            average_acquisition_price_yen: 14000.0,
-            realized_profit_and_loss: 10000.0,
-            taxes: 2000.0,
-            realized_profit_and_loss_after_tax: 8000.0,
+            shares: dec!(10000),
+            exchange_rate: dec!(1),
+            cancellation_unit_price_yen: dec!(15000),
+            cancellation_amount_yen: dec!(150000),
+            average_acquisition_price_yen: dec!(14000),
+            realized_profit_and_loss: dec!(10000),
+            taxes: dec!(2000),
+            realized_profit_and_loss_after_tax: dec!(8000),
         };
 
         assert!(request.validate().is_ok());

--- a/backend/src/services/asset_balance.rs
+++ b/backend/src/services/asset_balance.rs
@@ -5,6 +5,7 @@ use crate::models::csv_import::{CsvPreviewResponse, CsvUploadResponse};
 use crate::services::csv_import::{finish_csv_upload, parse_csv};
 use crate::services::csv_parse::{decode_bytes, parse_number, parse_optional_string};
 use csv::StringRecord;
+use rust_decimal::Decimal;
 use sqlx::PgPool;
 use std::collections::HashMap;
 use std::time::Instant;
@@ -45,15 +46,16 @@ pub async fn bulk_create(
     let user_ids: Vec<Uuid> = vec![user_id; total];
     let security_codes: Vec<&str> = items.iter().map(|i| i.security_code.as_str()).collect();
     let security_names: Vec<&str> = items.iter().map(|i| i.security_name.as_str()).collect();
-    let shares: Vec<f64> = items.iter().map(|i| i.shares).collect();
-    let executing_shares: Vec<f64> = items.iter().map(|i| i.executing_shares).collect();
-    let average_purchase_prices: Vec<f64> =
+    let shares: Vec<Decimal> = items.iter().map(|i| i.shares).collect();
+    let executing_shares: Vec<Decimal> = items.iter().map(|i| i.executing_shares).collect();
+    let average_purchase_prices: Vec<Decimal> =
         items.iter().map(|i| i.average_purchase_price).collect();
-    let total_purchase_amounts: Vec<f64> = items.iter().map(|i| i.total_purchase_amount).collect();
-    let current_prices: Vec<f64> = items.iter().map(|i| i.current_price).collect();
-    let daily_changes: Vec<f64> = items.iter().map(|i| i.daily_change).collect();
-    let market_values: Vec<f64> = items.iter().map(|i| i.market_value).collect();
-    let profit_loss_rates: Vec<f64> = items.iter().map(|i| i.profit_loss_rate).collect();
+    let total_purchase_amounts: Vec<Decimal> =
+        items.iter().map(|i| i.total_purchase_amount).collect();
+    let current_prices: Vec<Decimal> = items.iter().map(|i| i.current_price).collect();
+    let daily_changes: Vec<Decimal> = items.iter().map(|i| i.daily_change).collect();
+    let market_values: Vec<Decimal> = items.iter().map(|i| i.market_value).collect();
+    let profit_loss_rates: Vec<Decimal> = items.iter().map(|i| i.profit_loss_rate).collect();
 
     // トランザクション内で全削除 → 全件挿入（スナップショット置き換え）
     let mut tx = pool.begin().await?;
@@ -76,8 +78,8 @@ pub async fn bulk_create(
                                         average_purchase_price, total_purchase_amount, current_price,
                                         daily_change, market_value, profit_loss_rate)
             SELECT * FROM UNNEST(
-                $1::uuid[], $2::text[], $3::text[], $4::float8[], $5::float8[],
-                $6::float8[], $7::float8[], $8::float8[], $9::float8[], $10::float8[], $11::float8[]
+                $1::uuid[], $2::text[], $3::text[], $4::numeric[], $5::numeric[],
+                $6::numeric[], $7::numeric[], $8::numeric[], $9::numeric[], $10::numeric[], $11::numeric[]
             )
             "#,
         )
@@ -196,7 +198,7 @@ fn parse_asset_balance_row(
         shares: num("保有数量［株］")?,
         // 執行中は "-" / 空欄が仕様上ありうるため 0.0 フォールバック
         executing_shares: parse_number(&parse_optional_string(record, header_map, "執行中［株］"))
-            .unwrap_or(0.0),
+            .unwrap_or(Decimal::ZERO),
         average_purchase_price: num("平均取得価額［円］")?,
         total_purchase_amount: num("取得総額［円］")?,
         current_price: num("現在値［円］")?,
@@ -206,7 +208,7 @@ fn parse_asset_balance_row(
             header_map,
             "現在値（前日比）［円］",
         ))
-        .unwrap_or(0.0),
+        .unwrap_or(Decimal::ZERO),
         market_value: num("時価評価額［円］")?,
         // 評価損益は NISA 等で表示されない場合に "-" が仕様上ありうるため 0.0 フォールバック
         profit_loss_rate: parse_number(&parse_optional_string(
@@ -214,7 +216,7 @@ fn parse_asset_balance_row(
             header_map,
             "評価損益［％］",
         ))
-        .unwrap_or(0.0),
+        .unwrap_or(Decimal::ZERO),
     })
 }
 
@@ -228,6 +230,7 @@ pub async fn delete_all(pool: &PgPool, user_id: Uuid) -> Result<u64, ApiError> {
 mod tests {
     use super::*;
     use crate::services::csv_import::parse_csv;
+    use rust_decimal_macros::dec;
 
     fn make_csv(header: &str, row: &str) -> String {
         format!("{}\n{}\n", header, row)
@@ -246,10 +249,10 @@ mod tests {
         assert!(errors.is_empty());
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].security_code, "1234");
-        assert_eq!(items[0].shares, 100.0);
-        assert_eq!(items[0].executing_shares, 0.0); // "-" → 0.0
-        assert_eq!(items[0].average_purchase_price, 1500.0);
-        assert_eq!(items[0].current_price, 1600.0);
+        assert_eq!(items[0].shares, dec!(100));
+        assert_eq!(items[0].executing_shares, Decimal::ZERO); // "-" → 0
+        assert_eq!(items[0].average_purchase_price, dec!(1500));
+        assert_eq!(items[0].current_price, dec!(1600));
     }
 
     #[test]
@@ -291,7 +294,7 @@ mod tests {
         let csv = make_csv(HEADER, "5678,ファンド,50,-,2000,100000,2100,-,105000,-");
         let (items, errors) = parse_csv(csv.as_bytes(), parse_asset_balance_row).unwrap();
         assert!(errors.is_empty());
-        assert_eq!(items[0].daily_change, 0.0);
-        assert_eq!(items[0].profit_loss_rate, 0.0);
+        assert_eq!(items[0].daily_change, Decimal::ZERO);
+        assert_eq!(items[0].profit_loss_rate, Decimal::ZERO);
     }
 }

--- a/backend/src/services/csv_parse.rs
+++ b/backend/src/services/csv_parse.rs
@@ -90,7 +90,7 @@ pub fn parse_required_string(
     row_num: usize,
 ) -> Result<String, CsvRowError> {
     let val = get_cell(record, header_map, col);
-    if val.is_empty() {
+    if val.trim().is_empty() {
         return Err(CsvRowError {
             row: row_num,
             message: format!("必須列 '{}' が空または存在しません", col),
@@ -107,7 +107,7 @@ pub fn parse_required_number(
     row_num: usize,
 ) -> Result<Decimal, CsvRowError> {
     let raw = get_cell(record, header_map, col);
-    if raw.is_empty() {
+    if raw.trim().is_empty() {
         return Err(CsvRowError {
             row: row_num,
             message: format!("必須列 '{}' が空または存在しません", col),

--- a/backend/src/services/csv_parse.rs
+++ b/backend/src/services/csv_parse.rs
@@ -1,7 +1,9 @@
 use crate::models::csv_import::CsvRowError;
 use chrono::NaiveDate;
 use encoding_rs::{SHIFT_JIS, UTF_8};
+use rust_decimal::Decimal;
 use std::collections::HashMap;
+use std::str::FromStr;
 
 /// UTF-8 デコードを試み、失敗時は Shift-JIS にフォールバック
 pub fn decode_bytes(bytes: &[u8]) -> String {
@@ -16,11 +18,11 @@ pub fn decode_bytes(bytes: &[u8]) -> String {
 }
 
 /// 数値文字列をパース（カンマ区切り・括弧マイナス対応）
-/// 例: "1,234" → 1234.0、"(500)" → -500.0、"-" → 0.0（値なし）
-pub fn parse_number(s: &str) -> Result<f64, String> {
+/// 例: "1,234" → 1234、"(500)" → -500、"-" → 0（値なし）
+pub fn parse_number(s: &str) -> Result<Decimal, String> {
     let s = s.trim();
     if s.is_empty() || s == "-" {
-        return Ok(0.0);
+        return Ok(Decimal::ZERO);
     }
     // 括弧表記はマイナス
     let (negative, s) = if s.starts_with('(') && s.ends_with(')') {
@@ -29,9 +31,8 @@ pub fn parse_number(s: &str) -> Result<f64, String> {
         (false, s)
     };
     let s = s.replace(',', "");
-    let value: f64 = s
-        .parse()
-        .map_err(|_| format!("数値のパースに失敗しました: '{}'", s))?;
+    let value =
+        Decimal::from_str(&s).map_err(|_| format!("数値のパースに失敗しました: '{}'", s))?;
     Ok(if negative { -value } else { value })
 }
 
@@ -48,14 +49,14 @@ pub fn parse_date(s: &str) -> Result<NaiveDate, String> {
 }
 
 /// 税金を計算する（特定口座かつ利益がある場合のみ）
-pub fn compute_taxes(account: &str, realized_pnl: f64) -> (f64, f64) {
-    const TAX_RATE: f64 = 0.20315;
-    if account.contains("特定") && realized_pnl > 0.0 {
-        let taxes = (realized_pnl * TAX_RATE).floor();
+pub fn compute_taxes(account: &str, realized_pnl: Decimal) -> (Decimal, Decimal) {
+    let tax_rate = Decimal::from_str("0.20315").unwrap();
+    if account.contains("特定") && realized_pnl > Decimal::ZERO {
+        let taxes = (realized_pnl * tax_rate).floor();
         let after_tax = realized_pnl - taxes;
         (taxes, after_tax)
     } else {
-        (0.0, realized_pnl)
+        (Decimal::ZERO, realized_pnl)
     }
 }
 
@@ -103,7 +104,7 @@ pub fn parse_required_number(
     header_map: &HashMap<String, usize>,
     col: &str,
     row_num: usize,
-) -> Result<f64, CsvRowError> {
+) -> Result<Decimal, CsvRowError> {
     let raw = get_cell(record, header_map, col);
     if raw.is_empty() {
         return Err(CsvRowError {
@@ -134,15 +135,16 @@ pub fn parse_required_date(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rust_decimal_macros::dec;
 
     #[test]
     fn test_parse_number_normal() {
-        assert_eq!(parse_number("1,234").unwrap(), 1234.0);
-        assert_eq!(parse_number("500").unwrap(), 500.0);
-        assert_eq!(parse_number("(500)").unwrap(), -500.0);
-        assert_eq!(parse_number("").unwrap(), 0.0);
-        // ハイフン単独は「値なし」として 0.0
-        assert_eq!(parse_number("-").unwrap(), 0.0);
+        assert_eq!(parse_number("1,234").unwrap(), dec!(1234));
+        assert_eq!(parse_number("500").unwrap(), dec!(500));
+        assert_eq!(parse_number("(500)").unwrap(), dec!(-500));
+        assert_eq!(parse_number("").unwrap(), Decimal::ZERO);
+        // ハイフン単独は「値なし」として 0
+        assert_eq!(parse_number("-").unwrap(), Decimal::ZERO);
     }
 
     #[test]
@@ -175,23 +177,23 @@ mod tests {
 
     #[test]
     fn test_compute_taxes_tokutei_profit() {
-        let (taxes, after) = compute_taxes("特定", 10000.0);
-        assert_eq!(taxes, 2031.0); // floor(10000 * 0.20315)
-        assert_eq!(after, 7969.0);
+        let (taxes, after) = compute_taxes("特定", dec!(10000));
+        assert_eq!(taxes, dec!(2031)); // floor(10000 * 0.20315)
+        assert_eq!(after, dec!(7969));
     }
 
     #[test]
     fn test_compute_taxes_loss() {
-        let (taxes, after) = compute_taxes("特定", -5000.0);
-        assert_eq!(taxes, 0.0);
-        assert_eq!(after, -5000.0);
+        let (taxes, after) = compute_taxes("特定", dec!(-5000));
+        assert_eq!(taxes, Decimal::ZERO);
+        assert_eq!(after, dec!(-5000));
     }
 
     #[test]
     fn test_compute_taxes_nisa() {
-        let (taxes, after) = compute_taxes("NISA", 10000.0);
-        assert_eq!(taxes, 0.0);
-        assert_eq!(after, 10000.0);
+        let (taxes, after) = compute_taxes("NISA", dec!(10000));
+        assert_eq!(taxes, Decimal::ZERO);
+        assert_eq!(after, dec!(10000));
     }
 
     #[test]
@@ -226,7 +228,7 @@ mod tests {
         assert_eq!(err.row, 5);
 
         let ok = parse_required_number(&record, &header_map, "good", 1).unwrap();
-        assert_eq!(ok, 1234.0);
+        assert_eq!(ok, dec!(1234));
     }
 
     #[test]

--- a/backend/src/services/csv_parse.rs
+++ b/backend/src/services/csv_parse.rs
@@ -33,7 +33,8 @@ pub fn parse_number(s: &str) -> Result<Decimal, String> {
     let s = s.replace(',', "");
     let value =
         Decimal::from_str(&s).map_err(|_| format!("数値のパースに失敗しました: '{}'", s))?;
-    Ok(if negative { -value } else { value })
+    // trailing zero を除去して表記差（"1" vs "1.0"）がハッシュに影響しないよう正規化する
+    Ok(if negative { -value } else { value }.normalize())
 }
 
 /// 日付文字列をパース（"YYYY/MM/DD" または "YYYY-MM-DD"）

--- a/backend/src/services/dividend.rs
+++ b/backend/src/services/dividend.rs
@@ -6,6 +6,7 @@ use crate::services::csv_import::{build_preview, finish_csv_upload, parse_csv};
 use crate::services::csv_parse::{
     parse_optional_string, parse_required_date, parse_required_number, parse_required_string,
 };
+use rust_decimal::Decimal;
 use sqlx::PgPool;
 use std::collections::HashMap;
 use std::time::Instant;
@@ -57,11 +58,12 @@ pub async fn bulk_create(
     let accounts: Vec<&str> = items.iter().map(|i| i.account.as_str()).collect();
     let security_codes: Vec<&str> = items.iter().map(|i| i.security_code.as_str()).collect();
     let security_names: Vec<&str> = items.iter().map(|i| i.security_name.as_str()).collect();
-    let unit_prices: Vec<f64> = items.iter().map(|i| i.unit_price).collect();
-    let shares: Vec<f64> = items.iter().map(|i| i.shares).collect();
-    let dividends_before_taxes: Vec<f64> = items.iter().map(|i| i.dividends_before_tax).collect();
-    let taxes: Vec<f64> = items.iter().map(|i| i.taxes).collect();
-    let net_amounts: Vec<f64> = items.iter().map(|i| i.net_amount_received).collect();
+    let unit_prices: Vec<Decimal> = items.iter().map(|i| i.unit_price).collect();
+    let shares: Vec<Decimal> = items.iter().map(|i| i.shares).collect();
+    let dividends_before_taxes: Vec<Decimal> =
+        items.iter().map(|i| i.dividends_before_tax).collect();
+    let taxes: Vec<Decimal> = items.iter().map(|i| i.taxes).collect();
+    let net_amounts: Vec<Decimal> = items.iter().map(|i| i.net_amount_received).collect();
 
     // UNNESTを使ったバルクINSERT（1回のクエリで全件挿入）
     let result = sqlx::query(
@@ -71,8 +73,8 @@ pub async fn bulk_create(
                                taxes, net_amount_received)
         SELECT * FROM UNNEST(
             $1::uuid[], $2::date[], $3::text[], $4::text[], $5::text[],
-            $6::text[], $7::float8[], $8::float8[], $9::float8[],
-            $10::float8[], $11::float8[]
+            $6::text[], $7::numeric[], $8::numeric[], $9::numeric[],
+            $10::numeric[], $11::numeric[]
         )
         ON CONFLICT (user_id, settlement_date, security_code, security_name, shares, dividends_before_tax)
         DO NOTHING

--- a/backend/src/services/domestic_stock.rs
+++ b/backend/src/services/domestic_stock.rs
@@ -6,6 +6,7 @@ use crate::services::csv_import::{build_preview, finish_csv_upload, parse_csv};
 use crate::services::csv_parse::{
     compute_taxes, parse_required_date, parse_required_number, parse_required_string,
 };
+use rust_decimal::Decimal;
 use sqlx::PgPool;
 use std::collections::HashMap;
 use std::time::Instant;
@@ -69,13 +70,13 @@ pub async fn bulk_create(
     let security_codes: Vec<&str> = items.iter().map(|i| i.security_code.as_str()).collect();
     let security_names: Vec<&str> = items.iter().map(|i| i.security_name.as_str()).collect();
     let accounts: Vec<&str> = items.iter().map(|i| i.account.as_str()).collect();
-    let shares: Vec<f64> = items.iter().map(|i| i.shares).collect();
-    let asked_prices: Vec<f64> = items.iter().map(|i| i.asked_price).collect();
-    let proceeds: Vec<f64> = items.iter().map(|i| i.proceeds).collect();
-    let purchase_prices: Vec<f64> = items.iter().map(|i| i.purchase_price).collect();
-    let realized_pls: Vec<f64> = items.iter().map(|i| i.realized_profit_and_loss).collect();
-    let taxes: Vec<f64> = items.iter().map(|i| i.taxes).collect();
-    let realized_pls_after_tax: Vec<f64> = items
+    let shares: Vec<Decimal> = items.iter().map(|i| i.shares).collect();
+    let asked_prices: Vec<Decimal> = items.iter().map(|i| i.asked_price).collect();
+    let proceeds: Vec<Decimal> = items.iter().map(|i| i.proceeds).collect();
+    let purchase_prices: Vec<Decimal> = items.iter().map(|i| i.purchase_price).collect();
+    let realized_pls: Vec<Decimal> = items.iter().map(|i| i.realized_profit_and_loss).collect();
+    let taxes: Vec<Decimal> = items.iter().map(|i| i.taxes).collect();
+    let realized_pls_after_tax: Vec<Decimal> = items
         .iter()
         .map(|i| i.realized_profit_and_loss_after_tax)
         .collect();
@@ -103,8 +104,8 @@ pub async fn bulk_create(
                 ) AS content_hash
             FROM UNNEST(
                 $1::uuid[], $2::date[], $3::date[], $4::text[],
-                $5::text[], $6::text[], $7::float8[], $8::float8[], $9::float8[],
-                $10::float8[], $11::float8[], $12::float8[], $13::float8[]
+                $5::text[], $6::text[], $7::numeric[], $8::numeric[], $9::numeric[],
+                $10::numeric[], $11::numeric[], $12::numeric[], $13::numeric[]
             ) WITH ORDINALITY AS t(user_id, trade_date, settlement_date, security_code,
                    security_name, account, shares, asked_price, proceeds,
                    purchase_price, realized_profit_and_loss, taxes,
@@ -222,6 +223,7 @@ pub async fn delete_all(pool: &PgPool, user_id: Uuid) -> Result<u64, ApiError> {
 mod tests {
     use super::*;
     use chrono::NaiveDate;
+    use rust_decimal_macros::dec;
 
     fn make_test_item() -> CreateDomesticStockRequest {
         CreateDomesticStockRequest {
@@ -230,13 +232,13 @@ mod tests {
             security_code: "9508".to_string(),
             security_name: "九州電力".to_string(),
             account: "特定".to_string(),
-            shares: 100.0,
-            asked_price: 1880.0,
-            proceeds: 188000.0,
-            purchase_price: 1770.0,
-            realized_profit_and_loss: 11000.0,
-            taxes: 2234.0,
-            realized_profit_and_loss_after_tax: 8766.0,
+            shares: dec!(100),
+            asked_price: dec!(1880),
+            proceeds: dec!(188000),
+            purchase_price: dec!(1770),
+            realized_profit_and_loss: dec!(11000),
+            taxes: dec!(2234),
+            realized_profit_and_loss_after_tax: dec!(8766),
         }
     }
 

--- a/backend/src/services/mutualfund.rs
+++ b/backend/src/services/mutualfund.rs
@@ -6,6 +6,7 @@ use crate::services::csv_import::{build_preview, finish_csv_upload, parse_csv};
 use crate::services::csv_parse::{
     compute_taxes, get_cell, parse_required_date, parse_required_number, parse_required_string,
 };
+use rust_decimal::Decimal;
 use sqlx::PgPool;
 use std::collections::HashMap;
 use std::time::Instant;
@@ -58,20 +59,21 @@ pub async fn bulk_create(
     let fund_names: Vec<&str> = items.iter().map(|i| i.fund_name.as_str()).collect();
     let dividends: Vec<Option<&str>> = items.iter().map(|i| i.dividends.as_deref()).collect();
     let accounts: Vec<&str> = items.iter().map(|i| i.account.as_str()).collect();
-    let shares: Vec<f64> = items.iter().map(|i| i.shares).collect();
-    let exchange_rates: Vec<f64> = items.iter().map(|i| i.exchange_rate).collect();
-    let cancellation_unit_prices: Vec<f64> = items
+    let shares: Vec<Decimal> = items.iter().map(|i| i.shares).collect();
+    let exchange_rates: Vec<Decimal> = items.iter().map(|i| i.exchange_rate).collect();
+    let cancellation_unit_prices: Vec<Decimal> = items
         .iter()
         .map(|i| i.cancellation_unit_price_yen)
         .collect();
-    let cancellation_amounts: Vec<f64> = items.iter().map(|i| i.cancellation_amount_yen).collect();
-    let avg_acquisition_prices: Vec<f64> = items
+    let cancellation_amounts: Vec<Decimal> =
+        items.iter().map(|i| i.cancellation_amount_yen).collect();
+    let avg_acquisition_prices: Vec<Decimal> = items
         .iter()
         .map(|i| i.average_acquisition_price_yen)
         .collect();
-    let realized_pls: Vec<f64> = items.iter().map(|i| i.realized_profit_and_loss).collect();
-    let taxes: Vec<f64> = items.iter().map(|i| i.taxes).collect();
-    let realized_pls_after_tax: Vec<f64> = items
+    let realized_pls: Vec<Decimal> = items.iter().map(|i| i.realized_profit_and_loss).collect();
+    let taxes: Vec<Decimal> = items.iter().map(|i| i.taxes).collect();
+    let realized_pls_after_tax: Vec<Decimal> = items
         .iter()
         .map(|i| i.realized_profit_and_loss_after_tax)
         .collect();
@@ -85,8 +87,8 @@ pub async fn bulk_create(
                                  realized_profit_and_loss, taxes, realized_profit_and_loss_after_tax)
         SELECT * FROM UNNEST(
             $1::uuid[], $2::date[], $3::date[], $4::text[], $5::text[],
-            $6::text[], $7::float8[], $8::float8[], $9::float8[],
-            $10::float8[], $11::float8[], $12::float8[], $13::float8[], $14::float8[]
+            $6::text[], $7::numeric[], $8::numeric[], $9::numeric[],
+            $10::numeric[], $11::numeric[], $12::numeric[], $13::numeric[], $14::numeric[]
         )
         ON CONFLICT (user_id, trade_date, fund_name, shares, cancellation_amount_yen)
         DO NOTHING

--- a/backend/tests/db_integration.rs
+++ b/backend/tests/db_integration.rs
@@ -12,6 +12,7 @@ use backend::{
 };
 use chrono::NaiveDate;
 use reqwest::Client;
+use rust_decimal_macros::dec;
 use sqlx::{postgres::PgPoolOptions, PgPool};
 use std::{env, sync::Arc, time::Duration};
 use testcontainers::runners::AsyncRunner;
@@ -152,14 +153,14 @@ fn make_asset_item(code: &str) -> CreateAssetBalanceRequest {
     CreateAssetBalanceRequest {
         security_code: code.to_string(),
         security_name: format!("テスト銘柄{}", code),
-        shares: 100.0,
-        executing_shares: 0.0,
-        average_purchase_price: 1000.0,
-        total_purchase_amount: 100_000.0,
-        current_price: 1100.0,
-        daily_change: 10.0,
-        market_value: 110_000.0,
-        profit_loss_rate: 10.0,
+        shares: dec!(100),
+        executing_shares: dec!(0),
+        average_purchase_price: dec!(1000),
+        total_purchase_amount: dec!(100000),
+        current_price: dec!(1100),
+        daily_change: dec!(10),
+        market_value: dec!(110000),
+        profit_loss_rate: dec!(10),
     }
 }
 


### PR DESCRIPTION
## 概要

金融データの計算精度問題を解消するため、バックエンド全体で `f64` から `rust_decimal::Decimal` へ移行しました。

## 主な変更

- **Cargo.toml**: `rust_decimal`（`serde-float` feature）、`rust_decimal_macros`、`sqlx` の `rust_decimal` feature を追加
- **models**: 全 4 テーブルの Decimal フィールドに `#[schema(value_type = f64)]` を付与し utoipa/OpenAPI 互換を確保
- **services**: `Vec<f64>` → `Vec<Decimal>`、UNNEST SQL キャストを `float8[]` → `numeric[]` に変更
- **csv_parse**: `parse_number` に `.normalize()` を追加し trailing zero による content_hash 表記差を解消
- **migration 0016**: 全テーブルの `DOUBLE PRECISION` 列を `NUMERIC`（無制限精度）へ変換
- **migration 0017**: `domestic_stocks.content_hash` を `trim_scale()` + `occurrence_index` を DROP/RECREATE 付きで再計算
- **tests**: `f64` リテラルを `dec!()` / `Decimal::ZERO` に更新

## テスト結果

- `cargo fmt --check`: ✅
- `cargo clippy -- -D warnings`: ✅
- `cargo test`: ✅ 129 passed, 0 failed（Docker 不要テスト）
- `bash scripts/check-openapi.sh`: ✅ openapi.json と api.ts 差分なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced precision for financial calculations across all investment types (asset balances, dividends, stocks, mutual funds) by using arbitrary-precision arithmetic instead of floating-point calculations, eliminating rounding errors in financial reporting and data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->