### PR TITLE
refactor: CSS不要クラス削除・yearMonths デッドコード除去・ReceiptHeader アクセシビリティ修正

### DIFF
--- a/frontend/src/components/molecules/ReceiptHeader/ReceiptHeader.tsx
+++ b/frontend/src/components/molecules/ReceiptHeader/ReceiptHeader.tsx
@@ -29,14 +29,6 @@ export const ReceiptHeader: React.FC<ReceiptHeaderProps> = ({
         setIsExpanded(prev => !prev);
     };
 
-    const handleKeyDown = (e: React.KeyboardEvent) => {
-        if (!collapsible) return;
-        if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            handleToggleExpanded();
-        }
-    };
-
     const getCompactItemTone = (item: HeaderItem) => {
         const token = `${item.className ?? ''} ${item.valueClassName ?? ''}`;
         if (token.includes('emerald')) {
@@ -75,7 +67,6 @@ export const ReceiptHeader: React.FC<ReceiptHeaderProps> = ({
                         type="button"
                         className="flex w-full items-start justify-between gap-3 border-b border-slate-200/80 pb-4 text-left"
                         onClick={handleToggleExpanded}
-                        onKeyDown={handleKeyDown}
                         aria-expanded={effectiveExpanded}
                         aria-controls={bodyId}
                         data-testid="receipt-header"
@@ -162,7 +153,6 @@ export const ReceiptHeader: React.FC<ReceiptHeaderProps> = ({
                             effectiveExpanded ? 'hover:bg-slate-700' : 'hover:bg-slate-500',
                         )}
                         onClick={handleToggleExpanded}
-                        onKeyDown={handleKeyDown}
                         aria-expanded={effectiveExpanded}
                         aria-controls={bodyId}
                         data-testid="receipt-header"

--- a/frontend/src/components/molecules/ReceiptHeader/ReceiptHeader.tsx
+++ b/frontend/src/components/molecules/ReceiptHeader/ReceiptHeader.tsx
@@ -52,38 +52,45 @@ export const ReceiptHeader: React.FC<ReceiptHeaderProps> = ({
     };
 
     if (compact) {
+        const compactChevron = collapsible && (
+            <span className="flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-2.5 py-1 text-slate-700" aria-hidden="true">
+                <span className="text-xs font-semibold">{effectiveExpanded ? '閉じる' : '開く'}</span>
+                <svg
+                    className={cn('w-4 h-4 text-slate-500 transition-transform duration-200', effectiveExpanded && 'rotate-180')}
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                >
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                </svg>
+            </span>
+        );
         return (
             <section
                 className="rounded-[2rem] border border-slate-200/90 bg-white/85 px-5 py-5 shadow-[0_22px_48px_-36px_rgba(15,23,42,0.45)]"
                 data-testid="receipt-summary-strip"
             >
-                <div
-                    className="flex items-start justify-between gap-3 border-b border-slate-200/80 pb-4"
-                    onClick={collapsible ? handleToggleExpanded : undefined}
-                    onKeyDown={collapsible ? handleKeyDown : undefined}
-                    role={collapsible ? 'button' : undefined}
-                    tabIndex={collapsible ? 0 : undefined}
-                    aria-expanded={collapsible ? effectiveExpanded : undefined}
-                    aria-controls={collapsible ? bodyId : undefined}
-                    data-testid="receipt-header"
-                >
-                    <div>
-                        <h2 className="text-sm font-semibold text-slate-800">{title}</h2>
+                {collapsible ? (
+                    <button
+                        type="button"
+                        className="flex w-full items-start justify-between gap-3 border-b border-slate-200/80 pb-4 text-left"
+                        onClick={handleToggleExpanded}
+                        onKeyDown={handleKeyDown}
+                        aria-expanded={effectiveExpanded}
+                        aria-controls={bodyId}
+                        data-testid="receipt-header"
+                    >
+                        <div><h2 className="text-sm font-semibold text-slate-800">{title}</h2></div>
+                        {compactChevron}
+                    </button>
+                ) : (
+                    <div
+                        className="flex items-start justify-between gap-3 border-b border-slate-200/80 pb-4"
+                        data-testid="receipt-header"
+                    >
+                        <div><h2 className="text-sm font-semibold text-slate-800">{title}</h2></div>
                     </div>
-                    {collapsible && (
-                        <span className="flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-2.5 py-1 text-slate-700" aria-hidden="true">
-                            <span className="text-xs font-semibold">{effectiveExpanded ? '閉じる' : '開く'}</span>
-                            <svg
-                                className={cn('w-4 h-4 text-slate-500 transition-transform duration-200', effectiveExpanded && 'rotate-180')}
-                                fill="none"
-                                stroke="currentColor"
-                                viewBox="0 0 24 24"
-                            >
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                            </svg>
-                        </span>
-                    )}
-                </div>
+                )}
                 <div id={bodyId} hidden={collapsible && !effectiveExpanded} className="pt-4">
                     {items.length > 0 && (
                         <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3" data-testid="kpi-grid">
@@ -117,42 +124,54 @@ export const ReceiptHeader: React.FC<ReceiptHeaderProps> = ({
         );
     }
 
+    const chevron = (
+        <span
+            className="flex items-center gap-1.5 rounded border border-white/30 bg-white/10 px-2 py-0.5"
+            aria-hidden="true"
+        >
+            <span className="text-xs font-semibold text-white">
+                {effectiveExpanded ? '閉じる' : '開く'}
+            </span>
+            <svg
+                className={cn('w-4 h-4 transition-transform duration-200', effectiveExpanded && 'rotate-180')}
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+            >
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+            </svg>
+        </span>
+    );
+
     return (
         <Card>
             <CardHeader
                 variant="secondary"
                 className={cn(
-                    'flex items-center justify-between',
                     collapsible
-                        ? cn('cursor-pointer select-none transition-colors', effectiveExpanded ? 'bg-slate-600 hover:bg-slate-700' : 'bg-slate-400 hover:bg-slate-500')
-                        : 'bg-slate-600'
+                        ? cn('p-0', effectiveExpanded ? 'bg-slate-600' : 'bg-slate-400')
+                        : 'flex items-center justify-between bg-slate-600'
                 )}
-                onClick={collapsible ? handleToggleExpanded : undefined}
-                onKeyDown={collapsible ? handleKeyDown : undefined}
-                role={collapsible ? 'button' : undefined}
-                tabIndex={collapsible ? 0 : undefined}
-                aria-expanded={collapsible ? effectiveExpanded : undefined}
-                aria-controls={collapsible ? bodyId : undefined}
-                data-testid="receipt-header"
+                data-testid={collapsible ? undefined : 'receipt-header'}
             >
-                <h5 className="text-sm font-semibold text-white">{title}</h5>
-                {collapsible && (
-                    <span
-                        className="flex items-center gap-1.5 rounded border border-white/30 bg-white/10 px-2 py-0.5"
-                        aria-hidden="true"
+                {collapsible ? (
+                    <button
+                        type="button"
+                        className={cn(
+                            'flex w-full items-center justify-between px-4 py-2 transition-colors',
+                            effectiveExpanded ? 'hover:bg-slate-700' : 'hover:bg-slate-500',
+                        )}
+                        onClick={handleToggleExpanded}
+                        onKeyDown={handleKeyDown}
+                        aria-expanded={effectiveExpanded}
+                        aria-controls={bodyId}
+                        data-testid="receipt-header"
                     >
-                        <span className="text-xs font-semibold text-white">
-                            {effectiveExpanded ? '閉じる' : '開く'}
-                        </span>
-                        <svg
-                            className={cn('w-4 h-4 transition-transform duration-200', effectiveExpanded && 'rotate-180')}
-                            fill="none"
-                            stroke="currentColor"
-                            viewBox="0 0 24 24"
-                        >
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                        </svg>
-                    </span>
+                        <h5 className="text-sm font-semibold text-white">{title}</h5>
+                        {chevron}
+                    </button>
+                ) : (
+                    <h5 className="text-sm font-semibold text-white">{title}</h5>
                 )}
             </CardHeader>
             {/* 折りたたみ時はhiddenで非表示（children内のstateを保持するため） */}

--- a/frontend/src/components/organisms/SearchCard/__tests__/SearchCard.test.tsx
+++ b/frontend/src/components/organisms/SearchCard/__tests__/SearchCard.test.tsx
@@ -147,8 +147,7 @@ describe('SearchCard', () => {
           securities: [],
           products: [],
           accounts: [],
-          years: [],
-          yearMonths: []
+          years: []
         }}
       />
     );
@@ -165,8 +164,7 @@ describe('SearchCard', () => {
           securities: undefined,
           products: undefined,
           accounts: undefined,
-          years: [{ value: '2024', label: '2024年' }],
-          yearMonths: undefined
+          years: [{ value: '2024', label: '2024年' }]
         }}
       />
     );
@@ -186,8 +184,7 @@ describe('SearchCard', () => {
           securities: undefined,
           products: undefined,
           accounts: undefined,
-          years: undefined,
-          yearMonths: undefined
+          years: undefined
         }}
       />
     );

--- a/frontend/src/components/templates/__tests__/ReceiptTemplate.test.tsx
+++ b/frontend/src/components/templates/__tests__/ReceiptTemplate.test.tsx
@@ -61,8 +61,7 @@ describe('ReceiptTemplate', () => {
           securities: [{ value: 'AAPL', label: 'Apple' }],
           products: ['株式'],
           accounts: ['一般口座'],
-          years: [{ value: '2024', label: '2024年' }],
-          yearMonths: [{ value: '2024-01', label: '2024年1月' }]
+          years: [{ value: '2024', label: '2024年' }]
         }}
       />
     );

--- a/frontend/src/lib/utils/searchUtils.ts
+++ b/frontend/src/lib/utils/searchUtils.ts
@@ -20,26 +20,6 @@ export function createYearOptions<T>(
 }
 
 /**
- * 年月の検索オプションを生成
- */
-export function createYearMonthOptions<T>(
-  data: T[],
-  dateGetter: (item: T) => Date
-): { value: string; label: string }[] {
-  const seen = new Map<string, { value: string; label: string }>();
-  for (const item of data) {
-    const date = dateGetter(item);
-    const year = date.getFullYear();
-    const month = date.getMonth() + 1;
-    const value = `${year}-${month.toString().padStart(2, '0')}`;
-    if (!seen.has(value)) {
-      seen.set(value, { value, label: `${year}年${month.toString().padStart(2, '0')}月` });
-    }
-  }
-  return [...seen.values()].sort((a, b) => a.value.localeCompare(b.value));
-}
-
-/**
  * 配列から重複を除いたユニーク値を取得
  */
 export function getUniqueValues<T>(

--- a/frontend/src/pages/Receipt/Dividend.tsx
+++ b/frontend/src/pages/Receipt/Dividend.tsx
@@ -20,7 +20,6 @@ import { renderSecurityCode } from '@/components/atoms/SecurityCodeLink';
 import { useReceiptCalculations, useReceiptBaseData } from '@/hooks/receipt/useReceiptData';
 import {
     createYearOptions,
-    createYearMonthOptions,
     getUniqueValues,
     matchesYear,
     matchesYearMonth,
@@ -70,8 +69,7 @@ export const Dividend: React.FC<DividendProps> = ({ data, previewData, utilityRa
         securities: createSearchOptions(dividendData, 'security_code', 'security_name', true),
         products: getUniqueValues(dividendData, item => item.product),
         accounts: getUniqueValues(dividendData, item => item.account),
-        years: createYearOptions(dividendData, item => item.settlement_date),
-        yearMonths: createYearMonthOptions(dividendData, item => item.settlement_date)
+        years: createYearOptions(dividendData, item => item.settlement_date)
     };
 
     // 表示用の集計（検索前後で同一ロジック: フィルタ後データから計算）

--- a/frontend/src/pages/Receipt/DomesticStock.tsx
+++ b/frontend/src/pages/Receipt/DomesticStock.tsx
@@ -16,7 +16,6 @@ import { renderSecurityCode } from '@/components/atoms/SecurityCodeLink';
 import { useReceiptCalculations, useReceiptBaseData } from '@/hooks/receipt/useReceiptData';
 import {
     createYearOptions,
-    createYearMonthOptions,
     getUniqueValues,
     FilterConfig
 } from '@/lib/utils/searchUtils';
@@ -59,8 +58,7 @@ export const DomesticStock: React.FC<DomesticStockProps> = ({ data, previewData,
     const searchCategories = {
         securities: createSearchOptions(domesticStockData, 'security_code', 'security_name', true),
         accounts: getUniqueValues(domesticStockData, item => item.account),
-        years: createYearOptions(domesticStockData, item => item.trade_date),
-        yearMonths: createYearMonthOptions(domesticStockData, item => item.trade_date)
+        years: createYearOptions(domesticStockData, item => item.trade_date)
     };
 
     // 日次集計（searchQuery がある場合はフィルタ後データ、ない場合は全データを使用）

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -96,42 +96,6 @@
 }
 
 @layer components {
-  .panel-card {
-    @apply bg-white border border-border rounded-lg shadow-sm;
-  }
-
-  .panel-card-header {
-    @apply bg-slate-100 text-slate-800 px-4 py-3 text-base font-semibold border-b border-slate-200;
-  }
-
-  .panel-card-body {
-    @apply px-4 py-3;
-  }
-
-  .panel-section-title {
-    @apply text-sm font-semibold text-primary flex items-center gap-1;
-  }
-
-  .panel-toolbar {
-    @apply flex flex-wrap items-center gap-2;
-  }
-
-  .muted-text {
-    @apply text-sm text-secondary;
-  }
-
-  .table-heading {
-    @apply bg-slate-100 text-center text-xs font-semibold uppercase tracking-wide text-slate-700 border-b border-slate-200;
-  }
-
-  .table-chip {
-    @apply inline-flex items-center rounded bg-white/30 px-2 py-0.5 text-[11px] font-semibold text-white;
-  }
-
-  .button-set > *:not(:last-child) {
-    @apply mr-2;
-  }
-
   /* フォーム入力コンテナ（CSV入力等） */
   .form-input-container {
     @apply w-full max-w-[400px];

--- a/frontend/src/types/common.ts
+++ b/frontend/src/types/common.ts
@@ -19,5 +19,4 @@ export interface SearchCategories {
   products?: string[];
   accounts?: string[];
   years?: { value: string, label: string }[];
-  yearMonths?: { value: string, label: string }[];
 }


### PR DESCRIPTION
## Summary

- `tailwind.css` から未使用の `@layer components` クラスを削除（`.panel-card` など8クラス）
- `SearchCategories.yearMonths` を型・実装・テストから完全除去（SearchCardで未使用のデッドコード）
- `createYearMonthOptions` を `searchUtils.ts` から削除（`matchesYearMonth` フィルタ関数は保持）
- `ReceiptHeader` の `div[role="button"]` をセマンティックな `<button>` 要素に修正（アクセシビリティ改善）

## Test plan

- [x] `npx tsc --noEmit` エラー 0
- [x] `npm test -- --run` 個別テストファイルはすべてパス（並列実行時のタイムアウトは既存の既知問題）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * レシートヘッダーの操作をボタン化し、コンパクト表示でのチェビオン表示やキーボード操作の扱いを整理してアクセシビリティを向上
  * KPIカードのグリッドとカード本文のレイアウト／スペーシングを最適化

* **削除**
  * 年月（年＋月）単位の絞り込みオプションを廃止し、年単位に統一

* **Chores**
  * 未使用のスタイル定義を整理削除
<!-- end of auto-generated comment: release notes by coderabbit.ai -->