### PR TITLE
refactor: CsvDomain トレイトで CSV ハンドラーを統一

### DIFF
--- a/backend/src/handlers/asset_balance.rs
+++ b/backend/src/handlers/asset_balance.rs
@@ -6,6 +6,7 @@ use crate::{
     models::common::{BulkCreateResponse, MessageResponse},
     models::csv_import::{CsvPreviewResponse, CsvUploadForm, CsvUploadResponse},
     services::asset_balance as asset_balance_service,
+    services::csv_domain::AssetBalanceDomain,
     state::AppState,
 };
 use axum::{extract::Multipart, extract::State, http::StatusCode, response::IntoResponse, Json};
@@ -69,9 +70,7 @@ pub async fn preview_csv(
     _auth_user: AuthenticatedUser,
     multipart: Multipart,
 ) -> Result<impl IntoResponse, ApiError> {
-    let bytes = crate::handlers::csv_import::read_csv_file_bytes(multipart).await?;
-    let response = asset_balance_service::preview_csv(&bytes)?;
-    Ok((StatusCode::OK, Json(response)))
+    crate::handlers::csv_import::handle_preview_csv::<AssetBalanceDomain>(multipart).await
 }
 
 /// CSV ファイルをアップロードして保有銘柄を一括登録（既存データ全置換）
@@ -92,9 +91,12 @@ pub async fn upload_csv(
     auth_user: AuthenticatedUser,
     multipart: Multipart,
 ) -> Result<impl IntoResponse, ApiError> {
-    let bytes = crate::handlers::csv_import::read_csv_file_bytes(multipart).await?;
-    let response = asset_balance_service::upload_csv(&state.pool, auth_user.id(), &bytes).await?;
-    Ok((StatusCode::CREATED, Json(response)))
+    crate::handlers::csv_import::handle_upload_csv::<AssetBalanceDomain>(
+        &state.pool,
+        auth_user.id(),
+        multipart,
+    )
+    .await
 }
 
 /// 認証ユーザーの保有銘柄を全削除

--- a/backend/src/handlers/csv_import.rs
+++ b/backend/src/handlers/csv_import.rs
@@ -1,5 +1,7 @@
 use crate::errors::ApiError;
-use axum::extract::Multipart;
+use crate::services::csv_domain::CsvDomain;
+use axum::{extract::Multipart, http::StatusCode, response::IntoResponse, Json};
+use uuid::Uuid;
 
 /// マルチパートフォームから `file` フィールドのバイト列を取得する
 pub async fn read_csv_file_bytes(mut multipart: Multipart) -> Result<Vec<u8>, ApiError> {
@@ -23,4 +25,28 @@ pub async fn read_csv_file_bytes(mut multipart: Multipart) -> Result<Vec<u8>, Ap
     Err(ApiError::ValidationError(
         "fileフィールドが見つかりません".to_string(),
     ))
+}
+
+/// ドメイン共通のプレビュー処理
+///
+/// ハンドラーから `handle_preview_csv::<DividendDomain>(multipart).await` のように呼ぶ。
+pub async fn handle_preview_csv<D: CsvDomain>(
+    multipart: Multipart,
+) -> Result<impl IntoResponse, ApiError> {
+    let bytes = read_csv_file_bytes(multipart).await?;
+    let response = D::preview_csv(&bytes)?;
+    Ok((StatusCode::OK, Json(response)))
+}
+
+/// ドメイン共通のアップロード処理
+///
+/// ハンドラーから `handle_upload_csv::<DividendDomain>(&state.pool, auth_user.id(), multipart).await` のように呼ぶ。
+pub async fn handle_upload_csv<D: CsvDomain>(
+    pool: &sqlx::PgPool,
+    user_id: Uuid,
+    multipart: Multipart,
+) -> Result<impl IntoResponse, ApiError> {
+    let bytes = read_csv_file_bytes(multipart).await?;
+    let response = D::upload_csv(pool, user_id, &bytes).await?;
+    Ok((StatusCode::CREATED, Json(response)))
 }

--- a/backend/src/handlers/dividend.rs
+++ b/backend/src/handlers/dividend.rs
@@ -4,6 +4,7 @@ use crate::{
     models::common::MessageResponse,
     models::csv_import::{CsvPreviewResponse, CsvUploadForm, CsvUploadResponse},
     models::dividend::Dividend,
+    services::csv_domain::DividendDomain,
     services::dividend as dividend_service,
     state::AppState,
 };
@@ -45,9 +46,7 @@ pub async fn preview_csv(
     _auth_user: AuthenticatedUser,
     multipart: Multipart,
 ) -> Result<impl IntoResponse, ApiError> {
-    let bytes = crate::handlers::csv_import::read_csv_file_bytes(multipart).await?;
-    let response = dividend_service::preview_csv(&bytes)?;
-    Ok((StatusCode::OK, Json(response)))
+    crate::handlers::csv_import::handle_preview_csv::<DividendDomain>(multipart).await
 }
 
 /// CSV ファイルをアップロードして配当金を一括登録
