### PR TITLE
chore: レビュー→修正→返信ワークフローを明文化

### DIFF
--- a/.claude/rules/00-general.md
+++ b/.claude/rules/00-general.md
@@ -18,8 +18,12 @@
 2. Claude が `.claude/skills/claude-codex-handoff/SKILL.md` で Codex に実装を委譲する
 3. Codex が実装・lint/test/build・commit・push・PR 作成を行う
 4. Claude が `/pr-review` スキルで PR をレビューし、GitHub にコメントを投稿する
-5. 修正が必要な場合は Claude が再度 `claude-codex-handoff` で Codex に指示する
-6. Claude が LGTM 判断 → マージ
+5. **修正が必要な場合**: Claude が `claude-codex-handoff` で指摘一覧（コメント ID 付き）を Codex に渡す
+6. **Codex が指摘への対応をする**: 各指摘コメントに返信 → 修正実装 → lint/test/build → push（PR 作成は不要）
+7. Claude が再レビュー（ステップ 4 に戻る）
+8. LGTM → Claude がマージ
+
+**重要: ステップ 5〜7 は LGTM が出るまで繰り返す。返信なし・未修正の指摘が 1 件でも残ればマージ禁止。**
 
 ### タスク管理ルール
 - `docs/tasks/<branch-name>.md` が存在する場合は、作業前に必ず読み、進捗とレビュー指摘を更新する
@@ -31,7 +35,10 @@
 ### Codex が遵守するルール
 - 実装後は必ず lint/test/build を通してからコミットする
 - push 後に PR を作成し、Claude のレビューを待つ
-- Claude から指摘が来たら修正して再 push する（再レビューは Claude が行う）
+- Claude からレビュー指摘が来たら、**まず各指摘コメントに返信し、その後修正して再 push する**
+  - 返信なしで修正だけするのは禁止
+  - 修正しない場合（スコープ外など）も「対応しない理由」を必ずコメントに返信する
+- CodeRabbit 等の自動レビューコメントにも同様に返信する
 - Codex から Claude に設計相談・調査依頼する場合は `.claude/skills/codex-claude-handoff/SKILL.md` を使用する
 
 ## 出力制約

--- a/.claude/skills/claude-codex-handoff/SKILL.md
+++ b/.claude/skills/claude-codex-handoff/SKILL.md
@@ -15,7 +15,7 @@ Codex が最短で実装に着手できる依頼文を作成し、`codex exec "<
 
 ### 1. 依頼文を組み立てる
 
-以下の要素をすべて含める:
+**A. 新規実装の場合**（以下の要素をすべて含める）:
 
 ```markdown
 ## タスク概要
