### PR TITLE
fix: fetchStockData の ApiError 誤ラップ修正（銘柄検索エラー誤表示解消）

### DIFF
--- a/frontend/src/features/stock/__tests__/api.test.ts
+++ b/frontend/src/features/stock/__tests__/api.test.ts
@@ -18,6 +18,16 @@ describe('Stock API', () => {
   });
 
   describe('fetchStockData', () => {
+    it('ApiErrorの場合、同じエラーをそのまま再スローする', async () => {
+      const apiError = new ApiError(ApiErrorType.NOT_FOUND_ERROR, 'リソースが見つかりません');
+      vi.mocked(axios.isAxiosError).mockReturnValue(false);
+      (apiClient.get as ReturnType<typeof vi.fn>).mockRejectedValue(apiError);
+      const fromAxiosErrorSpy = vi.spyOn(ApiError, 'fromAxiosError');
+
+      await expect(fetchStockData('1234')).rejects.toBe(apiError);
+      expect(fromAxiosErrorSpy).not.toHaveBeenCalled();
+    });
+
     it('Axiosエラーの場合、ApiErrorを投げる', async () => {
       const axiosError = new Error('Network Error');
       vi.mocked(axios.isAxiosError).mockReturnValue(true);

--- a/frontend/src/features/stock/api.ts
+++ b/frontend/src/features/stock/api.ts
@@ -13,6 +13,10 @@ export async function fetchStockData(query: string): Promise<StockData> {
     const response = await apiClient.get<StockData>(`/stock/${query}`);
     return response;
   } catch (error) {
+    if (error instanceof ApiError) {
+      throw error;
+    }
+
     if (axios.isAxiosError(error)) {
       throw ApiError.fromAxiosError(error);
     }


### PR DESCRIPTION
## 概要

銘柄検索で任意のエラーが「J-Quants API の応答形式が変更された可能性があります」と表示される誤表示を修正。

## 原因

`ApiClient` のレスポンスインターセプターが Axios エラーを `ApiError` に変換して reject するため、`fetchStockData` の catch ブロックでは `axios.isAxiosError(error)` が常に false。結果として 404・500・認証エラーなど全エラーが `DESERIALIZATION_ERROR` に上書きされていた。

## 変更内容

- `frontend/src/features/stock/api.ts`: `catch` 先頭に `instanceof ApiError` チェックを追加し、インターセプター変換済みの `ApiError` をそのまま再スロー
- `frontend/src/features/stock/__tests__/api.test.ts`: `ApiError` が潰されずに伝播することを確認する回帰テストを追加

## テスト結果

`npm run lint && npm test -- --run && npm run build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 株価データ取得時のエラーハンドリングを改善しました。既存のエラーを適切に判別し、より正確なエラー処理を実行するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->