### PR TITLE
test: バックエンドテストカバレッジを80%以上に引き上げる

### DIFF
--- a/backend/src/errors.rs
+++ b/backend/src/errors.rs
@@ -251,4 +251,43 @@ mod tests {
         assert_eq!(details.message, "test message");
         assert!(details.details.is_none());
     }
+
+    #[test]
+    fn test_unauthorized_into_response() {
+        let error = ApiError::Unauthorized("認証が必要です".to_string());
+        let response = error.into_response();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn test_network_error_into_response() {
+        let error = ApiError::NetworkError("接続エラー".to_string());
+        let response = error.into_response();
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+    }
+
+    #[test]
+    fn test_api_error_variant_into_response() {
+        let error = ApiError::ApiError("API エラー".to_string());
+        let response = error.into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn test_serde_json_error_into_response() {
+        let serde_err: serde_json::Error =
+            serde_json::from_str::<serde_json::Value>("invalid json").unwrap_err();
+        let error = ApiError::SerdeJsonError(serde_err);
+        let response = error.into_response();
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[test]
+    fn test_database_error_other_variant_into_response() {
+        // RowNotFound 以外の sqlx::Error バリアントで catch-all ブランチをカバー
+        let sql_error = SqlxError::ColumnNotFound("test_column".to_string());
+        let error = ApiError::DatabaseError(sql_error);
+        let response = error.into_response();
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
 }

--- a/backend/src/services/csv_import.rs
+++ b/backend/src/services/csv_import.rs
@@ -133,6 +133,22 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_csv_collects_record_read_errors() {
+        let csv = "col_a,col_b\nfoo,123\nbar\nbaz,456\n";
+        let (items, errors) = parse_csv::<String, _>(csv.as_bytes(), |record, header_map, _row| {
+            let a = get_cell(record, header_map, "col_a").to_string();
+            let b = get_cell(record, header_map, "col_b").to_string();
+            Ok(format!("{}/{}", a, b))
+        })
+        .unwrap();
+
+        assert_eq!(items, vec!["foo/123", "baz/456"]);
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].row, 2);
+        assert!(errors[0].message.contains("CSV行の読み込み"));
+    }
+
+    #[test]
     fn test_finish_csv_upload() {
         use crate::models::csv_import::CsvRowError;
         let result = crate::models::common::BulkCreateResponse {

--- a/backend/src/services/csv_util.rs
+++ b/backend/src/services/csv_util.rs
@@ -371,4 +371,26 @@ mod tests {
         assert_eq!(normalize_security_name("  KDDI  "), "KDDI");
         assert_eq!(normalize_security_name(""), "");
     }
+
+    #[test]
+    fn test_parse_required_number_empty_is_error() {
+        let record = csv::StringRecord::from(vec![""]);
+        let mut header_map = HashMap::new();
+        header_map.insert("required".to_string(), 0);
+
+        let err = parse_required_number(&record, &header_map, "required", 7).unwrap_err();
+        assert_eq!(err.row, 7);
+        assert!(err.message.contains("required"));
+    }
+
+    #[test]
+    fn test_parse_required_date_invalid_is_error() {
+        let record = csv::StringRecord::from(vec!["2024/13/40"]);
+        let mut header_map = HashMap::new();
+        header_map.insert("date".to_string(), 0);
+
+        let err = parse_required_date(&record, &header_map, "date", 9).unwrap_err();
+        assert_eq!(err.row, 9);
+        assert!(err.message.contains("date"));
+    }
 }

--- a/backend/src/services/dividend.rs
+++ b/backend/src/services/dividend.rs
@@ -198,4 +198,35 @@ mod tests {
             Err(ApiError::ValidationError(_))
         ));
     }
