### PR TITLE
refactor: ReceiptHeader の compact 分岐重複整理

### DIFF
--- a/frontend/src/components/molecules/ReceiptHeader/ReceiptHeader.tsx
+++ b/frontend/src/components/molecules/ReceiptHeader/ReceiptHeader.tsx
@@ -12,6 +12,92 @@ interface ReceiptHeaderProps {
     compact?: boolean;
 }
 
+// コンポーネント外に定義（毎レンダーで新参照が生成されるのを防ぐ）
+const COMPACT_BG: Record<KpiTone, string> = {
+    emerald: 'border-emerald-100 bg-emerald-50/90 shadow-[0_12px_24px_-28px_rgba(5,150,105,0.35)]',
+    red:     'border-rose-100 bg-rose-50/90 shadow-[0_12px_24px_-28px_rgba(225,29,72,0.28)]',
+    blue:    'border-blue-100 bg-blue-50/90 shadow-[0_12px_24px_-28px_rgba(37,99,235,0.28)]',
+    slate:   'border-slate-200/90 bg-white shadow-[0_12px_24px_-28px_rgba(15,23,42,0.4)]',
+};
+
+const NON_COMPACT_BG: Record<KpiTone, string> = {
+    emerald: 'bg-emerald-50',
+    red:     'bg-red-50',
+    blue:    'bg-blue-50',
+    slate:   'bg-slate-50',
+};
+
+const TONE_VALUE_COLOR: Record<KpiTone, string> = {
+    emerald: 'text-emerald-600',
+    red:     'text-red-500',
+    blue:    'text-blue-600',
+    slate:   'text-slate-800',
+};
+
+const resolveTone = (item: HeaderItem): KpiTone => item.tone ?? 'slate';
+
+// KPI 1枚分の描画
+interface KpiCardProps {
+    item: HeaderItem;
+    cardClassName: string;
+    valueSizeClassName: string;
+}
+
+function KpiCard({ item, cardClassName, valueSizeClassName }: KpiCardProps) {
+    return (
+        <div className={cardClassName}>
+            <p className="mb-1 text-xs font-medium text-slate-600">{item.title}</p>
+            <p
+                className={cn(valueSizeClassName, 'font-bold tabular-nums', TONE_VALUE_COLOR[resolveTone(item)])}
+                data-negative={item.value < 0 ? 'true' : undefined}
+            >
+                {item.format(item.value)}
+            </p>
+        </div>
+    );
+}
+
+// KPI グリッド描画
+interface KpiGridProps {
+    items: HeaderItem[];
+    gridClassName: string;
+    cardBg: Record<KpiTone, string>;
+    cardBaseClassName: string;
+    valueSizeClassName: string;
+}
+
+function KpiGrid({ items, gridClassName, cardBg, cardBaseClassName, valueSizeClassName }: KpiGridProps) {
+    if (items.length === 0) return null;
+    return (
+        <div className={gridClassName} data-testid="kpi-grid">
+            {items.map((item) => (
+                <KpiCard
+                    key={item.title}
+                    item={item}
+                    cardClassName={cn(cardBaseClassName, cardBg[resolveTone(item)])}
+                    valueSizeClassName={valueSizeClassName}
+                />
+            ))}
+        </div>
+    );
+}
+
+// children セクション描画（KPI グリッドとの境界線を含む）
+interface ChildrenSectionProps {
+    children: ReactNode;
+    hasItems: boolean;
+    dividerClassName: string;
+}
+
+function ChildrenSection({ children, hasItems, dividerClassName }: ChildrenSectionProps) {
+    if (!children) return null;
+    return (
+        <div className={hasItems ? dividerClassName : ''}>
+            {children}
+        </div>
+    );
+}
+
 export const ReceiptHeader: React.FC<ReceiptHeaderProps> = ({
     items,
     title = '集計情報',
@@ -28,30 +114,6 @@ export const ReceiptHeader: React.FC<ReceiptHeaderProps> = ({
         if (!collapsible) return;
         setIsExpanded(prev => !prev);
     };
-
-    // compact モード: カード背景 + border + shadow
-    const COMPACT_BG: Record<KpiTone, string> = {
-        emerald: 'border-emerald-100 bg-emerald-50/90 shadow-[0_12px_24px_-28px_rgba(5,150,105,0.35)]',
-        red:     'border-rose-100 bg-rose-50/90 shadow-[0_12px_24px_-28px_rgba(225,29,72,0.28)]',
-        blue:    'border-blue-100 bg-blue-50/90 shadow-[0_12px_24px_-28px_rgba(37,99,235,0.28)]',
-        slate:   'border-slate-200/90 bg-white shadow-[0_12px_24px_-28px_rgba(15,23,42,0.4)]',
-    };
-    // non-compact モード: カード背景のみ
-    const NON_COMPACT_BG: Record<KpiTone, string> = {
-        emerald: 'bg-emerald-50',
-        red:     'bg-red-50',
-        blue:    'bg-blue-50',
-        slate:   'bg-slate-50',
-    };
-    // 値テキスト色（compact / non-compact 共通）
-    const TONE_VALUE_COLOR: Record<KpiTone, string> = {
-        emerald: 'text-emerald-600',
-        red:     'text-red-500',
-        blue:    'text-blue-600',
-        slate:   'text-slate-800',
-    };
-
-    const resolveTone = (item: HeaderItem): KpiTone => item.tone ?? 'slate';
 
     if (compact) {
         const compactChevron = collapsible && (
@@ -93,32 +155,19 @@ export const ReceiptHeader: React.FC<ReceiptHeaderProps> = ({
                     </div>
                 )}
                 <div id={bodyId} hidden={collapsible && !effectiveExpanded} className="pt-4">
-                    {items.length > 0 && (
-                        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3" data-testid="kpi-grid">
-                            {items.map((item) => (
-                                <div
-                                    key={item.title}
-                                    className={cn(
-                                        'rounded-[1.35rem] border px-4 py-4',
-                                        COMPACT_BG[resolveTone(item)],
-                                    )}
-                                >
-                                    <p className="mb-1 text-xs font-medium text-slate-600">{item.title}</p>
-                                    <p
-                                        className={cn('text-3xl font-bold tabular-nums', TONE_VALUE_COLOR[resolveTone(item)])}
-                                        data-negative={item.value < 0 ? 'true' : undefined}
-                                    >
-                                        {item.format(item.value)}
-                                    </p>
-                                </div>
-                            ))}
-                        </div>
-                    )}
-                    {children && (
-                        <div className={items.length > 0 ? 'mt-4 border-t border-slate-200/90 pt-4' : ''}>
-                            {children}
-                        </div>
-                    )}
+                    <KpiGrid
+                        items={items}
+                        gridClassName="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3"
+                        cardBg={COMPACT_BG}
+                        cardBaseClassName="rounded-[1.35rem] border px-4 py-4"
+                        valueSizeClassName="text-3xl"
+                    />
+                    <ChildrenSection
+                        hasItems={items.length > 0}
+                        dividerClassName="mt-4 border-t border-slate-200/90 pt-4"
+                    >
+                        {children}
+                    </ChildrenSection>
                 </div>
             </section>
         );
@@ -175,29 +224,19 @@ export const ReceiptHeader: React.FC<ReceiptHeaderProps> = ({
             </CardHeader>
             {/* 折りたたみ時はhiddenで非表示（children内のstateを保持するため） */}
             <CardBody id={bodyId} hidden={collapsible && !effectiveExpanded} className="p-4">
-                {items.length > 0 && (
-                    <div className="grid grid-cols-1 gap-4 md:grid-cols-3" data-testid="kpi-grid">
-                        {items.map((item) => (
-                            <div
-                                key={item.title}
-                                className={cn('rounded-lg px-4 py-3', NON_COMPACT_BG[resolveTone(item)])}
-                            >
-                                <p className="text-xs font-medium text-slate-600 mb-1">{item.title}</p>
-                                <p
-                                    className={cn('text-2xl font-bold tabular-nums', TONE_VALUE_COLOR[resolveTone(item)])}
-                                    data-negative={item.value < 0 ? 'true' : undefined}
-                                >
-                                    {item.format(item.value)}
-                                </p>
-                            </div>
-                        ))}
-                    </div>
-                )}
-                {children && (
-                    <div className={items.length > 0 ? 'mt-4 pt-4 border-t border-slate-200' : ''}>
-                        {children}
-                    </div>
-                )}
+                <KpiGrid
+                    items={items}
+                    gridClassName="grid grid-cols-1 gap-4 md:grid-cols-3"
+                    cardBg={NON_COMPACT_BG}
+                    cardBaseClassName="rounded-lg px-4 py-3"
+                    valueSizeClassName="text-2xl"
+                />
+                <ChildrenSection
+                    hasItems={items.length > 0}
+                    dividerClassName="mt-4 pt-4 border-t border-slate-200"
+                >
+                    {children}
+                </ChildrenSection>
             </CardBody>
         </Card>
     );


### PR DESCRIPTION
## 概要

`ReceiptHeader` の compact / non-compact 描画分岐にある重複を整理し、
表示仕様を変えずに責務を分離した。

## 変更内容

- `COMPACT_BG` / `NON_COMPACT_BG` / `TONE_VALUE_COLOR` / `resolveTone` をコンポーネント関数外の定数・関数に移動（毎レンダー再生成を防止）
- KPI 1枚分の描画を `KpiCard` サブコンポーネントに抽出
- KPI グリッド全体を `KpiGrid` サブコンポーネントに抽出（`gridClassName` / `cardBg` / `valueSizeClassName` で compact/non-compact の差分を吸収）
- children セクションを `ChildrenSection` サブコンポーネントに抽出
- compact / non-compact の分岐に残るのは外側シェルとヘッダー部（chevron スタイル等）のみ

## 表示変更

なし（見た目・挙動は完全に保持）

## テスト

```
cd frontend && npm test -- ReceiptHeader
→ 11 tests passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * ReceiptHeaderコンポーネントの内部構造を改善しました。KPI表示ロジックをモジュール化し、スタイリング管理を統一しました。機能的な動作に変わりはありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->