### PR TITLE
fix: SearchCard の initialExpanded を useEffect で同期

### DIFF
--- a/frontend/src/components/organisms/SearchCard/SearchCard.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { SearchCategories } from '@/types/common';
 import { Button } from '@/components/atoms/Button';
 import { Card, CardBody, CardHeader } from '@/components/atoms/Card';
@@ -176,6 +176,11 @@ export const SearchCard: React.FC<SearchCardProps> = ({
 }) => {
 
     const [isExpanded, setIsExpanded] = useState(initialExpanded);
+
+    // layout 切り替えなどで initialExpanded が変化したときに展開状態を同期する
+    useEffect(() => {
+        setIsExpanded(initialExpanded);
+    }, [initialExpanded]);
     const [searchQuery, setSearchQuery] = useState('');
     // アクティブな検索タイプを追跡（ドロップダウンの表示制御用）
     const [activeSearchType, setActiveSearchType] = useState<'securities' | 'years' | 'products' | 'accounts' | null>(null);


### PR DESCRIPTION
## 変更内容

`SearchCard` の `initialExpanded` prop が変化しても展開状態が更新されなかった問題を修正。

## 背景

`useState(initialExpanded)` は初回マウント時の値しか使わないため、
`layout` が `'workspace' ↔ 'stack'` で切り替わった場合など
`initialExpanded` が変化しても `isExpanded` state が追随しなかった。

react-doctor スコア 99/100 の唯一の warning として検出された。

## 修正

`useEffect` で `initialExpanded` の変化を監視し、state を同期するよう変更。

## テスト結果

- `vp lint` ✅
- `tsc --noEmit` ✅
- `npm test` ✅（514 passed）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * SearchCard コンポーネントの展開・折りたたみ状態がレイアウト変更などの画面変化に応じて正しく同期・更新されるようになりました。これにより、ユーザーが期待する通りにコンポーネントの状態が保持されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->