### PR TITLE
chore: Claude運用資産を追加

### DIFF
--- a/.claude/agents/api-contract-reviewer.md
+++ b/.claude/agents/api-contract-reviewer.md
@@ -1,0 +1,45 @@
+---
+name: api-contract-reviewer
+description: Use this agent when backend API contracts may have drifted from OpenAPI, generated frontend types, or UI consumers. PROACTIVELY use it after changing J-Quants handlers, models, generated API types, or contract-sensitive frontend hooks.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+skills: jquants-contract-maintenance, backend-build-test, frontend-build-test
+color: teal
+---
+
+# API Contract Reviewer
+
+J-Quants や OpenAPI 契約差分を起点に、backend / generated type / frontend consumer の不整合を検出する専任 agent。
+
+## What This Agent Does
+
+- backend route / model / schema の契約差分を確認する
+- `docs/openapi.json` と `frontend/src/generated/api.ts` の同期漏れを確認する
+- hand-written frontend 型と consumer hook の追従漏れを確認する
+- 影響範囲を `must fix` と `follow-up` に分けて返す
+
+## When to Use This Agent
+
+- `backend/src/models/jquants.rs` を変更したとき
+- `backend/src/handlers/jquants.rs` や `backend/src/openapi.rs` を変更したとき
+- `frontend/src/features/jquants/` や `frontend/src/generated/api.ts` を変更したとき
+- 実 API と app 内 contract のズレが疑われるとき
+
+## How It Proceeds
+
+1. **Inspect**: J-Quants 関連の backend / frontend / generated file を読む
+2. **Compare**: route shape、schema、generated type、consumer 前提を照合する
+3. **Verify**: 必要なら `scripts/check-openapi.sh` と関連テスト実行を提案または実行する
+4. **Report**: 契約差分、回帰リスク、修正順序を返す
+
+## Output Format
+
+- Scope reviewed
+- Must fix
+- Follow-up
+- Verification commands
+
+## Notes
+
+- false positive を避けるため、必ず file reference 付きで指摘する
+- backend だけ、frontend だけで完結すると決めつけない

--- a/.claude/rules/00-general.md
+++ b/.claude/rules/00-general.md
@@ -21,6 +21,9 @@
 - Claude は Codex の指摘に対応し、必要な修正と検証を行う
 - 修正後は Codex が再レビューし、指摘事項の解消を確認する
 - Codex から Claude に修正実装を依頼する場合は `.claude/skills/codex-claude-handoff/SKILL.md` を使用する
+- Codex CLI のレビュー起動は `codex exec review` を優先し、必要なら `codex exec "/pr-review してください"` を使う
+- push 後にレビューを省略しない。修正を push したら毎回再レビューする
+- backend の API 契約変更時は `bash scripts/check-openapi.sh` を実行して `docs/openapi.json` と `frontend/src/generated/api.ts` を同期する
 
 ## 出力制約
 

