### PR TITLE
chore: Vite+ コマンドへの置き換え（vp lint / vp build / vp dev）

### DIFF
--- a/.claude/skills/claude-codex-handoff/SKILL.md
+++ b/.claude/skills/claude-codex-handoff/SKILL.md
@@ -40,7 +40,7 @@ Codex が最短で実装に着手できる依頼文を作成し、`codex exec "<
 ## 確認コマンド
 ```bash
 # フロントエンド変更がある場合
-cd frontend && npm run lint && npm test && npm run build
+cd frontend && vp lint && npm test && vp build
 
 # バックエンド変更がある場合
 cd backend && cargo clippy --all-targets -- -D warnings && cargo test
@@ -76,7 +76,7 @@ PR #<番号> のレビュー指摘に対応する。各指摘に返信してか�
 ## 確認コマンド
 ```bash
 # フロントエンド変更がある場合
-cd frontend && npm run lint && npx tsc --noEmit && npm test -- --run && npm run build
+cd frontend && vp lint && npx tsc --noEmit && npm test -- --run && vp build
 
 # バックエンド変更がある場合
 cd backend && cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test

--- a/.claude/skills/frontend-build-test/SKILL.md
+++ b/.claude/skills/frontend-build-test/SKILL.md
@@ -20,7 +20,7 @@ cd frontend && npm install
 
 ### Lint
 ```bash
-cd frontend && npm run lint
+cd frontend && vp lint
 ```
 
 ### Lint 自動修正
@@ -45,15 +45,15 @@ cd frontend && npm run dev
 
 ### 本番ビルド
 ```bash
-cd frontend && npm run build
+cd frontend && vp build
 ```
 
 ## 推奨実行順序
 
-1. `npm run lint` - Lint
+1. `vp lint` - Lint
 2. `npx tsc --noEmit` - 型チェック
 3. `npm test` - テスト
-4. `npm run build` - ビルド
+4. `vp build` - ビルド
 
 ## よくあるエラー
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -33,10 +33,10 @@ Codex が実装して push した PR を Claude がレビューする。
 変更範囲に応じて実行:
 
 - フロントエンド変更がある場合:
-  - `cd frontend && npm run lint`
+  - `cd frontend && vp lint`
   - `cd frontend && npx tsc --noEmit`
   - `cd frontend && npm test`
-  - `cd frontend && npm run build`
+  - `cd frontend && vp build`
 - バックエンド変更がある場合:
   - `cd backend && cargo fmt --check`
   - `cd backend && cargo clippy --all-targets -- -D warnings`

--- a/frontend/.claude/rules/00-frontend.md
+++ b/frontend/.claude/rules/00-frontend.md
@@ -152,6 +152,14 @@ npm test           # テスト実行
 npm run test:watch # ウォッチモード
 ```
 
+### 補助コマンド
+
+```bash
+vp dev   # 開発サーバー起動
+vp lint  # Lint 実行
+vp build # ビルド
+```
+
 ### 方針
 
 - テストファイルは各機能配下の `__tests__/` に配置する

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -13,10 +13,10 @@
 
 ## コマンド
 
-- `npm run dev` - 開発サーバー起動
-- `npm run lint` - Lint 実行
+- `vp dev` - 開発サーバー起動
+- `vp lint` - Lint 実行
 - `npm test` - テスト実行
-- `npm run build` - ビルド
+- `vp build` - ビルド
 
 ## 補足
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,8 +5,11 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:vp": "vp dev",
     "build": "vite build",
+    "build:vp": "vp build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "lint:vp": "vp lint",
     "preview": "vite preview",
     "test": "NODE_OPTIONS='--max-old-space-size=8192' vitest",
     "test:watch": "NODE_OPTIONS='--max-old-space-size=8192' vitest --watch",


### PR DESCRIPTION
## 概要

動作確認済みの Vite+ コマンドを各 skill / rule / config ファイルに適用し、開発体験を改善する。

## 変更内容

| ファイル | 変更内容 |
|--------|---------|
| `frontend/package.json` | `dev:vp` / `lint:vp` / `build:vp` スクリプト追加 |
| `frontend/CLAUDE.md` | コマンドを `vp lint` / `vp build` / `vp dev` に更新 |
| `frontend/.claude/rules/00-frontend.md` | 補助コマンドセクション追加 |
| `.claude/skills/pr-review/SKILL.md` | フロントエンド検証コマンドを `vp lint` / `vp build` に更新 |
| `.claude/skills/frontend-build-test/SKILL.md` | lint/build コマンドを `vp lint` / `vp build` に更新 |
| `.claude/skills/claude-codex-handoff/SKILL.md` | 確認コマンドを `vp lint` / `vp build` に更新 |

## 非対象

- `npm test` → `vp test` は ERR_MODULE_NOT_FOUND のため現状維持
- `vp check` は fmt 失敗のため現状維持

## 前提条件

PR #234（chore/viteplus-compat）がマージ済み。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * フロントエンド開発コマンドのドキュメントを更新しました。

* **Chores**
  * フロントエンド検証コマンドを新しいコマンド形式に統一しました。
  * スキル定義ファイルの記述を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->