### PR TITLE
test: receipt 計算ロジックに単体テスト追加

### DIFF
--- a/frontend/src/features/receipt/calculations/__tests__/dividendCalculations.test.ts
+++ b/frontend/src/features/receipt/calculations/__tests__/dividendCalculations.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+
+import type { DividendData } from '@/lib/interfaces/dividend';
+
+import { calculateDividends } from '../dividendCalculations';
+
+const createDividendData = (overrides: Partial<DividendData> = {}): DividendData => ({
+  settlement_date: new Date(2024, 2, 5),
+  product: '配当金',
+  account: '特定口座',
+  security_code: '1234',
+  security_name: 'テスト銘柄',
+  unit_price: 100,
+  shares: 10,
+  dividends_before_tax: 1000,
+  taxes: 203,
+  net_amount_received: 797,
+  ...overrides,
+});
+
+describe('calculateDividends', () => {
+  it('空配列の場合は全フィールド0を返す', () => {
+    expect(calculateDividends([])).toEqual({
+      total_dividends_before_tax: 0,
+      total_taxes: 0,
+      total_net_amount_received: 0,
+    });
+  });
+
+  it('1件の場合は値をそのまま返す', () => {
+    const data = createDividendData({
+      dividends_before_tax: 5000,
+      taxes: 1015,
+      net_amount_received: 3985,
+    });
+
+    expect(calculateDividends([data])).toEqual({
+      total_dividends_before_tax: 5000,
+      total_taxes: 1015,
+      total_net_amount_received: 3985,
+    });
+  });
+
+  it('複数件の場合は各フィールドを合計する', () => {
+    const data = [
+      createDividendData({
+        security_code: '1111',
+        dividends_before_tax: 1000,
+        taxes: 203,
+        net_amount_received: 797,
+      }),
+      createDividendData({
+        security_code: '2222',
+        dividends_before_tax: 2500,
+        taxes: 507,
+        net_amount_received: 1993,
+      }),
+      createDividendData({
+        security_code: '3333',
+        dividends_before_tax: 1800,
+        taxes: 365,
+        net_amount_received: 1435,
+      }),
+    ];
+
+    expect(calculateDividends(data)).toEqual({
+      total_dividends_before_tax: 5300,
+      total_taxes: 1075,
+      total_net_amount_received: 4225,
+    });
+  });
+
+  it('マイナス値を含んでも正しく加算する', () => {
+    const data = [
+      createDividendData({
+        dividends_before_tax: 1000,
+        taxes: 200,
+        net_amount_received: 800,
+      }),
+      createDividendData({
+        security_code: '9999',
+        dividends_before_tax: -150,
+        taxes: -30,
+        net_amount_received: -120,
+      }),
+    ];
+
+    expect(calculateDividends(data)).toEqual({
+      total_dividends_before_tax: 850,
+      total_taxes: 170,
+      total_net_amount_received: 680,
+    });
+  });
+});

