### PR TITLE
test(e2e): 主要フロー E2E テストを追加（auth / receipt / search）

### DIFF
--- a/frontend/e2e/auth-flow.spec.ts
+++ b/frontend/e2e/auth-flow.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const MOCK_USER = {
+  id: '00000000-0000-0000-0000-000000000001',
+  email: 'test@example.com',
+  name: 'テストユーザー',
+};
+
+const ROUTES = {
+  authMe: /\/auth\/me$/,
+};
+
+async function mockUnauthorizedAuth(page: Page) {
+  await page.route(ROUTES.authMe, (route) =>
+    route.fulfill({ status: 401, contentType: 'application/json', body: '{}' }),
+  );
+}
+
+async function mockAuthorizedAuth(page: Page) {
+  await page.route(ROUTES.authMe, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_USER),
+    }),
+  );
+}
+
+test('未認証時に /receipts へアクセスするとログインページにリダイレクトされる', async ({ page }) => {
+  await mockUnauthorizedAuth(page);
+
+  await page.goto('/receipts');
+
+  await page.waitForURL('**/login');
+  await expect(page).toHaveURL(/\/login$/);
+});
+
+test('未認証時に /assetbalance へアクセスするとログインページにリダイレクトされる', async ({ page }) => {
+  await mockUnauthorizedAuth(page);
+
+  await page.goto('/assetbalance');
+
+  await page.waitForURL('**/login');
+  await expect(page).toHaveURL(/\/login$/);
+});
+
+test('認証済みユーザーのホームページにユーザー名が表示される', async ({ page }) => {
+  await mockAuthorizedAuth(page);
+
+  await page.goto('/');
+
+  await expect(page.getByText('テストユーザー')).toBeVisible();
+});

--- a/frontend/e2e/receipt-flow.spec.ts
+++ b/frontend/e2e/receipt-flow.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const MOCK_USER = {
+  id: '00000000-0000-0000-0000-000000000002',
+  email: 'test@example.com',
+  name: 'テストユーザー',
+};
+
+const ROUTES = {
+  authMe: /\/auth\/me$/,
+  dividends: /\/dividends$/,
+  domesticStocks: /\/domestic-stocks$/,
+  mutualfunds: /\/mutualfunds$/,
+};
+
+const DIVIDEND_RECORD = [
+  {
+    id: '00000000-0000-0000-0000-000000000001',
+    user_id: '00000000-0000-0000-0000-000000000002',
+    settlement_date: '2024-03-01',
+    product: '特定口座',
+    account: 'SBI証券',
+    security_code: '7203',
+    security_name: 'トヨタ自動車',
+    unit_price: '30.0',
+    shares: '100',
+    dividends_before_tax: '3000',
+    taxes: '609',
+    net_amount_received: '2391',
+    created_at: '2024-03-01T00:00:00Z',
+    updated_at: '2024-03-01T00:00:00Z',
+  },
+];
+
+async function setupAuthMocks(
+  page: Page,
+  {
+    dividends = [],
+    domesticStocks = [],
+    mutualfunds = [],
+  }: {
+    dividends?: unknown[];
+    domesticStocks?: unknown[];
+    mutualfunds?: unknown[];
+  } = {},
+) {
+  await page.route(ROUTES.authMe, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_USER),
+    }),
+  );
+  await page.route(ROUTES.dividends, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(dividends),
+    }),
+  );
+  await page.route(ROUTES.domesticStocks, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(domesticStocks),
+    }),
+  );
+  await page.route(ROUTES.mutualfunds, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(mutualfunds),
+    }),
+  );
+}
+
+test('取引明細ページの初期表示でタブが3つある', async ({ page }) => {
+  await setupAuthMocks(page);
+
+  await page.goto('/receipts');
+
+  await expect(page.getByRole('tab')).toHaveCount(3);
+});
+
+test('配当金タブにデータがないとき EmptyState が表示される', async ({ page }) => {
+  await setupAuthMocks(page, { dividends: [] });
+
+  await page.goto('/receipts');
+
+  await expect(page.getByText('データがありません')).toBeVisible();
+});
+
+test('配当金データが1件あるとき行が表示される', async ({ page }) => {
+  await setupAuthMocks(page, { dividends: DIVIDEND_RECORD });
+
+  await page.goto('/receipts');
+
+  await expect(page.getByRole('cell', { name: 'トヨタ自動車' })).toBeVisible();
+});

--- a/frontend/e2e/search-flow.spec.ts
+++ b/frontend/e2e/search-flow.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const MOCK_USER = {
+  id: '00000000-0000-0000-0000-000000000001',
+  email: 'test@example.com',
+  name: 'テストユーザー',
+};
+
+const MOCK_STOCK = {
+  date: '2024-03-01',
+  code: '7974',
+  name: '任天堂',
+  market_category: 'プライム',
+  industry_code_33: '37',
+  industry_category_33: '情報・通信業',
+  industry_code_17: '10',
+  industry_category_17: '情報通信・サービスその他',
+  size_code: '7',
+  size_category: 'TOPIX Large70',
+};
+
+const ROUTES = {
+  authMe: /\/auth\/me$/,
+  // API エンドポイントのみ一致させる（Vite のソースファイルパスと衝突しないよう末尾を限定）
+  stock: /\/stock\/\d+$/,
+};
+
+async function setupAuthMocks(page: Page) {
+  await page.route(ROUTES.authMe, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_USER),
+    }),
+  );
+  await page.route(ROUTES.stock, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_STOCK),
+    }),
+  );
+}
+
+test('検索ページの初期表示で検索フォームが表示される', async ({ page }) => {
+  await setupAuthMocks(page);
+
+  await page.goto('/search');
+  await page.waitForLoadState('networkidle');
+
+  await expect(page.getByRole('textbox', { name: '銘柄コードまたは銘柄名' })).toBeVisible();
+});
+
+test('検索フォームに文字を入力できる', async ({ page }) => {
+  await setupAuthMocks(page);
+
+  await page.goto('/search');
+  await page.waitForLoadState('networkidle');
+
+  const searchInput = page.getByRole('textbox', { name: '銘柄コードまたは銘柄名' });
+  await searchInput.fill('任天堂');
+
+  await expect(searchInput).toHaveValue('任天堂');
+});

