### PR TITLE
fix: console.warn/error の Error オブジェクト露出を message のみに限定

### DIFF
--- a/frontend/src/lib/csv/encoding.ts
+++ b/frontend/src/lib/csv/encoding.ts
@@ -69,7 +69,7 @@ export const tryDecodeWithMultipleEncodings = (uint8Array: Uint8Array): DecodeRe
       try {
         decoder = new TextDecoder(encoding, { fatal: false });
       } catch (e) {
-        console.warn(`エンコーディング ${encoding} はサポートされていません:`, e);
+        console.warn(`エンコーディング ${encoding} はサポートされていません:`, e instanceof Error ? e.message : String(e));
         continue;
       }
 
@@ -78,14 +78,14 @@ export const tryDecodeWithMultipleEncodings = (uint8Array: Uint8Array): DecodeRe
       try {
         text = decoder.decode(uint8Array);
       } catch (error) {
-        console.warn(`${encoding} でのデコードに失敗しました:`, error);
+        console.warn(`${encoding} でのデコードに失敗しました:`, error instanceof Error ? error.message : String(error));
         continue;
       }
 
       const confidence = calculateEncodingConfidence(text);
       results.push({ text, encoding, confidence });
     } catch (error) {
-      console.warn(`${encoding} でのデコードに失敗しました:`, error);
+      console.warn(`${encoding} でのデコードに失敗しました:`, error instanceof Error ? error.message : String(error));
     }
   }
 

--- a/frontend/src/lib/utils/formatters.ts
+++ b/frontend/src/lib/utils/formatters.ts
@@ -194,7 +194,7 @@ export function formatNumber(
       return formattedNumber;
     }
   } catch (error) {
-    console.error('数値のフォーマットに失敗しました:', error);
+    console.error('数値のフォーマットに失敗しました:', error instanceof Error ? error.message : String(error));
     return '-';
   }
 }
@@ -250,7 +250,7 @@ export function formatCurrency(
       return `${currency} ${formattedNumber}`;
     }
   } catch (error) {
-    console.error('通貨のフォーマットに失敗しました:', error);
+    console.error('通貨のフォーマットに失敗しました:', error instanceof Error ? error.message : String(error));
     return '-';
   }
 }


### PR DESCRIPTION
## 概要

セキュリティ監査の結果、フロントエンドの console.warn/error が Error オブジェクト全体をブラウザコンソールに出力していた問題を修正。

## 背景（監査結果）

- バックエンドのエラーレスポンス: 本番では内部情報をブロック済み → 変更不要
- OAuth state（CSRF）: 正しく生成・保存・検証済み → 変更不要
- セッションクッキー: HttpOnly/Secure/SameSite 適切設定済み → 変更不要
- console.warn/error の Error オブジェクト露出: 軽微修正

## 変更内容

| ファイル | 箇所 | 修正内容 |
|---|---|---|
| `lib/csv/encoding.ts` | L72, L81, L88 | `e` / `error` → `e.message` / `error.message` |
| `lib/utils/formatters.ts` | L197, L253 | `error` → `error.message` |

## テスト結果

```
Test Files  57 passed (57)
     Tests 491 passed (491)
npm run lint → pass
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* エラーメッセージの表示がより明確かつ読みやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->