### PR TITLE
refactor: react-doctor スコアを 100/100 に到達させる残り警告の解消

### DIFF
--- a/frontend/knip.json
+++ b/frontend/knip.json
@@ -1,0 +1,3 @@
+{
+  "ignore": ["src/generated/**"]
+}

--- a/frontend/src/types/common.ts
+++ b/frontend/src/types/common.ts
@@ -11,13 +11,6 @@ export interface HeaderItem {
   valueClassName?: string;
 }
 
-export interface SelectOption {
-  value: string;
-  label: string;
-  disabled?: boolean;
-  group?: string;
-}
-
 export type TableColumnAlignment = 'left' | 'center' | 'right';
 
 // 検索カテゴリ


### PR DESCRIPTION
## 概要

react-doctor スコア 99/100 → 100/100 に改善。

## 変更内容

- `SelectOption` インターフェース（未使用）を `src/types/common.ts` から削除
- `frontend/knip.json` を追加して `src/generated/**` を解析対象外に設定
  - openapi-typescript が生成する `paths` 型の誤検知（unused type 警告 4 件）を抑制

## テスト結果

```
react-doctor: 100/100（警告 0）
npm test: 434/434 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling configuration to optimize build process and improve source file handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->