### PR TITLE
perf: Shift-JIS CSV の decode_bytes 二重デコードを解消

### DIFF
--- a/backend/src/services/csv_parse.rs
+++ b/backend/src/services/csv_parse.rs
@@ -1,18 +1,17 @@
 use crate::models::csv_import::CsvRowError;
 use chrono::NaiveDate;
-use encoding_rs::{SHIFT_JIS, UTF_8};
+use encoding_rs::SHIFT_JIS;
 use rust_decimal::Decimal;
 use std::collections::HashMap;
 use std::str::FromStr;
 
 /// UTF-8 デコードを試み、失敗時は Shift-JIS にフォールバック
 pub fn decode_bytes(bytes: &[u8]) -> String {
-    // まず UTF-8 を試みる
-    let (result, _, had_errors) = UTF_8.decode(bytes);
-    if !had_errors {
-        return result.into_owned();
+    // std::str::from_utf8 はアロケーションなしで UTF-8 妥当性を検証する
+    if let Ok(s) = std::str::from_utf8(bytes) {
+        return s.strip_prefix('\u{FEFF}').unwrap_or(s).to_string();
     }
-    // Shift-JIS にフォールバック
+    // UTF-8 でない場合は Shift-JIS にフォールバック
     let (result, _, _) = SHIFT_JIS.decode(bytes);
     result.into_owned()
 }
@@ -214,6 +213,12 @@ mod tests {
     #[test]
     fn test_decode_bytes_utf8() {
         let input = "テスト".as_bytes();
+        assert_eq!(decode_bytes(input), "テスト");
+    }
+
+    #[test]
+    fn test_decode_bytes_utf8_with_bom() {
+        let input = b"\xEF\xBB\xBF\xE3\x83\x86\xE3\x82\xB9\xE3\x83\x88";
         assert_eq!(decode_bytes(input), "テスト");
     }
 


### PR DESCRIPTION
## 概要

`decode_bytes()` で Shift-JIS ファイル処理時に発生していた UTF-8 + Shift-JIS の二重デコードを解消する（backlog タスク B）。

## 変更内容

| 変更前 | 変更後 |
|--------|--------|
| `encoding_rs::UTF_8.decode()` でフルデコード（ヒープアロケーション込み）→ エラー時 Shift-JIS | `std::str::from_utf8()` でアロケーションなし検証 → 成功時のみ `String` 化 |

```rust
// 変更前
let (result, _, had_errors) = UTF_8.decode(bytes);
if !had_errors { return result.into_owned(); }
let (result, _, _) = SHIFT_JIS.decode(bytes);
result.into_owned()

// 変更後
if let Ok(s) = std::str::from_utf8(bytes) {
    return s.strip_prefix('\u{FEFF}').unwrap_or(s).to_string();
}
let (result, _, _) = SHIFT_JIS.decode(bytes);
result.into_owned()
```

- UTF-8 BOM (`0xEF 0xBB 0xBF`) 付きファイルへの対応を追加
- 未使用になった `use encoding_rs::UTF_8` を削除
- `test_decode_bytes_utf8_with_bom` テストを追加

## パフォーマンス改善

`docs/performance.md` のベースライン値より、Shift-JIS パスで約 5.5 倍のオーバーヘッドが発生していた。今回の変更で UTF-8 検証のアロケーションが不要になる。

## 検証結果

- `cargo fmt --check`: ✅ pass
- `cargo clippy --all-targets -- -D warnings`: ✅ pass
- `cargo test --lib`: ✅ pass（132 passed, 0 failed）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * CSV ファイルの文字エンコーディング処理が改善されました。UTF-8 ファイルの先頭にあるバイト順マーク（BOM）が正しく処理されるようになります。
  * Shift-JIS エンコーディングへのフォールバック機能により、複数の文字コードに対応しています。

* **テスト**
  * BOM を含む UTF-8 ファイルのデコード処理を検証するテストが追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->