### PR TITLE
refactor: WorkspaceShell で workspace グリッドと rail を共通化

### DIFF
--- a/frontend/src/components/templates/ReceiptTemplate.tsx
+++ b/frontend/src/components/templates/ReceiptTemplate.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode } from 'react';
 import { SearchCard } from '@/components/organisms/SearchCard/SearchCard';
 import { Card, CardBody } from '@/components/atoms/Card';
+import { WorkspaceShell } from '@/components/templates/WorkspaceShell';
 import { ResizeProvider } from '@/contexts/ResizeContext';
 import { useTriggerResize } from '@/hooks/common/useResize';
 import { SearchCategories } from '@/types/common';
@@ -60,21 +61,12 @@ const ReceiptTemplateContent: React.FC<ReceiptTemplateProps> = ({
   if (layout === 'workspace') {
     return (
       <div className="space-y-2" data-testid="receipt-container">
-        <div
-          className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_22rem] lg:items-start xl:gap-6 xl:grid-cols-[minmax(0,1fr)_24rem]"
-          data-testid="receipt-workspace"
-        >
-          <div className="min-w-0 space-y-4" data-testid="receipt-main-stage">
-            {header}
-            {mainCard}
-          </div>
-          <aside data-testid="receipt-utility-rail">
-            <div className="overflow-hidden rounded-[2rem] border border-slate-200/90 bg-white/80 shadow-[0_20px_48px_-34px_rgba(15,23,42,0.45)] backdrop-blur-sm divide-y divide-slate-200/80">
-              {utilityRail}
-              {searchCard}
-            </div>
-          </aside>
-        </div>
+        <WorkspaceShell
+          testIdPrefix="receipt"
+          mainClassName="space-y-4"
+          main={<>{header}{mainCard}</>}
+          rail={<>{utilityRail}{searchCard}</>}
+        />
         {footer && <div>{footer}</div>}
       </div>
     );

--- a/frontend/src/components/templates/WorkspaceShell.tsx
+++ b/frontend/src/components/templates/WorkspaceShell.tsx
@@ -1,0 +1,32 @@
+import { ReactNode } from 'react';
+import { cn } from '@/lib/utils/classNames';
+
+interface WorkspaceShellProps {
+  main: ReactNode;
+  rail: ReactNode;
+  mainClassName?: string;
+  testIdPrefix?: string;
+}
+
+/**
+ * 2カラム workspace レイアウト（main stage + utility rail）の共通テンプレート。
+ * ReceiptTemplate および AssetBalance の grid / rail スタイルを一元管理する。
+ */
+export function WorkspaceShell({ main, rail, mainClassName, testIdPrefix = '' }: WorkspaceShellProps) {
+  const prefix = testIdPrefix ? `${testIdPrefix}-` : '';
+  return (
+    <div
+      className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_22rem] lg:items-start xl:gap-6 xl:grid-cols-[minmax(0,1fr)_24rem]"
+      data-testid={`${prefix}workspace`}
+    >
+      <div className={cn('min-w-0', mainClassName)} data-testid={`${prefix}main-stage`}>
+        {main}
+      </div>
+      <aside data-testid={`${prefix}utility-rail`}>
+        <div className="overflow-hidden rounded-[2rem] border border-slate-200/90 bg-white/80 shadow-[0_20px_48px_-34px_rgba(15,23,42,0.45)] backdrop-blur-sm divide-y divide-slate-200/80">
+          {rail}
+        </div>
+      </aside>
+    </div>
+  );
+}

--- a/frontend/src/pages/AssetBalance.tsx
+++ b/frontend/src/pages/AssetBalance.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo, useCallback, Suspense, lazy } from 'react';
 import { Layout } from '../components/templates/Layout';
+import { WorkspaceShell } from '@/components/templates/WorkspaceShell';
 import { PageHeader } from '../components/atoms/PageHeader';
 import { CSVFileInput } from '../components/molecules/CSVFileInput';
 import { CsvSaveResultNotice } from '@/components/molecules/CsvSaveResultNotice';
