### PR TITLE
refactor: KpiTone で KPI カードの色判定を型安全に変更

### DIFF
--- a/frontend/src/components/molecules/ReceiptHeader/ReceiptHeader.tsx
+++ b/frontend/src/components/molecules/ReceiptHeader/ReceiptHeader.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, useId, useState } from 'react';
 import { cn } from '@/lib/utils/classNames';
 import { Card, CardHeader, CardBody } from '@/components/atoms/Card';
-import { HeaderItem } from '@/types/common';
+import { HeaderItem, KpiTone } from '@/types/common';
 
 interface ReceiptHeaderProps {
     items: HeaderItem[];
@@ -29,18 +29,21 @@ export const ReceiptHeader: React.FC<ReceiptHeaderProps> = ({
         setIsExpanded(prev => !prev);
     };
 
+    const TONE_CLASSES: Record<KpiTone, string> = {
+        emerald: 'border-emerald-100 bg-emerald-50/90 shadow-[0_12px_24px_-28px_rgba(5,150,105,0.35)]',
+        red:     'border-rose-100 bg-rose-50/90 shadow-[0_12px_24px_-28px_rgba(225,29,72,0.28)]',
+        blue:    'border-blue-100 bg-blue-50/90 shadow-[0_12px_24px_-28px_rgba(37,99,235,0.28)]',
+        slate:   'border-slate-200/90 bg-white shadow-[0_12px_24px_-28px_rgba(15,23,42,0.4)]',
+    };
+
     const getCompactItemTone = (item: HeaderItem) => {
+        // tone prop が優先。未指定の場合は後方互換で className から推定
+        if (item.tone) return TONE_CLASSES[item.tone];
         const token = `${item.className ?? ''} ${item.valueClassName ?? ''}`;
-        if (token.includes('emerald')) {
-            return 'border-emerald-100 bg-emerald-50/90 shadow-[0_12px_24px_-28px_rgba(5,150,105,0.35)]';
-        }
-        if (token.includes('red')) {
-            return 'border-rose-100 bg-rose-50/90 shadow-[0_12px_24px_-28px_rgba(225,29,72,0.28)]';
-        }
-        if (token.includes('blue')) {
-            return 'border-blue-100 bg-blue-50/90 shadow-[0_12px_24px_-28px_rgba(37,99,235,0.28)]';
-        }
-        return 'border-slate-200/90 bg-white shadow-[0_12px_24px_-28px_rgba(15,23,42,0.4)]';
+        if (token.includes('emerald')) return TONE_CLASSES.emerald;
+        if (token.includes('red'))     return TONE_CLASSES.red;
+        if (token.includes('blue'))    return TONE_CLASSES.blue;
+        return TONE_CLASSES.slate;
     };
 
     if (compact) {

--- a/frontend/src/components/molecules/ReceiptHeader/ReceiptHeader.tsx
+++ b/frontend/src/components/molecules/ReceiptHeader/ReceiptHeader.tsx
@@ -51,15 +51,7 @@ export const ReceiptHeader: React.FC<ReceiptHeaderProps> = ({
         slate:   'text-slate-800',
     };
 
-    const resolveTone = (item: HeaderItem): KpiTone => {
-        if (item.tone) return item.tone;
-        // 後方互換: className / valueClassName から推定
-        const token = `${item.className ?? ''} ${item.valueClassName ?? ''}`;
-        if (token.includes('emerald')) return 'emerald';
-        if (token.includes('red'))     return 'red';
-        if (token.includes('blue'))    return 'blue';
-        return 'slate';
-    };
+    const resolveTone = (item: HeaderItem): KpiTone => item.tone ?? 'slate';
 
     if (compact) {
         const compactChevron = collapsible && (

--- a/frontend/src/components/molecules/ReceiptHeader/ReceiptHeader.tsx
+++ b/frontend/src/components/molecules/ReceiptHeader/ReceiptHeader.tsx
@@ -29,21 +29,36 @@ export const ReceiptHeader: React.FC<ReceiptHeaderProps> = ({
         setIsExpanded(prev => !prev);
     };
 
-    const TONE_CLASSES: Record<KpiTone, string> = {
+    // compact モード: カード背景 + border + shadow
+    const COMPACT_BG: Record<KpiTone, string> = {
         emerald: 'border-emerald-100 bg-emerald-50/90 shadow-[0_12px_24px_-28px_rgba(5,150,105,0.35)]',
         red:     'border-rose-100 bg-rose-50/90 shadow-[0_12px_24px_-28px_rgba(225,29,72,0.28)]',
         blue:    'border-blue-100 bg-blue-50/90 shadow-[0_12px_24px_-28px_rgba(37,99,235,0.28)]',
         slate:   'border-slate-200/90 bg-white shadow-[0_12px_24px_-28px_rgba(15,23,42,0.4)]',
     };
+    // non-compact モード: カード背景のみ
+    const NON_COMPACT_BG: Record<KpiTone, string> = {
+        emerald: 'bg-emerald-50',
+        red:     'bg-red-50',
+        blue:    'bg-blue-50',
+        slate:   'bg-slate-50',
+    };
+    // 値テキスト色（compact / non-compact 共通）
+    const TONE_VALUE_COLOR: Record<KpiTone, string> = {
+        emerald: 'text-emerald-600',
+        red:     'text-red-500',
+        blue:    'text-blue-600',
+        slate:   'text-slate-800',
+    };
 
-    const getCompactItemTone = (item: HeaderItem) => {
-        // tone prop が優先。未指定の場合は後方互換で className から推定
-        if (item.tone) return TONE_CLASSES[item.tone];
+    const resolveTone = (item: HeaderItem): KpiTone => {
+        if (item.tone) return item.tone;
+        // 後方互換: className / valueClassName から推定
         const token = `${item.className ?? ''} ${item.valueClassName ?? ''}`;
-        if (token.includes('emerald')) return TONE_CLASSES.emerald;
-        if (token.includes('red'))     return TONE_CLASSES.red;
-        if (token.includes('blue'))    return TONE_CLASSES.blue;
-        return TONE_CLASSES.slate;
+        if (token.includes('emerald')) return 'emerald';
+        if (token.includes('red'))     return 'red';
+        if (token.includes('blue'))    return 'blue';
+        return 'slate';
     };
 
     if (compact) {
@@ -93,13 +108,12 @@ export const ReceiptHeader: React.FC<ReceiptHeaderProps> = ({
                                     key={item.title}
                                     className={cn(
                                         'rounded-[1.35rem] border px-4 py-4',
-                                        getCompactItemTone(item),
-                                        item.className,
+                                        COMPACT_BG[resolveTone(item)],
                                     )}
                                 >
                                     <p className="mb-1 text-xs font-medium text-slate-600">{item.title}</p>
                                     <p
-                                        className={cn('text-3xl font-bold tabular-nums', item.valueClassName ?? 'text-slate-800')}
+                                        className={cn('text-3xl font-bold tabular-nums', TONE_VALUE_COLOR[resolveTone(item)])}
                                         data-negative={item.value < 0 ? 'true' : undefined}
                                     >
                                         {item.format(item.value)}
@@ -174,11 +188,11 @@ export const ReceiptHeader: React.FC<ReceiptHeaderProps> = ({
                         {items.map((item) => (
                             <div
                                 key={item.title}
-                                className={cn('rounded-lg px-4 py-3', item.className ?? 'bg-slate-50')}
+                                className={cn('rounded-lg px-4 py-3', NON_COMPACT_BG[resolveTone(item)])}
                             >
                                 <p className="text-xs font-medium text-slate-600 mb-1">{item.title}</p>
                                 <p
-                                    className={cn('text-2xl font-bold tabular-nums', item.valueClassName ?? 'text-slate-800')}
+                                    className={cn('text-2xl font-bold tabular-nums', TONE_VALUE_COLOR[resolveTone(item)])}
                                     data-negative={item.value < 0 ? 'true' : undefined}
                                 >
                                     {item.format(item.value)}

--- a/frontend/src/pages/Receipt/Dividend.tsx
+++ b/frontend/src/pages/Receipt/Dividend.tsx
@@ -144,22 +144,19 @@ export const Dividend: React.FC<DividendProps> = ({ data, previewData, utilityRa
             title: '配当金',
             value: calculations.total_dividends_before_tax,
             format: formatCurrency,
-            className: 'bg-emerald-50',
-            valueClassName: 'text-emerald-600'
+            tone: 'emerald' as const,
         },
         {
             title: '税額',
             value: calculations.total_taxes,
             format: formatCurrency,
-            className: 'bg-red-50',
-            valueClassName: 'text-red-500'
+            tone: 'red' as const,
         },
         {
             title: '受取金額',
             value: calculations.total_net_amount_received,
             format: formatCurrency,
-            className: 'bg-emerald-50',
-            valueClassName: 'text-emerald-600'
+            tone: 'emerald' as const,
         }
     ];
 

--- a/frontend/src/pages/Receipt/DomesticStock.tsx
+++ b/frontend/src/pages/Receipt/DomesticStock.tsx
@@ -76,22 +76,19 @@ export const DomesticStock: React.FC<DomesticStockProps> = ({ data, previewData,
             title: '実現損益',
             value: calculations.total_realized_profit_and_loss,
             format: formatCurrency,
-            className: 'bg-emerald-50',
-            valueClassName: 'text-emerald-600'
+            tone: 'emerald' as const,
         },
         {
             title: '税額',
             value: calculations.total_taxes,
             format: formatCurrency,
-            className: 'bg-red-50',
-            valueClassName: 'text-red-500'
+            tone: 'red' as const,
         },
         {
             title: '実現損益(税引)',
             value: calculations.total_realized_profit_and_loss_after_tax,
             format: formatCurrency,
-            className: 'bg-emerald-50',
-            valueClassName: 'text-emerald-600'
+            tone: 'emerald' as const,
         }
     ];
 

--- a/frontend/src/pages/Receipt/Mutualfund.tsx
+++ b/frontend/src/pages/Receipt/Mutualfund.tsx
@@ -77,22 +77,19 @@ export const Mutualfund: React.FC<MutualfundProps> = ({ data, previewData, utili
             title: '実現損益',
             value: calculations.total_realized_profit_and_loss,
             format: formatCurrency,
-            className: 'bg-emerald-50',
-            valueClassName: 'text-emerald-600'
+            tone: 'emerald' as const,
         },
         {
             title: '税額',
             value: calculations.total_taxes,
             format: formatCurrency,
-            className: 'bg-red-50',
-            valueClassName: 'text-red-500'
+            tone: 'red' as const,
         },
         {
             title: '実現損益(税引)',
             value: calculations.total_realized_profit_and_loss_after_tax,
             format: formatCurrency,
-            className: 'bg-emerald-50',
-            valueClassName: 'text-emerald-600'
+            tone: 'emerald' as const,
         }
     ];
 

--- a/frontend/src/types/common.ts
+++ b/frontend/src/types/common.ts
@@ -10,10 +10,6 @@ export interface HeaderItem {
   value: number;
   format: (value: number) => string;
   tone?: KpiTone;
-  /** @deprecated tone を使用してください */
-  className?: string;
-  /** @deprecated tone を使用してください */
-  valueClassName?: string;
 }
 
 export type TableColumnAlignment = 'left' | 'center' | 'right';

--- a/frontend/src/types/common.ts
+++ b/frontend/src/types/common.ts
@@ -3,11 +3,16 @@ import React from 'react';
 // 共通の型定義
 export type FormatFunction<T = unknown> = (value: T) => string | number | React.ReactNode;
 
+export type KpiTone = 'emerald' | 'red' | 'blue' | 'slate';
+
 export interface HeaderItem {
   title: string;
   value: number;
   format: (value: number) => string;
+  tone?: KpiTone;
+  /** @deprecated tone を使用してください */
   className?: string;
+  /** @deprecated tone を使用してください */
   valueClassName?: string;
 }
 


### PR DESCRIPTION
## Summary

- \`KpiTone\` 型を \`common.ts\` に追加（\`emerald | red | blue | slate\`）
- \`HeaderItem\` に \`tone\` フィールドを追加し、\`className\`/\`valueClassName\` を**完全削除**（すべての呼び出し元を同時移行）
- \`ReceiptHeader\` の \`getCompactItemTone\` を \`string.includes\` から tone ルックアップテーブルに変更（文字列パース廃止）
- compact / non-compact 両パスで \`COMPACT_BG\` / \`NON_COMPACT_BG\` / \`TONE_VALUE_COLOR\` の3テーブルにより tone を解決
- \`Dividend\` / \`DomesticStock\` / \`Mutualfund\` の HeaderItem 定義を \`tone\` prop に移行（すべて移行済みのため \`className\`/\`valueClassName\` は残さない）

## Test plan

- [x] \`npx tsc --noEmit\` エラー 0
- [x] \`ReceiptHeader.test.tsx\` + 各 Receipt ページテスト 計 33 件通過
- [x] \`npm test\` 44 files / 446 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * レシートヘッダーに色調テーマシステムを導入。翡翠（emerald）、赤（red）、青（blue）、グレー（slate）のトーンをサポート。

* **リファクタリング**
  * 配当金・国内株式・投信ページのヘッダー表示を統一されたトーン指定に移行し、見た目の一貫性を向上。

* **互換性注意**
  * ヘッダー項目のスタイル指定がトーンベースに変わり、従来の個別クラス指定は廃止されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->