### PR TITLE
chore: eslint-plugin-react-hooks を 7.0.1 に更新

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -34,7 +34,7 @@
         "eslint": "9.39.2",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-compiler": "^19.1.0-rc.2",
-        "eslint-plugin-react-hooks": "^5.2.0",
+        "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "0.5.2",
         "globals": "17.4.0",
         "jsdom": "29.0.0",
@@ -4279,13 +4279,20 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
-      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
+      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "peerDependencies": {
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,7 +48,7 @@
     "eslint": "9.39.2",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-compiler": "^19.1.0-rc.2",
-    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "0.5.2",
     "globals": "17.4.0",
     "jsdom": "29.0.0",


### PR DESCRIPTION
## 変更内容

- `eslint-plugin-react-hooks` 5.2.0 → 7.0.1
- `terser` patch 更新

## 対象外（peer dependency 制約により保留）

| パッケージ | 理由 |
|-----------|------|
| `eslint` 9→10 | `eslint-plugin-react-hooks@7` が eslint 10 未対応 |
| `@vitejs/plugin-react` 5→6 | vite 8 必須（@tailwindcss/vite が未対応） |
| `vite` 7→8 | `@tailwindcss/vite` が vite 8 未対応 |

## テスト結果

- `vp lint` ✅
- `tsc --noEmit` ✅
- `npm test` ✅（514 passed）
- `vp build` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 開発ツールの依存関係をアップグレードしました。ユーザー体験に直接的な変更はございません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->