### PR TITLE
test: backend の no-op テストを削除し Secrets フィールド検証テストに置き換え

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -168,6 +168,7 @@ pub fn is_secure_cookie() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_env::{EnvGuard, ENV_MUTEX};
     use crate::{routes::app_router, state::AppState};
     use axum::{
         body::Body,
@@ -176,35 +177,7 @@ mod tests {
     };
     use reqwest::Client;
     use std::sync::Arc;
-    use tokio::sync::Mutex;
     use tower::ServiceExt;
-
-    static ENV_MUTEX: Mutex<()> = Mutex::const_new(());
-
-    struct EnvGuard {
-        key: &'static str,
-        previous: Option<String>,
-    }
-
-    impl EnvGuard {
-        fn set(key: &'static str, value: Option<&str>) -> Self {
-            let previous = env::var(key).ok();
-            match value {
-                Some(value) => env::set_var(key, value),
-                None => env::remove_var(key),
-            }
-            Self { key, previous }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            match &self.previous {
-                Some(value) => env::set_var(self.key, value),
-                None => env::remove_var(self.key),
-            }
-        }
-    }
 
     fn build_test_app(config: &Config) -> Router {
         let database_url = "postgresql://user:password@localhost/test_db";

--- a/backend/src/extractors/auth.rs
+++ b/backend/src/extractors/auth.rs
@@ -49,11 +49,3 @@ where
         Ok(AuthenticatedUser(user))
     }
 }
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn test_module_compilation() {
-        // モジュールが正常にコンパイルされることを確認
-    }
-}

--- a/backend/src/handlers/asset_balance.rs
+++ b/backend/src/handlers/asset_balance.rs
@@ -118,11 +118,3 @@ pub async fn delete_all(
         Json(serde_json::json!({"message": "全ての保有銘柄データを削除しました"})),
     ))
 }
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn test_module_compilation() {
-        // モジュールが正常にコンパイルされることを確認
-    }
-}

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -259,11 +259,3 @@ pub async fn delete_account(
         Json(serde_json::json!({"message": "アカウントを削除しました"})),
     ))
 }
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn test_module_compilation() {
-        // モジュールが正常にコンパイルされることを確認
-    }
-}

--- a/backend/src/handlers/dividend.rs
+++ b/backend/src/handlers/dividend.rs
@@ -94,11 +94,3 @@ pub async fn delete_all(
         Json(serde_json::json!({"message": "全ての配当金データを削除しました"})),
     ))
 }
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn test_module_compilation() {
-        // モジュールが正常にコンパイルされることを確認
-    }
-}

--- a/backend/src/handlers/dividend_per_share.rs
+++ b/backend/src/handlers/dividend_per_share.rs
@@ -35,11 +35,3 @@ pub async fn batch(
 
     Ok(Json(DividendPerShareBatchResponse { items }))
 }
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn test_module_compilation() {
-        // モジュールが正常にコンパイルされることを確認
-    }
-}

--- a/backend/src/handlers/domestic_stock.rs
+++ b/backend/src/handlers/domestic_stock.rs
@@ -94,11 +94,3 @@ pub async fn delete_all(
         Json(serde_json::json!({"message": "全ての国内株式取引データを削除しました"})),
     ))
 }
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn test_module_compilation() {
-        // モジュールが正常にコンパイルされることを確認
-    }
-}

--- a/backend/src/handlers/jquants.rs
+++ b/backend/src/handlers/jquants.rs
@@ -41,11 +41,3 @@ pub async fn get_fin_summary(
     let response = JQuantsService::get_fin_summary(&state.client, params, api_key).await?;
     Ok(Json(response))
 }
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn test_module_compilation() {
-        // モジュールが正常にコンパイルされることを確認
-    }
-}