@@ -68,9 +67,12 @@ pub async fn upload_csv(
     auth_user: AuthenticatedUser,
     multipart: Multipart,
 ) -> Result<impl IntoResponse, ApiError> {
-    let bytes = crate::handlers::csv_import::read_csv_file_bytes(multipart).await?;
-    let response = dividend_service::upload_csv(&state.pool, auth_user.id(), &bytes).await?;
-    Ok((StatusCode::CREATED, Json(response)))
+    crate::handlers::csv_import::handle_upload_csv::<DividendDomain>(
+        &state.pool,
+        auth_user.id(),
+        multipart,
+    )
+    .await
 }
 
 /// 認証ユーザーの配当金を全削除

--- a/backend/src/handlers/domestic_stock.rs
+++ b/backend/src/handlers/domestic_stock.rs
@@ -4,6 +4,7 @@ use crate::{
     models::common::MessageResponse,
     models::csv_import::{CsvPreviewResponse, CsvUploadForm, CsvUploadResponse},
     models::domestic_stock::DomesticStock,
+    services::csv_domain::DomesticStockDomain,
     services::domestic_stock as domestic_stock_service,
     state::AppState,
 };
@@ -45,9 +46,7 @@ pub async fn preview_csv(
     _auth_user: AuthenticatedUser,
     multipart: Multipart,
 ) -> Result<impl IntoResponse, ApiError> {
-    let bytes = crate::handlers::csv_import::read_csv_file_bytes(multipart).await?;
-    let response = domestic_stock_service::preview_csv(&bytes)?;
-    Ok((StatusCode::OK, Json(response)))
+    crate::handlers::csv_import::handle_preview_csv::<DomesticStockDomain>(multipart).await
 }
 
 /// CSV ファイルをアップロードして国内株式取引を一括登録
@@ -68,9 +67,12 @@ pub async fn upload_csv(
     auth_user: AuthenticatedUser,
     multipart: Multipart,
 ) -> Result<impl IntoResponse, ApiError> {
-    let bytes = crate::handlers::csv_import::read_csv_file_bytes(multipart).await?;
-    let response = domestic_stock_service::upload_csv(&state.pool, auth_user.id(), &bytes).await?;
-    Ok((StatusCode::CREATED, Json(response)))
+    crate::handlers::csv_import::handle_upload_csv::<DomesticStockDomain>(
+        &state.pool,
+        auth_user.id(),
+        multipart,
+    )
+    .await
 }
 
 /// 認証ユーザーの国内株式取引を全削除

--- a/backend/src/handlers/mutualfund.rs
+++ b/backend/src/handlers/mutualfund.rs
@@ -4,6 +4,7 @@ use crate::{
     models::common::MessageResponse,
     models::csv_import::{CsvPreviewResponse, CsvUploadForm, CsvUploadResponse},
     models::mutualfund::Mutualfund,
+    services::csv_domain::MutualfundDomain,
     services::mutualfund as mutualfund_service,
     state::AppState,
 };
@@ -45,9 +46,7 @@ pub async fn preview_csv(
     _auth_user: AuthenticatedUser,
     multipart: Multipart,
 ) -> Result<impl IntoResponse, ApiError> {
-    let bytes = crate::handlers::csv_import::read_csv_file_bytes(multipart).await?;
-    let response = mutualfund_service::preview_csv(&bytes)?;
-    Ok((StatusCode::OK, Json(response)))
+    crate::handlers::csv_import::handle_preview_csv::<MutualfundDomain>(multipart).await
 }
 
 /// CSV ファイルをアップロードして投資信託を一括登録
@@ -68,9 +67,12 @@ pub async fn upload_csv(
     auth_user: AuthenticatedUser,
     multipart: Multipart,
 ) -> Result<impl IntoResponse, ApiError> {
-    let bytes = crate::handlers::csv_import::read_csv_file_bytes(multipart).await?;
-    let response = mutualfund_service::upload_csv(&state.pool, auth_user.id(), &bytes).await?;
-    Ok((StatusCode::CREATED, Json(response)))
+    crate::handlers::csv_import::handle_upload_csv::<MutualfundDomain>(
+        &state.pool,
+        auth_user.id(),
+        multipart,
+    )
+    .await
 }
 
 /// 認証ユーザーの投資信託を全削除

--- a/backend/src/services.rs
+++ b/backend/src/services.rs
@@ -1,5 +1,6 @@
 pub mod asset_balance;
 pub mod auth;
+pub mod csv_domain;
 pub mod csv_import;
 pub mod csv_parse;
 pub mod dividend;