--- a/.claude/skills/jquants-contract-maintenance/SKILL.md
+++ b/.claude/skills/jquants-contract-maintenance/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: jquants-contract-maintenance
+description: J-Quants API の仕様差分、deserialize エラー、OpenAPI/generated type の不整合、frontend の配当表示崩れを調査して修正するための手順。J-Quants 関連ファイル、配当表示、外部 API 契約差分、型同期、V1→V2 移行、実レスポンス追従が必要なときに使う。
+allowed-tools: Read, Grep, Glob, Bash
+---
+
+# J-Quants Contract Maintenance
+
+## Overview
+
+J-Quants 関連の不具合は、backend service / Rust model / OpenAPI / frontend generated type / consumer hook のどこかで契約がずれると連鎖して壊れる。まず契約差分を確定し、その後に backend と frontend の同期を一気に確認する。
+
+## When to Use
+
+- `missing field ...` のような deserialize エラーが出たとき
+- frontend で `is not iterable` など J-Quants 応答 shape 不一致が出たとき
+- J-Quants V1/V2 の仕様差分対応をするとき
+- `backend/src/models/jquants.rs` や `frontend/src/features/jquants/` を触るとき
+- backend の API 変更後に `docs/openapi.json` と `frontend/src/generated/api.ts` の同期が必要なとき
+
+## Workflow
+
+1. 症状を分類する
+2. 契約の正本を確定する
+3. backend の parser / model / route を合わせる
+4. OpenAPI と generated type を再同期する
+5. frontend hook / UI consumer を合わせる
+6. 関連テストと同期チェックを実行する
+
+## 1. 症状を分類する
+
+- backend ログで失敗:
+  - `missing field`, `invalid type`, `unknown variant`
+  - まず `backend/src/models/jquants.rs` と `backend/src/services/jquants.rs` を確認
+- frontend だけ失敗:
+  - `statements is not iterable`, `undefined.data`, `map is not a function`
+  - まず `frontend/src/features/jquants/api/types.ts`、`frontend/src/generated/api.ts`、consumer hook を確認
+- API は成功だが表示だけ崩れる:
+  - `frontend/src/features/jquants/hooks/` と `frontend/src/components/molecules/DividendInfo/DividendInfo.tsx`、`frontend/src/pages/Receipt/Dividend.tsx` を確認
+
+症状別の詳細は [references/symptoms-and-fixes.md](references/symptoms-and-fixes.md) を読む。
+
+## 2. 契約の正本を確定する
+
+優先順:
+
+1. 実際の J-Quants 応答
+2. `backend/src/models/jquants.rs`
+3. `backend/src/handlers/jquants.rs` と `backend/src/openapi.rs`
+4. `docs/openapi.json`
+5. `frontend/src/generated/api.ts`
+6. `frontend/src/features/jquants/api/types.ts` と hook 群
+
+注意:
+
+- `frontend/src/features/jquants/api/types.ts` は hand-written 型なので、`frontend/src/generated/api.ts` と矛盾しやすい
+- backend API を変えたら OpenAPI と frontend generated type の再生成を必ず行う
+- frontend 側の一時対応で hand-written 型だけ直して終わらせない
+
+関連ファイル一覧は [references/file-map.md](references/file-map.md) を読む。
+
+## 3. backend を合わせる
+
+最小確認範囲:
+
+- `backend/src/services/jquants.rs`
+- `backend/src/models/jquants.rs`
+- `backend/src/handlers/jquants.rs`
+- `backend/src/routes.rs`
+- `backend/src/openapi.rs`
+
+契約変更が API surface に出るなら:
+
+- `#[utoipa::path]`
+- schema 用 `ToSchema`
+- `generate_openapi`
+
+を一緒に更新する。
+
+## 4. OpenAPI と generated type を再同期する
+
+標準コマンド:
+
+```bash
+bash scripts/check-openapi.sh
+```
+
+個別実行:
+
+```bash
+cd backend && cargo run --bin generate_openapi
+cd frontend && npm run generate:types
+```
+
+## 5. frontend を合わせる
+
+優先確認:
+
+- `frontend/src/features/jquants/api/client.ts`
+- `frontend/src/features/jquants/api/types.ts`
+- `frontend/src/features/jquants/hooks/useJQuantsDividend.ts`
+- `frontend/src/features/jquants/hooks/useJQuantsDividendBatch.ts`
+- `frontend/src/features/jquants/hooks/useDividendBatch.ts`
+- `frontend/src/components/molecules/DividendInfo/DividendInfo.tsx`
+- `frontend/src/pages/Receipt/Dividend.tsx`
+- `frontend/src/pages/AssetBalance.tsx`
+
+原則:
+
+- backend route shape に frontend を寄せる
+- generated type が使えるなら hand-written 型より generated type を優先する
+- 一時的な `as any` は避ける
+
+## 6. 検証
+
+通常はまずこのスクリプトを使う:
+
+```bash
+bash .claude/skills/jquants-contract-maintenance/scripts/check_jquants_contract.sh
+```
+
+追加確認:
+
+```bash
+cd backend && cargo test jquants
+cd frontend && npm test -- --run src/features/jquants/api/__tests__/client.test.ts src/features/jquants/hooks/__tests__/useJQuantsDividend.test.ts src/features/jquants/hooks/__tests__/useJQuantsDividendBatch.test.ts src/features/jquants/hooks/__tests__/useDividendBatch.test.ts
+```
+
+実 API まで確認したいときは `backend/src/services/jquants.rs` の ignored test を読む。通常実行には含めない。
+
+## References
+
+- ファイル配置と責務: [references/file-map.md](references/file-map.md)
+- 症状別の当たり先: [references/symptoms-and-fixes.md](references/symptoms-and-fixes.md)