--- a/backend/src/handlers/mutualfund.rs
+++ b/backend/src/handlers/mutualfund.rs
@@ -94,11 +94,3 @@ pub async fn delete_all(
         Json(serde_json::json!({"message": "全ての投資信託データを削除しました"})),
     ))
 }
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn test_module_compilation() {
-        // モジュールが正常にコンパイルされることを確認
-    }
-}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -11,6 +11,9 @@ pub mod routes;
 pub mod services;
 pub mod state;
 
+#[cfg(test)]
+pub mod test_env;
+
 pub use config::Config;
 pub use errors::ApiError;
 pub use extractors::validated_json::ValidatedJson;

--- a/backend/src/logging.rs
+++ b/backend/src/logging.rs
@@ -9,13 +9,3 @@ pub fn init_tracing() {
         .with(tracing_subscriber::fmt::layer())
         .init();
 }
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn test_module_compilation() {
-        // ロギング初期化はグローバル状態を変更するため、
-        // 複数テストでの呼び出しは避ける
-        // このテストはモジュールのコンパイルを確認する
-    }
-}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -20,9 +20,6 @@ use state::{AppState, Secrets};
 use std::sync::{atomic::AtomicBool, Arc};
 use tokio::net::TcpListener;
 
-#[cfg(test)]
-use db::connect_pool_lazy;
-
 #[tokio::main]
 async fn main() {
     // 環境変数の読み込み
@@ -69,93 +66,4 @@ async fn main() {
     axum::serve(listener, router)
         .await
         .expect("サーバーの起動に失敗しました");
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use axum::http::Method;
-    use axum::Router;
-
-    /// テスト用のアプリケーションルーターを作成する
-    pub fn create_test_router() -> Router {
-        let database_url = "postgresql://user:password@localhost/test_db";
-        let pool = connect_pool_lazy(database_url, 1).expect("Failed to create connection pool");
-
-        let secrets = Arc::new(Secrets {
-            database_url: database_url.to_string(),
-            jquants_api_key: Some("test_api_key".to_string()),
-            google_client_id: None,
-            google_client_secret: None,
-            frontend_url: "http://localhost:8080".to_string(),
-        });
-
-        let client = Client::new();
-        let state = AppState {
-            pool,
-            secrets,
-            client,
-            background_task_running: Arc::new(AtomicBool::new(false)),
-        };
-
-        let config = Config::default();
-        app_router(state, &config)
-    }
-
-    #[tokio::test]
-    async fn test_router_creation() {
-        let _router = create_test_router();
-        // ルーターが正常に作成されることを確認
-    }
-
-    #[tokio::test]
-    async fn test_cors_configuration() {
-        let allowed_headers = [
-            axum::http::header::CONTENT_TYPE,
-            axum::http::header::ACCEPT,
-            axum::http::header::ORIGIN,
-            axum::http::header::AUTHORIZATION,
-        ];
-
-        let allowed_methods = [
-            Method::GET,
-            Method::POST,
-            Method::PUT,
-            Method::DELETE,
-            Method::OPTIONS,
-        ];
-
-        // CORS設定が正しく構成されることを確認
-        assert_eq!(allowed_headers.len(), 4);
-        assert_eq!(allowed_methods.len(), 5);
-        assert!(allowed_methods.contains(&Method::GET));
-        assert!(allowed_methods.contains(&Method::POST));
-    }
-
-    #[tokio::test]
-    async fn test_app_state_creation_from_config() {
-        let database_url = "postgresql://user:password@localhost/test_db";
-        let pool = connect_pool_lazy(database_url, 5).expect("Failed to create connection pool");
-
-        let secrets = Arc::new(Secrets {
-            database_url: database_url.to_string(),
-            jquants_api_key: None,
-            google_client_id: None,
-            google_client_secret: None,
-            frontend_url: "http://localhost:8080".to_string(),
-        });
-        let client = Client::new();
-
-        let state = AppState {
-            pool,
-            secrets,
-            client,
-            background_task_running: Arc::new(AtomicBool::new(false)),
-        };
-
-        // AppStateが正常に作成されることを確認
-        let _ = &state.pool;
-        let _ = &state.secrets;
-        let _ = &state.client;
-    }
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -11,6 +11,9 @@ mod routes;
 mod services;
 mod state;
 
+#[cfg(test)]
+mod test_env;
+
 use config::Config;
 use db::{connect_pool, run_migrations};
 use dotenvy::dotenv;

--- a/backend/src/services/jquants.rs
+++ b/backend/src/services/jquants.rs
@@ -91,11 +91,6 @@ mod tests {
     use super::*;
     use crate::models::jquants::FinSummaryQuery;
 
-    #[test]
-    fn test_module_compilation() {
-        // モジュールが正常にコンパイルされることを確認
-    }
-
     /// 実際のJ-Quants APIを呼び出すテスト
     /// 実行には環境変数 JQUANTS_API_KEY が必要
     /// cargo test test_get_fin_summary_real_api -- --ignored

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -40,16 +40,42 @@ pub struct AppState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{LazyLock, Mutex};
+    use std::env;
+    use tokio::sync::Mutex;
 
-    // env var 操作テストを直列化するためのロック（並行テストによる競合防止）
-    static ENV_MUTEX: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+    // env var 操作テストを直列化するためのロック（config.rs と同じパターン）
+    static ENV_MUTEX: Mutex<()> = Mutex::const_new(());
 
-    #[test]
-    fn test_secrets_from_env_error_without_database_url() {
-        let _guard = ENV_MUTEX.lock().unwrap();
-        let saved = std::env::var("DATABASE_URL").ok();
-        std::env::remove_var("DATABASE_URL");
+    /// env var を操作し、Drop 時に元の値へ自動復元するガード
+    struct EnvGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: Option<&str>) -> Self {
+            let previous = env::var(key).ok();
+            match value {
+                Some(v) => env::set_var(key, v),
+                None => env::remove_var(key),
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(v) => env::set_var(self.key, v),
+                None => env::remove_var(self.key),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_secrets_from_env_error_without_database_url() {
+        let _lock = ENV_MUTEX.lock().await;
+        let _db = EnvGuard::set("DATABASE_URL", None);
 
         let result = Secrets::from_env();
 
@@ -59,59 +85,37 @@ mod tests {
             err_msg.contains("DATABASE_URL"),
             "エラーメッセージに DATABASE_URL が含まれること: {err_msg}"
         );
-
-        if let Some(val) = saved {
-            std::env::set_var("DATABASE_URL", val);
-        }
     }
 
-    #[test]
-    fn test_secrets_from_env_frontend_url_default() {
+    #[tokio::test]
+    async fn test_secrets_from_env_frontend_url_default() {
         // FRONTEND_URL 未設定時はデフォルト値 "http://localhost:8080" を使用する
-        let _guard = ENV_MUTEX.lock().unwrap();
-        let saved_db = std::env::var("DATABASE_URL").ok();
-        let saved_fe = std::env::var("FRONTEND_URL").ok();
-
-        std::env::set_var("DATABASE_URL", "postgresql://user:password@localhost/test");
-        std::env::remove_var("FRONTEND_URL");
+        let _lock = ENV_MUTEX.lock().await;
+        let _db = EnvGuard::set(
+            "DATABASE_URL",
+            Some("postgresql://user:password@localhost/test"),
+        );
+        let _fe = EnvGuard::set("FRONTEND_URL", None);
 
         let result = Secrets::from_env();
 
         assert!(result.is_ok());
         assert_eq!(result.unwrap().frontend_url, "http://localhost:8080");
-
-        match saved_db {
-            Some(val) => std::env::set_var("DATABASE_URL", val),
-            None => std::env::remove_var("DATABASE_URL"),
-        }
-        match saved_fe {
-            Some(val) => std::env::set_var("FRONTEND_URL", val),
-            None => std::env::remove_var("FRONTEND_URL"),
-        }
     }
 
-    #[test]
-    fn test_secrets_from_env_jquants_key_is_optional() {
+    #[tokio::test]
+    async fn test_secrets_from_env_jquants_key_is_optional() {
         // JQUANTS_API_KEY は省略可能で None になる
-        let _guard = ENV_MUTEX.lock().unwrap();
-        let saved_db = std::env::var("DATABASE_URL").ok();
-        let saved_jq = std::env::var("JQUANTS_API_KEY").ok();
-
-        std::env::set_var("DATABASE_URL", "postgresql://user:password@localhost/test");
-        std::env::remove_var("JQUANTS_API_KEY");
+        let _lock = ENV_MUTEX.lock().await;
+        let _db = EnvGuard::set(
+            "DATABASE_URL",
+            Some("postgresql://user:password@localhost/test"),
+        );
+        let _jq = EnvGuard::set("JQUANTS_API_KEY", None);
 
         let result = Secrets::from_env();
 
         assert!(result.is_ok());
         assert!(result.unwrap().jquants_api_key.is_none());
-
-        match saved_db {
-            Some(val) => std::env::set_var("DATABASE_URL", val),
-            None => std::env::remove_var("DATABASE_URL"),
-        }
-        match saved_jq {
-            Some(val) => std::env::set_var("JQUANTS_API_KEY", val),
-            None => std::env::remove_var("JQUANTS_API_KEY"),
-        }
     }
 }

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -40,37 +40,7 @@ pub struct AppState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::env;
-    use tokio::sync::Mutex;
-
-    // env var 操作テストを直列化するためのロック（config.rs と同じパターン）
-    static ENV_MUTEX: Mutex<()> = Mutex::const_new(());
-
-    /// env var を操作し、Drop 時に元の値へ自動復元するガード
-    struct EnvGuard {
-        key: &'static str,
-        previous: Option<String>,
-    }
-
-    impl EnvGuard {
-        fn set(key: &'static str, value: Option<&str>) -> Self {
-            let previous = env::var(key).ok();
-            match value {
-                Some(v) => env::set_var(key, v),
-                None => env::remove_var(key),
-            }
-            Self { key, previous }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            match &self.previous {
-                Some(v) => env::set_var(self.key, v),
-                None => env::remove_var(self.key),
-            }
-        }
-    }
+    use crate::test_env::{EnvGuard, ENV_MUTEX};
 
     #[tokio::test]
     async fn test_secrets_from_env_error_without_database_url() {

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -40,71 +40,42 @@ pub struct AppState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sqlx::postgres::PgPoolOptions;
 
-    fn create_test_secrets() -> Secrets {
-        Secrets {
+    #[test]
+    fn test_secrets_fields() {
+        // Secrets の各フィールドに値が正しく格納されることを確認
+        let secrets = Secrets {
             database_url: "postgresql://user:password@localhost/test_db".to_string(),
             jquants_api_key: Some("test_api_key".to_string()),
+            google_client_id: Some("client_id".to_string()),
+            google_client_secret: Some("client_secret".to_string()),
+            frontend_url: "http://localhost:8080".to_string(),
+        };
+        assert_eq!(
+            secrets.database_url,
+            "postgresql://user:password@localhost/test_db"
+        );
+        assert_eq!(secrets.jquants_api_key.as_deref(), Some("test_api_key"));
+        assert_eq!(secrets.google_client_id.as_deref(), Some("client_id"));
+        assert_eq!(
+            secrets.google_client_secret.as_deref(),
+            Some("client_secret")
+        );
+        assert_eq!(secrets.frontend_url, "http://localhost:8080");
+    }
+
+    #[test]
+    fn test_secrets_optional_fields_can_be_none() {
+        // jquants_api_key, google_client_id, google_client_secret は省略可能
+        let secrets = Secrets {
+            database_url: "postgresql://localhost/db".to_string(),
+            jquants_api_key: None,
             google_client_id: None,
             google_client_secret: None,
             frontend_url: "http://localhost:8080".to_string(),
-        }
-    }
-
-    #[tokio::test]
-    async fn test_app_state_creation() {
-        let database_url = "postgresql://user:password@localhost/test_db";
-
-        let pool = PgPoolOptions::new()
-            .max_connections(1)
-            .connect_lazy(database_url)
-            .expect("Failed to create connection pool");
-
-        let secrets = Arc::new(create_test_secrets());
-        let client = Client::new();
-
-        let app_state = AppState {
-            pool: pool.clone(),
-            secrets: secrets.clone(),
-            client: client.clone(),
-            background_task_running: Arc::new(AtomicBool::new(false)),
         };
-
-        // AppStateが正常に作成されることを確認
-        let _ = &app_state.pool;
-        let _ = &app_state.secrets;
-        let _ = &app_state.client;
-
-        // AppStateのクローンが正常に動作することを確認
-        let cloned_state = app_state.clone();
-        let _ = &cloned_state.pool;
-        let _ = &cloned_state.secrets;
-        let _ = &cloned_state.client;
-    }
-
-    #[tokio::test]
-    async fn test_app_state_clone() {
-        let database_url = "postgresql://user:password@localhost/test_db";
-        let pool = PgPoolOptions::new()
-            .max_connections(1)
-            .connect_lazy(database_url)
-            .expect("Failed to create connection pool");
-
-        let secrets = Arc::new(create_test_secrets());
-        let client = Client::new();
-
-        let original_state = AppState {
-            pool,
-            secrets,
-            client,
-            background_task_running: Arc::new(AtomicBool::new(false)),
-        };
-
-        let cloned_state = original_state.clone();
-
-        let _ = &cloned_state.pool;
-        let _ = &cloned_state.secrets;
-        let _ = &cloned_state.client;
+        assert!(secrets.jquants_api_key.is_none());
+        assert!(secrets.google_client_id.is_none());
+        assert!(secrets.google_client_secret.is_none());
     }
 }

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -40,42 +40,78 @@ pub struct AppState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{LazyLock, Mutex};
+
+    // env var 操作テストを直列化するためのロック（並行テストによる競合防止）
+    static ENV_MUTEX: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
     #[test]
-    fn test_secrets_fields() {
-        // Secrets の各フィールドに値が正しく格納されることを確認
-        let secrets = Secrets {
-            database_url: "postgresql://user:password@localhost/test_db".to_string(),
-            jquants_api_key: Some("test_api_key".to_string()),
-            google_client_id: Some("client_id".to_string()),
-            google_client_secret: Some("client_secret".to_string()),
-            frontend_url: "http://localhost:8080".to_string(),
-        };
-        assert_eq!(
-            secrets.database_url,
-            "postgresql://user:password@localhost/test_db"
+    fn test_secrets_from_env_error_without_database_url() {
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let saved = std::env::var("DATABASE_URL").ok();
+        std::env::remove_var("DATABASE_URL");
+
+        let result = Secrets::from_env();
+
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err();
+        assert!(
+            err_msg.contains("DATABASE_URL"),
+            "エラーメッセージに DATABASE_URL が含まれること: {err_msg}"
         );
-        assert_eq!(secrets.jquants_api_key.as_deref(), Some("test_api_key"));
-        assert_eq!(secrets.google_client_id.as_deref(), Some("client_id"));
-        assert_eq!(
-            secrets.google_client_secret.as_deref(),
-            Some("client_secret")
-        );
-        assert_eq!(secrets.frontend_url, "http://localhost:8080");
+
+        if let Some(val) = saved {
+            std::env::set_var("DATABASE_URL", val);
+        }
     }
 
     #[test]
-    fn test_secrets_optional_fields_can_be_none() {
-        // jquants_api_key, google_client_id, google_client_secret は省略可能
-        let secrets = Secrets {
-            database_url: "postgresql://localhost/db".to_string(),
-            jquants_api_key: None,
-            google_client_id: None,
-            google_client_secret: None,
-            frontend_url: "http://localhost:8080".to_string(),
-        };
-        assert!(secrets.jquants_api_key.is_none());
-        assert!(secrets.google_client_id.is_none());
-        assert!(secrets.google_client_secret.is_none());
+    fn test_secrets_from_env_frontend_url_default() {
+        // FRONTEND_URL 未設定時はデフォルト値 "http://localhost:8080" を使用する
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let saved_db = std::env::var("DATABASE_URL").ok();
+        let saved_fe = std::env::var("FRONTEND_URL").ok();
+
+        std::env::set_var("DATABASE_URL", "postgresql://user:password@localhost/test");
+        std::env::remove_var("FRONTEND_URL");
+
+        let result = Secrets::from_env();
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().frontend_url, "http://localhost:8080");
+
+        match saved_db {
+            Some(val) => std::env::set_var("DATABASE_URL", val),
+            None => std::env::remove_var("DATABASE_URL"),
+        }
+        match saved_fe {
+            Some(val) => std::env::set_var("FRONTEND_URL", val),
+            None => std::env::remove_var("FRONTEND_URL"),
+        }
+    }
+
+    #[test]
+    fn test_secrets_from_env_jquants_key_is_optional() {
+        // JQUANTS_API_KEY は省略可能で None になる
+        let _guard = ENV_MUTEX.lock().unwrap();
+        let saved_db = std::env::var("DATABASE_URL").ok();
+        let saved_jq = std::env::var("JQUANTS_API_KEY").ok();
+
+        std::env::set_var("DATABASE_URL", "postgresql://user:password@localhost/test");
+        std::env::remove_var("JQUANTS_API_KEY");
+
+        let result = Secrets::from_env();
+
+        assert!(result.is_ok());
+        assert!(result.unwrap().jquants_api_key.is_none());
+
+        match saved_db {
+            Some(val) => std::env::set_var("DATABASE_URL", val),
+            None => std::env::remove_var("DATABASE_URL"),
+        }
+        match saved_jq {
+            Some(val) => std::env::set_var("JQUANTS_API_KEY", val),
+            None => std::env::remove_var("JQUANTS_API_KEY"),
+        }
     }
 }

--- a/backend/src/test_env.rs
+++ b/backend/src/test_env.rs
@@ -1,0 +1,34 @@
+/// env var 操作を伴うテスト全体で共有するユーティリティ
+///
+/// `std::env::set_var` / `remove_var` はプロセス全体に影響するため、
+/// crate 内の env テストは必ずここの `ENV_MUTEX` を取得してから実行する。
+use std::env;
+use tokio::sync::Mutex;
+
+pub static ENV_MUTEX: Mutex<()> = Mutex::const_new(());
+
+/// env var を操作し、Drop 時に元の値へ自動復元するガード
+pub struct EnvGuard {
+    key: &'static str,
+    previous: Option<String>,
+}
+
+impl EnvGuard {
+    pub fn set(key: &'static str, value: Option<&str>) -> Self {
+        let previous = env::var(key).ok();
+        match value {
+            Some(v) => env::set_var(key, v),
+            None => env::remove_var(key),
+        }
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        match &self.previous {
+            Some(v) => env::set_var(self.key, v),
+            None => env::remove_var(self.key),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `test_module_compilation`（空ボディ）を 10 箇所から削除
- `main.rs` の 3 テスト（ローカル定数のみ検証、観測可能な結果なし）を削除
- `state.rs` の no-op テストを `Secrets` フィールド検証テストに置き換え

## Test plan

- [x] `cargo fmt --check` pass
- [x] `cargo clippy -- -D warnings` pass
- [x] `cargo test` 119 passed / 0 failed / 5 ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Removed numerous redundant module-level unit tests across backend files to streamline the suite.
  * Added centralized test utilities (EnvGuard and ENV_MUTEX) to serialize and safely manage env-var changes.
  * Reworked state and config tests to focus on environment-based behaviors for secrets and defaults, replacing heavier in-file scaffolding with the new test helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->