### PR TITLE
test: StockInfoLinks の未追跡テストファイルを追加

### DIFF
--- a/frontend/src/components/molecules/__tests__/StockInfoLinks.test.tsx
+++ b/frontend/src/components/molecules/__tests__/StockInfoLinks.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { StockInfoLinks } from '../StockInfoLinks';
+
+describe('StockInfoLinks', () => {
+  it('楽天証券リンクとSBI証券リンクを表示する', () => {
+    render(<StockInfoLinks code="7203" />);
+
+    const rakutenLink = screen.getByRole('link', { name: /楽天証券/ });
+    const sbiLink = screen.getByRole('link', { name: /SBI証券/ });
+
+    expect(rakutenLink).toHaveAttribute(
+      'href',
+      'https://www.rakuten-sec.co.jp/web/market/search/quote.html?ric=7203.T'
+    );
+    expect(sbiLink).toHaveAttribute(
+      'href',
+      'https://site3.sbisec.co.jp/ETGate/?_ControlID=WPLETsiR001Control&_DataStoreID=DSWPLETsiR001Control&_PageID=WPLETsiR001Ilst10&_ActionID=getDetailOfStockPriceJP&s_rkbn=1&i_stock_sec=%94%43%93%56%93%B0&i_dom_flg=1&i_exchange_code=JPN&i_output_type=0&stock_sec_code_mul=7203'
+    );
+  });
+
+  it('銘柄コードがない場合は何も表示しない', () => {
+    const { container } = render(<StockInfoLinks />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});


### PR DESCRIPTION
## 概要

`frontend/src/components/molecules/__tests__/StockInfoLinks.test.tsx` が未追跡のまま残っていたため、git 管理に追加する。

## テスト内容

- 楽天証券・SBI証券リンクの href が正しく設定されるか
- 銘柄コードが未指定の場合は何も表示しないか

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * 既存コンポーネントの動作検証テストを追加しました。提供されたデータに基づいた正確な表示と、データなしの場合の適切な処理をカバーします。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->