### PR TITLE
fix: Receipt / Dividend テストを現行 UI に追従させ skip を解消

### DIFF
--- a/frontend/src/components/templates/__tests__/ReceiptTemplate.integration.test.tsx
+++ b/frontend/src/components/templates/__tests__/ReceiptTemplate.integration.test.tsx
@@ -189,8 +189,7 @@ describe('ReceiptTemplate Context API統合テスト', () => {
     expect(mockOnSearchExpandToggle).toHaveBeenCalledTimes(6);
   });
 
-  // TODO: テーブルデータの表示確認テストを修正する必要あり
-  test.skip('テーブルデータが正しく表示される', () => {
+  test('テーブルデータが正しく表示される', () => {
     render(
       <ReceiptTemplate
         title="データ表示テスト"
@@ -213,15 +212,15 @@ describe('ReceiptTemplate Context API統合テスト', () => {
     expect(screen.getByText('金額')).toBeInTheDocument();
     expect(screen.getByText('カテゴリ')).toBeInTheDocument();
 
-    // データの確認
-    expect(screen.getByText('1')).toBeInTheDocument();
+    // データの確認（複数箇所に同一テキストが出る場合は getAllByText を使用）
+    expect(screen.getAllByText('1').length).toBeGreaterThan(0);
     expect(screen.getByText('商品A')).toBeInTheDocument();
     expect(screen.getByText('1000')).toBeInTheDocument();
-    expect(screen.getByText('カテゴリ1')).toBeInTheDocument();
+    expect(screen.getAllByText('カテゴリ1').length).toBeGreaterThan(0);
 
-    // サマリーの確認
+    // サマリーの確認（1500 はデータ行とサマリー行の両方に出る）
     expect(screen.getByText('3000')).toBeInTheDocument();
-    expect(screen.getByText('1500')).toBeInTheDocument();
+    expect(screen.getAllByText('1500').length).toBeGreaterThan(0);
   });
 
   test('検索カテゴリのドロップダウンが正常に動作する', () => {

--- a/frontend/src/components/templates/__tests__/ReceiptTemplate.test.tsx
+++ b/frontend/src/components/templates/__tests__/ReceiptTemplate.test.tsx
@@ -104,49 +104,33 @@ describe('ReceiptTemplate', () => {
     expect(screen.getByText('カスタムフッター')).toBeInTheDocument();
   });
 
-  // TODO: forceResizeの実装変更に伴いテストを修正する必要あり
-  test.skip('SearchCard展開時にforceResizeが更新される', () => {
+  test('SearchCard展開時にonSearchExpandToggleが呼ばれる', () => {
     render(
-      <ReceiptTemplate 
+      <ReceiptTemplate
         {...defaultProps}
         onSearch={mockOnSearch}
         onSearchExpandToggle={mockOnSearchExpandToggle}
       />
     );
 
-    const initialForceResize = screen.getByTestId('mock-receipt-table').getAttribute('data-force-resize');
-    
-    // SearchCardを展開
     const expandButton = screen.getByText('Expand');
     fireEvent.click(expandButton);
 
-    const updatedForceResize = screen.getByTestId('mock-receipt-table').getAttribute('data-force-resize');
-    
-    // forceResizeが更新されることを確認
-    expect(updatedForceResize).not.toBe(initialForceResize);
     expect(mockOnSearchExpandToggle).toHaveBeenCalledWith(true);
   });
 
-  // TODO: forceResizeの実装変更に伴いテストを修正する必要あり
-  test.skip('SearchCard折りたたみ時にforceResizeが更新される', () => {
+  test('SearchCard折りたたみ時にonSearchExpandToggleが呼ばれる', () => {
     render(
-      <ReceiptTemplate 
+      <ReceiptTemplate
         {...defaultProps}
         onSearch={mockOnSearch}
         onSearchExpandToggle={mockOnSearchExpandToggle}
       />
     );
 
-    const initialForceResize = screen.getByTestId('mock-receipt-table').getAttribute('data-force-resize');
-    
-    // SearchCardを折りたたみ
     const collapseButton = screen.getByText('Collapse');
     fireEvent.click(collapseButton);
 
-    const updatedForceResize = screen.getByTestId('mock-receipt-table').getAttribute('data-force-resize');
-    
-    // forceResizeが更新されることを確認
-    expect(updatedForceResize).not.toBe(initialForceResize);
     expect(mockOnSearchExpandToggle).toHaveBeenCalledWith(false);
   });
 

--- a/frontend/src/pages/Receipt/__tests__/Dividend.test.tsx
+++ b/frontend/src/pages/Receipt/__tests__/Dividend.test.tsx
@@ -246,35 +246,28 @@ describe('Dividend', () => {
         expect(table).toHaveClass('w-full', 'border-collapse');
     });
 
-    // TODO: 配当情報フォームの数値計算テストを修正する必要あり
-    it.skip('配当情報フォームで数値計算が動作する', async () => {
+    it('銘柄選択後にread-onlyの集計情報が表示される', async () => {
         const user = userEvent.setup();
         const { container } = render(<Dividend data={mockData} />);
 
-        // 検索オプションは初期状態で展開済み - 銘柄を選択して配当情報フォームを表示（IDで指定）
+        // 検索オプションは初期状態で展開済み - 銘柄を選択（IDで指定）
         await waitFor(() => {
             expect(container.querySelector('#securities-search')).toBeInTheDocument();
         });
         const selectElement = container.querySelector('#securities-search') as HTMLSelectElement;
         await user.selectOptions(selectElement, '1234');
 
+        // 銘柄詳細ヘッダーが表示されることを確認
         await waitFor(() => {
-            expect(screen.getByText('銘柄詳細')).toBeInTheDocument();
+            expect(screen.getByText('集計情報 / 銘柄詳細')).toBeInTheDocument();
         });
 
-        // フォームが存在し、入力可能であることを確認
-        const inputs = screen.getAllByRole('spinbutton');
-        expect(inputs.length).toBeGreaterThan(0);
+        // embedded モードでは read-only KPI カードが表示される
+        expect(screen.getByText('平均取得価格')).toBeVisible();
+        expect(screen.getByText('保有数量(株)')).toBeVisible();
+        expect(screen.getByText('一株配当')).toBeVisible();
 
-        // 最初の入力フィールドに数値を入力してテスト
-        if (inputs.length > 0) {
-            await user.clear(inputs[0]);
-            await user.type(inputs[0], '1000');
-
-            // 入力が反映されることを確認
-            await waitFor(() => {
-                expect(inputs[0]).toHaveValue(1000);
-            });
-        }
+        // 入力フォーム（spinbutton）は表示されない（embedded モードは read-only）
+        expect(screen.queryAllByRole('spinbutton').length).toBe(0);
     });
 });


### PR DESCRIPTION
## 概要

実装変更で古くなった Receipt / Dividend 系テストを現行 UI の挙動に合わせて修正し、skip を 4 件解消。

## 変更内容

- **ReceiptTemplate.test.tsx**: `forceResize` prop 前提の 2 テストを `ResizeContext` 経由の `onSearchExpandToggle` コールバック検証に書き換え
- **ReceiptTemplate.integration.test.tsx**: テーブルデータ確認テストで重複テキストに `getAllByText` を使用
- **Dividend.test.tsx**: 廃止済みの入力フォームテストを embedded モードの read-only KPI 表示確認に置き換え

## テスト結果

- Before: 422 passed / 7 skipped
- After: 426 passed / 3 skipped（4 テスト解消）
- `cd frontend && npm test -- --run` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled and updated table data rendering verification tests with improved assertion logic.
  * Updated SearchCard behavior tests to verify expand/collapse callback invocations.
  * Updated aggregated information display tests to verify read-only mode behavior in embedded contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->