--- a/.claude/skills/jquants-contract-maintenance/agents/openai.yaml
+++ b/.claude/skills/jquants-contract-maintenance/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "J-Quants Contract Maintenance"
+  short_description: "Maintain J-Quants API contracts and type sync"
+  default_prompt: "Use $jquants-contract-maintenance to investigate J-Quants API contract drift and update backend/frontend types."
+  brand_color: "#0F766E"

--- a/.claude/skills/jquants-contract-maintenance/references/file-map.md
+++ b/.claude/skills/jquants-contract-maintenance/references/file-map.md
@@ -1,0 +1,44 @@
+# File Map
+
+## Backend
+
+- `backend/src/services/jquants.rs`
+  - J-Quants 外部 API 呼び出し
+- `backend/src/models/jquants.rs`
+  - Rust 側の応答モデル
+- `backend/src/handlers/jquants.rs`
+  - 自アプリ API の handler
+- `backend/src/openapi.rs`
+  - OpenAPI へ露出する schema / path
+- `backend/src/bin/generate_openapi.rs`
+  - `docs/openapi.json` の再生成
+
+## Frontend
+
+- `frontend/src/generated/api.ts`
+  - OpenAPI から生成される正規の API 型
+- `frontend/src/features/jquants/api/types.ts`
+  - hand-written 型。generated 型とズレやすい
+- `frontend/src/features/jquants/api/client.ts`
+  - backend の J-Quants route を呼ぶ client
+- `frontend/src/features/jquants/hooks/useJQuantsDividend.ts`
+  - 単一銘柄の配当 hook
+- `frontend/src/features/jquants/hooks/useJQuantsDividendBatch.ts`
+  - 複数銘柄の配当 hook
+- `frontend/src/features/jquants/hooks/useDividendBatch.ts`
+  - UI からの利用側 batch hook
+- `frontend/src/components/molecules/DividendInfo/DividendInfo.tsx`
+  - 配当 KPI 表示
+- `frontend/src/pages/Receipt/Dividend.tsx`
+  - 配当ページの consumer
+- `frontend/src/pages/AssetBalance.tsx`
+  - 保有銘柄ページの consumer
+
+## Sync Path
+
+1. `backend/src/models/jquants.rs`
+2. `backend/src/handlers/jquants.rs`
+3. `backend/src/openapi.rs`
+4. `docs/openapi.json`
+5. `frontend/src/generated/api.ts`
+6. `frontend/src/features/jquants/*`

