### PR TITLE
chore: 依存パッケージ更新（tinyvec 1.10.0 → 1.11.0）

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3470,9 +3470,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]


### PR DESCRIPTION
## 概要

Cargo の依存パッケージを semver 互換の最新バージョンに更新。

## 変更内容

| パッケージ | 変更前 | 変更後 |
|-----------|--------|--------|
| `tinyvec` | 1.10.0 | 1.11.0 |

## 検証結果

- `cargo fmt --check`: ✅ pass
- `cargo clippy --all-targets -- -D warnings`: ✅ pass
- `cargo test`: ✅ pass（0 failed）

## 非対象

- npm パッケージ: 全パッケージが semver 範囲内で最新のため変更なし
- major バージョンアップ（eslint v10, vite v8 等）: 別タスクで対応