### PR TITLE
fix: SearchCard の derived state を useEffect からレンダー中調整に変更

### DIFF
--- a/frontend/src/components/organisms/SearchCard/SearchCard.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchCard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { SearchCategories } from '@/types/common';
 import { Button } from '@/components/atoms/Button';
 import { Card, CardBody, CardHeader } from '@/components/atoms/Card';
@@ -176,11 +176,13 @@ export const SearchCard: React.FC<SearchCardProps> = ({
 }) => {
 
     const [isExpanded, setIsExpanded] = useState(initialExpanded);
-
     // layout 切り替えなどで initialExpanded が変化したときに展開状態を同期する
-    useEffect(() => {
+    // useEffect ではなくレンダー中に調整することで余分な再レンダーを防ぐ
+    const [prevInitialExpanded, setPrevInitialExpanded] = useState(initialExpanded);
+    if (prevInitialExpanded !== initialExpanded) {
+        setPrevInitialExpanded(initialExpanded);
         setIsExpanded(initialExpanded);
-    }, [initialExpanded]);
+    }
     const [searchQuery, setSearchQuery] = useState('');
     // アクティブな検索タイプを追跡（ドロップダウンの表示制御用）
     const [activeSearchType, setActiveSearchType] = useState<'securities' | 'years' | 'products' | 'accounts' | null>(null);


### PR DESCRIPTION
react-doctor で検出された `useEffect` 内 `setState`（derived state anti-pattern）を修正。

## 変更内容

- `useEffect(() => setIsExpanded(initialExpanded), [initialExpanded])` を削除
- React 公式推奨のレンダー中調整パターン（`prevInitialExpanded` 比較）に置き換え

## 効果

react-doctor スコア: **98 → 99 / 100**（error 1件 解消）

## テスト

`npm test`: 521 passed ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * SearchCardコンポーネントの状態管理ロジックを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->