### PR TITLE
feat: a11y対応（外部リンク新タブ開示・SearchCard aria-label修正）

### DIFF
--- a/frontend/src/components/molecules/StockInfoLinks.tsx
+++ b/frontend/src/components/molecules/StockInfoLinks.tsx
@@ -33,6 +33,7 @@ export const StockInfoLinks = ({ code }: StockInfoLinksProps) => {
           href={item.url.replace('{}', code)}
           target='_blank'
           rel="noopener noreferrer"
+          aria-label={`${item.name}（新しいタブで開く）`}
         >
           {item.name}
           <svg className="h-3.5 w-3.5 shrink-0 text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">

--- a/frontend/src/components/organisms/Footer.tsx
+++ b/frontend/src/components/organisms/Footer.tsx
@@ -19,6 +19,7 @@ export function Footer() {
             target="_blank"
             rel="noopener noreferrer"
             className="hover:text-slate-700 hover:underline"
+            aria-label={`${label}（新しいタブで開く）`}
           >
             {label}
           </a>

--- a/frontend/src/components/organisms/SearchCard/SearchCard.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchCard.tsx
@@ -28,7 +28,6 @@ const QuickSearchDropdown: React.FC<QuickSearchDropdownProps> = ({
                 }`}
                 value={displayValue}
                 onChange={(e) => onSearch(e.target.value, searchType)}
-                aria-label="検索フィルター"
             >
                 <option value="">全て表示</option>
                 {items.map((option) => (

--- a/frontend/src/components/organisms/__tests__/Footer.test.tsx
+++ b/frontend/src/components/organisms/__tests__/Footer.test.tsx
@@ -5,19 +5,19 @@ describe('Footer', () => {
   it('プライバシーポリシーリンクを表示する', () => {
     render(<Footer />);
 
-    expect(screen.getByRole('link', { name: 'プライバシーポリシー' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'プライバシーポリシー（新しいタブで開く）' })).toBeInTheDocument();
   });
 
   it('利用規約リンクを表示する', () => {
     render(<Footer />);
 
-    expect(screen.getByRole('link', { name: '利用規約' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '利用規約（新しいタブで開く）' })).toBeInTheDocument();
   });
 
   it('Cookie ポリシーリンクを表示する', () => {
     render(<Footer />);
 
-    expect(screen.getByRole('link', { name: 'Cookie ポリシー' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Cookie ポリシー（新しいタブで開く）' })).toBeInTheDocument();
   });
 
   it('コピーライトを表示する', () => {


### PR DESCRIPTION
## 概要

静的コード解析で特定した WCAG 2.1 AA 違反を修正。

## 変更内容

| ファイル | 変更内容 |
|---|---|
| `StockInfoLinks.tsx` | 外部リンク10件に `aria-label="{name}（新しいタブで開く）"` を追加 |
| `Footer.tsx` | 外部リンク3件に `aria-label="{label}（新しいタブで開く）"` を追加 |
| `SearchCard.tsx` | `select` の冗長な `aria-label="検索フィルター"` を削除（`<label htmlFor>` で十分） |
| `Footer.test.tsx` | aria-label 変更に合わせてテスト名を更新 |

## 対応した WCAG 2.1 AA 違反

- **3.2.2 On Input**: `target="_blank"` リンクが新しいタブで開くことをスクリーンリーダーに伝えていなかった
- **1.3.1 Info and Relationships**: `aria-label` が `<label>` の関連付けを上書きしていた

## テスト結果

```
npm run lint → pass
npm test -- --run → Footer テスト pass（既存フレーキー10件は本PR無関係）
npm run build → pass
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

**アクセシビリティ改善**
- 複数のコンポーネント内のリンクにアクセシビリティラベルを追加し、スクリーンリーダー利用者に対して新しいタブで開くことを明示するようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->