+
+    #[test]
+    fn test_preview_csv_blank_code_and_normalized_name() {
+        let csv = [
+            "入金日,商品,口座,銘柄コード,銘柄,受取通貨,単価[円/現地通貨],数量[株/口],配当・分配金合計（税引前）[円/現地通貨],税額合計[円/現地通貨],受取金額[円/現地通貨]",
+            "\"2025/12/09\",\"国内株式\",\"特定・一般\",\"\",\"K D D I\",\"円\",\"93.76\",\"200\",\"18752\",\"3808\",\"14944\"",
+        ]
+        .join("\n");
+
+        let preview = preview_csv(csv.as_bytes()).unwrap();
+
+        assert_eq!(preview.valid_rows, 1);
+        assert_eq!(preview.rows[0]["security_code"], "");
+        assert_eq!(preview.rows[0]["security_name"], "KDDI");
+    }
+
+    #[test]
+    fn test_preview_csv_invalid_date_is_row_error() {
+        let csv = [
+            "入金日,商品,口座,銘柄コード,銘柄,受取通貨,単価[円/現地通貨],数量[株/口],配当・分配金合計（税引前）[円/現地通貨],税額合計[円/現地通貨],受取金額[円/現地通貨]",
+            "\"2025/13/09\",\"国内株式\",\"特定・一般\",\"8591\",\"オリックス\",\"円\",\"93.76\",\"200\",\"18752\",\"3808\",\"14944\"",
+        ]
+        .join("\n");
+
+        let preview = preview_csv(csv.as_bytes()).unwrap();
+
+        assert_eq!(preview.total_rows, 1);
+        assert_eq!(preview.valid_rows, 0);
+        assert_eq!(preview.errors.len(), 1);
+        assert!(preview.errors[0].message.contains("入金日"));
+    }
 }

--- a/backend/src/services/domestic_stock.rs
+++ b/backend/src/services/domestic_stock.rs
@@ -265,6 +265,41 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn test_preview_csv_normalizes_name_and_keeps_nisa_profit_untaxed() {
+        let csv = [
+            "約定日,受渡日,銘柄コード,銘柄名,口座,信用区分,取引,数量[株],売却/決済単価[円],売却/決済額[円],平均取得価額[円],実現損益[円]",
+            "\"2026/02/09\",\"2026/02/12\",\"9433\",\"K D D I\",\"NISA\",\"-\",\"売付\",\"100\",\"1441.0\",\"144100\",\"1350.00\",\"9100\"",
+        ]
+        .join("\n");
+
+        let preview = preview_csv(csv.as_bytes()).unwrap();
+
+        assert_eq!(preview.valid_rows, 1);
+        assert_eq!(preview.rows[0]["security_name"], "KDDI");
+        assert_eq!(preview.rows[0]["taxes"], 0.0);
+        assert_eq!(
+            preview.rows[0]["realized_profit_and_loss_after_tax"],
+            9100.0
+        );
+    }
+
+    #[test]
+    fn test_preview_csv_invalid_realized_profit_is_row_error() {
+        let csv = [
+            "約定日,受渡日,銘柄コード,銘柄名,口座,信用区分,取引,数量[株],売却/決済単価[円],売却/決済額[円],平均取得価額[円],実現損益[円]",
+            "\"2026/02/09\",\"2026/02/12\",\"5020\",\"ＥＮＥＯＳ\",\"特定\",\"-\",\"売付\",\"100\",\"1441.0\",\"144100\",\"1350.00\",\"N/A\"",
+        ]
+        .join("\n");
+
+        let preview = preview_csv(csv.as_bytes()).unwrap();
+
+        assert_eq!(preview.total_rows, 1);
+        assert_eq!(preview.valid_rows, 0);
+        assert_eq!(preview.errors.len(), 1);
+        assert!(preview.errors[0].message.contains("実現損益[円]"));
+    }
+
     fn make_test_item() -> CreateDomesticStockRequest {
         CreateDomesticStockRequest {
             trade_date: NaiveDate::from_ymd_opt(2026, 2, 12).unwrap(),

--- a/backend/src/services/mutualfund.rs
+++ b/backend/src/services/mutualfund.rs
@@ -215,4 +215,17 @@ mod tests {
             Err(ApiError::ValidationError(_))
         ));
     }