@@ -51,6 +51,38 @@ cd backend && cargo clippy --all-targets -- -D warnings && cargo test
 2. PR 作成 (`gh pr create --base main`)
 ```
 
+**B. レビュー指摘の修正依頼の場合**（以下の要素をすべて含める）:
+
+```markdown
+## タスク概要
+PR #<番号> のレビュー指摘に対応する。各指摘に返信してから修正を実装すること。
+
+## 対応手順（順番厳守）
+1. 各指摘コメントに返信する（修正前に返信する）
+2. 修正を実装する
+3. 確認コマンドを通す
+4. push する（PR は作成済みのため gh pr create は不要）
+
+## 指摘一覧（全件対応必須）
+
+| # | 重大度 | 内容 | ファイル:行 | 返信コマンド |
+|---|--------|------|-----------|------------|
+| 1 | [high] | <指摘内容> | path/to/file.ts:42 | `gh api repos/zaichu/shoken-webapp/issues/comments/<id> --method PATCH -f body='対応しました。<一言>'` |
+| 2 | [low]  | <指摘内容> | path/to/other.rs:10 | `gh api repos/zaichu/shoken-webapp/pulls/comments/<id>/replies --method POST --field 'body=対応しました。<一言>'` |
+
+※ 対応しない場合（スコープ外など）も返信は必須。理由を明記すること。
+※ CodeRabbit など自動レビューのコメントも同様に返信すること。
+
+## 確認コマンド
+```bash
+# フロントエンド変更がある場合
+cd frontend && npm run lint && npx tsc --noEmit && npm test -- --run && npm run build
+
+# バックエンド変更がある場合
+cd backend && cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test
+```
+```
+
 ### 2. Codex に渡す
 
 依頼文を作成したら以下で実行:
@@ -66,6 +98,7 @@ codex exec "<依頼文をここに貼る>"
 - ファイルパスを必ず明示する（Codex が探索コストをかけないようにする）
 - 非対象を明記する（ついでの変更を防ぐ）
 - 受け入れ条件を検証可能に書く（テスト名、コマンド結果を具体化）
+- レビュー指摘対応時は**コメント ID と返信コマンドを必ず含める**（返信漏れ防止）
 
 ## Output
 `codex exec` に渡す依頼文（Markdown）を出力し、そのまま実行する。

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -57,19 +57,48 @@ findings first で重大度順に出す:
 - 存在する場合は更新: `gh api repos/{owner}/{repo}/issues/comments/<comment_id> -X PATCH -f body="..."`
 - 存在しない場合は新規投稿: `gh pr comment <PR番号> --body "..."`
 - コメント先頭は `🤖 Claude review` で始める
+- **inline レビューコメントも必ず確認・返信する**:
+  - 取得: `gh api repos/{owner}/{repo}/pulls/<PR番号>/comments --jq '.[] | {id, path, body}'`
+  - 返信: `gh api repos/{owner}/{repo}/pulls/comments/<comment_id>/replies --method POST --field 'body=...'`
 
 ### 6. 修正が必要な場合
-- `.claude/skills/claude-codex-handoff/SKILL.md` を使って Codex に修正を依頼する
-- 修正 push 後は本スキルで再レビューする（LGTM まで繰り返す）
+`claude-codex-handoff` スキルを使って Codex に修正を依頼する。依頼文には**以下を必ず含める**:
+
+```markdown
+## レビュー指摘への対応（全件返信 + 修正）
+
+以下の各指摘を順番に処理する:
+1. PR コメントに返信する
+2. 修正を実装する
+3. lint/test/build を通す
+4. push する（PR は既に作成済みのため gh pr create は不要）
+
+### 指摘一覧
+
+| # | 重大度 | 内容 | ファイル:行 | コメントID | 返信コマンド |
+|---|--------|------|-----------|-----------|------------|
+| 1 | [high] | <内容> | path/to/file.ts:42 | issue_comment:<id> | `gh api repos/{owner}/{repo}/issues/comments/<id> --method PATCH -f body='対応しました。<一言>'` |
+| 2 | [low]  | <内容> | path/to/other.rs:10 | pulls_comment:<id> | `gh api repos/{owner}/{repo}/pulls/comments/<id>/replies --method POST --field 'body=対応しました。<一言>'` |
+
+対応しない場合（スコープ外など）も「対応しない理由」を必ずコメントに返信すること。
+CodeRabbit 等の自動レビューコメントも同様に返信すること。
+```
+
+修正 push 後は本スキルで再レビューする（LGTM まで繰り返す）。
 
 ### 7. LGTM 後
+- **全コメント返信済みか最終確認する**:
+  - `gh api repos/{owner}/{repo}/issues/<PR番号>/comments` — issue コメントに未返信がないか
+  - `gh api repos/{owner}/{repo}/pulls/<PR番号>/comments` — inline コメントに未返信がないか
+  - 未返信があれば返信してからマージする
 - PR をマージする: `gh pr merge <PR番号> --squash --delete-branch`
 - main を更新: `git switch main && git pull --ff-only origin main`
 
 ## Review Rules
 - findings first / 重大度順 / ファイルパスと行番号を必須とする
 - 検証コマンドと pass/fail を必ず記録する
-- PR コメントへの返信も必ず行う（CodeRabbit 等の自動レビューも含む）
+- issue コメント・inline コメント・CodeRabbit コメントすべてに返信する
+- **未返信の指摘が 1 件でも残ればマージしない**
 
 ## Output
 レビュー結果（findings first）を出力し、PR にコメントする。


### PR DESCRIPTION
## 概要

ユーザー指摘「Codex がレビュー指摘に返信していない」問題を解消するため、3 ファイルを更新。

## 変更内容

### `.claude/rules/00-general.md`
- 標準フローを 6 ステップ → 8 ステップに拡張
- 「Codex が各指摘コメントに返信 → 修正実装 → push」を明示
- 「未返信の指摘が 1 件でも残ればマージ禁止」を追記
- Codex ルールに「返信してから修正する」「CodeRabbit 含む全コメントに返信」を追加

### `.claude/skills/pr-review/SKILL.md`
- Step 5: inline コメント（pulls API）の確認・返信手順を追加
- Step 6: 修正依頼テンプレートにコメント ID・返信コマンドを必須化
- Step 7: マージ前に全コメント返信済みか確認するステップを追加

### `.claude/skills/claude-codex-handoff/SKILL.md`
- テンプレートを「A. 新規実装」「B. レビュー指摘の修正依頼」に分離
- B テンプレートに指摘一覧（コメント ID・返信コマンド）を明示化

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * コードレビュープロセスがより詳細で構造化された手順に変更されました
  * すべてのレビューコメントへの回答が必須となり、マージ前にすべての指摘が確実に対応されるようになりました
  * レビュー指摘に対する修正作業の追跡可能性が向上しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->