--- a/frontend/src/features/receipt/calculations/__tests__/domesticStockCalculations.test.ts
+++ b/frontend/src/features/receipt/calculations/__tests__/domesticStockCalculations.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from 'vitest';
+
+import type { DomesticStockData, DomesticStockSummary } from '@/lib/interfaces/domesticStock';
+
+import {
+  calculateDailyData,
+  calculateDomesticStock,
+} from '../domesticStockCalculations';
+
+const createDomesticStockData = (
+  overrides: Partial<DomesticStockData> = {},
+): DomesticStockData => ({
+  settlement_date: new Date(2024, 2, 4),
+  trade_date: new Date(2024, 2, 1),
+  security_code: '1234',
+  security_name: 'テスト株',
+  account: '特定口座',
+  shares: 100,
+  asked_price: 1200,
+  proceeds: 120000,
+  purchase_price: 100000,
+  realized_profit_and_loss: 20000,
+  taxes: 0,
+  realized_profit_and_loss_after_tax: 20000,
+  ...overrides,
+});
+
+const createDailySummary = (
+  overrides: Partial<DomesticStockSummary> = {},
+): DomesticStockSummary => ({
+  filter: '2024-03-01',
+  total_realized_profit_and_loss: 1000,
+  total_taxes: 203,
+  total_realized_profit_and_loss_after_tax: 797,
+  ...overrides,
+});
+
+describe('calculateDailyData', () => {
+  it('同一日付の複数件を1件のサマリーに集約する', () => {
+    const result = calculateDailyData([
+      createDomesticStockData({
+        security_code: '1111',
+        realized_profit_and_loss: 1000,
+        proceeds: 10000,
+      }),
+      createDomesticStockData({
+        security_code: '2222',
+        realized_profit_and_loss: 2000,
+        proceeds: 20000,
+      }),
+    ]);
+
+    expect(result).toEqual([
+      {
+        filter: '2024-03-01',
+        total_realized_profit_and_loss: 3000,
+        total_taxes: 609,
+        total_realized_profit_and_loss_after_tax: 2391,
+      },
+    ]);
+  });
+
+  it('特定口座で利益がある場合は税金を計算する', () => {
+    const result = calculateDailyData([
+      createDomesticStockData({
+        realized_profit_and_loss: 10000,
+      }),
+    ]);
+
+    expect(result[0]).toEqual({
+      filter: '2024-03-01',
+      total_realized_profit_and_loss: 10000,
+      total_taxes: 2031,
+      total_realized_profit_and_loss_after_tax: 7969,
+    });
+  });
+
+  it('特定口座で損失の場合は税金が0になる', () => {
+    const result = calculateDailyData([
+      createDomesticStockData({
+        realized_profit_and_loss: -10000,
+      }),
+    ]);
+
+    expect(result[0]).toEqual({
+      filter: '2024-03-01',
+      total_realized_profit_and_loss: -10000,
+      total_taxes: 0,
+      total_realized_profit_and_loss_after_tax: -10000,
+    });
+  });
+
+  it('NISA口座は利益があっても税金が0になる', () => {
+    const result = calculateDailyData([
+      createDomesticStockData({
+        account: 'NISA口座',
+        realized_profit_and_loss: 10000,
+      }),
+    ]);
+
+    expect(result[0]).toEqual({
+      filter: '2024-03-01',
+      total_realized_profit_and_loss: 10000,
+      total_taxes: 0,
+      total_realized_profit_and_loss_after_tax: 10000,
+    });
+  });
+
+  it('特定口座とNISA口座が混在する場合は特定口座分のみ課税する', () => {
+    const result = calculateDailyData([
+      createDomesticStockData({
+        account: '特定口座',
+        realized_profit_and_loss: 10000,
+      }),
+      createDomesticStockData({
+        account: 'NISA口座',
+        security_code: '5678',
+        realized_profit_and_loss: 5000,
+      }),
+    ]);
+
+    expect(result[0]).toEqual({
+      filter: '2024-03-01',
+      total_realized_profit_and_loss: 15000,
+      total_taxes: 2031,
+      total_realized_profit_and_loss_after_tax: 12969,
+    });
+  });
+
+  it('別日付のデータは日付昇順のサマリーで返す', () => {
+    const result = calculateDailyData([
+      createDomesticStockData({
+        trade_date: new Date(2024, 2, 2),
+        settlement_date: new Date(2024, 2, 5),
+        realized_profit_and_loss: 2000,
+      }),
+      createDomesticStockData({
+        trade_date: new Date(2024, 2, 1),
+        settlement_date: new Date(2024, 2, 4),
+        security_code: '5678',
+        realized_profit_and_loss: 1000,
+      }),
+    ]);
+
+    expect(result).toEqual([
+      {
+        filter: '2024-03-01',
+        total_realized_profit_and_loss: 1000,
+        total_taxes: 203,
+        total_realized_profit_and_loss_after_tax: 797,
+      },
+      {
+        filter: '2024-03-02',
+        total_realized_profit_and_loss: 2000,
+        total_taxes: 406,
+        total_realized_profit_and_loss_after_tax: 1594,
+      },
+    ]);
+  });
+});
+
+describe('calculateDomesticStock', () => {
+  it('空配列の場合は全フィールド0を返す', () => {
+    expect(calculateDomesticStock([])).toEqual({
+      total_realized_profit_and_loss: 0,
+      total_taxes: 0,
+      total_realized_profit_and_loss_after_tax: 0,
+    });
+  });
+
+  it('複数サマリーの各フィールドを合計する', () => {
+    const result = calculateDomesticStock([
+      createDailySummary({
+        total_realized_profit_and_loss: 10000,
+        total_taxes: 2031,
+        total_realized_profit_and_loss_after_tax: 7969,
+      }),
+      createDailySummary({
+        filter: '2024-03-02',
+        total_realized_profit_and_loss: -3000,
+        total_taxes: 0,
+        total_realized_profit_and_loss_after_tax: -3000,
+      }),
+      createDailySummary({
+        filter: '2024-03-03',
+        total_realized_profit_and_loss: 5000,
+        total_taxes: 1015,
+        total_realized_profit_and_loss_after_tax: 3985,
+      }),
+    ]);
+
+    expect(result).toEqual({
+      total_realized_profit_and_loss: 12000,
+      total_taxes: 3046,
+      total_realized_profit_and_loss_after_tax: 8954,
+    });
+  });
+});

