### PR TITLE
fix: SearchCard defaultExpanded → initialExpanded リネーム（react-doctor 警告解消）

### DIFF
--- a/frontend/src/components/organisms/SearchCard/SearchCard.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchCard.tsx
@@ -158,7 +158,7 @@ interface SearchCardProps {
     categories?: SearchCategories;
     onExpandToggle?: (isExpanded: boolean) => void; // 展開状態変更の通知
     value?: string; // 親の検索状態と同期（外部クリア対応）
-    defaultExpanded?: boolean; // 初期展開状態（デフォルト: true）
+    initialExpanded?: boolean; // 初期展開状態（デフォルト: true）
     compact?: boolean; // コンパクトモード: aside などで lg:grid-cols-4 を抑制する
 }
 
@@ -171,11 +171,11 @@ export const SearchCard: React.FC<SearchCardProps> = ({
     categories,
     onExpandToggle,
     value,
-    defaultExpanded = true,
+    initialExpanded = true,
     compact = false,
 }) => {
 
-    const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+    const [isExpanded, setIsExpanded] = useState(initialExpanded);
     const [searchQuery, setSearchQuery] = useState('');
     // アクティブな検索タイプを追跡（ドロップダウンの表示制御用）
     const [activeSearchType, setActiveSearchType] = useState<'securities' | 'years' | 'products' | 'accounts' | null>(null);

--- a/frontend/src/components/organisms/SearchCard/__tests__/SearchCard.test.tsx
+++ b/frontend/src/components/organisms/SearchCard/__tests__/SearchCard.test.tsx
@@ -49,6 +49,21 @@ describe('SearchCard', () => {
     expect(screen.getByText('口座')).toBeInTheDocument();
   });
 
+  test('initialExpanded=falseのとき初期状態では検索オプションが折りたたまれている', () => {
+    render(
+      <SearchCard
+        onSearch={mockOnSearch}
+        categories={defaultCategories}
+        initialExpanded={false}
+      />
+    );
+
+    expect(screen.queryByText('銘柄')).not.toBeInTheDocument();
+    expect(screen.queryByText('西暦')).not.toBeInTheDocument();
+    expect(screen.queryByText('商品')).not.toBeInTheDocument();
+    expect(screen.queryByText('口座')).not.toBeInTheDocument();
+  });
+
   test('ヘッダーをクリックすると検索オプションが折りたたまれる', () => {
     render(
       <SearchCard

--- a/frontend/src/components/templates/ReceiptTemplate.tsx
+++ b/frontend/src/components/templates/ReceiptTemplate.tsx
@@ -45,7 +45,7 @@ const ReceiptTemplateContent: React.FC<ReceiptTemplateProps> = ({
       onSearch={onSearch}
       categories={searchCategories}
       onExpandToggle={handleSearchExpandToggle}
-      defaultExpanded={layout === 'workspace'}
+      initialExpanded={layout === 'workspace'}
       compact={layout === 'workspace'}
     />
   ) : null;


### PR DESCRIPTION
## 概要

react-doctor が `default*` プレフィックスの prop を `useState` 初期値に渡すパターンを警告するため、prop 名を `initialExpanded` に変更する。挙動は変えない。

## 変更内容

- `SearchCard.tsx`: `defaultExpanded` → `initialExpanded` にリネーム（型定義・デフォルト引数・useState参照）
- `ReceiptTemplate.tsx`: 呼び出し元を `initialExpanded` に追従
- `SearchCard.test.tsx`: `initialExpanded={false}` で初期折りたたみになるテストを追加

## テスト結果

`npm run lint && npm test -- --run && npm run build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * 検索カード機能のプロップ名を更新し、初期状態の制御をより明確にしました。

* **テスト**
  * 検索カードが最初に閉じた状態で表示される場合のテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->