+
+    #[test]
+    fn test_preview_csv_empty_dividends() {
+        let csv = concat!(
+            "約定日,受渡日,ファンド名,分配金,口座,取引,数量[口],為替レート［円］,解約単価［円］,解約額［円］,平均取得価額［円］,実現損益［円］\n",
+            "\"2022/10/28\",\"2022/11/2\",\"eMAXIS Slim\",\"\",\"特定\",\"解約\",\"1000\",\"1\",\"12000\",\"12000000\",\"10000\",\"615849\""
+        );
+
+        let preview = preview_csv(csv.as_bytes()).unwrap();
+
+        assert_eq!(preview.valid_rows, 1);
+        assert_eq!(preview.rows[0]["dividends"], serde_json::Value::Null);
+    }
 }

--- a/backend/tests/db_integration.rs
+++ b/backend/tests/db_integration.rs
@@ -220,6 +220,40 @@ fn make_mutualfund_item(fund_name: &str) -> CreateMutualfundRequest {
     }
 }
 
+fn make_mutualfund_csv() -> &'static str {
+    concat!(
+        "約定日,受渡日,ファンド名,分配金,口座,取引,数量[口],為替レート［円］,解約単価［円］,解約額［円］,平均取得価額［円］,実現損益［円］\n",
+        "\"2022/10/28\",\"2022/11/2\",\"eMAXIS Slim 米国株式(S&P500)\",\"\",\"特定\",\"解約\",\"1000\",\"1\",\"12000\",\"12000000\",\"10000\",\"615849\""
+    )
+}
+
+fn make_dividend_csv() -> &'static str {
+    concat!(
+        "入金日,商品,口座,銘柄コード,銘柄,受取通貨,単価[円/現地通貨],数量[株/口],配当・分配金合計（税引前）[円/現地通貨],税額合計[円/現地通貨],受取金額[円/現地通貨]\n",
+        "\"2025/12/09\",\"国内株式\",\"特定・一般\",\"8592\",\"テスト配当\",\"円\",\"93.76\",\"200\",\"18752\",\"3808\",\"14944\""
+    )
+}
+
+fn make_domestic_stock_csv() -> &'static str {
+    concat!(
+        "約定日,受渡日,銘柄コード,銘柄名,口座,信用区分,取引,数量[株],売却/決済単価[円],売却/決済額[円],平均取得価額[円],実現損益[円]\n",
+        "\"2026/02/09\",\"2026/02/12\",\"5020\",\"ＥＮＥＯＳ\",\"特定\",\"-\",\"売付\",\"100\",\"1441.0\",\"144100\",\"1350.00\",\"9100\""
+    )
+}
+
+fn make_asset_balance_csv() -> &'static str {
+    concat!(
+        "■現在の評価額合計［円］,,\"1,100,000\"\n",
+        "■評価損益合計,前日比［円］,\"10,000\"\n",
+        ",前月比［円］,\"5,000\"\n",
+        ",評価損益［円］,\"100,000\"\n",
+        "■特定口座\n",
+        "\n",
+        "銘柄コード,銘柄名,保有数量［株］,執行中［株］,(内訳　通常数量[株]),(内訳　積立数量[株]),平均取得価額［円］,取得総額［円］,現在値［円］,現在値（前日比）［円］,時価評価額［円］,評価損益［％］\n",
+        "\"7203\",\"トヨタ自動車\",\"100\",\"-\",\"100\",\"0\",\"2500\",\"250000\",\"2650\",\"15\",\"265000\",\"6.0\""
+    )
+}
+
 /// Docker が必要なテスト用の Postgres コンテナ起動ヘルパー
 async fn start_test_pool() -> (PgPool, impl Drop) {
     let node = Postgres::default().start().await.unwrap();
@@ -240,6 +274,198 @@ async fn create_test_user(pool: &PgPool) -> Uuid {
         .await
         .expect("failed to insert test user");
     user_id
+}
+
+#[tokio::test]
+async fn service_coverage_all_domains() {
+    let (pool, _node) = start_test_pool().await;
+    let user_id = create_test_user(&pool).await;
+
+    assert!(mutualfund_svc::list(&pool, user_id)
+        .await
+        .expect("initial mutualfund list failed")
+        .is_empty());
+    let mutualfund_empty = mutualfund_svc::bulk_create(&pool, user_id, &[])
+        .await
+        .expect("empty mutualfund bulk_create failed");
+    assert_eq!(mutualfund_empty.inserted, 0);
+    assert_eq!(mutualfund_empty.skipped, 0);
+
+    let mutualfund_items = vec![
+        make_mutualfund_item("テスト投信A"),
+        make_mutualfund_item("テスト投信B"),
+    ];
+    let mutualfund_created = mutualfund_svc::bulk_create(&pool, user_id, &mutualfund_items)
+        .await
+        .expect("mutualfund bulk_create failed");
+    assert_eq!(mutualfund_created.inserted, 2);
+    assert_eq!(mutualfund_created.skipped, 0);
+
+    let mutualfund_uploaded =
+        mutualfund_svc::upload_csv(&pool, user_id, make_mutualfund_csv().as_bytes())
+            .await
+            .expect("mutualfund upload_csv failed");
+    assert_eq!(mutualfund_uploaded.inserted, 1);
+    assert_eq!(mutualfund_uploaded.skipped, 0);
+    assert!(mutualfund_uploaded.errors.is_empty());
+
+    assert_eq!(
+        mutualfund_svc::list(&pool, user_id)
+            .await
+            .expect("mutualfund list failed")
+            .len(),
+        3
+    );
+    assert_eq!(
+        mutualfund_svc::delete_all(&pool, user_id)
+            .await
+            .expect("mutualfund delete_all failed"),
+        3
+    );
+    assert!(mutualfund_svc::list(&pool, user_id)
+        .await
+        .expect("mutualfund list after delete failed")
+        .is_empty());
+
+    assert!(dividend_svc::list(&pool, user_id)
+        .await
+        .expect("initial dividend list failed")
+        .is_empty());
+    let dividend_empty = dividend_svc::bulk_create(&pool, user_id, &[])
+        .await
+        .expect("empty dividend bulk_create failed");
+    assert_eq!(dividend_empty.inserted, 0);
+    assert_eq!(dividend_empty.skipped, 0);
+
+    let dividend_items = vec![make_dividend_item("1001"), make_dividend_item("1002")];
+    let dividend_created = dividend_svc::bulk_create(&pool, user_id, &dividend_items)
+        .await
+        .expect("dividend bulk_create failed");
+    assert_eq!(dividend_created.inserted, 2);
+    assert_eq!(dividend_created.skipped, 0);
+
+    let dividend_uploaded =
+        dividend_svc::upload_csv(&pool, user_id, make_dividend_csv().as_bytes())
+            .await
+            .expect("dividend upload_csv failed");
+    assert_eq!(dividend_uploaded.inserted, 1);
+    assert_eq!(dividend_uploaded.skipped, 0);
+    assert!(dividend_uploaded.errors.is_empty());
+
+    assert_eq!(
+        dividend_svc::list(&pool, user_id)
+            .await
+            .expect("dividend list failed")
+            .len(),
+        3
+    );
+    assert_eq!(
+        dividend_svc::delete_all(&pool, user_id)
+            .await
+            .expect("dividend delete_all failed"),
+        3
+    );
+    assert!(dividend_svc::list(&pool, user_id)
+        .await
+        .expect("dividend list after delete failed")
+        .is_empty());
+
+    assert!(domestic_stock_svc::list(&pool, user_id)
+        .await
+        .expect("initial domestic_stock list failed")
+        .is_empty());
+    let domestic_stock_empty = domestic_stock_svc::bulk_create(&pool, user_id, &[])
+        .await
+        .expect("empty domestic_stock bulk_create failed");
+    assert_eq!(domestic_stock_empty.inserted, 0);
+    assert_eq!(domestic_stock_empty.skipped, 0);
+
+    let domestic_stock_items = vec![
+        make_domestic_stock_item("3001"),
+        make_domestic_stock_item("3002"),
+    ];
+    let domestic_stock_created =
+        domestic_stock_svc::bulk_create(&pool, user_id, &domestic_stock_items)
+            .await
+            .expect("domestic_stock bulk_create failed");
+    assert_eq!(domestic_stock_created.inserted, 2);
+    assert_eq!(domestic_stock_created.skipped, 0);
+
+    let domestic_stock_uploaded =
+        domestic_stock_svc::upload_csv(&pool, user_id, make_domestic_stock_csv().as_bytes())
+            .await
+            .expect("domestic_stock upload_csv failed");
+    assert_eq!(domestic_stock_uploaded.inserted, 1);
+    assert_eq!(domestic_stock_uploaded.skipped, 0);
+    assert!(domestic_stock_uploaded.errors.is_empty());
+
+    assert_eq!(
+        domestic_stock_svc::list(&pool, user_id)
+            .await
+            .expect("domestic_stock list failed")
+            .len(),
+        3
+    );
+    assert_eq!(
+        domestic_stock_svc::delete_all(&pool, user_id)
+            .await
+            .expect("domestic_stock delete_all failed"),
+        3
+    );
+    assert!(domestic_stock_svc::list(&pool, user_id)
+        .await
+        .expect("domestic_stock list after delete failed")
+        .is_empty());
+
+    assert!(asset_balance_svc::list(&pool, user_id)
+        .await
+        .expect("initial asset_balance list failed")
+        .is_empty());
+    let asset_balance_empty = asset_balance_svc::bulk_create(&pool, user_id, &[])
+        .await
+        .expect("empty asset_balance bulk_create failed");
+    assert_eq!(asset_balance_empty.inserted, 0);
+    assert_eq!(asset_balance_empty.skipped, 0);
+
+    let asset_balance_items = vec![make_asset_item("1301"), make_asset_item("1605")];
+    let asset_balance_created =
+        asset_balance_svc::bulk_create(&pool, user_id, &asset_balance_items)
+            .await
+            .expect("asset_balance bulk_create failed");
+    assert_eq!(asset_balance_created.inserted, 2);
+    assert_eq!(asset_balance_created.skipped, 0);
+    assert_eq!(
+        asset_balance_svc::list(&pool, user_id)
+            .await
+            .expect("asset_balance list after bulk_create failed")
+            .len(),
+        2
+    );
+
+    let asset_balance_uploaded =
+        asset_balance_svc::upload_csv(&pool, user_id, make_asset_balance_csv().as_bytes())
+            .await
+            .expect("asset_balance upload_csv failed");
+    assert_eq!(asset_balance_uploaded.inserted, 1);
+    assert_eq!(asset_balance_uploaded.skipped, 0);
+    assert!(asset_balance_uploaded.errors.is_empty());
+
+    let asset_balance_rows = asset_balance_svc::list(&pool, user_id)
+        .await
+        .expect("asset_balance list failed");
+    assert_eq!(asset_balance_rows.len(), 1);
+    assert_eq!(asset_balance_rows[0].security_code, "7203");
+
+    assert_eq!(
+        asset_balance_svc::delete_all(&pool, user_id)
+            .await
+            .expect("asset_balance delete_all failed"),
+        1
+    );
+    assert!(asset_balance_svc::list(&pool, user_id)
+        .await
+        .expect("asset_balance list after delete failed")
+        .is_empty());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## 概要
- 非ignoreの service_coverage_all_domains 統合テストを追加し、主要4ドメインの list / bulk_create / upload_csv / delete_all を1コンテナで検証
- mutualfund/dividend/domestic_stock/csv_import/csv_util に CSV パース周辺の unit test を追加
- tarpaulin の実測カバレッジを 87.62% まで引き上げ

## テスト
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test
- cd backend && cargo tarpaulin --out Stdout --timeout 120 2>&1 | grep -E "^[0-9]+\.[0-9]+% coverage"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * エラーハンドリング、CSV解析、CSVプレビュー処理に関するテストを追加しました。
  * 複数のドメイン（投信、配当、国内株式、資産残高）の統合テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->