### PR TITLE
fix: UIレビュー高優先度指摘の修正（エラーメッセージ・DividendInfo）

### DIFF
--- a/frontend/src/components/molecules/DividendInfo/DividendInfo.tsx
+++ b/frontend/src/components/molecules/DividendInfo/DividendInfo.tsx
@@ -24,6 +24,9 @@ const JQuantsBadge = () => (
   </a>
 );
 
+const ASSET_BALANCE_HINT = '資産管理にCSVを取り込むと表示されます';
+const JQUANTS_HINT = 'J-Quants APIから取得します';
+
 interface DividendInfoProps {
   searchQuery: string;
   securityCode?: string;
@@ -138,10 +141,13 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({
             </p>
             <p
               className="text-2xl font-bold tabular-nums text-primary"
-              title={averageUnitPrice === undefined ? '資産管理にCSVを取り込むと表示されます' : undefined}
+              title={averageUnitPrice === undefined ? ASSET_BALANCE_HINT : undefined}
             >
               {averageUnitPrice !== undefined ? formatCurrency(averageUnitPrice) : '---'}
             </p>
+            {averageUnitPrice === undefined && (
+              <p className="mt-0.5 text-xs text-slate-400">{ASSET_BALANCE_HINT}</p>
+            )}
           </div>
           <div className="rounded-lg bg-slate-50 px-4 py-3">
             <p className="text-xs font-medium text-slate-600 mb-1">
@@ -149,10 +155,13 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({
             </p>
             <p
               className="text-2xl font-bold tabular-nums text-primary"
-              title={holdingQuantity === undefined ? '資産管理にCSVを取り込むと表示されます' : undefined}
+              title={holdingQuantity === undefined ? ASSET_BALANCE_HINT : undefined}
             >
               {holdingQuantity !== undefined ? holdingQuantity.toLocaleString('ja-JP') : '---'}
             </p>
+            {holdingQuantity === undefined && (
+              <p className="mt-0.5 text-xs text-slate-400">{ASSET_BALANCE_HINT}</p>
+            )}
           </div>
           <div className="rounded-lg bg-slate-50 px-4 py-3">
             <p className="text-xs font-medium text-slate-600 mb-1">
@@ -161,6 +170,9 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({
             <p className="text-2xl font-bold tabular-nums text-primary">
               {apiLoading ? '取得中...' : dividendPerShare !== undefined ? formatCurrency(dividendPerShare) : '---'}
             </p>
+            {!apiLoading && dividendPerShare === undefined && (
+              <p className="mt-0.5 text-xs text-slate-400">{JQUANTS_HINT}</p>
+            )}
           </div>
         </div>
 

--- a/frontend/src/components/molecules/__tests__/DividendInfo.test.tsx
+++ b/frontend/src/components/molecules/__tests__/DividendInfo.test.tsx
@@ -63,4 +63,13 @@ describe('DividendInfo', () => {
 
     expect(mockUseDividendBatch).toHaveBeenCalledWith(['7203'], true);
   });
+
+  it('embedded モードで未取得値にヒントを表示する', () => {
+    render(<DividendInfo embedded searchQuery="7203: トヨタ自動車" summary={[]} />);
+
+    expect(
+      screen.getAllByText('資産管理にCSVを取り込むと表示されます')
+    ).toHaveLength(2);
+    expect(screen.getByText('J-Quants APIから取得します')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/lib/types/__tests__/api.test.ts
+++ b/frontend/src/lib/types/__tests__/api.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+
+import { ApiError, ApiErrorType } from '../api';
+
+describe('ApiError', () => {
+  it('DESERIALIZATION_ERROR ではユーザー向けメッセージを返す', () => {
+    const error = new ApiError(
+      ApiErrorType.DESERIALIZATION_ERROR,
+      'J-Quants API の応答形式が変更された可能性があります'
+    );
+
+    expect(error.getUserMessage()).toBe(
+      '銘柄情報の取得に失敗しました。時間をおいて再度お試しください。'
+    );
+  });
+});

--- a/frontend/src/lib/types/api.ts
+++ b/frontend/src/lib/types/api.ts
@@ -95,6 +95,8 @@ export class ApiError extends Error {
         return '入力内容を確認してください';
       case ApiErrorType.SERVER_ERROR:
         return 'サーバーエラーが発生しました。しばらくしてから再度お試しください';
+      case ApiErrorType.DESERIALIZATION_ERROR:
+        return '銘柄情報の取得に失敗しました。時間をおいて再度お試しください。';
       default:
         return this.message;
     }

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -8,6 +8,7 @@ import { EmptyState } from '../components/atoms/EmptyState';
 import { PageHeader } from '../components/atoms/PageHeader';
 import { useStockSearch } from '../features/stock/hooks/useStockSearch';
 import { usePageTitle } from '../hooks/usePageTitle';
+import { ApiError } from '@/lib/types/api';
 import { SECURITY_CODE_REGEX } from '@/lib/utils/formatters';
 
 export function SearchPage() {
@@ -62,7 +63,10 @@ export function SearchPage() {
 
         {isError && (
           <Alert variant="danger">
-            <strong>エラー:</strong> {error?.message || '銘柄情報の取得に失敗しました。'}
+            <strong>エラー:</strong>{' '}
+            {error instanceof ApiError
+              ? error.getUserMessage()
+              : (error?.message || '銘柄情報の取得に失敗しました。')}
           </Alert>
         )}
 

--- a/frontend/src/pages/__tests__/Search.test.tsx
+++ b/frontend/src/pages/__tests__/Search.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ApiError, ApiErrorType } from '@/lib/types/api';
+import { SearchPage } from '../Search';
+
+const { mockUseStockSearch } = vi.hoisted(() => ({
+  mockUseStockSearch: vi.fn(),
+}));
+
+vi.mock('@/components/templates/Layout', () => ({
+  Layout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/organisms/SearchForm', () => ({
+  SearchForm: () => <div>SearchForm</div>,
+}));
+
+vi.mock('@/components/organisms/StockInfo', () => ({
+  StockInfo: () => <div>StockInfo</div>,
+}));
+
+vi.mock('@/components/atoms/EmptyState', () => ({
+  EmptyState: ({ title, description }: { title: string; description?: string }) => (
+    <div>
+      <div>{title}</div>
+      {description && <div>{description}</div>}
+    </div>
+  ),
+}));
+
+vi.mock('@/components/atoms/PageHeader', () => ({
+  PageHeader: ({ title, description }: { title: string; description?: string }) => (
+    <div>
+      <h1>{title}</h1>
+      {description && <p>{description}</p>}
+    </div>
+  ),
+}));
+
+vi.mock('@/components/atoms/Alert', () => ({
+  Alert: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/features/stock/hooks/useStockSearch', () => ({
+  useStockSearch: (...args: unknown[]) => mockUseStockSearch(...args),
+}));
+
+vi.mock('@/hooks/usePageTitle', () => ({
+  usePageTitle: vi.fn(),
+}));
+
+describe('SearchPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockUseStockSearch.mockReturnValue({
+      stockCode: '',
+      setStockCode: vi.fn(),
+      stockData: undefined,
+      error: null,
+      isLoading: false,
+      isError: false,
+      handleSearch: vi.fn(),
+      searchByCode: vi.fn(),
+    });
+  });
+
+  it('ApiError のユーザー向けメッセージを表示する', () => {
+    mockUseStockSearch.mockReturnValue({
+      stockCode: '',
+      setStockCode: vi.fn(),
+      stockData: undefined,
+      error: new ApiError(
+        ApiErrorType.DESERIALIZATION_ERROR,
+        'J-Quants API の応答形式が変更された可能性があります'
+      ),
+      isLoading: false,
+      isError: true,
+      handleSearch: vi.fn(),
+      searchByCode: vi.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <SearchPage />
+      </MemoryRouter>
+    );
+
+    expect(
+      screen.getByText('銘柄情報の取得に失敗しました。時間をおいて再度お試しください。')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('J-Quants API の応答形式が変更された可能性があります')
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 変更内容
- 銘柄検索エラー時に ApiError.getUserMessage() を使用してユーザー向けメッセージを表示
- DESERIALIZATION_ERROR のユーザー向けメッセージを追加
- DividendInfo embedded モードで値未取得時のヒントテキストを表示

## テスト
- vp lint / npm test / vp build 通過確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 配当情報カードに一貫した説明的ヒントテキストを追加しました。平均単価・保有数が不明な場合に案内表示します。
* **バグ修正**
  * データ取得エラー時に、より分かりやすいユーザー向けエラーメッセージを表示するよう改善しました。
* **テスト**
  * 表示とエラーメッセージ挙動を検証する単体テストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


テストを追加しました
