### PR TITLE
feat: 各ページに動的タイトルと meta description を追加

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="株式・投資信託・配当金の取引履歴と資産残高を管理するWebアプリ" />
   <title>証券Web</title>
   <script type="text/javascript">
     (function () {

--- a/frontend/src/hooks/usePageTitle.ts
+++ b/frontend/src/hooks/usePageTitle.ts
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+
+const BASE_TITLE = '証券Web';
+
+export function usePageTitle(pageTitle?: string) {
+  useEffect(() => {
+    document.title = pageTitle ? `${pageTitle} - ${BASE_TITLE}` : BASE_TITLE;
+    return () => {
+      document.title = BASE_TITLE;
+    };
+  }, [pageTitle]);
+}

--- a/frontend/src/pages/AssetBalance.tsx
+++ b/frontend/src/pages/AssetBalance.tsx
@@ -13,6 +13,7 @@ import { useDividendBatch } from '@/features/jquants/hooks/useDividendBatch';
 import { DividendStatus } from '@/features/jquants/api/dividendPerShareApi';
 import { useAssetBalanceDataSource } from '@/features/assetBalance/hooks/useAssetBalanceDataSource';
 import { createSearchOptions } from '@/lib/utils/dataTransformer';
+import { usePageTitle } from '../hooks/usePageTitle';
 import { filterByConfig, FilterConfig } from '@/lib/utils/searchUtils';
 import { ConfirmDeleteModal } from '@/components/molecules/ConfirmDeleteModal/ConfirmDeleteModal';
 
@@ -64,6 +65,8 @@ export const AssetBalanceInfo: React.FC<AssetBalanceInfoProps> = ({
  * 保有銘柄管理ページコンポーネント
  */
 export function AssetBalancePage() {
+  usePageTitle('資産管理');
+
   const { isAuthenticated, isLoading: authLoading, login } = useAuth();
 
   const {

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router-dom';
 import { Layout } from '../components/templates/Layout';
 import { Card, CardBody } from '../components/atoms/Card';
 import { PageHeader } from '../components/atoms/PageHeader';
+import { usePageTitle } from '../hooks/usePageTitle';
 
 // クイックアクション（ショートカット）
 const QUICK_ACTIONS = [
@@ -47,6 +48,8 @@ const FEATURES = [
 ] as const;
 
 export function HomePage() {
+  usePageTitle();
+
   return (
     <Layout>
       <div className="page-surface">

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -3,9 +3,12 @@ import { useAuth } from '../features/auth/hooks/useAuth';
 import { useNavigate } from 'react-router-dom';
 import { useEffect } from 'react';
 import { Card, CardBody } from '../components/atoms/Card';
+import { usePageTitle } from '../hooks/usePageTitle';
 import { Spinner } from '../components/atoms/Spinner';
 
 export function LoginPage() {
+  usePageTitle('ログイン');
+
   const { login, isAuthenticated, isLoading } = useAuth();
   const navigate = useNavigate();
 

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -1,7 +1,10 @@
 import { ErrorPage } from '../components/templates/ErrorPage';
+import { usePageTitle } from '../hooks/usePageTitle';
 import { Layout } from '../components/templates/Layout';
 
 export function NotFoundPage() {
+  usePageTitle('ページが見つかりません');
+
   return (
     <Layout>
       <ErrorPage

--- a/frontend/src/pages/Receipts.tsx
+++ b/frontend/src/pages/Receipts.tsx
@@ -1,6 +1,7 @@
 import { useReducer, useEffect, useCallback, useRef } from 'react';
 import { Layout } from '../components/templates/Layout';
 import { PageHeader } from '../components/atoms/PageHeader';
+import { usePageTitle } from '../hooks/usePageTitle';
 import { Spinner } from '@/components/atoms/Spinner';
 import { useAuth } from '@/features/auth/hooks/useAuth';
 import { Dividend } from './Receipt/Dividend';
@@ -22,6 +23,8 @@ import { ReceiptsAlerts } from './ReceiptsAlerts';
  * 明細種類ごとにCSVデータを管理するページコンポーネント
  */
 export function ReceiptsPage() {
+  usePageTitle('取引明細');
+
   const { isAuthenticated, isLoading: authLoading, onLogout } = useAuth();
   const [state, dispatch] = useReducer(receiptsReducer, initialState);
   const { receiptsType, rawFiles, lastImportResults, showDeleteConfirm } = state;

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -7,9 +7,12 @@ import { Alert } from '../components/atoms/Alert';
 import { EmptyState } from '../components/atoms/EmptyState';
 import { PageHeader } from '../components/atoms/PageHeader';
 import { useStockSearch } from '../features/stock/hooks/useStockSearch';
+import { usePageTitle } from '../hooks/usePageTitle';
 import { SECURITY_CODE_REGEX } from '@/lib/utils/formatters';
 
 export function SearchPage() {
+  usePageTitle('銘柄検索');
+
   const [searchParams] = useSearchParams();
   const codeParam = searchParams.get('code');
   const normalizedCodeParam = useMemo(() => {


### PR DESCRIPTION
## 変更内容

- `frontend/src/hooks/usePageTitle.ts` 新規追加
- `frontend/index.html` に `<meta name="description">` 追加
- 全ページコンポーネントに `usePageTitle` 適用

## ページごとのタイトル

| ページ | タイトル |
|-------|---------|
| ホーム | 証券Web |
| 銘柄検索 | 銘柄検索 - 証券Web |
| 取引明細 | 取引明細 - 証券Web |
| 資産管理 | 資産管理 - 証券Web |
| ログイン | ログイン - 証券Web |
| 404 | ページが見つかりません - 証券Web |

## テスト結果

- `vp lint` ✅
- `tsc --noEmit` ✅
- `npm test` ✅（525 passed）
- `vp build` ✅