### PR TITLE
refactor: フロントエンド処理経路の高速化

### DIFF
--- a/frontend/src/components/organisms/ReceiptTable/ReceiptTable.tsx
+++ b/frontend/src/components/organisms/ReceiptTable/ReceiptTable.tsx
@@ -92,14 +92,13 @@ function renderDataRows<T extends DataItem>(
 
 function renderGroupedRows<T extends DataItem, S extends SummaryItem>(
     summaryToRender: S[],
-    data: T[],
+    groupedDataMap: Map<string, T[]>,
     columns: TableColumnConfig[],
     summaryColumns: SummaryColumnConfig[],
-    getGroupKey: (item: T) => string,
     formatGroupHeader: (key: string) => string
 ) {
     return summaryToRender.map((summaryItem, summaryIndex) => {
-        const groupItems = data.filter(item => getGroupKey(item) === summaryItem.filter);
+        const groupItems = groupedDataMap.get(summaryItem.filter) ?? [];
         const headerText = formatGroupHeader(summaryItem.filter);
         const itemCount = groupItems.length;
 
@@ -209,8 +208,18 @@ export function ReceiptTable<T extends DataItem, S extends SummaryItem>({
         }
     };
 
-    const summaryGroupKeys = new Set(data.map(item => getGroupKey(item)));
-    const summaryToRender = summary.filter(summaryItem => summaryGroupKeys.has(summaryItem.filter));
+    // データをグループキーで事前にマップ化（O(n) → O(n+m) に削減）
+    const groupedDataMap = new Map<string, T[]>();
+    for (const item of data) {
+        const key = getGroupKey(item);
+        const group = groupedDataMap.get(key);
+        if (group) {
+            group.push(item);
+        } else {
+            groupedDataMap.set(key, [item]);
+        }
+    }
+    const summaryToRender = summary.filter(summaryItem => groupedDataMap.has(summaryItem.filter));
 
     return (
         <Table
@@ -237,7 +246,7 @@ export function ReceiptTable<T extends DataItem, S extends SummaryItem>({
             </TableHeader>
             <TableBody>
                 {summaryToRender.length > 0
-                    ? renderGroupedRows(summaryToRender, data, columns, summaryColumns, getGroupKey, formatGroupHeader)
+                    ? renderGroupedRows(summaryToRender, groupedDataMap, columns, summaryColumns, formatGroupHeader)
                     : renderDataRows(data, columns, 'item')
                 }
             </TableBody>

--- a/frontend/src/components/organisms/SearchCard/SearchCard.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchCard.tsx
@@ -119,19 +119,17 @@ export const SearchCard: React.FC<SearchCardProps> = ({
     const effectiveSearchQuery = value ?? searchQuery;
     const effectiveActiveSearchType = value === '' ? null : activeSearchType;
 
-    // データが存在するかチェックするヘルパー関数
-    const hasData = (data: unknown[] | undefined): boolean => {
-        return Boolean(data && data.length > 0);
-    };
+    // データが存在するかチェック
+    const hasData = (data: unknown[] | undefined): boolean =>
+        Boolean(data && data.length > 0);
 
-    // 全ての検索カテゴリが空かチェック（UIで描画するカテゴリのみ判定）
-    const hasAnyCategories = () => {
-        if (!categories) return false;
-        return hasData(categories.securities) ||
-            hasData(categories.products) ||
-            hasData(categories.accounts) ||
-            hasData(categories.years);
-    };
+    // 描画対象カテゴリが1つ以上あるか（毎レンダーで再評価されないよう定数化）
+    const hasAnyCategories = categories != null && (
+        hasData(categories.securities) ||
+        hasData(categories.products) ||
+        hasData(categories.accounts) ||
+        hasData(categories.years)
+    );
 
     // 展開状態の切り替え処理
     const handleToggleExpanded = () => {
@@ -165,7 +163,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
     };
 
     // カテゴリが何もない場合は SearchCard 自体を非表示
-    if (!hasAnyCategories()) {
+    if (!hasAnyCategories) {
         return null;
     }
 

--- a/frontend/src/features/jquants/hooks/__tests__/useDividendBatch.test.ts
+++ b/frontend/src/features/jquants/hooks/__tests__/useDividendBatch.test.ts
@@ -157,4 +157,24 @@ describe('useDividendBatch', () => {
     // 再フェッチされていない
     expect(mockFetch).toHaveBeenCalledTimes(callCount);
   });
+
+  it('同じ銘柄集合だが配列参照が変わっても再フェッチしない', async () => {
+    mockFetch.mockResolvedValue([makeItem('6001', 'ok', 80)]);
+
+    let codes = ['6001'];
+    const { rerender, result } = renderHook(({ c }: { c: string[] }) => useDividendBatch(c, true), {
+      initialProps: { c: codes },
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false), waitOpts);
+    const callCount = mockFetch.mock.calls.length;
+
+    // 内容は同じだが新しい配列参照に変更
+    codes = ['6001'];
+    rerender({ c: codes });
+    rerender({ c: codes });
+
+    // codesKey が同じなので再フェッチしない
+    expect(mockFetch).toHaveBeenCalledTimes(callCount);
+  });
 });

--- a/frontend/src/features/jquants/hooks/useDividendBatch.ts
+++ b/frontend/src/features/jquants/hooks/useDividendBatch.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import { fetchDividendPerShareBatch, DividendStatus } from '../api/dividendPerShareApi';
 
 const BASE_RETRIES = 3;
@@ -22,9 +22,14 @@ export const useDividendBatch = (
   const retryCountRef = useRef(0);
   const prevCodesRef = useRef<string>('');
 
+  // 重複排除・ソートした安定キー（配列参照の変化に影響されない）
+  const codesKey = useMemo(
+    () => [...new Set(securityCodes)].sort().join(','),
+    [securityCodes]
+  );
+
   useEffect(() => {
-    const codesKey = securityCodes.slice().sort().join(',');
-    if (!enabled || securityCodes.length === 0) {
+    if (!enabled || codesKey === '') {
       setDividendPerShareMap(new Map());
       setDividendStatusMap(new Map());
       setFetchedCount(0);
@@ -42,7 +47,8 @@ export const useDividendBatch = (
     }
 
     // バックエンドが12秒/銘柄で処理するため、銘柄数に応じて最大リトライ数を動的に計算
-    const uniqueCount = new Set(securityCodes).size;
+    const uniqueCodes = codesKey.split(',');
+    const uniqueCount = uniqueCodes.length;
     const maxRetries = Math.max(BASE_RETRIES, Math.ceil(uniqueCount * SECS_PER_CODE / RETRY_DELAY_MS) + 3);
 
     let isActive = true;
@@ -65,7 +71,6 @@ export const useDividendBatch = (
 
     const fetchAll = async () => {
       setLoading(true);
-      const uniqueCodes = Array.from(new Set(securityCodes));
       setTotalCount(uniqueCodes.length);
 
       const items = await fetchDividendPerShareBatch(uniqueCodes);
@@ -112,7 +117,7 @@ export const useDividendBatch = (
       isActive = false;
       if (retryTimer !== null) clearTimeout(retryTimer);
     };
-  }, [securityCodes, enabled, retryCount]);
+  }, [codesKey, enabled, retryCount]);
 
   return { dividendPerShareMap, dividendStatusMap, loading, fetchedCount, totalCount };
 };

--- a/frontend/src/lib/utils/dataTransformer.ts
+++ b/frontend/src/lib/utils/dataTransformer.ts
@@ -4,17 +4,19 @@ export function createSearchOptions<T>(
     labelField: keyof T,
     prefix?: boolean
 ): { value: string, label: string }[] {
-    return data
-        .map(item => ({
-            value: String(item[valueField] || item[labelField]),
-            label: prefix
-                ? `${item[valueField] ? `${String(item[valueField])}: ` : ''}${String(item[labelField])}`
-                : String(item[labelField]),
-        }))
-        .filter((item, index, self) =>
-            index === self.findIndex(t => t.value === item.value)
-        )
-        .sort((a, b) => a.value.localeCompare(b.value));
+    const seen = new Map<string, { value: string; label: string }>();
+    for (const item of data) {
+        const value = String(item[valueField] || item[labelField]);
+        if (!seen.has(value)) {
+            seen.set(value, {
+                value,
+                label: prefix
+                    ? `${item[valueField] ? `${String(item[valueField])}: ` : ''}${String(item[labelField])}`
+                    : String(item[labelField]),
+            });
+        }
+    }
+    return [...seen.values()].sort((a, b) => a.value.localeCompare(b.value));
 }
 
 export type SummaryResult<K extends string | number | symbol> = {

--- a/frontend/src/lib/utils/searchUtils.ts
+++ b/frontend/src/lib/utils/searchUtils.ts
@@ -9,13 +9,14 @@ export function createYearOptions<T>(
   data: T[],
   dateGetter: (item: T) => Date
 ): { value: string; label: string }[] {
-  return [...new Set(data.map(item => {
+  const seen = new Map<string, { value: string; label: string }>();
+  for (const item of data) {
     const year = dateGetter(item).getFullYear().toString();
-    const label = `${year}年`;
-    return { value: year, label };
-  }))].filter((item, index, self) =>
-    index === self.findIndex(t => t.value === item.value)
-  ).sort((a, b) => a.value.localeCompare(b.value));
+    if (!seen.has(year)) {
+      seen.set(year, { value: year, label: `${year}年` });
+    }
+  }
+  return [...seen.values()].sort((a, b) => a.value.localeCompare(b.value));
 }
 
 /**
@@ -25,16 +26,17 @@ export function createYearMonthOptions<T>(
   data: T[],
   dateGetter: (item: T) => Date
 ): { value: string; label: string }[] {
-  return [...new Set(data.map(item => {
+  const seen = new Map<string, { value: string; label: string }>();
+  for (const item of data) {
     const date = dateGetter(item);
     const year = date.getFullYear();
     const month = date.getMonth() + 1;
     const value = `${year}-${month.toString().padStart(2, '0')}`;
-    const label = `${year}年${month.toString().padStart(2, '0')}月`;
-    return { value, label };
-  }))].filter((item, index, self) =>
-    index === self.findIndex(t => t.value === item.value)
-  ).sort((a, b) => a.value.localeCompare(b.value));
+    if (!seen.has(value)) {
+      seen.set(value, { value, label: `${year}年${month.toString().padStart(2, '0')}月` });
+    }
+  }
+  return [...seen.values()].sort((a, b) => a.value.localeCompare(b.value));
 }
 
 /**
@@ -71,13 +73,6 @@ export function matchesYearMonth(date: Date, query: string): boolean {
 function matchesDate(date: Date, query: string): boolean {
   const dateStr = date.toISOString().split('T')[0];
   return dateStr === query;
-}
-
-/**
- * 金額配列の部分一致検索
- */
-function matchesAmounts(amounts: number[], query: string): boolean {
-  return amounts.some(amount => amount.toString().includes(query));
 }
 
 // ==================== 汎用フィルタ設定 ====================
@@ -159,9 +154,10 @@ export function filterByConfig<T>(
 
     // 金額の部分一致検索
     if (config.amountFields) {
-      const amounts = config.amountFields.map(getter => getter(item));
-      if (matchesAmounts(amounts, normalizedQuery)) {
-        return true;
+      for (const getter of config.amountFields) {
+        if (getter(item).toString().includes(normalizedQuery)) {
+          return true;
+        }
       }
     }
 


### PR DESCRIPTION
## 概要

検索オプション生成・フィルタ・テーブル描画・配当バッチ取得の計算コストを削減。

## 変更内容

### Task A: 検索オプション生成とフィルタ utility
- `createSearchOptions` / `createYearOptions` / `createYearMonthOptions`: `findIndex` O(n²) → `Map` single-pass に変更
- `filterByConfig`: `amountFields.map()` で毎回一時配列を生成していた部分を直接ループに変更し、`matchesAmounts` 関数を削除

### Task B: ReceiptTable のグループ描画最適化
- `renderGroupedRows` 内の `data.filter(item => getGroupKey(item) === key)` はグループ数×件数の O(n×m) だった
- 事前に `Map<key, T[]>` を O(n) で構築し、ルックアップを O(1) に変更

### Task C: useDividendBatch の request key 安定化
- `codesKey` 計算（重複排除・ソート・join）を `useEffect` 内部から `useMemo` へ移動
- `useEffect` の依存配列を配列参照 `securityCodes` → 文字列 `codesKey` に変更し、参照変化による不要な再フェッチを抑制

### Task D: SearchCard の hasAnyCategories 最適化
- インライン関数 `hasAnyCategories()` を定数評価に変更（毎レンダーでの再評価を排除）

## テスト結果

- `npm run lint` ✅
- `npx tsc --noEmit` ✅
- `npm test` ✅ 433 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved data grouping, filtering, and deduplication for better performance and stability.
  * Streamlined component and state logic to reduce unnecessary work.

* **Bug Fixes**
  * Prevented redundant background fetches when inputs are unchanged, reducing network/activity noise.

* **Tests**
  * Added tests to ensure stable behavior around batch fetching and deduplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->