--- a/.claude/skills/jquants-contract-maintenance/references/symptoms-and-fixes.md
+++ b/.claude/skills/jquants-contract-maintenance/references/symptoms-and-fixes.md
@@ -1,0 +1,48 @@
+# Symptoms and Fixes
+
+## `missing field ...`
+
+見る場所:
+
+- `backend/src/models/jquants.rs`
+- `backend/src/services/jquants.rs`
+
+原因の典型:
+
+- API の field 名変更
+- optional / required の取り違え
+- V1/V2 の field 命名混在
+
+## `... is not iterable`
+
+見る場所:
+
+- `frontend/src/features/jquants/api/types.ts`
+- `frontend/src/generated/api.ts`
+- hook 側の `response.data` / `response.statements` 参照
+
+原因の典型:
+
+- frontend が古い response shape を読んでいる
+- generated type 再生成漏れ
+
+## backend は成功、UI 表示だけ壊れる
+
+見る場所:
+
+- `frontend/src/components/molecules/DividendInfo/DividendInfo.tsx`
+- `frontend/src/pages/Receipt/Dividend.tsx`
+- `frontend/src/pages/AssetBalance.tsx`
+
+原因の典型:
+
+- hook の返り値 shape は合っているが consumer の前提が古い
+- `Map` / 配列 / 単一値の変換漏れ
+
+## fix の順番
+
+1. 実 API か backend route のどちらを正本にするか決める
+2. backend model / handler を合わせる
+3. OpenAPI と generated type を再生成する
+4. frontend hand-written 型と consumer を合わせる
+5. テストと同期チェックを回す

--- a/.claude/skills/jquants-contract-maintenance/scripts/check_jquants_contract.sh
+++ b/.claude/skills/jquants-contract-maintenance/scripts/check_jquants_contract.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+
+echo "[1/3] backend jquants tests"
+(cd backend && cargo test jquants)
+
+echo "[2/3] openapi sync"
+bash scripts/check-openapi.sh
+
+echo "[3/3] frontend jquants tests"
+(cd frontend && npm test -- --run \
+  src/features/jquants/api/__tests__/client.test.ts \
+  src/features/jquants/hooks/__tests__/useJQuantsDividend.test.ts \
+  src/features/jquants/hooks/__tests__/useJQuantsDividendBatch.test.ts \
+  src/features/jquants/hooks/__tests__/useDividendBatch.test.ts)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,12 @@
 - task file がある場合は、その内容を優先してスコープと非対象を守る
 - task 完了時または作業中止時には、対応する task file を削除する
 
+## 設計方針
+
+- API 契約の正本は `docs/openapi.json` とし、backend の API 変更時は `frontend/src/generated/api.ts` まで必ず同期する
+- CSV 取り込みは原則 backend で `parse / validate / import` する。frontend はファイル送信と結果表示を優先する
+- unrelated な修正は同じブランチに混在させない。`1 ブランチ = 1 タスク` を守る
+
 ## 参照ルール
 
 1. `.claude/rules/00-general.md`

--- a/claude-review-ops-plugin/.claude-plugin/plugin.json
+++ b/claude-review-ops-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "review-ops",
+  "version": "0.1.0",
+  "description": "PR review operations commands and reminders for Claude Code",
+  "author": {
+    "name": "zaichu"
+  },
+  "license": "MIT",
+  "keywords": ["review", "pr", "codex", "workflow"]
+}

--- a/claude-review-ops-plugin/commands/address-review-comments.md
+++ b/claude-review-ops-plugin/commands/address-review-comments.md
@@ -1,0 +1,34 @@
+---
+description: Resolve GitHub PR review comments on the current branch and prepare a minimal fix plan
+argument-hint: [pr-number]
+---
+
+# Address Review Comments
+
+Collect open review comments for the current PR, group them by fix area, and prepare an implementation plan.
+
+## Context
+
+Use this when a PR already exists and the user asks to handle reviewer comments.
+
+## Instructions
+
+1. Identify the current PR. If `$ARGUMENTS` is present, treat it as the PR number.
+2. Verify GitHub authentication before attempting to fetch comments.
+3. Retrieve unresolved review comments and issue comments relevant to code changes.
+4. Group comments into:
+   - must-fix correctness issues
+   - contract / typing issues
+   - tests / verification gaps
+   - low-priority cleanup
+5. Produce a minimal implementation plan that preserves existing behavior unless the comment explicitly asks for behavior change.
+6. After fixes are made, instruct the user to run `/review-ops:pr-review-loop`.
+
+## Arguments
+
+- `$ARGUMENTS`: Optional PR number.
+
+## Notes
+
+- Keep fixes scoped to the comment intent.
+- Prefer concrete reproduction and validation commands over broad suggestions.

