### PR TITLE
fix: UIレビュー所見（中・低）対応 - 全角銘柄名正規化・集計タイトル統一

### DIFF
--- a/frontend/src/components/organisms/AssetPortfolioSummary/AssetPortfolioSummary.tsx
+++ b/frontend/src/components/organisms/AssetPortfolioSummary/AssetPortfolioSummary.tsx
@@ -3,7 +3,12 @@ import { Card, CardBody } from '@/components/atoms/Card';
 import { EmptyState } from '@/components/atoms/EmptyState';
 import { PortfolioPieChart, PortfolioItem } from '@/components/molecules/PortfolioPieChart';
 import { AssetBalanceData } from '@/lib/interfaces/assetBalance';
-import { formatCurrency, formatPercentageValue, safeAdd } from '@/lib/utils/formatters';
+import {
+  formatCurrency,
+  formatPercentageValue,
+  normalizeSecurityName,
+  safeAdd,
+} from '@/lib/utils/formatters';
 import { DividendStatus } from '@/features/jquants/api/dividendPerShareApi';
 
 interface AssetPortfolioSummaryProps {
@@ -58,7 +63,7 @@ export const AssetPortfolioSummary: React.FC<AssetPortfolioSummaryProps> = ({
     return assetBalanceData
       .filter((item) => (item.total_purchase_amount || 0) > 0)
       .map((item) => ({
-        name: item.security_name || item.security_code,
+        name: normalizeSecurityName(item.security_name || item.security_code),
         value: item.total_purchase_amount || 0,
         securityCode: item.security_code,
         shares: item.shares,

--- a/frontend/src/components/organisms/AssetPortfolioSummary/__tests__/AssetPortfolioSummary.test.tsx
+++ b/frontend/src/components/organisms/AssetPortfolioSummary/__tests__/AssetPortfolioSummary.test.tsx
@@ -66,6 +66,18 @@ describe('AssetPortfolioSummary', () => {
     expect(screen.queryByText('保有比率と配当効率をまとめて確認できます。')).not.toBeInTheDocument();
   });
 
+  it('全角英数字の銘柄名を半角に正規化して表示する', () => {
+    const mockData = createMockData([
+      { security_code: '9433', security_name: 'ＫＤＤＩ' },
+      { security_code: '1605', security_name: 'ＩＮＰＥＸ' },
+    ]);
+    render(<AssetPortfolioSummary assetBalanceData={mockData} />);
+
+    expect(screen.getByText('KDDI')).toBeInTheDocument();
+    expect(screen.getByText('INPEX')).toBeInTheDocument();
+    expect(screen.queryByText('ＫＤＤＩ')).not.toBeInTheDocument();
+  });
+
   it('データがない場合は空状態が表示される', () => {
     render(<AssetPortfolioSummary assetBalanceData={[]} />);
 

--- a/frontend/src/features/jquants/hooks/__tests__/useJQuantsDividend.test.ts
+++ b/frontend/src/features/jquants/hooks/__tests__/useJQuantsDividend.test.ts
@@ -10,9 +10,13 @@ vi.mock('../../api/client', () => ({
   },
 }));
 
-vi.mock('@/lib/utils/formatters', () => ({
-  parseNumber: vi.fn(),
-}));
+vi.mock('@/lib/utils/formatters', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/utils/formatters')>();
+  return {
+    ...actual,
+    parseNumber: vi.fn(),
+  };
+});
 
 describe('useJQuantsDividend', () => {
   beforeEach(() => {

--- a/frontend/src/features/jquants/hooks/__tests__/useJQuantsDividendBatch.test.ts
+++ b/frontend/src/features/jquants/hooks/__tests__/useJQuantsDividendBatch.test.ts
@@ -10,9 +10,13 @@ vi.mock('../../api/client', () => ({
   },
 }));
 
-vi.mock('@/lib/utils/formatters', () => ({
-  parseNumber: vi.fn(),
-}));
+vi.mock('@/lib/utils/formatters', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/utils/formatters')>();
+  return {
+    ...actual,
+    parseNumber: vi.fn(),
+  };
+});
 
 describe('useJQuantsDividendBatch', () => {
   beforeEach(() => {

--- a/frontend/src/lib/utils/__tests__/formatters.test.ts
+++ b/frontend/src/lib/utils/__tests__/formatters.test.ts
@@ -16,7 +16,8 @@ import {
   safeDivide,
   calculatePercentage,
   TAX_RATE,
-  normalizeSecurityCode
+  normalizeSecurityCode,
+  normalizeSecurityName,
 } from '../formatters';
 
 describe('日付関連のフォーマット関数', () => {
@@ -114,6 +115,21 @@ describe('数値関連のフォーマット関数', () => {
 
     it('英字コードを大文字化する', () => {
       expect(normalizeSecurityCode('brk.b')).toBe('BRK.B');
+    });
+  });
+
+  describe('normalizeSecurityName', () => {
+    it('全角英字を半角英字に変換する', () => {
+      expect(normalizeSecurityName('ＫＤＤＩ')).toBe('KDDI');
+      expect(normalizeSecurityName('ＩＮＰＥＸ')).toBe('INPEX');
+    });
+
+    it('全角数字を半角数字に変換する', () => {
+      expect(normalizeSecurityName('ＡＢＣ１２３')).toBe('ABC123');
+    });
+
+    it('日本語や半角文字はそのまま保持する', () => {
+      expect(normalizeSecurityName('日本株ABC123')).toBe('日本株ABC123');
     });
   });
   describe('parseNumberString', () => {

--- a/frontend/src/lib/utils/formatters.ts
+++ b/frontend/src/lib/utils/formatters.ts
@@ -38,6 +38,16 @@ export function normalizeSecurityCode(value: unknown): string {
   return token.replace(/\s+/g, '').toUpperCase();
 }
 
+/**
+ * 銘柄名の表示を正規化する
+ * - 全角英数字を半角に変換する
+ */
+export function normalizeSecurityName(name: string): string {
+  return name.replace(/[Ａ-Ｚａ-ｚ０-９]/g, (char) =>
+    String.fromCharCode(char.charCodeAt(0) - 0xFEE0)
+  );
+}
+
 // ==================== 日付関連 ====================
 
 /**
@@ -321,4 +331,3 @@ export function calculatePercentage(value: number, total: number, decimals = 2):
   if (total === 0) return 0;
   return Number(((value / total) * 100).toFixed(decimals));
 }
-

--- a/frontend/src/pages/Receipt/Dividend.tsx
+++ b/frontend/src/pages/Receipt/Dividend.tsx
@@ -199,7 +199,7 @@ export const Dividend: React.FC<DividendProps> = ({ data, previewData, utilityRa
             header={dividendData.length > 0 ? (
                 <ReceiptHeader
                     items={headerItems}
-                    title={isSecurityCodeSearch ? "集計情報 / 銘柄詳細" : "集計情報"}
+                    title="集計情報"
                     collapsible={isSecurityCodeSearch}
                     compact={Boolean(utilityRail)}
                 >

--- a/frontend/src/pages/Receipt/__tests__/Dividend.test.tsx
+++ b/frontend/src/pages/Receipt/__tests__/Dividend.test.tsx
@@ -159,7 +159,7 @@ describe('Dividend', () => {
 
         // 銘柄詳細ヘッダーが表示されることを確認（初期状態は展開済み）
         await waitFor(() => {
-            expect(screen.getByText('集計情報 / 銘柄詳細')).toBeInTheDocument();
+            expect(screen.getByText('集計情報')).toBeInTheDocument();
         });
 
         // 展開済みなのでembeddedモードの入力とStatItemが表示される
@@ -188,7 +188,7 @@ describe('Dividend', () => {
 
         // 初期状態は展開済み
         await waitFor(() => {
-            expect(screen.getByText('集計情報 / 銘柄詳細')).toBeInTheDocument();
+            expect(screen.getByText('集計情報')).toBeInTheDocument();
         });
         expect(screen.getByText('平均取得価格')).toBeVisible();
 
@@ -221,7 +221,7 @@ describe('Dividend', () => {
 
         // 銘柄詳細ヘッダーが表示されることを確認
         await waitFor(() => {
-            expect(screen.getByText('集計情報 / 銘柄詳細')).toBeInTheDocument();
+            expect(screen.getByText('集計情報')).toBeInTheDocument();
         });
 
         // 検索をクリア
@@ -230,7 +230,6 @@ describe('Dividend', () => {
         // 通常の集計情報ヘッダーに戻ることを確認
         await waitFor(() => {
             expect(screen.getByText('集計情報')).toBeInTheDocument();
-            expect(screen.queryByText('集計情報 / 銘柄詳細')).not.toBeInTheDocument();
         });
     });
 
@@ -277,7 +276,7 @@ describe('Dividend', () => {
 
         // 銘柄詳細ヘッダーが表示されることを確認
         await waitFor(() => {
-            expect(screen.getByText('集計情報 / 銘柄詳細')).toBeInTheDocument();
+            expect(screen.getByText('集計情報')).toBeInTheDocument();
         });
 
         // embedded モードでは read-only KPI カードが表示される

--- a/frontend/src/pages/__tests__/AssetBalance.test.tsx
+++ b/frontend/src/pages/__tests__/AssetBalance.test.tsx
@@ -10,12 +10,16 @@ vi.mock('@/components/atoms/SecurityCodeLink', () => ({
 }));
 
 // ユーティリティ関数のモック
-vi.mock('@/lib/utils/formatters', () => ({
-  formatCurrency: vi.fn().mockImplementation((value: number) => `¥${value.toLocaleString()}`),
-  formatNumber: vi.fn().mockImplementation((value: number) => value.toLocaleString()),
-  formatPercentageValue: vi.fn().mockImplementation((value: number) => `${value.toFixed(2)}%`),
-  safeAdd: vi.fn().mockImplementation((a: number, b: number) => a + b),
-}));
+vi.mock('@/lib/utils/formatters', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/utils/formatters')>();
+  return {
+    ...actual,
+    formatCurrency: vi.fn().mockImplementation((value: number) => `¥${value.toLocaleString()}`),
+    formatNumber: vi.fn().mockImplementation((value: number) => value.toLocaleString()),
+    formatPercentageValue: vi.fn().mockImplementation((value: number) => `${value.toFixed(2)}%`),
+    safeAdd: vi.fn().mockImplementation((a: number, b: number) => a + b),
+  };
+});
 
 const mockAssetBalanceData: AssetBalanceData[] = [
   {


### PR DESCRIPTION
## 概要

UIレビューで発見した2件の表示問題を修正。

## 変更内容

### 中: 資産管理の全角銘柄名スペーシング崩れ

`ＫＤＤＩ`・`ＩＮＰＥＸ` など全角英数字が等幅フォントで「K D D I」のように表示される問題を修正。

- `formatters.ts`: `normalizeSecurityName()` を追加（全角英数字→半角に変換）
- `AssetPortfolioSummary.tsx`: グラフラベル生成時に `normalizeSecurityName` を適用

### 低: 配当金ヘッダータイトルの冗長表現

銘柄絞り込み時「集計情報 / 銘柄詳細」→「集計情報」に統一。

- `Dividend.tsx`: `ReceiptHeader` の `title` を常に `"集計情報"` に変更

## テスト結果

`npm run lint && npx tsc --noEmit && npm test -- --run && npm run build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 株式名の表示を自動的に正規化し、全角文字を半角文字に変換します
  * 資産ポートフォリオに配当情報の統合サポートを追加しました
  * 資産サマリーにフィルタリング機能を追加しました

* **改善**
  * 配当ページのヘッダー表示をシンプル化しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->