--- a/backend/src/services/csv_domain.rs
+++ b/backend/src/services/csv_domain.rs
@@ -1,0 +1,97 @@
+use async_trait::async_trait;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::{
+    errors::ApiError,
+    models::csv_import::{CsvPreviewResponse, CsvUploadResponse},
+};
+
+/// CSV アップロードをサポートするドメインのトレイト
+///
+/// 新規ドメインを追加する場合は本トレイトを実装し、
+/// ハンドラーから `handle_preview_csv<D>` / `handle_upload_csv<D>` を呼ぶだけでよい。
+#[async_trait]
+pub trait CsvDomain: Send + Sync + 'static {
+    /// CSV バイト列をパースして DB 書き込みなしのプレビューを返す
+    fn preview_csv(bytes: &[u8]) -> Result<CsvPreviewResponse, ApiError>;
+
+    /// CSV バイト列をパースして DB に一括登録する
+    async fn upload_csv(
+        pool: &PgPool,
+        user_id: Uuid,
+        bytes: &[u8],
+    ) -> Result<CsvUploadResponse, ApiError>;
+}
+
+/// 配当金ドメイン
+pub struct DividendDomain;
+
+/// 国内株式ドメイン
+pub struct DomesticStockDomain;
+
+/// 投資信託ドメイン
+pub struct MutualfundDomain;
+
+/// 資産残高（保有銘柄）ドメイン
+pub struct AssetBalanceDomain;
+
+#[async_trait]
+impl CsvDomain for DividendDomain {
+    fn preview_csv(bytes: &[u8]) -> Result<CsvPreviewResponse, ApiError> {
+        crate::services::dividend::preview_csv(bytes)
+    }
+
+    async fn upload_csv(
+        pool: &PgPool,
+        user_id: Uuid,
+        bytes: &[u8],
+    ) -> Result<CsvUploadResponse, ApiError> {
+        crate::services::dividend::upload_csv(pool, user_id, bytes).await
+    }
+}
+
+#[async_trait]
+impl CsvDomain for DomesticStockDomain {
+    fn preview_csv(bytes: &[u8]) -> Result<CsvPreviewResponse, ApiError> {
+        crate::services::domestic_stock::preview_csv(bytes)
+    }
+
+    async fn upload_csv(
+        pool: &PgPool,
+        user_id: Uuid,
+        bytes: &[u8],
+    ) -> Result<CsvUploadResponse, ApiError> {
+        crate::services::domestic_stock::upload_csv(pool, user_id, bytes).await
+    }
+}
+
+#[async_trait]
+impl CsvDomain for MutualfundDomain {
+    fn preview_csv(bytes: &[u8]) -> Result<CsvPreviewResponse, ApiError> {
+        crate::services::mutualfund::preview_csv(bytes)
+    }
+
+    async fn upload_csv(
+        pool: &PgPool,
+        user_id: Uuid,
+        bytes: &[u8],
+    ) -> Result<CsvUploadResponse, ApiError> {
+        crate::services::mutualfund::upload_csv(pool, user_id, bytes).await
+    }
+}
+
+#[async_trait]
+impl CsvDomain for AssetBalanceDomain {
+    fn preview_csv(bytes: &[u8]) -> Result<CsvPreviewResponse, ApiError> {
+        crate::services::asset_balance::preview_csv(bytes)
+    }
+
+    async fn upload_csv(
+        pool: &PgPool,
+        user_id: Uuid,
+        bytes: &[u8],
+    ) -> Result<CsvUploadResponse, ApiError> {
+        crate::services::asset_balance::upload_csv(pool, user_id, bytes).await
+    }
+}


### PR DESCRIPTION
## 概要

4 ドメイン（dividend / domestic_stock / mutualfund / asset_balance）で同一パターンだった CSV ハンドラーを `CsvDomain` トレイトで統一。

## 変更内容

- `backend/src/services/csv_domain.rs`（新規）
  - `CsvDomain` トレイト（`preview_csv` / `upload_csv`）を定義
  - 4 ドメイン分の実装を追加（各 service 関数への委譲）
- `backend/src/handlers/csv_import.rs`
  - `handle_preview_csv<D: CsvDomain>` / `handle_upload_csv<D: CsvDomain>` を追加
- `handlers/dividend.rs` / `domestic_stock.rs` / `mutualfund.rs` / `asset_balance.rs`
  - `preview_csv` / `upload_csv` ハンドラーのボディを 1 行委譲に簡略化
  - utoipa アノテーションは維持（OpenAPI 契約変更なし）

## テスト結果

- `cargo fmt --check`: pass
- `cargo clippy -- -D warnings`: pass（警告なし）
- `cargo test`: 120 passed / 0 failed / 5 ignored

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated CSV import and export logic across asset types (dividends, domestic stocks, mutual funds, asset balances) for improved maintainability and reduced code duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->