### PR TITLE
chore: vite.config.ts を Vite+ (Rolldown/ESM) 対応に修正

### DIFF
--- a/frontend/src/test/__tests__/viteConfig.test.ts
+++ b/frontend/src/test/__tests__/viteConfig.test.ts
@@ -1,0 +1,119 @@
+import { readFileSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { describe, expect, it } from 'vitest';
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const configPath = resolve(currentDir, '../../../vite.config.ts');
+
+type MinimalViteConfig = {
+  resolve?: {
+    alias?: Record<string, string>;
+  };
+  build?: {
+    rollupOptions?: {
+      output?:
+        | {
+            manualChunks?: unknown;
+          }
+        | Array<{
+            manualChunks?: unknown;
+          }>;
+    };
+  };
+};
+
+async function loadViteConfig() {
+  const source = readFileSync(configPath, 'utf8');
+  const originalUint8Array = globalThis.Uint8Array;
+  const encoderUint8Array = new TextEncoder().encode('').constructor as typeof Uint8Array;
+
+  try {
+    Object.defineProperty(globalThis, 'Uint8Array', {
+      configurable: true,
+      value: encoderUint8Array,
+      writable: true,
+    });
+    const executableSource = source
+      .replace(/import\s+\{\s*defineConfig\s*\}\s+from\s+['"]vitest\/config['"];?\r?\n?/g, '')
+      .replace(/import\s+react\s+from\s+['"]@vitejs\/plugin-react['"];?\r?\n?/g, '')
+      .replace(/import\s+tailwindcss\s+from\s+['"]@tailwindcss\/vite['"];?\r?\n?/g, '')
+      .replace(/import\s+\{\s*[^}]*\bresolve\b[^}]*\}\s+from\s+['"]path['"];?\r?\n?/g, '')
+      .replace(/import\s+\{\s*fileURLToPath\s*\}\s+from\s+['"]url['"];?\r?\n?/g, '')
+      .replace(/\s+as const/g, '')
+      .replace(/id: string/g, 'id')
+      .replace(/import\.meta/g, 'import_meta')
+      .replace('export default defineConfig(', 'return defineConfig(');
+
+    const evaluateConfig = new Function(
+      'defineConfig',
+      'react',
+      'tailwindcss',
+      'resolve',
+      'dirname',
+      'fileURLToPath',
+      'process',
+      'importMetaUrl',
+      `
+        "use strict";
+        const import_meta = { url: importMetaUrl };
+        ${executableSource}
+      `,
+    ) as (
+      defineConfig: <T>(config: T) => T,
+      react: (...args: unknown[]) => unknown,
+      tailwindcss: (...args: unknown[]) => unknown,
+      resolve: typeof import('path').resolve,
+      dirname: typeof import('path').dirname,
+      fileURLToPath: typeof import('url').fileURLToPath,
+      process: NodeJS.Process,
+      importMetaUrl: string,
+    ) => MinimalViteConfig;
+
+    return evaluateConfig(
+      <T>(config: T) => config,
+      () => ({ name: 'react' }),
+      () => ({ name: 'tailwindcss' }),
+      resolve,
+      dirname,
+      fileURLToPath,
+      process,
+      pathToFileURL(configPath).href,
+    );
+  } finally {
+    Object.defineProperty(globalThis, 'Uint8Array', {
+      configurable: true,
+      value: originalUint8Array,
+      writable: true,
+    });
+  }
+}
+
+describe('vite.config.ts', () => {
+  it('ESM として読み込めて @ エイリアスを src に解決する', async () => {
+    const config = await loadViteConfig();
+
+    expect(config.resolve?.alias).toMatchObject({
+      '@': resolve(currentDir, '../../../src'),
+    });
+  });
+
+  it('manualChunks で vendor チャンクを関数で振り分ける', async () => {
+    const config = await loadViteConfig();
+    const output = Array.isArray(config.build?.rollupOptions?.output)
+      ? config.build.rollupOptions.output[0]
+      : config.build?.rollupOptions?.output;
+    const { manualChunks } = output ?? {};
+
+    expect(typeof manualChunks).toBe('function');
+
+    if (typeof manualChunks !== 'function') {
+      throw new Error('manualChunks が関数ではありません');
+    }
+
+    expect(manualChunks('/node_modules/react/index.js')).toBe('vendor');
+    expect(manualChunks('/node_modules/react-dom/index.js')).toBe('vendor');
+    expect(manualChunks('/node_modules/react-router-dom/index.js')).toBe('vendor');
+    expect(manualChunks('/src/main.tsx')).toBeUndefined();
+  });
+});

--- a/frontend/src/test/__tests__/viteConfig.test.ts
+++ b/frontend/src/test/__tests__/viteConfig.test.ts
@@ -114,6 +114,7 @@ describe('vite.config.ts', () => {
     expect(manualChunks('/node_modules/react/index.js')).toBe('vendor');
     expect(manualChunks('/node_modules/react-dom/index.js')).toBe('vendor');
     expect(manualChunks('/node_modules/react-router-dom/index.js')).toBe('vendor');
+    expect(manualChunks('/node_modules/@vitejs/plugin-react/dist/index.js')).toBeUndefined();
     expect(manualChunks('/src/main.tsx')).toBeUndefined();
   });
 });

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,7 +1,10 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
-import { resolve } from 'path';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   plugins: [
@@ -26,8 +29,10 @@ export default defineConfig({
     minify: 'terser',
     rollupOptions: {
       output: {
-        manualChunks: {
-          vendor: ['react', 'react-dom', 'react-router-dom'],
+        manualChunks: (id: string) => {
+          if (id.includes('react') || id.includes('react-dom') || id.includes('react-router-dom')) {
+            return 'vendor';
+          }
         },
       },
     },

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -30,7 +30,11 @@ export default defineConfig({
     rollupOptions: {
       output: {
         manualChunks: (id: string) => {
-          if (id.includes('react') || id.includes('react-dom') || id.includes('react-router-dom')) {
+          if (
+            id.includes('/node_modules/react/') ||
+            id.includes('/node_modules/react-dom/') ||
+            id.includes('/node_modules/react-router-dom/')
+          ) {
             return 'vendor';
           }
         },


### PR DESCRIPTION
## 概要

`vp lint` / `vp build` が動作するよう `vite.config.ts` の非互換箇所を修正。

## 変更内容

- `__dirname` を `import.meta.url` ベースに変更（Vite+ が ESM として評価するため）
- `manualChunks` をオブジェクト→関数形式に変更（Rolldown は関数のみ対応）
- `viteConfig.test.ts` を追加（`@` エイリアス解決と `manualChunks` 挙動を固定）

## 動作確認

| コマンド | 結果 |
|---------|------|
| `npm run build` | ✅ |
| `npm test -- --run` | ✅ |
| `vp build` | ✅ |
| `vp lint` | ✅（既存 no-useless-spread 警告 1 件のみ） |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Tests**
  * Vite設定の挙動を検証するテストを追加。エイリアス解決と手動チャンク分割（vendor判定）の動作を確認します。

* **Build/Infrastructure**
  * ビルド設定のチャンク分割を動的化。React関連ライブラリを想定したベンダー分割が適切に機能するよう改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->