### PR TITLE
fix: AssetBalancePage テストの any 型を AssetBalanceData に置き換え

### DIFF
--- a/frontend/src/pages/__tests__/AssetBalancePage.test.tsx
+++ b/frontend/src/pages/__tests__/AssetBalancePage.test.tsx
@@ -14,6 +14,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import { AssetBalancePage } from '../AssetBalance';
 import { assetBalanceQueryKeys } from '@/features/assetBalance/queryKeys';
+import { AssetBalanceData } from '@/lib/interfaces/assetBalance';
 
 // ────────────────────────────────────────────────────────
 // モック定義
@@ -135,8 +136,7 @@ function renderWithQuery(ui: React.ReactElement, qc?: QueryClient) {
 }
 
 // DBデータの型に合わせたモック行
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const mockDbRow: any = {
+const mockDbRow: AssetBalanceData = {
   security_code: '7203',
   security_name: 'トヨタ自動車',
   shares: 100,


### PR DESCRIPTION
## 変更内容
- `mockDbRow: any` を `AssetBalanceData` 型に置き換え
- `AssetBalanceData` のインポートを追加
- `eslint-disable-next-line @typescript-eslint/no-explicit-any` コメントを削除

## テスト
- `grep -r ': any' frontend/src/`: 0件確認
- vitest: 64ファイル / 521件 全パス

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * テストコードの型安全性を向上させ、フォーマットを統一しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->