### PR TITLE
test: csv_import / auth ハンドラーに単体テスト追加

### DIFF
--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -259,3 +259,97 @@ pub async fn delete_account(
         Json(serde_json::json!({"message": "アカウントを削除しました"})),
     ))
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        config::Config,
+        db::connect_pool_lazy,
+        errors::ErrorResponse,
+        models::common::MessageResponse,
+        routes::app_router,
+        state::{AppState, Secrets},
+    };
+    use axum::{
+        body::{to_bytes, Body},
+        http::{Request, StatusCode},
+        Router,
+    };
+    use reqwest::Client;
+    use serde::de::DeserializeOwned;
+    use std::sync::{atomic::AtomicBool, Arc};
+    use tower::ServiceExt;
+
+    const BODY_LIMIT: usize = 1024 * 1024;
+
+    fn make_test_state() -> AppState {
+        let database_url = "postgresql://user:password@localhost/test_db";
+        let pool = connect_pool_lazy(database_url, 1).expect("pool");
+        let secrets = Arc::new(Secrets {
+            database_url: database_url.to_string(),
+            jquants_api_key: None,
+            google_client_id: None,
+            google_client_secret: None,
+            frontend_url: "http://localhost:8080".to_string(),
+        });
+
+        AppState {
+            pool,
+            secrets,
+            client: Client::new(),
+            background_task_running: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    fn test_app() -> Router {
+        let config = Config {
+            auth_rate_limit_rps: 0,
+            jquants_rate_limit_rps: 0,
+            ..Config::default()
+        };
+
+        app_router(make_test_state(), &config)
+    }
+
+    async fn read_json_response<T: DeserializeOwned>(response: axum::response::Response) -> T {
+        let body = to_bytes(response.into_body(), BODY_LIMIT).await.unwrap();
+        serde_json::from_slice(&body).unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_get_current_user_no_cookie() {
+        let response = test_app()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/auth/me")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        let error: ErrorResponse = read_json_response(response).await;
+        assert_eq!(error.error.code, "UNAUTHORIZED");
+        assert!(error.error.message.contains("ログインが必要"));
+    }
+
+    #[tokio::test]
+    async fn test_logout_no_cookie() {
+        let response = test_app()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/auth/logout")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let message: MessageResponse = read_json_response(response).await;
+        assert_eq!(message.message, "ログアウトしました");
+    }
+}

--- a/backend/src/handlers/csv_import.rs
+++ b/backend/src/handlers/csv_import.rs
@@ -50,3 +50,106 @@ pub async fn handle_upload_csv<D: CsvDomain>(
     let response = D::upload_csv(pool, user_id, &bytes).await?;
     Ok((StatusCode::CREATED, Json(response)))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::errors::ErrorResponse;
+    use axum::{
+        body::{to_bytes, Body},
+        extract::Multipart,
+        http::{Request, StatusCode},
+        routing::post,
+        Router,
+    };
+    use tower::ServiceExt;
+
+    const BODY_LIMIT: usize = 1024 * 1024;
+
+    fn test_app() -> Router {
+        Router::new().route("/csv", post(csv_bytes_endpoint))
+    }
+
+    async fn csv_bytes_endpoint(multipart: Multipart) -> Result<Vec<u8>, ApiError> {
+        read_csv_file_bytes(multipart).await
+    }
+
+    fn multipart_request(field_name: &str, filename: Option<&str>, content: &str) -> Request<Body> {
+        let boundary = "boundary123";
+        let content_disposition = match filename {
+            Some(filename) => format!(
+                "Content-Disposition: form-data; name=\"{field_name}\"; filename=\"{filename}\"\r\n"
+            ),
+            None => format!("Content-Disposition: form-data; name=\"{field_name}\"\r\n"),
+        };
+        let body = format!(
+            "--{boundary}\r\n{content_disposition}Content-Type: text/csv\r\n\r\n{content}\r\n--{boundary}--\r\n"
+        );
+
+        Request::builder()
+            .method("POST")
+            .uri("/csv")
+            .header(
+                "content-type",
+                format!("multipart/form-data; boundary={boundary}"),
+            )
+            .body(Body::from(body))
+            .unwrap()
+    }
+
+    async fn read_error_response(response: axum::response::Response) -> ErrorResponse {
+        let body = to_bytes(response.into_body(), BODY_LIMIT).await.unwrap();
+        serde_json::from_slice(&body).unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_read_csv_file_bytes_valid() {
+        let content = "symbol,amount\n7203,100\n";
+        let response = test_app()
+            .oneshot(multipart_request("file", Some("positions.csv"), content))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), BODY_LIMIT).await.unwrap();
+        assert_eq!(body.as_ref(), content.as_bytes());
+    }
+
+    #[tokio::test]
+    async fn test_read_csv_file_bytes_no_file_field() {
+        let response = test_app()
+            .oneshot(multipart_request("other", Some("positions.csv"), "dummy"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let error = read_error_response(response).await;
+        assert_eq!(error.error.code, "VALIDATION_ERROR");
+        assert!(error.error.message.contains("fileフィールド"));
+    }
+
+    #[tokio::test]
+    async fn test_read_csv_file_bytes_wrong_extension() {
+        let response = test_app()
+            .oneshot(multipart_request("file", Some("positions.txt"), "dummy"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let error = read_error_response(response).await;
+        assert_eq!(error.error.code, "VALIDATION_ERROR");
+        assert!(error.error.message.contains(".csv"));
+    }
+
+    #[tokio::test]
+    async fn test_read_csv_file_bytes_no_filename() {
+        let response = test_app()
+            .oneshot(multipart_request("file", Some(""), "dummy"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let error = read_error_response(response).await;
+        assert_eq!(error.error.code, "VALIDATION_ERROR");
+    }
+}


### PR DESCRIPTION
## 概要

ハンドラー層テストゼロの状態を解消する（backlog タスク A）。

## 変更内容

| ファイル | 追加テスト |
|---------|-----------|
| `backend/src/handlers/csv_import.rs` | `read_csv_file_bytes` 正常系1件・異常系3件 |
| `backend/src/handlers/auth.rs` | `get_current_user` / `logout` の異常系2件 |

### テスト一覧

**csv_import**
- `test_read_csv_file_bytes_valid`: .csv ファイル → Ok(bytes)
- `test_read_csv_file_bytes_no_file_field`: file フィールドなし → 400 ValidationError
- `test_read_csv_file_bytes_wrong_extension`: .txt 拡張子 → 400 ValidationError
- `test_read_csv_file_bytes_no_filename`: ファイル名空文字 → 400 ValidationError

**auth**
- `test_get_current_user_no_cookie`: セッション Cookie なし → 401 Unauthorized
- `test_logout_no_cookie`: セッション Cookie なし → 200（冪等）

## 実装方針

- `csv_import` は multipart を手組みした最小ルーター + `oneshot` 経由でテスト
- `auth` はダミー AppState + `app_router` 経由でテスト（DB 接続なし）
- すべて `#[ignore]` なし（Docker 不要）

## 検証結果

- `cargo fmt --check`: ✅ pass
- `cargo clippy --all-targets -- -D warnings`: ✅ pass
- `cargo test --lib`: ✅ pass（131 passed, 0 failed）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * 認証エンドポイントのテストカバレッジを拡張
  * CSVファイルアップロード処理のテストカバレッジを拡張

<!-- end of auto-generated comment: release notes by coderabbit.ai -->