--- a/claude-review-ops-plugin/commands/create-pr-summary.md
+++ b/claude-review-ops-plugin/commands/create-pr-summary.md
@@ -1,0 +1,26 @@
+---
+description: Draft a Japanese PR title and body from the current branch diff and test results
+argument-hint: [base-branch]
+---
+
+# Create PR Summary
+
+Draft a concise Japanese PR title and body for the current branch.
+
+## Context
+
+Use this right before `gh pr create` or when the PR description needs to be refreshed.
+
+## Instructions
+
+1. Inspect the current branch name, recent commits, and diff against `$ARGUMENTS` or `main`.
+2. Extract only user-facing or reviewer-relevant changes.
+3. Build:
+   - a short Japanese PR title
+   - a body with `変更内容` and `テスト`
+4. If tests were not run, state that explicitly instead of inventing results.
+5. Keep the body tight enough to paste directly into `gh pr create` or `gh pr edit`.
+
+## Arguments
+
+- `$ARGUMENTS`: Optional base branch. Default is `main`.

--- a/claude-review-ops-plugin/commands/pr-review-loop.md
+++ b/claude-review-ops-plugin/commands/pr-review-loop.md
@@ -1,0 +1,32 @@
+---
+description: Run the project PR review loop from the current branch and require re-review after fixes
+argument-hint: [pr-number]
+---
+
+# PR Review Loop
+
+Run the project's standard PR review loop for the current branch.
+
+## Context
+
+Use this command after implementation is done, before merge, or after review fixes were pushed.
+
+## Instructions
+
+1. Detect the current branch and associated PR. If `$ARGUMENTS` is present, treat it as the PR number.
+2. If no PR exists yet, explain that this command should be run after PR creation and stop.
+3. Run the project-standard review entrypoint:
+   - Prefer `codex exec review`
+   - If that is unavailable, use `codex exec "/pr-review してください"`
+4. Summarize the findings with `findings first`.
+5. If findings exist, tell the user that fixes must be pushed and the same review loop must be run again.
+6. If no findings exist, state that re-review is no longer required for the current diff.
+
+## Arguments
+
+- `$ARGUMENTS`: Optional PR number to review explicitly.
+
+## Notes
+
+- Do not replace Codex CLI review with ad-hoc manual review.
+- Re-review is mandatory after every fix push until findings are cleared.

