### PR TITLE
chore: settings.json に許可操作を追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,21 @@
 {
   "permissions": {
     "allow": [
-      "Bash(fly version:*)"
+      "Bash(fly version:*)",
+      "Bash(cargo:*)",
+      "Bash(git:*)",
+      "Bash(gh:*)",
+      "Bash(npm:*)",
+      "Bash(npx:*)",
+      "Bash(codex:*)",
+      "Bash(~/.vite-plus/0.1.12/bin/vp:*)",
+      "Bash(make:*)",
+      "Bash(bash:*)",
+      "Bash(rm:*)",
+      "Bash(ls:*)",
+      "Bash(curl:*)",
+      "Bash(sed:*)",
+      "Bash(grep:*)"
     ]
   },
   "env": {


### PR DESCRIPTION
よく使うコマンド（cargo / git / gh / npm / npx / vp / codex 等）をプロジェクト共通の許可リストに追記する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **その他**
  * 内部開発設定ファイルが更新されました。エンドユーザーに対する直接的な影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->