@@ -160,40 +161,39 @@ export function AssetBalancePage() {
         {/* ログイン済みの場合のメインコンテンツ */}
         {!authLoading && isAuthenticated && (
           <>
-            <div
-              className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_22rem] lg:items-start xl:gap-6 xl:grid-cols-[minmax(0,1fr)_24rem]"
-              data-testid="assetbalance-workspace"
-            >
-              <div className="min-w-0" data-testid="assetbalance-main-stage">
-                <div aria-live="polite" aria-atomic="true">
-                  {(loading || saving || deleting || previewing) && (
-                    <div className="status-message" role="status">
-                      <Spinner size="md" className="text-primary" />
-                      <p className="text-sm text-secondary">
-                        {loading && 'データを読み込んでいます...'}
-                        {saving && 'データを保存しています...'}
-                        {deleting && 'データを削除しています...'}
-                        {previewing && 'CSVファイルを解析しています...'}
-                      </p>
-                    </div>
+            <WorkspaceShell
+              testIdPrefix="assetbalance"
+              main={
+                <>
+                  <div aria-live="polite" aria-atomic="true">
+                    {(loading || saving || deleting || previewing) && (
+                      <div className="status-message" role="status">
+                        <Spinner size="md" className="text-primary" />
+                        <p className="text-sm text-secondary">
+                          {loading && 'データを読み込んでいます...'}
+                          {saving && 'データを保存しています...'}
+                          {deleting && 'データを削除しています...'}
+                          {previewing && 'CSVファイルを解析しています...'}
+                        </p>
+                      </div>
+                    )}
+                  </div>
+
+                  {/* ローディング完了後に表示（空データでもEmptyStateを表示） */}
+                  {!loading && !previewing && (
+                    <AssetBalanceInfo
+                      assetBalanceData={assetBalanceData}
+                      filteredData={filteredData}
+                      searchQuery={searchQuery}
+                      onClearFilter={() => setSearchQuery('')}
+                      dividendPerShareMap={dividendPerShareMap}
+                      dividendStatusMap={dividendStatusMap}
+                    />
                   )}
-                </div>
-
-                {/* ローディング完了後に表示（空データでもEmptyStateを表示） */}
-                {!loading && !previewing && (
-                  <AssetBalanceInfo
-                    assetBalanceData={assetBalanceData}
-                    filteredData={filteredData}
-                    searchQuery={searchQuery}
-                    onClearFilter={() => setSearchQuery('')}
-                    dividendPerShareMap={dividendPerShareMap}
-                    dividendStatusMap={dividendStatusMap}
-                  />
-                )}
-              </div>
-
-              <aside data-testid="assetbalance-utility-rail">
-                <div className="overflow-hidden rounded-[2rem] border border-slate-200/90 bg-white/80 shadow-[0_20px_48px_-34px_rgba(15,23,42,0.45)] backdrop-blur-sm divide-y divide-slate-200/80">
+                </>
+              }
+              rail={
+                <>
                   <section className="space-y-3 px-5 py-5" role="group" aria-label="データ操作">
                     <div className="space-y-3">
                       <CSVFileInput
@@ -251,9 +251,9 @@ export function AssetBalancePage() {
                       compact
                     />
                   )}
-                </div>
-              </aside>
-            </div>
+                </>
+              }
+            />
 
             <ConfirmDeleteModal
               isOpen={showDeleteConfirm}


### PR DESCRIPTION
## Summary

- `WorkspaceShell` コンポーネントを `components/templates/` に新設
- `ReceiptTemplate`（workspace モード）と `AssetBalance` で重複していた grid レイアウトクラスと rail 装飾クラスを `WorkspaceShell` に集約
- 各ページは `main` / `rail` スロットにコンテンツを渡す形に変更

## Test plan

- [x] `npx tsc --noEmit` エラー 0
- [x] `ReceiptTemplate.test.tsx` + `AssetBalancePage.test.tsx` 全通過（計 19 件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * ワークスペースレイアウトコンポーネントを導入し、複数ページの共通レイアウト構造を統一しました。メインコンテンツとサイドパネルの管理がより効率的になり、レイアウト一貫性が向上します。
  * 既存のグリッド構造をシェルコンポーネントに置き換え、保守性を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->