--- a/frontend/src/features/receipt/calculations/__tests__/mutualfundCalculations.test.ts
+++ b/frontend/src/features/receipt/calculations/__tests__/mutualfundCalculations.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import type { MutualfundData } from '@/lib/interfaces/mutualfund';
+
+import { calculateMutualfund } from '../mutualfundCalculations';
+
+const createMutualfundData = (overrides: Partial<MutualfundData> = {}): MutualfundData => ({
+  settlement_date: new Date(2024, 2, 5),
+  trade_date: new Date(2024, 2, 1),
+  fund_name: 'テスト投資信託',
+  dividends: '再投資',
+  account: '特定口座',
+  shares: 1000,
+  exchange_rate: 1,
+  cancellation_unit_price_yen: 12000,
+  cancellation_amount_yen: 1200000,
+  average_acquisition_price_yen: 10000,
+  realized_profit_and_loss: 200000,
+  taxes: 40630,
+  realized_profit_and_loss_after_tax: 159370,
+  ...overrides,
+});
+
+describe('calculateMutualfund', () => {
+  it('空配列の場合は全フィールド0を返す', () => {
+    expect(calculateMutualfund([])).toEqual({
+      total_realized_profit_and_loss: 0,
+      total_taxes: 0,
+      total_realized_profit_and_loss_after_tax: 0,
+    });
+  });
+
+  it('1件の場合は値をそのまま返す', () => {
+    const data = createMutualfundData({
+      realized_profit_and_loss: 50000,
+      taxes: 10157,
+      realized_profit_and_loss_after_tax: 39843,
+    });
+
+    expect(calculateMutualfund([data])).toEqual({
+      total_realized_profit_and_loss: 50000,
+      total_taxes: 10157,
+      total_realized_profit_and_loss_after_tax: 39843,
+    });
+  });
+
+  it('複数件の場合は各フィールドを合計する', () => {
+    const data = [
+      createMutualfundData({
+        fund_name: 'ファンドA',
+        realized_profit_and_loss: 50000,
+        taxes: 10157,
+        realized_profit_and_loss_after_tax: 39843,
+      }),
+      createMutualfundData({
+        fund_name: 'ファンドB',
+        realized_profit_and_loss: -10000,
+        taxes: 0,
+        realized_profit_and_loss_after_tax: -10000,
+      }),
+      createMutualfundData({
+        fund_name: 'ファンドC',
+        realized_profit_and_loss: 25000,
+        taxes: 5078,
+        realized_profit_and_loss_after_tax: 19922,
+      }),
+    ];
+
+    expect(calculateMutualfund(data)).toEqual({
+      total_realized_profit_and_loss: 65000,
+      total_taxes: 15235,
+      total_realized_profit_and_loss_after_tax: 49765,
+    });
+  });
+});


### PR DESCRIPTION
## 概要

receipt 計算ロジックの3ファイルにテストがゼロだった状態を解消する（backlog タスク C）。

## 変更内容

| ファイル | テスト数 | 内容 |
|---------|---------|------|
| `dividendCalculations.test.ts` | 4件 | 空配列・1件・複数件・マイナス値 |
| `domesticStockCalculations.test.ts` | 8件 | 日次集約・特定/NISA税計算・日付昇順・合計 |
| `mutualfundCalculations.test.ts` | 3件 | 空配列・1件・複数件 |

## 検証結果

- `vp lint`: ✅ pass
- `npx tsc --noEmit`: ✅ pass
- `npm test`: ✅ pass（514 passed / 61 files）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * 配当金、日本株、および投資信託の計算機能に対する包括的なテストカバレッジを追加しました。
    * 空入力、単一/複数エントリ、エッジケース、および税計算シナリオをカバーしています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->