--- a/frontend/playwright.ci.config.ts
+++ b/frontend/playwright.ci.config.ts
@@ -4,12 +4,18 @@ import { defineConfig, devices } from '@playwright/test';
  * CI 用 Playwright 設定
  *
  * - Vite dev server を自動起動
- * - error-scenarios.spec.ts のみ実行（API モックのため認証不要）
+ * - API モック前提の E2E spec を実行
  * - 失敗時に trace / screenshot / HTML レポートを保存
  */
 export default defineConfig({
   testDir: './e2e',
-  testMatch: ['**/error-scenarios.spec.ts', '**/a11y.spec.ts'],
+  testMatch: [
+    '**/error-scenarios.spec.ts',
+    '**/a11y.spec.ts',
+    '**/auth-flow.spec.ts',
+    '**/receipt-flow.spec.ts',
+    '**/search-flow.spec.ts',
+  ],
   fullyParallel: false,
   forbidOnly: true,
   retries: 1,
@@ -35,6 +41,8 @@ export default defineConfig({
       // バックエンドは page.route() でモックするため実際に接続しない
       VITE_SHOKEN_WEBAPI_API_URL: 'http://localhost:3001',
       PLAYWRIGHT_TEST: '1',
+      // React Compiler を無効化（VITEST フラグを流用）
+      VITEST: '1',
     },
   },
 });

--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -1,8 +1,9 @@
-import { lazy, Suspense } from 'react';
+import { lazy, Suspense, type ReactNode } from 'react';
 import { createBrowserRouter, RouterProvider, Navigate } from 'react-router-dom';
 import { ErrorBoundary } from '../components/molecules/ErrorBoundary';
 import { ErrorPage } from '../components/templates/ErrorPage';
 import { Spinner } from '../components/atoms/Spinner';
+import { useAuth } from '@/features/auth/hooks/useAuth';
 
 const HomePage = lazy(() => import('../pages/Home').then(m => ({ default: m.HomePage })));
 const SearchPage = lazy(() => import('../pages/Search').then(m => ({ default: m.SearchPage })));
@@ -19,6 +20,20 @@ function PageLoader() {
   );
 }
 
+function ProtectedRoute({ children }: { children: ReactNode }) {
+  const { isAuthenticated, isLoading } = useAuth();
+
+  if (isLoading) {
+    return <PageLoader />;
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return children;
+}
+
 const router = createBrowserRouter([
   {
     path: "/",
@@ -31,11 +46,19 @@ const router = createBrowserRouter([
   },
   {
     path: "/receipts",
-    element: <Suspense fallback={<PageLoader />}><ReceiptsPage /></Suspense>,
+    element: (
+      <ProtectedRoute>
+        <Suspense fallback={<PageLoader />}><ReceiptsPage /></Suspense>
+      </ProtectedRoute>
+    ),
   },
   {
     path: "/assetbalance",
-    element: <Suspense fallback={<PageLoader />}><AssetBalancePage /></Suspense>,
+    element: (
+      <ProtectedRoute>
+        <Suspense fallback={<PageLoader />}><AssetBalancePage /></Suspense>
+      </ProtectedRoute>
+    ),
   },
   {
     path: "/login",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -11,8 +11,8 @@ export default defineConfig({
     react({
       babel: {
         plugins: [
-          // Vitest 実行時は React Compiler を無効化（dev/prod のみ有効）
-          ...(process.env.VITEST ? [] : [['babel-plugin-react-compiler', {}] as const]),
+          // Vitest / Playwright 実行時は React Compiler を無効化（dev/prod のみ有効）
+          ...(process.env.VITEST || process.env.PLAYWRIGHT_TEST ? [] : [['babel-plugin-react-compiler', {}] as const]),
         ],
       },
     }),


### PR DESCRIPTION
## 変更内容

- `auth-flow.spec.ts`: 未認証リダイレクト・ユーザー名表示を検証（3件）
- `receipt-flow.spec.ts`: 取引明細タブ・EmptyState・データ行表示を検証（3件）
- `search-flow.spec.ts`: 検索フォーム表示・入力を検証（2件）
- `AppRoutes.tsx`: `ProtectedRoute` コンポーネントを追加し `/receipts`・`/assetbalance` を認証保護
- `vite.config.ts`: `PLAYWRIGHT_TEST` 環境変数でも React Compiler を無効化
- `playwright.ci.config.ts`: webServer env に `VITEST`・`PLAYWRIGHT_TEST` を追加

## 不具合修正

`search-flow.spec.ts` の `page.route(/\/stock\//)` が Vite ソースファイルパス
（`/src/features/stock/hooks/useStockSearch.ts`）に誤マッチし、
JSON を返したことで動的 import が失敗していた問題を修正。
パターンを `/\/stock\/\d+$/` に限定。

## テスト結果

```
8 passed (auth-flow: 3, receipt-flow: 3, search-flow: 2)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ページアクセス時に認証チェック機能を実装しました。認証されていないユーザーは自動的にログインページへリダイレクトされます。

* **テスト**
  * 認証フロー、領収書フロー、検索機能に関する包括的なエンドツーエンドテストを新たに追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->