--- a/claude-review-ops-plugin/hooks/hooks.json
+++ b/claude-review-ops-plugin/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "description": "Remind Claude to re-run the review loop after push or PR creation commands",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/review_reminder.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/claude-review-ops-plugin/hooks/review_reminder.py
+++ b/claude-review-ops-plugin/hooks/review_reminder.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+import json
+import re
+import sys
+
+
+def extract_command(payload: dict) -> str:
+    tool_input = payload.get("tool_input")
+    if isinstance(tool_input, dict):
+        for key in ("command", "cmd"):
+            value = tool_input.get(key)
+            if isinstance(value, str):
+                return value
+    tool_result = payload.get("tool_result")
+    if isinstance(tool_result, str):
+        return tool_result
+    return ""
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0
+
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    command_text = extract_command(payload)
+    if not command_text:
+        return 0
+
+    if not re.search(r"\bgit push\b|\bgh pr create\b|\bgh pr edit\b|\bgh pr merge\b", command_text):
+        return 0
+
+    message = {
+        "systemMessage": (
+            "コード変更を push / PR 更新したので、レビュー運用では Codex CLI の再レビューを必ず実行してください。 "
+            "必要なら /review-ops:pr-review-loop を使ってください。"
+        )
+    }
+    print(json.dumps(message, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/claude-session-audit-2026-03-09.md
+++ b/docs/claude-session-audit-2026-03-09.md
@@ -1,0 +1,181 @@
+# Claude Session Audit
+
+## 対象
+
+- 実施日: 2026-03-09
+- 標準保存領域:
+  - `/home/zaichu/.claude/projects/-home-zaichu-project-shoken-webapp/sessions-index.json`
+  - `/home/zaichu/.claude/projects/-home-zaichu-project-shoken-webapp/memory/MEMORY.md`
+  - `/home/zaichu/.claude/projects/-home-zaichu-project-shoken-webapp/memory/redesign-proposal.md`
+  - `/home/zaichu/.claude/tasks/*`
+- 注記: 標準保存領域で検出できた `sessions-index.json` は `shoken-webapp` のみだった。削除済みセッションや非標準保存先は対象外。
+
+## 概況
+
+- セッション数: 31
+- 期間: 2026-01 から 2026-02
+- 主ブランチ: `develop` 29 件、`feature/migrate-to-tailwindcss` 1 件、`fix/frontend-lint-type-errors` 1 件
+- 高頻度テーマ:
+  - review / PR / 実行フロー
+  - J-Quants / 配当 / API 契約差分
+  - Tailwind / UI / レスポンシブ修正
+  - Fly.io / Neon / デプロイ移行
+  - CSV 処理の backend 化と型同期
+
+## 根拠のある反復ワーク
+
+### 1. J-Quants / 配当 API 契約メンテナンス
+
+代表セッション:
+- `J-Quants V1→V2移行とバックエンド自動デプロイ`
+- `J-Quants API deserialization error fix with real API test`
+- `配当取得エラー修正：API仕様と型定義の不一致解決`
+- `配当金ページデータ取得バグ修正とレビュー指摘対応`
+
+反復パターン:
+- 実 API レスポンス確認
+- Rust struct の deserialize 修正
+- OpenAPI / frontend 型の追従
+- frontend の配当表示ロジック調整
+
+### 2. review / PR / 再レビュー運用
+
+代表セッション:
+- `Shoken webapp development PR creation workflow`
+- `Frontend lint, type, test fixes & PR creation`
+- `https://github.com/zaichu/shoken-webapp/pull/57 こちらのPRの指摘を対応してください。`
+- `Rust Backend Build & Test Automation`
+
+反復パターン:
+- PR 作成
+- PR コメント対応
+- lint / test / build 実行
+- Codex CLI レビューと再レビューの往復
+
+### 3. Tailwind / UI / レスポンシブ補修
+
+代表セッション:
+- `Bootstrap→Tailwind CSS移行：テーブルレスポンシブ修正`
+- `CSS refactor: Unified styling with Tailwind`
+- `action-toolbar` 二重カード問題対応
+- `保有銘柄ページの持ち株分析 UI 追加`
+
+反復パターン:
+- Bootstrap クラス除去
+- Tailwind への寄せ
+- レスポンシブ table / toolbar / card 修正
+- Asset Balance / Receipt 画面の表示改善
+
+### 4. Fly.io / Neon / backend 運用
+
+代表セッション:
+- `Fly.io + Neon 無料デプロイ環境構築`
+- `Shuttle to Fly.io migration, OAuth, warnings fixed`
+- `J-Quants V1→V2移行とバックエンド自動デプロイ`
+
+反復パターン:
+- Fly.io への移行
+- Neon 接続
+- Makefile / deploy 手順の整理
+- 本番相当環境での外部 API 障害調査
+
+### 5. CSV backend 化 / 型同期
+
+根拠:
+- task artifact `CSV処理バックエンド化（配当金・国内株式・投資信託）`
+- `redesign-proposal.md` にある「CSV 処理を backend へ寄せる」設計方針
+
+反復パターン:
+- CSV を frontend で処理しすぎない
+- multipart upload で backend 側 parse / validate / import
+- OpenAPI を通じた型同期
+
+## 分類結果
+
+### Skill にすべきもの
+
+#### `jquants-contract-maintenance`
+
+理由:
+- 仕様差分、実レスポンス確認、backend / frontend 型追従の反復が明確
+- 手順と判断基準をまとめると往復が減る
+
+対象:
+- J-Quants API 応答差分
+- Rust model / parser 修正
+- OpenAPI / frontend 型同期
+- 実 API 検証時の注意点
+
+#### 既存 skill を強化すべきもの
+
+- `frontend-refactor`
+  - Tailwind 移行、responsive table、toolbar/card 崩れ修正を追加
+- `deploy`
+  - Fly.io / Neon / Makefile / post-deploy verification を追加
+- `review-implementing`
+  - PR コメント対応から再レビュー依頼までを強化
+- `webapp-testing`
+  - Playwright を使った UI 監査、auth state、スクリーンショット取得の標準手順を強化
+
+### Plugin にすべきもの
+
+#### `review-ops`
+
+理由:
+- slash command / hook / agent を束ねるのに向く
+- review 運用はプロジェクト横断で使い回せる
+
+持たせるべきもの:
+- `/review-ops:pr-review-loop`
+- `/review-ops:address-review-comments`
+- `/review-ops:create-pr-summary`
+- push 後に再レビューを促す hook
+
+### Agent にすべきもの
+
+#### `api-contract-reviewer`
+
+理由:
+- J-Quants / OpenAPI / generated types / frontend consumer の整合だけを見る専任 agent の価値が高い
+
+責務:
+- API 契約差分の検出
+- backend / frontend / generated code の三点照合
+- 影響範囲と修正優先度の提示
+
+### CLAUDE.md / rules に入れるべきもの
+
+#### review ループの固定化
+
+根拠:
+- `MEMORY.md` に Codex CLI レビューと再レビュー必須ルールが置かれている
+- これはメモでなく恒久運用ルール
+
+#### OpenAPI を API 契約の正本にする
+
+根拠:
+- `redesign-proposal.md` と複数セッションで型同期の問題が再発している
+
+#### CSV は原則 backend で parse / validate / import
+
+根拠:
+- task artifact と再設計案の両方で同じ方向を指している
+
+#### 1 ブランチ 1 タスク
+
+根拠:
+- unrelated 修正の混在が繰り返し friction になっている
+
+## 優先順位
+
+1. 新規 skill: `jquants-contract-maintenance`
+2. 新規 plugin: `review-ops`
+3. 新規 agent: `api-contract-reviewer`
+4. `CLAUDE.md` / `.claude/rules/` への恒久ルール反映
+
+## 実装方針
+
+- skill は project local の `.claude/skills/` に置く
+- agent は project local の `.claude/agents/` に置く
+- plugin は repo 直下に独立ディレクトリとして置く
+- 恒久ルールは `CLAUDE.md` と `.claude/rules/` の両方で重複させず、正本を rules に寄せる


### PR DESCRIPTION
## 変更内容
- Claude セッション監査レポートを追加し、反復作業を skill / plugin / agent / CLAUDE.md へ分類
- `jquants-contract-maintenance` skill を追加し、J-Quants API 契約差分と OpenAPI / frontend 型同期の手順を明文化
- `review-ops` plugin と `api-contract-reviewer` agent を追加し、PR レビュー運用と API 契約差分レビューの足場を追加
- `CLAUDE.md` / `.claude/rules/00-general.md` に OpenAPI 同期、CSV backend 原則、Codex 再レビュー運用を反映

## テスト
- `python3 /home/zaichu/.codex/skills/.system/skill-creator/scripts/quick_validate.py .claude/skills/jquants-contract-maintenance`
- `python3 -m json.tool claude-review-ops-plugin/.claude-plugin/plugin.json`
- `python3 -m json.tool claude-review-ops-plugin/hooks/hooks.json`
- `python3 -m py_compile claude-review-ops-plugin/hooks/review_reminder.py`

## 補足
- repo 全体の frontend / backend テストは未実行


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive guides for API contract maintenance workflows and PR review operations.

* **Chores**
  * Introduced automation tools for streamlined PR review and validation.
  * Enhanced development guidelines for backend-frontend API synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->