### PR TITLE
chore: agent link の復旧導線を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,12 @@
 - CSV 取り込みは原則 backend で `parse / validate / import` する。frontend はファイル送信と結果表示を優先する
 - unrelated な修正は同じブランチに混在させない。`1 ブランチ = 1 タスク` を守る
 
+## Agent Assets
+
+- repo 内の agent 設定の正本は `./.claude` とする
+- `./.agents` と `./.codex` は `./.claude` を指す symlink として維持する
+- symlink が壊れた場合は `./scripts/repair-agent-links.sh` を実行して復旧する
+
 ## 参照ルール
 
 1. `.claude/rules/00-general.md`

--- a/scripts/repair-agent-links.sh
+++ b/scripts/repair-agent-links.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+for name in .agents .codex; do
+  if [ -e "$name" ] && [ ! -L "$name" ]; then
+    echo "$name exists and is not a symlink. Refusing to replace it." >&2
+    echo "Move or remove $name first, then rerun this script." >&2
+    exit 1
+  fi
+
+  ln -sfn .claude "$name"
+done
+
+echo "Repaired symlinks:"
+ls -lad .claude .agents .codex


### PR DESCRIPTION
## 変更内容
- agent 設定の正本を `./.claude` に統一する運用を [CLAUDE.md](/home/zaichu/project/shoken-webapp/CLAUDE.md) に追記
- symlink が壊れたときの復旧用に [scripts/repair-agent-links.sh](/home/zaichu/project/shoken-webapp/scripts/repair-agent-links.sh) を追加

## テスト
- `bash -n scripts/repair-agent-links.sh`
- `bash scripts/repair-agent-links.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded internal documentation with additional configuration rule references.

* **Chores**
  * Added a maintenance utility to repair system configuration integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->