### PR TITLE
test: フロントエンドコンポーネントのユニットテストを追加

### DIFF
--- a/frontend/src/components/atoms/__tests__/Alert.test.tsx
+++ b/frontend/src/components/atoms/__tests__/Alert.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import { Alert } from '../Alert';
+
+describe('Alert', () => {
+  it('デフォルトの info で children を表示する', () => {
+    render(<Alert>お知らせ</Alert>);
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent('お知らせ');
+    expect(alert).toHaveClass('bg-info/10');
+  });
+
+  it('warning variant のクラスを適用する', () => {
+    render(<Alert variant="warning">警告</Alert>);
+
+    expect(screen.getByRole('alert')).toHaveClass('bg-warning/15');
+  });
+
+  it('danger variant のクラスを適用する', () => {
+    render(<Alert variant="danger">危険</Alert>);
+
+    expect(screen.getByRole('alert')).toHaveClass('bg-danger/10');
+  });
+
+  it('success variant のクラスを適用する', () => {
+    render(<Alert variant="success">成功</Alert>);
+
+    expect(screen.getByRole('alert')).toHaveClass('bg-success/10');
+  });
+});

--- a/frontend/src/components/atoms/__tests__/Card.test.tsx
+++ b/frontend/src/components/atoms/__tests__/Card.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import { Card, CardBody, CardHeader } from '../Card';
+
+describe('Card', () => {
+  it('children を表示する', () => {
+    render(<Card>カード本文</Card>);
+
+    expect(screen.getByText('カード本文')).toBeInTheDocument();
+  });
+});
+
+describe('CardHeader', () => {
+  it('children を表示し variant クラスを適用する', () => {
+    render(<CardHeader variant="primary">ヘッダー</CardHeader>);
+
+    const header = screen.getByText('ヘッダー');
+    expect(header).toBeInTheDocument();
+    expect(header).toHaveClass('bg-slate-700');
+  });
+});
+
+describe('CardBody', () => {
+  it('children を表示する', () => {
+    render(<CardBody>本文</CardBody>);
+
+    expect(screen.getByText('本文')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/atoms/__tests__/EmptyState.test.tsx
+++ b/frontend/src/components/atoms/__tests__/EmptyState.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import { EmptyState } from '../EmptyState';
+
+describe('EmptyState', () => {
+  it('title を表示する', () => {
+    render(<EmptyState title="データがありません" />);
+
+    expect(screen.getByRole('heading', { level: 3, name: 'データがありません' })).toBeInTheDocument();
+  });
+
+  it('description を表示する', () => {
+    render(<EmptyState title="データがありません" description="CSV を読み込んでください" />);
+
+    expect(screen.getByText('CSV を読み込んでください')).toBeInTheDocument();
+  });
+
+  it('action を表示する', () => {
+    render(<EmptyState title="データがありません" action={<button>再読み込み</button>} />);
+
+    expect(screen.getByRole('button', { name: '再読み込み' })).toBeInTheDocument();
+  });
+
+  it('headingLevel が h1 のとき h1 を使う', () => {
+    render(<EmptyState title="トップ見出し" headingLevel="h1" />);
+
+    expect(screen.getByRole('heading', { level: 1, name: 'トップ見出し' })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/atoms/__tests__/PageHeader.test.tsx
+++ b/frontend/src/components/atoms/__tests__/PageHeader.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import { PageHeader } from '../PageHeader';
+
+describe('PageHeader', () => {
+  it('title を h1 として表示する', () => {
+    render(<PageHeader title="資産管理" />);
+
+    expect(screen.getByRole('heading', { level: 1, name: '資産管理' })).toBeInTheDocument();
+  });
+
+  it('description を表示する', () => {
+    render(<PageHeader title="資産管理" description="保有資産の一覧です" />);
+
+    expect(screen.getByText('保有資産の一覧です')).toBeInTheDocument();
+  });
+
+  it('actions を表示する', () => {
+    render(<PageHeader title="資産管理" actions={<button>追加</button>} />);
+
+    expect(screen.getByRole('button', { name: '追加' })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/atoms/__tests__/SecurityCodeLink.test.tsx
+++ b/frontend/src/components/atoms/__tests__/SecurityCodeLink.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { SecurityCodeLink } from '../SecurityCodeLink';
+
+describe('SecurityCodeLink', () => {
+  it('有効な 4 桁コードをリンクとして表示する', () => {
+    render(
+      <MemoryRouter>
+        <SecurityCodeLink value="7203" />
+      </MemoryRouter>
+    );
+
+    const link = screen.getByRole('link', { name: '7203' });
+    expect(link).toHaveAttribute('href', '/search?code=7203');
+  });
+
+  it.each([null, undefined, ''])('無効な値 %p の場合は - を表示する', (value) => {
+    render(
+      <MemoryRouter>
+        <SecurityCodeLink value={value} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('-')).toBeInTheDocument();
+  });
+
+  it('正規表現に合わない文字列はリンク化せずテキスト表示する', () => {
+    render(
+      <MemoryRouter>
+        <SecurityCodeLink value="7203?" />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('7203?')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: '7203?' })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/atoms/__tests__/Spinner.test.tsx
+++ b/frontend/src/components/atoms/__tests__/Spinner.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import { Spinner } from '../Spinner';
+
+describe('Spinner', () => {
+  it('デフォルト label を aria-label で確認できる', () => {
+    render(<Spinner />);
+
+    expect(screen.getByRole('status', { name: '読み込み中...' })).toBeInTheDocument();
+  });
+
+  it('label props を aria-label に反映する', () => {
+    render(<Spinner label="保存中" />);
+
+    expect(screen.getByRole('status', { name: '保存中' })).toBeInTheDocument();
+  });
+
+  it('size が lg のときクラスを適用する', () => {
+    render(<Spinner size="lg" />);
+
+    expect(screen.getByRole('status')).toHaveClass('h-8', 'w-8');
+  });
+});

--- a/frontend/src/components/molecules/__tests__/DividendInfo.test.tsx
+++ b/frontend/src/components/molecules/__tests__/DividendInfo.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, vi } from 'vitest';
+
+const { mockUseDividendBatch, mockUseAssetBalance } = vi.hoisted(() => ({
+  mockUseDividendBatch: vi.fn(),
+  mockUseAssetBalance: vi.fn(),
+}));
+
+vi.mock('@/features/jquants/hooks/useDividendBatch', () => ({
+  useDividendBatch: (...args: unknown[]) => mockUseDividendBatch(...args),
+}));
+
+vi.mock('@/features/assetBalance/hooks/useAssetBalance', () => ({
+  useAssetBalance: (...args: unknown[]) => mockUseAssetBalance(...args),
+}));
+
+import { DividendInfo } from '../DividendInfo/DividendInfo';
+
+describe('DividendInfo', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockUseDividendBatch.mockReturnValue({
+      dividendPerShareMap: new Map(),
+      dividendStatusMap: new Map(),
+      loading: false,
+      fetchedCount: 0,
+      totalCount: 0,
+    });
+
+    mockUseAssetBalance.mockReturnValue({
+      assetBalanceData: [],
+      isLoading: false,
+      getAssetBalanceByCode: vi.fn(() => undefined),
+      getTotalMarketValue: vi.fn(() => 0),
+      refetch: vi.fn(),
+    });
+  });
+
+  it('summary が空でも正常にレンダリングされる', () => {
+    render(<DividendInfo searchQuery="7203: トヨタ自動車" summary={[]} />);
+
+    expect(screen.getByText('配当シミュレーション')).toBeInTheDocument();
+  });
+
+  it('J-Quants バッジのリンクを表示する', () => {
+    mockUseDividendBatch.mockReturnValue({
+      dividendPerShareMap: new Map([['7203', 120]]),
+      dividendStatusMap: new Map([['7203', 'ok']]),
+      loading: false,
+      fetchedCount: 1,
+      totalCount: 1,
+    });
+
+    render(<DividendInfo searchQuery="7203: トヨタ自動車" summary={[]} />);
+
+    const link = screen.getByRole('link', { name: 'J-Quants' });
+    expect(link).toHaveAttribute('href', 'https://jpx-jquants.com/');
+  });
+
+  it('searchQuery から銘柄コードを解決して useDividendBatch に渡す', () => {
+    render(<DividendInfo searchQuery="7203: トヨタ自動車" summary={[]} />);
+
+    expect(mockUseDividendBatch).toHaveBeenCalledWith(['7203'], true);
+  });
+});

--- a/frontend/src/components/organisms/__tests__/DataActionRail.test.tsx
+++ b/frontend/src/components/organisms/__tests__/DataActionRail.test.tsx
@@ -1,0 +1,54 @@
+import type { ComponentProps } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import { DataActionRail } from '../DataActionRail/DataActionRail';
+
+const createProps = (overrides: Partial<ComponentProps<typeof DataActionRail>> = {}) => ({
+  onFileSelect: vi.fn(),
+  hasCsvFile: true,
+  saveLabel: '保存する',
+  onSave: vi.fn(),
+  hasDbData: true,
+  deleteLabel: '削除する',
+  onDeleteRequest: vi.fn(),
+  saveModeLabel: 'CSV',
+  ...overrides,
+});
+
+describe('DataActionRail', () => {
+  it('hasCsvFile=true で saveLabel のボタンを表示する', () => {
+    render(<DataActionRail {...createProps()} />);
+
+    expect(screen.getByRole('button', { name: '保存する' })).toBeInTheDocument();
+  });
+
+  it('hasCsvFile=false で保存ボタンを表示しない', () => {
+    render(<DataActionRail {...createProps({ hasCsvFile: false })} />);
+
+    expect(screen.queryByRole('button', { name: '保存する' })).not.toBeInTheDocument();
+  });
+
+  it('hasDbData=true で deleteLabel のボタンを表示する', () => {
+    render(<DataActionRail {...createProps()} />);
+
+    expect(screen.getByRole('button', { name: '削除する' })).toBeInTheDocument();
+  });
+
+  it('保存ボタンのクリックで onSave を呼ぶ', () => {
+    const handleSave = vi.fn();
+    render(<DataActionRail {...createProps({ onSave: handleSave })} />);
+
+    fireEvent.click(screen.getByRole('button', { name: '保存する' }));
+
+    expect(handleSave).toHaveBeenCalledTimes(1);
+  });
+
+  it('削除ボタンのクリックで onDeleteRequest を呼ぶ', () => {
+    const handleDelete = vi.fn();
+    render(<DataActionRail {...createProps({ onDeleteRequest: handleDelete })} />);
+
+    fireEvent.click(screen.getByRole('button', { name: '削除する' }));
+
+    expect(handleDelete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/organisms/__tests__/Footer.test.tsx
+++ b/frontend/src/components/organisms/__tests__/Footer.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import { Footer } from '../Footer';
+
+describe('Footer', () => {
+  it('プライバシーポリシーリンクを表示する', () => {
+    render(<Footer />);
+
+    expect(screen.getByRole('link', { name: 'プライバシーポリシー' })).toBeInTheDocument();
+  });
+
+  it('利用規約リンクを表示する', () => {
+    render(<Footer />);
+
+    expect(screen.getByRole('link', { name: '利用規約' })).toBeInTheDocument();
+  });
+
+  it('Cookie ポリシーリンクを表示する', () => {
+    render(<Footer />);
+
+    expect(screen.getByRole('link', { name: 'Cookie ポリシー' })).toBeInTheDocument();
+  });
+
+  it('コピーライトを表示する', () => {
+    render(<Footer />);
+
+    expect(screen.getByText('© 2026 shoken-webapp')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/organisms/__tests__/Header.test.tsx
+++ b/frontend/src/components/organisms/__tests__/Header.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+import { Header } from '../Header';
+
+vi.mock('@/features/auth/hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: {
+      name: 'テストユーザー',
+      email: 'test@example.com',
+      picture: null,
+      picture_url: null,
+    },
+    login: vi.fn(),
+    logout: vi.fn(),
+    deleteAccount: vi.fn(),
+    isAuthenticated: true,
+    isLoading: false,
+  }),
+}));
+
+describe('Header', () => {
+  it('主要ナビゲーションリンクを表示する', () => {
+    render(
+      <MemoryRouter>
+        <Header />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('link', { name: '銘柄検索' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '資産管理' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '取引明細' })).toBeInTheDocument();
+  });
+
+  it('ログイン状態でユーザーアバターを表示する', () => {
+    render(
+      <MemoryRouter>
+        <Header />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByLabelText('テストユーザー')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/organisms/__tests__/SearchForm.test.tsx
+++ b/frontend/src/components/organisms/__tests__/SearchForm.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import { SearchForm } from '../SearchForm';
+
+describe('SearchForm', () => {
+  it('input に stockCode を表示する', () => {
+    render(
+      <SearchForm
+        stockCode="7203"
+        onStockCodeChange={vi.fn()}
+        onSubmit={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('textbox', { name: '銘柄コードまたは銘柄名' })).toHaveValue('7203');
+  });
+
+  it('input の変更で onStockCodeChange を呼ぶ', () => {
+    const handleChange = vi.fn();
+    render(
+      <SearchForm
+        stockCode="7203"
+        onStockCodeChange={handleChange}
+        onSubmit={vi.fn()}
+      />
+    );
+
+    fireEvent.change(screen.getByRole('textbox', { name: '銘柄コードまたは銘柄名' }), {
+      target: { value: '6758' },
+    });
+
+    expect(handleChange).toHaveBeenCalledWith('6758');
+  });
+
+  it('フォーム送信で onSubmit を呼ぶ', () => {
+    const handleSubmit = vi.fn();
+    render(
+      <SearchForm
+        stockCode="7203"
+        onStockCodeChange={vi.fn()}
+        onSubmit={handleSubmit}
+      />
+    );
+
+    const input = screen.getByRole('textbox', { name: '銘柄コードまたは銘柄名' });
+    fireEvent.submit(input.closest('form') as HTMLFormElement);
+
+    expect(handleSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('isLoading=true で送信ボタンを無効化する', () => {
+    render(
+      <SearchForm
+        stockCode="7203"
+        onStockCodeChange={vi.fn()}
+        onSubmit={vi.fn()}
+        isLoading
+      />
+    );
+
+    expect(screen.getByRole('button', { name: '検索中' })).toBeDisabled();
+  });
+});

--- a/frontend/src/components/organisms/__tests__/StockInfo.test.tsx
+++ b/frontend/src/components/organisms/__tests__/StockInfo.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { StockInfo } from '../StockInfo';
+
+const mockStockData = {
+  date: '2026-03-16',
+  code: '7203',
+  name: 'トヨタ自動車',
+  market_category: 'プライム',
+  industry_code_33: '3700',
+  industry_category_33: '輸送用機器',
+  industry_code_17: '05',
+  industry_category_17: '自動車・輸送機',
+  size_code: '7',
+  size_category: '大型株',
+};
+
+describe('StockInfo', () => {
+  it('銘柄コードを表示する', () => {
+    render(
+      <MemoryRouter>
+        <StockInfo stockData={mockStockData} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getAllByText('7203').length).toBeGreaterThan(0);
+  });
+
+  it('銘柄名を表示する', () => {
+    render(
+      <MemoryRouter>
+        <StockInfo stockData={mockStockData} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getAllByText('トヨタ自動車').length).toBeGreaterThan(0);
+  });
+
+  it('市場カテゴリを表示する', () => {
+    render(
+      <MemoryRouter>
+        <StockInfo stockData={mockStockData} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('プライム')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要

atoms・molecules・organisms 層のコンポーネントに対するユニットテストを追加する。

## 変更内容

| 層 | コンポーネント | テスト数 |
|---|---|---|
| atoms | Alert, Card, EmptyState, PageHeader, SecurityCodeLink, Spinner | 22 |
| molecules | DividendInfo | 3 |
| organisms | DataActionRail, Footer, Header, SearchForm, StockInfo | 18 |
| **合計** | **12コンポーネント** | **43** |

## テスト結果

```
Test Files  57 passed (57)
     Tests 491 passed (491)
```

全テストスイートでパス（既存テスト含む）。

## テスト観点

- 主要な props のレンダリング確認
- ユーザー操作イベント（クリック・入力）の検証
- 認証状態によるコンテンツ切り替え（Header）
- 空データ時の EmptyState 表示

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * 複数のコンポーネントに対する単体テストを追加しました。アラート、カード、空状態、ページヘッダー、セキュリティコードリンク、スピナー、配当情報、データアクションレール、フッター、ヘッダー、検索フォーム、株式情報各コンポーネントの動作を検証するテストスイートが実装されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->