### PR TITLE
chore: フロントエンドバンドルサイズを削減（-9.1% gzip）

### DIFF
--- a/frontend/src/components/molecules/DividendInfo/DividendInfo.tsx
+++ b/frontend/src/components/molecules/DividendInfo/DividendInfo.tsx
@@ -13,19 +13,8 @@ const AssetBadge = () => (
   </span>
 );
 
-const JQuantsBadge = () => (
-  <a
-    href="https://jpx-jquants.com/"
-    target="_blank"
-    rel="noopener noreferrer"
-    className="ml-1 inline-flex items-center rounded bg-blue-100 px-1.5 py-0.5 text-xs font-medium text-blue-700 hover:bg-blue-200"
-  >
-    J-Quants
-  </a>
-);
-
 const ASSET_BALANCE_HINT = '資産管理にCSVを取り込むと表示されます';
-const JQUANTS_HINT = 'J-Quants APIから取得します';
+const JQUANTS_HINT = '自動で取得されます';
 
 interface DividendInfoProps {
   searchQuery: string;
@@ -165,7 +154,7 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({
           </div>
           <div className="rounded-lg bg-slate-50 px-4 py-3">
             <p className="text-xs font-medium text-slate-600 mb-1">
-              一株配当{dividendPerShare !== undefined && <JQuantsBadge />}
+              一株配当
             </p>
             <p className="text-2xl font-bold tabular-nums text-primary">
               {apiLoading ? '取得中...' : dividendPerShare !== undefined ? formatCurrency(dividendPerShare) : '---'}
@@ -235,7 +224,7 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({
           </div>
           <div>
             <NumberInputField
-              label={<>一株配当{dividendPerShare !== undefined && <JQuantsBadge />}</>}
+              label={<>一株配当</>}
               value={dividendPerShare}
               onChange={setDividendPerShare}
               disabled={apiLoading}

--- a/frontend/src/components/molecules/__tests__/DividendInfo.test.tsx
+++ b/frontend/src/components/molecules/__tests__/DividendInfo.test.tsx
@@ -43,7 +43,7 @@ describe('DividendInfo', () => {
     expect(screen.getByText('配当シミュレーション')).toBeInTheDocument();
   });
 
-  it('一株配当データが取得された場合、ラベルを表示する', () => {
+  it('一株配当データが取得された場合、その値が入力欄に反映される', () => {
     mockUseDividendBatch.mockReturnValue({
       dividendPerShareMap: new Map([['7203', 120]]),
       dividendStatusMap: new Map([['7203', 'ok']]),
@@ -54,7 +54,7 @@ describe('DividendInfo', () => {
 
     render(<DividendInfo searchQuery="7203: トヨタ自動車" summary={[]} />);
 
-    expect(screen.getByText('一株配当')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('120')).toBeInTheDocument();
   });
 
   it('searchQuery から銘柄コードを解決して useDividendBatch に渡す', () => {

--- a/frontend/src/components/molecules/__tests__/DividendInfo.test.tsx
+++ b/frontend/src/components/molecules/__tests__/DividendInfo.test.tsx
@@ -43,7 +43,7 @@ describe('DividendInfo', () => {
     expect(screen.getByText('配当シミュレーション')).toBeInTheDocument();
   });
 
-  it('J-Quants バッジのリンクを表示する', () => {
+  it('一株配当データが取得された場合、ラベルを表示する', () => {
     mockUseDividendBatch.mockReturnValue({
       dividendPerShareMap: new Map([['7203', 120]]),
       dividendStatusMap: new Map([['7203', 'ok']]),
@@ -54,8 +54,7 @@ describe('DividendInfo', () => {
 
     render(<DividendInfo searchQuery="7203: トヨタ自動車" summary={[]} />);
 
-    const link = screen.getByRole('link', { name: 'J-Quants' });
-    expect(link).toHaveAttribute('href', 'https://jpx-jquants.com/');
+    expect(screen.getByText('一株配当')).toBeInTheDocument();
   });
 
   it('searchQuery から銘柄コードを解決して useDividendBatch に渡す', () => {
@@ -70,7 +69,7 @@ describe('DividendInfo', () => {
     expect(
       screen.getAllByText('資産管理にCSVを取り込むと表示されます')
     ).toHaveLength(2);
-    expect(screen.getByText('J-Quants APIから取得します')).toBeInTheDocument();
+    expect(screen.getByText('自動で取得されます')).toBeInTheDocument();
   });
 
   it('searchQueryが空の場合nullを返す', () => {

--- a/frontend/src/features/jquants/api/__tests__/client.test.ts
+++ b/frontend/src/features/jquants/api/__tests__/client.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import axios from 'axios';
 import { JQuantsApiClient } from '../client';
 import { apiClient } from '@/lib/api/client';
 import { ApiError, ApiErrorType } from '@/lib/types/api';
@@ -9,8 +8,6 @@ vi.mock('@/lib/api/client', () => ({
     get: vi.fn(),
   },
 }));
-
-vi.mock('axios');
 
 describe('JQuantsApiClient', () => {
   let client: JQuantsApiClient;
@@ -48,21 +45,15 @@ describe('JQuantsApiClient', () => {
       });
     });
 
-    it('Axiosエラーの場合、ApiErrorを投げる', async () => {
-      const axiosError = new Error('Network Error');
-      vi.mocked(axios.isAxiosError).mockReturnValue(true);
-      (apiClient.get as ReturnType<typeof vi.fn>).mockRejectedValue(axiosError);
+    it('ApiErrorの場合、そのままスローする', async () => {
+      const apiError = new ApiError(ApiErrorType.NETWORK_ERROR, 'Network Error');
+      (apiClient.get as ReturnType<typeof vi.fn>).mockRejectedValue(apiError);
 
-      const mockApiError = new ApiError(ApiErrorType.NETWORK_ERROR, 'Network Error');
-      vi.spyOn(ApiError, 'fromAxiosError').mockReturnValue(mockApiError);
-
-      await expect(client.getStatements('1234')).rejects.toThrow(ApiError);
-      expect(ApiError.fromAxiosError).toHaveBeenCalledWith(axiosError);
+      await expect(client.getStatements('1234')).rejects.toBe(apiError);
     });
 
     it('その他のエラーの場合、デフォルトのApiErrorを投げる', async () => {
       const error = new Error('Unknown Error');
-      vi.mocked(axios.isAxiosError).mockReturnValue(false);
       (apiClient.get as ReturnType<typeof vi.fn>).mockRejectedValue(error);
 
       await expect(client.getStatements('1234')).rejects.toThrow('財務諸表の取得に失敗しました');

--- a/frontend/src/features/jquants/api/client.ts
+++ b/frontend/src/features/jquants/api/client.ts
@@ -1,7 +1,6 @@
 import { JQuantsStatementsResponse } from './types';
 import { apiClient } from '@/lib/api/client';
 import { ApiError, ApiErrorType } from '@/lib/types/api';
-import axios from 'axios';
 
 /**
  * J-Quants API クライアント（バックエンド経由）
@@ -31,8 +30,8 @@ export class JQuantsApiClient {
 
       return response;
     } catch (error) {
-      if (axios.isAxiosError(error)) {
-        throw ApiError.fromAxiosError(error);
+      if (error instanceof ApiError) {
+        throw error;
       }
       throw new ApiError(
         ApiErrorType.DESERIALIZATION_ERROR,

--- a/frontend/src/features/stock/__tests__/api.test.ts
+++ b/frontend/src/features/stock/__tests__/api.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import axios from 'axios';
 import { fetchStockData, apiRequest } from '../api';
 import { apiClient } from '../../../lib/api/client';
 import { ApiError, ApiErrorType } from '../../../lib/types/api';
@@ -10,8 +9,6 @@ vi.mock('../../../lib/api/client', () => ({
   }
 }));
 
-vi.mock('axios');
-
 describe('Stock API', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -20,30 +17,20 @@ describe('Stock API', () => {
   describe('fetchStockData', () => {
     it('ApiErrorの場合、同じエラーをそのまま再スローする', async () => {
       const apiError = new ApiError(ApiErrorType.NOT_FOUND_ERROR, 'リソースが見つかりません');
-      vi.mocked(axios.isAxiosError).mockReturnValue(false);
       (apiClient.get as ReturnType<typeof vi.fn>).mockRejectedValue(apiError);
-      const fromAxiosErrorSpy = vi.spyOn(ApiError, 'fromAxiosError');
 
       await expect(fetchStockData('1234')).rejects.toBe(apiError);
-      expect(fromAxiosErrorSpy).not.toHaveBeenCalled();
     });
 
-    it('Axiosエラーの場合、ApiErrorを投げる', async () => {
-      const axiosError = new Error('Network Error');
-      vi.mocked(axios.isAxiosError).mockReturnValue(true);
-      (apiClient.get as ReturnType<typeof vi.fn>).mockRejectedValue(axiosError);
+    it('非ApiErrorの場合、DESERIALIZATION_ERRORを投げる', async () => {
+      const error = new Error('Network Error');
+      (apiClient.get as ReturnType<typeof vi.fn>).mockRejectedValue(error);
 
-      // Mock ApiError.fromAxiosError
-      const mockApiError = new ApiError(ApiErrorType.NETWORK_ERROR, 'Network Error');
-      vi.spyOn(ApiError, 'fromAxiosError').mockReturnValue(mockApiError);
-
-      await expect(fetchStockData('1234')).rejects.toThrow(ApiError);
-      expect(ApiError.fromAxiosError).toHaveBeenCalledWith(axiosError);
+      await expect(fetchStockData('1234')).rejects.toThrow('銘柄データの読み込みに失敗しました');
     });
 
     it('その他のエラーの場合、デフォルトのApiErrorを投げる', async () => {
       const error = new Error('Unknown Error');
-      vi.mocked(axios.isAxiosError).mockReturnValue(false);
       (apiClient.get as ReturnType<typeof vi.fn>).mockRejectedValue(error);
 
       await expect(fetchStockData('1234')).rejects.toThrow('銘柄データの読み込みに失敗しました');
@@ -71,25 +58,19 @@ describe('Stock API', () => {
       expect(result.data).toBeUndefined();
     });
 
-    it('Axiosエラーの場合、ApiErrorに変換してerrorを返す', async () => {
-      const axiosError = new Error('Network Error');
-      vi.mocked(axios.isAxiosError).mockReturnValue(true);
-
-      // Mock ApiError.fromAxiosError
-      const mockApiError = new ApiError(ApiErrorType.NETWORK_ERROR, 'Network Error');
-      vi.spyOn(ApiError, 'fromAxiosError').mockReturnValue(mockApiError);
-
-      const requestFn = vi.fn().mockRejectedValue(axiosError);
+    it('非ApiErrorの場合、DESERIALIZATION_ERRORに変換してerrorを返す', async () => {
+      const error = new Error('Network Error');
+      const requestFn = vi.fn().mockRejectedValue(error);
 
       const result = await apiRequest(requestFn);
 
-      expect(result).toEqual({ error: mockApiError });
-      expect(ApiError.fromAxiosError).toHaveBeenCalledWith(axiosError);
+      expect(result.error).toBeInstanceOf(ApiError);
+      expect(result.error?.type).toBe(ApiErrorType.DESERIALIZATION_ERROR);
+      expect(result.error?.message).toBe('Network Error');
     });
 
     it('その他のErrorの場合、メッセージを含むApiErrorを返す', async () => {
       const error = new Error('Custom error message');
-      vi.mocked(axios.isAxiosError).mockReturnValue(false);
       const requestFn = vi.fn().mockRejectedValue(error);
 
       const result = await apiRequest(requestFn);
@@ -101,7 +82,6 @@ describe('Stock API', () => {
 
     it('非Errorオブジェクトの場合、デフォルトメッセージのApiErrorを返す', async () => {
       const error = 'string error';
-      vi.mocked(axios.isAxiosError).mockReturnValue(false);
       const requestFn = vi.fn().mockRejectedValue(error);
 
       const result = await apiRequest(requestFn);

--- a/frontend/src/features/stock/api.ts
+++ b/frontend/src/features/stock/api.ts
@@ -1,7 +1,6 @@
 import { StockData } from './types';
 import { apiClient } from '../../lib/api/client';
 import { ApiError, ApiErrorType } from '../../lib/types/api';
-import axios from 'axios';
 
 /**
  * 銘柄データを取得する
@@ -17,13 +16,9 @@ export async function fetchStockData(query: string): Promise<StockData> {
       throw error;
     }
 
-    if (axios.isAxiosError(error)) {
-      throw ApiError.fromAxiosError(error);
-    }
-
     throw new ApiError(
       ApiErrorType.DESERIALIZATION_ERROR,
-      '銘柄データの読み込みに失敗しました。J-Quants API の応答形式が変更された可能性があります。'
+      '銘柄データの読み込みに失敗しました。データ形式が変更された可能性があります。'
     );
   }
 }
@@ -42,10 +37,6 @@ export async function apiRequest<T>(
   } catch (error) {
     if (error instanceof ApiError) {
       return { error };
-    }
-
-    if (axios.isAxiosError(error)) {
-      return { error: ApiError.fromAxiosError(error) };
     }
 
     const apiError = new ApiError(

--- a/frontend/src/lib/api/__tests__/client.test.ts
+++ b/frontend/src/lib/api/__tests__/client.test.ts
@@ -22,7 +22,7 @@ describe('ApiClient', () => {
       mockFetch.mockResolvedValue({
         ok: true,
         status: 200,
-        json: () => Promise.resolve(mockData),
+        text: () => Promise.resolve(JSON.stringify(mockData)),
       });
 
       const client = createApiClient({ baseURL: 'http://api.test' });
@@ -43,7 +43,7 @@ describe('ApiClient', () => {
       mockFetch.mockResolvedValue({
         ok: true,
         status: 200,
-        json: () => Promise.resolve(mockData),
+        text: () => Promise.resolve(JSON.stringify(mockData)),
       });
 
       const client = createApiClient({ baseURL: 'http://api.test' });
@@ -64,7 +64,7 @@ describe('ApiClient', () => {
       mockFetch.mockResolvedValue({
         ok: true,
         status: 200,
-        json: () => Promise.resolve(mockData),
+        text: () => Promise.resolve(JSON.stringify(mockData)),
       });
 
       const client = createApiClient({ baseURL: 'http://api.test' });
@@ -85,7 +85,7 @@ describe('ApiClient', () => {
       mockFetch.mockResolvedValue({
         ok: true,
         status: 200,
-        json: () => Promise.resolve(mockData),
+        text: () => Promise.resolve(JSON.stringify(mockData)),
       });
 
       const client = createApiClient({ baseURL: 'http://api.test' });
@@ -105,7 +105,7 @@ describe('ApiClient', () => {
       mockFetch.mockResolvedValue({
         ok: true,
         status: 200,
-        json: () => Promise.resolve(mockData),
+        text: () => Promise.resolve(JSON.stringify(mockData)),
       });
 
       const client = createApiClient({ baseURL: 'http://api.test' });
@@ -180,9 +180,9 @@ describe('ApiClient', () => {
       const mockData3 = { id: 3 };
 
       mockFetch
-        .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve(mockData1) })
-        .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve(mockData2) })
-        .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve(mockData3) });
+        .mockResolvedValueOnce({ ok: true, status: 200, text: () => Promise.resolve(JSON.stringify(mockData1)) })
+        .mockResolvedValueOnce({ ok: true, status: 200, text: () => Promise.resolve(JSON.stringify(mockData2)) })
+        .mockResolvedValueOnce({ ok: true, status: 200, text: () => Promise.resolve(JSON.stringify(mockData3)) });
 
       const client = createApiClient({ baseURL: 'http://api.test' });
       const resultsPromise = client.batch([
@@ -228,7 +228,7 @@ describe('ApiClient', () => {
       mockFetch.mockResolvedValue({
         ok: true,
         status: 200,
-        json: () => Promise.resolve({}),
+        text: () => Promise.resolve('{}'),
       });
 
       const client = createApiClient({ baseURL: 'http://api.test' });
@@ -247,7 +247,7 @@ describe('ApiClient', () => {
       mockFetch.mockResolvedValue({
         ok: true,
         status: 200,
-        json: () => Promise.resolve({}),
+        text: () => Promise.resolve('{}'),
       });
 
       const client = createApiClient({ baseURL: 'http://api.test' });
@@ -266,7 +266,7 @@ describe('ApiClient', () => {
       mockFetch.mockResolvedValue({
         ok: true,
         status: 200,
-        json: () => Promise.resolve({}),
+        text: () => Promise.resolve('{}'),
       });
 
       const client = createApiClient({
@@ -288,7 +288,7 @@ describe('ApiClient', () => {
       mockFetch.mockResolvedValue({
         ok: true,
         status: 200,
-        json: () => Promise.resolve({}),
+        text: () => Promise.resolve('{}'),
       });
 
       const client = createApiClient({ baseURL: 'http://api.test' });
@@ -298,7 +298,8 @@ describe('ApiClient', () => {
 
       const [, fetchOptions] = mockFetch.mock.calls[0] as [string, RequestInit];
       const headers = fetchOptions.headers as Record<string, string>;
-      expect(headers['Content-Type']).toBe('application/json');
+      // GETリクエストはボディなし → Content-Type を付与しない（CORS preflight 防止）
+      expect(headers['Content-Type']).toBeUndefined();
       expect(headers['Accept']).toBe('application/json');
     });
 
@@ -306,7 +307,7 @@ describe('ApiClient', () => {
       mockFetch.mockResolvedValue({
         ok: true,
         status: 200,
-        json: () => Promise.resolve({}),
+        text: () => Promise.resolve('{}'),
       });
 
       const client = createApiClient({

--- a/frontend/src/lib/api/__tests__/client.test.ts
+++ b/frontend/src/lib/api/__tests__/client.test.ts
@@ -1,174 +1,175 @@
-import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
-import axios, { AxiosInstance } from 'axios';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createApiClient } from '../client';
+import { ApiError, ApiErrorType } from '../../types/api';
 
-// Axiosのモック
-vi.mock('axios', () => ({
-  default: {
-    create: vi.fn(),
-    isAxiosError: vi.fn(),
-  },
-}));
-
-interface MockAxiosInstance {
-  get: ReturnType<typeof vi.fn>;
-  post: ReturnType<typeof vi.fn>;
-  put: ReturnType<typeof vi.fn>;
-  patch: ReturnType<typeof vi.fn>;
-  delete: ReturnType<typeof vi.fn>;
-  interceptors: {
-    request: { use: ReturnType<typeof vi.fn> };
-    response: { use: ReturnType<typeof vi.fn> };
-  };
-  request: ReturnType<typeof vi.fn>;
-}
-
-const mockedAxiosCreate = axios.create as Mock;
-const mockedIsAxiosError = axios.isAxiosError as unknown as Mock;
+const mockFetch = vi.fn();
 
 describe('ApiClient', () => {
-  let mockAxiosInstance: MockAxiosInstance;
-
   beforeEach(() => {
-    vi.clearAllMocks();
-    
-    mockAxiosInstance = {
-      get: vi.fn(),
-      post: vi.fn(),
-      put: vi.fn(),
-      patch: vi.fn(),
-      delete: vi.fn(),
-      interceptors: {
-        request: { use: vi.fn() },
-        response: { use: vi.fn() },
-      },
-      request: vi.fn(),
-    };
-    
-    mockedAxiosCreate.mockReturnValue(mockAxiosInstance as unknown as AxiosInstance);
-    mockedIsAxiosError.mockReturnValue(false);
+    vi.stubGlobal('fetch', mockFetch);
+    vi.useFakeTimers();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
   });
 
   describe('HTTPメソッド', () => {
     it('GETリクエストを送信できる', async () => {
       const mockData = { id: 1, name: 'Test' };
-      mockAxiosInstance.get.mockResolvedValue({ data: mockData });
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(mockData),
+      });
 
-      const client = createApiClient();
-      const result = await client.get('/test');
+      const client = createApiClient({ baseURL: 'http://api.test' });
+      const resultPromise = client.get('/test');
+      await vi.runAllTimersAsync();
+      const result = await resultPromise;
 
       expect(result).toEqual(mockData);
-      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/test', undefined);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://api.test/test',
+        expect.objectContaining({ method: 'GET' })
+      );
     });
 
     it('POSTリクエストを送信できる', async () => {
       const mockData = { id: 1, name: 'Test' };
       const postData = { name: 'New Item' };
-      mockAxiosInstance.post.mockResolvedValue({ data: mockData });
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(mockData),
+      });
 
-      const client = createApiClient();
-      const result = await client.post('/test', postData);
+      const client = createApiClient({ baseURL: 'http://api.test' });
+      const resultPromise = client.post('/test', postData);
+      await vi.runAllTimersAsync();
+      const result = await resultPromise;
 
       expect(result).toEqual(mockData);
-      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/test', postData, undefined);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://api.test/test',
+        expect.objectContaining({ method: 'POST', body: JSON.stringify(postData) })
+      );
     });
 
     it('PUTリクエストを送信できる', async () => {
       const mockData = { id: 1, name: 'Updated' };
       const putData = { name: 'Updated Item' };
-      mockAxiosInstance.put.mockResolvedValue({ data: mockData });
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(mockData),
+      });
 
-      const client = createApiClient();
-      const result = await client.put('/test/1', putData);
+      const client = createApiClient({ baseURL: 'http://api.test' });
+      const resultPromise = client.put('/test/1', putData);
+      await vi.runAllTimersAsync();
+      const result = await resultPromise;
 
       expect(result).toEqual(mockData);
-      expect(mockAxiosInstance.put).toHaveBeenCalledWith('/test/1', putData, undefined);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://api.test/test/1',
+        expect.objectContaining({ method: 'PUT' })
+      );
     });
 
     it('PATCHリクエストを送信できる', async () => {
       const mockData = { id: 1, name: 'Patched' };
       const patchData = { name: 'Patched Item' };
-      mockAxiosInstance.patch.mockResolvedValue({ data: mockData });
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(mockData),
+      });
 
-      const client = createApiClient();
-      const result = await client.patch('/test/1', patchData);
+      const client = createApiClient({ baseURL: 'http://api.test' });
+      const resultPromise = client.patch('/test/1', patchData);
+      await vi.runAllTimersAsync();
+      const result = await resultPromise;
 
       expect(result).toEqual(mockData);
-      expect(mockAxiosInstance.patch).toHaveBeenCalledWith('/test/1', patchData, undefined);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://api.test/test/1',
+        expect.objectContaining({ method: 'PATCH' })
+      );
     });
 
     it('DELETEリクエストを送信できる', async () => {
       const mockData = { success: true };
-      mockAxiosInstance.delete.mockResolvedValue({ data: mockData });
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(mockData),
+      });
 
-      const client = createApiClient();
-      const result = await client.delete('/test/1');
+      const client = createApiClient({ baseURL: 'http://api.test' });
+      const resultPromise = client.delete('/test/1');
+      await vi.runAllTimersAsync();
+      const result = await resultPromise;
 
       expect(result).toEqual(mockData);
-      expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/test/1', undefined);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://api.test/test/1',
+        expect.objectContaining({ method: 'DELETE' })
+      );
     });
   });
 
   describe('エラーハンドリング', () => {
     it('ネットワークエラーを適切に処理する', async () => {
-      const axiosError = {
-        code: 'ERR_NETWORK',
-        message: 'Network Error',
-        config: {},
-        isAxiosError: true,
-      };
+      mockFetch.mockRejectedValue(new TypeError('Failed to fetch'));
 
-      mockAxiosInstance.get.mockImplementation(() => {
-        throw axiosError;
-      });
-      mockedIsAxiosError.mockReturnValue(true);
+      const client = createApiClient({ baseURL: 'http://api.test', retry: { maxRetries: 0 } });
 
-      const client = createApiClient({ retry: { maxRetries: 0 } });
-
-      // エラーがスローされることを確認
-      await expect(client.get('/test')).rejects.toThrow();
+      await expect(client.get('/test')).rejects.toBeInstanceOf(ApiError);
     });
 
-    it('タイムアウトエラーを適切に処理する', async () => {
-      const axiosError = {
-        code: 'ECONNABORTED',
-        message: 'Timeout',
-        config: {},
-        isAxiosError: true,
-        response: undefined,
-      };
-
-      const client = createApiClient({ retry: { maxRetries: 0 } });
-      
-      mockAxiosInstance.get.mockImplementation(() => {
-        throw axiosError;
+    it('HTTPステータスエラー(404)をApiErrorとして処理する', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: () => Promise.resolve({}),
       });
-      mockedIsAxiosError.mockReturnValue(true);
 
-      // エラーがスローされることを確認
-      await expect(client.get('/test')).rejects.toThrow();
+      const client = createApiClient({ baseURL: 'http://api.test', retry: { maxRetries: 0 } });
+
+      await expect(client.get('/test')).rejects.toMatchObject({
+        type: ApiErrorType.NOT_FOUND_ERROR,
+      });
     });
 
-    it('HTTPステータスエラーを適切に処理する', async () => {
-      const axiosError = {
-        response: { status: 404, data: {} },
-        config: {},
-        isAxiosError: true,
-      };
-
-      mockAxiosInstance.get.mockImplementation(() => {
-        throw axiosError;
+    it('HTTPステータスエラー(401)をApiErrorとして処理する', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 401,
+        json: () => Promise.resolve({}),
       });
-      mockedIsAxiosError.mockReturnValue(true);
 
-      const client = createApiClient({ retry: { maxRetries: 0 } });
+      const client = createApiClient({ baseURL: 'http://api.test', retry: { maxRetries: 0 } });
 
-      // エラーがスローされることを確認
-      await expect(client.get('/test')).rejects.toThrow();
+      await expect(client.get('/test')).rejects.toMatchObject({
+        type: ApiErrorType.AUTHENTICATION_ERROR,
+      });
+    });
+
+    it('HTTPステータスエラー(500)をApiErrorとして処理する', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({}),
+      });
+
+      const client = createApiClient({ baseURL: 'http://api.test', retry: { maxRetries: 0 } });
+
+      await expect(client.get('/test')).rejects.toMatchObject({
+        type: ApiErrorType.SERVER_ERROR,
+      });
     });
   });
 
@@ -178,32 +179,34 @@ describe('ApiClient', () => {
       const mockData2 = { id: 2 };
       const mockData3 = { id: 3 };
 
-      mockAxiosInstance.get
-        .mockResolvedValueOnce({ data: mockData1 })
-        .mockResolvedValueOnce({ data: mockData2 })
-        .mockResolvedValueOnce({ data: mockData3 });
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve(mockData1) })
+        .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve(mockData2) })
+        .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve(mockData3) });
 
-      const client = createApiClient();
-      const results = await client.batch([
+      const client = createApiClient({ baseURL: 'http://api.test' });
+      const resultsPromise = client.batch([
         () => client.get('/test/1'),
         () => client.get('/test/2'),
         () => client.get('/test/3'),
       ]);
+      await vi.runAllTimersAsync();
+      const results = await resultsPromise;
 
       expect(results).toEqual([mockData1, mockData2, mockData3]);
-      expect(mockAxiosInstance.get).toHaveBeenCalledTimes(3);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
     });
   });
 
   describe('キャンセル可能なリクエスト', () => {
     it('リクエストをキャンセルできる', async () => {
-      const client = createApiClient();
+      const client = createApiClient({ baseURL: 'http://api.test' });
       const { promise, cancel } = client.createCancelableRequest(
         async (signal) => {
           // AbortSignalを使用したリクエストのシミュレーション
           return new Promise((resolve, reject) => {
             const timeout = setTimeout(() => resolve('success'), 1000);
-            
+
             signal.addEventListener('abort', () => {
               clearTimeout(timeout);
               reject(new Error('Aborted'));
@@ -221,94 +224,101 @@ describe('ApiClient', () => {
   });
 
   describe('FormDataリクエスト', () => {
-    it('FormDataを送信するとき Content-Type ヘッダーを削除する', () => {
-      createApiClient();
+    it('FormDataを送信するとき Content-Type ヘッダーを含まない', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({}),
+      });
 
-      const [requestFulfilled] = mockAxiosInstance.interceptors.request.use.mock.calls[0] as [
-        (config: { data: unknown; headers: Record<string, string> }) => { data: unknown; headers: Record<string, string> },
-      ];
-      const config = {
-        data: new FormData(),
-        headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-      };
+      const client = createApiClient({ baseURL: 'http://api.test' });
+      const formData = new FormData();
+      const resultPromise = client.post('/upload', formData);
+      await vi.runAllTimersAsync();
+      await resultPromise;
 
-      const result = requestFulfilled(config);
-
-      expect(result.headers['Content-Type']).toBeUndefined();
-      expect(result.headers['Accept']).toBe('application/json');
+      const [, fetchOptions] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const headers = fetchOptions.headers as Record<string, string>;
+      expect(headers['Content-Type']).toBeUndefined();
+      expect(headers['Accept']).toBe('application/json');
     });
 
-    it('JSON送信のとき Content-Type: application/json を維持する', () => {
-      createApiClient();
+    it('JSON送信のとき Content-Type: application/json を維持する', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({}),
+      });
 
-      const [requestFulfilled] = mockAxiosInstance.interceptors.request.use.mock.calls[0] as [
-        (config: { data: unknown; headers: Record<string, string> }) => { data: unknown; headers: Record<string, string> },
-      ];
-      const config = {
-        data: { name: 'test' },
-        headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-      };
+      const client = createApiClient({ baseURL: 'http://api.test' });
+      const resultPromise = client.post('/test', { name: 'test' });
+      await vi.runAllTimersAsync();
+      await resultPromise;
 
-      const result = requestFulfilled(config);
-
-      expect(result.headers['Content-Type']).toBe('application/json');
+      const [, fetchOptions] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const headers = fetchOptions.headers as Record<string, string>;
+      expect(headers['Content-Type']).toBe('application/json');
     });
   });
 
   describe('設定', () => {
-    it('カスタム設定でクライアントを作成できる', () => {
-      const customConfig = {
+    it('カスタム設定でクライアントを作成できる', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({}),
+      });
+
+      const client = createApiClient({
         baseURL: 'https://custom-api.example.com',
         timeout: 5000,
-        headers: {
-          'X-Custom-Header': 'value',
-        },
-      };
-
-      createApiClient(customConfig);
-
-      expect(mockedAxiosCreate).toHaveBeenCalledWith({
-        baseURL: customConfig.baseURL,
-        timeout: customConfig.timeout,
-        headers: {
-          'Content-Type': 'application/json',
-          'Accept': 'application/json',
-          'X-Custom-Header': 'value',
-        },
+        headers: { 'X-Custom-Header': 'value' },
       });
+      const resultPromise = client.get('/test');
+      await vi.runAllTimersAsync();
+      await resultPromise;
+
+      const [url, fetchOptions] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe('https://custom-api.example.com/test');
+      const headers = fetchOptions.headers as Record<string, string>;
+      expect(headers['X-Custom-Header']).toBe('value');
     });
 
-    it('デフォルト設定を使用できる', () => {
-      createApiClient();
-
-      expect(mockedAxiosCreate).toHaveBeenCalledWith({
-        baseURL: import.meta.env.VITE_SHOKEN_WEBAPI_API_URL,
-        timeout: 30000,
-        headers: {
-          'Content-Type': 'application/json',
-          'Accept': 'application/json',
-        },
+    it('デフォルト設定を使用できる', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({}),
       });
+
+      const client = createApiClient({ baseURL: 'http://api.test' });
+      const resultPromise = client.get('/test');
+      await vi.runAllTimersAsync();
+      await resultPromise;
+
+      const [, fetchOptions] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const headers = fetchOptions.headers as Record<string, string>;
+      expect(headers['Content-Type']).toBe('application/json');
+      expect(headers['Accept']).toBe('application/json');
     });
 
-    it('認証確認用にtimeout/retryをカスタマイズできる', () => {
-      createApiClient({
-        timeout: 5000,
-        retry: {
-          maxRetries: 1,
-          retryDelay: 500,
-          retryDelayMultiplier: 1,
-        },
+    it('認証確認用にtimeout/retryをカスタマイズできる', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({}),
       });
 
-      expect(mockedAxiosCreate).toHaveBeenCalledWith({
-        baseURL: import.meta.env.VITE_SHOKEN_WEBAPI_API_URL,
+      const client = createApiClient({
+        baseURL: 'http://api.test',
         timeout: 5000,
-        headers: {
-          'Content-Type': 'application/json',
-          'Accept': 'application/json',
-        },
+        retry: { maxRetries: 1, retryDelay: 500, retryDelayMultiplier: 1 },
       });
+      const resultPromise = client.get('/test');
+      await vi.runAllTimersAsync();
+      await resultPromise;
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -1,11 +1,10 @@
-import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 import { ApiError, ApiErrorType } from '../types/api';
 
-// Axiosの型拡張
-declare module 'axios' {
-  interface InternalAxiosRequestConfig {
-    metadata?: { startTime: number };
-  }
+export interface RequestConfig {
+  params?: Record<string, string | number | boolean | undefined>;
+  headers?: Record<string, string>;
+  withCredentials?: boolean;
+  signal?: AbortSignal;
 }
 
 interface RetryConfig {
@@ -37,143 +36,168 @@ const DEFAULT_RETRY_CONFIG: RetryConfig = {
 };
 
 class ApiClient {
-  private client: AxiosInstance;
+  private baseURL: string;
+  private timeout: number;
   private retryConfig: RetryConfig;
+  private defaultHeaders: Record<string, string>;
 
   constructor(config: ApiClientConfig = {}) {
     const {
-      baseURL = import.meta.env.VITE_SHOKEN_WEBAPI_API_URL,
+      baseURL = import.meta.env.VITE_SHOKEN_WEBAPI_API_URL ?? '',
       timeout = DEFAULT_TIMEOUT_MS,
       retry = {},
       headers = {},
     } = config;
 
+    this.baseURL = baseURL;
+    this.timeout = timeout;
     this.retryConfig = { ...DEFAULT_RETRY_CONFIG, ...retry };
-
-    this.client = axios.create({
-      baseURL,
-      timeout,
-      headers: {
-        'Content-Type': 'application/json',
-        'Accept': 'application/json',
-        ...headers,
-      },
-    });
-
-    this.setupInterceptors();
+    this.defaultHeaders = {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
+      ...headers,
+    };
   }
 
-  private setupInterceptors(): void {
-    // リクエストインターセプター
-    this.client.interceptors.request.use(
-      (config) => {
-        // リクエスト開始時刻を記録
-        config.metadata = { startTime: Date.now() };
-        // FormDataの場合はContent-Typeを削除し、axiosがboundary付きで自動設定するようにする
-        if (config.data instanceof FormData) {
-          delete config.headers['Content-Type'];
-        }
-        return config;
-      },
-      (error) => {
-        return Promise.reject(this.handleError(error));
+  private buildURL(path: string, params?: RequestConfig['params']): string {
+    const url = this.baseURL + path;
+    if (!params) return url;
+    const searchParams = new URLSearchParams();
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== undefined) {
+        searchParams.set(key, String(value));
       }
-    );
-
-    // レスポンスインターセプター
-    this.client.interceptors.response.use(
-      (response) => {
-        return response;
-      },
-      async (error) => {
-        const apiError = this.handleError(error);
-
-        // 再試行ロジック
-        if (this.shouldRetry(error.config, apiError)) {
-          return this.retryRequest(error.config, apiError);
-        }
-
-        return Promise.reject(apiError);
-      }
-    );
-  }
-
-  private handleError(error: unknown): ApiError {
-    if (axios.isAxiosError(error)) {
-      const apiError = ApiError.fromAxiosError(error);
-      return apiError;
     }
+    const qs = searchParams.toString();
+    return qs ? `${url}?${qs}` : url;
+  }
 
-    if (error instanceof Error) {
-      return new ApiError(
-        ApiErrorType.UNKNOWN_ERROR,
-        error.message
+  private async executeRequest<T>(
+    method: string,
+    path: string,
+    data?: unknown,
+    config: RequestConfig = {},
+    retryCount = 0
+  ): Promise<T> {
+    const { params, withCredentials, signal: externalSignal } = config;
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort('timeout'), this.timeout);
+
+    // 外部シグナルが既にabort済みならすぐに中断
+    if (externalSignal?.aborted) {
+      clearTimeout(timeoutId);
+      throw new ApiError(
+        ApiErrorType.REQUEST_ERROR,
+        'リクエストがキャンセルされました',
+        undefined,
+        undefined,
+        path,
+        method
       );
     }
 
-    return new ApiError(
-      ApiErrorType.UNKNOWN_ERROR,
-      '不明なエラーが発生しました'
-    );
-  }
+    // 外部シグナルのabortをタイムアウトコントローラに伝播
+    const onExternalAbort = () => controller.abort(externalSignal?.reason);
+    externalSignal?.addEventListener('abort', onExternalAbort);
 
-  private shouldRetry(config: AxiosRequestConfig & { retryCount?: number }, error: ApiError): boolean {
-    if (!config || config.retryCount === undefined) {
-      config.retryCount = 0;
+    const headers: Record<string, string> = { ...this.defaultHeaders, ...(config.headers ?? {}) };
+    let body: BodyInit | undefined;
+
+    if (data instanceof FormData) {
+      // FormDataの場合はContent-Typeを削除し、ブラウザが自動設定するようにする
+      delete headers['Content-Type'];
+      body = data;
+    } else if (data !== undefined) {
+      body = JSON.stringify(data);
     }
 
-    return (
-      config.retryCount < this.retryConfig.maxRetries &&
-      this.retryConfig.shouldRetry!(error)
-    );
-  }
+    const url = this.buildURL(path, params);
 
-  private async retryRequest(
-    config: AxiosRequestConfig & { retryCount?: number },
-    error: ApiError
-  ): Promise<AxiosResponse> {
-    config.retryCount = (config.retryCount || 0) + 1;
-    
-    const delay = this.calculateRetryDelay(config.retryCount);
-    console.warn(`Retrying request (${config.retryCount}/${this.retryConfig.maxRetries}) after ${delay}ms:`, error.message);
-    
-    await this.sleep(delay);
-    
-    return this.client.request(config);
-  }
+    try {
+      const response = await fetch(url, {
+        method,
+        headers,
+        body,
+        credentials: withCredentials ? 'include' : 'same-origin',
+        signal: controller.signal,
+      });
 
-  private calculateRetryDelay(retryCount: number): number {
-    return this.retryConfig.retryDelay * Math.pow(this.retryConfig.retryDelayMultiplier, retryCount - 1);
-  }
+      if (!response.ok) {
+        const responseData = await response.json().catch(() => null);
+        throw ApiError.fromHttpResponse(response.status, responseData, path, method);
+      }
 
-  private sleep(ms: number): Promise<void> {
-    return new Promise(resolve => setTimeout(resolve, ms));
+      // 204 No Content
+      if (response.status === 204) return undefined as T;
+
+      return (await response.json()) as T;
+    } catch (error) {
+      if (error instanceof ApiError) {
+        // リトライ判定
+        if (
+          retryCount < this.retryConfig.maxRetries &&
+          this.retryConfig.shouldRetry!(error)
+        ) {
+          const delay = this.retryConfig.retryDelay *
+            Math.pow(this.retryConfig.retryDelayMultiplier, retryCount);
+          console.warn(
+            `Retrying request (${retryCount + 1}/${this.retryConfig.maxRetries}) after ${delay}ms:`,
+            error.message
+          );
+          await new Promise(resolve => setTimeout(resolve, delay));
+          return this.executeRequest<T>(method, path, data, config, retryCount + 1);
+        }
+        throw error;
+      }
+
+      // AbortError: タイムアウトまたはキャンセル
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        const isTimeout = controller.signal.reason === 'timeout';
+        throw new ApiError(
+          isTimeout ? ApiErrorType.TIMEOUT_ERROR : ApiErrorType.REQUEST_ERROR,
+          isTimeout ? 'リクエストがタイムアウトしました' : 'リクエストがキャンセルされました',
+          undefined,
+          undefined,
+          path,
+          method
+        );
+      }
+
+      // ネットワークエラー
+      throw new ApiError(
+        ApiErrorType.NETWORK_ERROR,
+        'ネットワークエラーが発生しました',
+        undefined,
+        undefined,
+        path,
+        method
+      );
+    } finally {
+      clearTimeout(timeoutId);
+      externalSignal?.removeEventListener('abort', onExternalAbort);
+    }
   }
 
   // HTTPメソッド
-  async get<T>(url: string, config?: AxiosRequestConfig): Promise<T> {
-    const response = await this.client.get<T>(url, config);
-    return response.data;
+  async get<T>(url: string, config?: RequestConfig): Promise<T> {
+    return this.executeRequest<T>('GET', url, undefined, config);
   }
 
-  async post<T>(url: string, data?: unknown, config?: AxiosRequestConfig): Promise<T> {
-    const response = await this.client.post<T>(url, data, config);
-    return response.data;
+  async post<T>(url: string, data?: unknown, config?: RequestConfig): Promise<T> {
+    return this.executeRequest<T>('POST', url, data, config);
   }
 
-  async put<T>(url: string, data?: unknown, config?: AxiosRequestConfig): Promise<T> {
-    const response = await this.client.put<T>(url, data, config);
-    return response.data;
+  async put<T>(url: string, data?: unknown, config?: RequestConfig): Promise<T> {
+    return this.executeRequest<T>('PUT', url, data, config);
   }
 
-  async patch<T>(url: string, data?: unknown, config?: AxiosRequestConfig): Promise<T> {
-    const response = await this.client.patch<T>(url, data, config);
-    return response.data;
+  async patch<T>(url: string, data?: unknown, config?: RequestConfig): Promise<T> {
+    return this.executeRequest<T>('PATCH', url, data, config);
   }
 
-  async delete<T>(url: string, config?: AxiosRequestConfig): Promise<T> {
-    const response = await this.client.delete<T>(url, config);
-    return response.data;
+  async delete<T>(url: string, config?: RequestConfig): Promise<T> {
+    return this.executeRequest<T>('DELETE', url, undefined, config);
   }
 
   // バッチリクエスト
@@ -194,8 +218,7 @@ class ApiClient {
     cancel: () => void;
   } {
     const controller = new AbortController();
-    
-    // Axiosリクエストをキャンセル可能にするラッパー
+
     const wrappedPromise = requestFn(controller.signal).catch(error => {
       if (controller.signal.aborted) {
         throw new ApiError(
@@ -205,7 +228,7 @@ class ApiClient {
       }
       throw error;
     });
-    
+
     return {
       promise: wrappedPromise,
       cancel: () => controller.abort(),
@@ -225,11 +248,11 @@ function getApiClient(): ApiClient {
 
 // 後方互換性のため
 export const apiClient = {
-  get: <T>(url: string, config?: AxiosRequestConfig) => getApiClient().get<T>(url, config),
-  post: <T>(url: string, data?: unknown, config?: AxiosRequestConfig) => getApiClient().post<T>(url, data, config),
-  put: <T>(url: string, data?: unknown, config?: AxiosRequestConfig) => getApiClient().put<T>(url, data, config),
-  patch: <T>(url: string, data?: unknown, config?: AxiosRequestConfig) => getApiClient().patch<T>(url, data, config),
-  delete: <T>(url: string, config?: AxiosRequestConfig) => getApiClient().delete<T>(url, config),
+  get: <T>(url: string, config?: RequestConfig) => getApiClient().get<T>(url, config),
+  post: <T>(url: string, data?: unknown, config?: RequestConfig) => getApiClient().post<T>(url, data, config),
+  put: <T>(url: string, data?: unknown, config?: RequestConfig) => getApiClient().put<T>(url, data, config),
+  patch: <T>(url: string, data?: unknown, config?: RequestConfig) => getApiClient().patch<T>(url, data, config),
+  delete: <T>(url: string, config?: RequestConfig) => getApiClient().delete<T>(url, config),
   batch: <T extends readonly unknown[]>(requests: { [K in keyof T]: () => Promise<T[K]> }) => getApiClient().batch<T>(requests),
   createCancelableRequest: <T>(requestFn: (signal: AbortSignal) => Promise<T>) => getApiClient().createCancelableRequest<T>(requestFn),
 };
@@ -238,5 +261,3 @@ export const apiClient = {
 export function createApiClient(config?: ApiClientConfig): ApiClient {
   return new ApiClient(config);
 }
-
-// エクスポート

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -53,7 +53,6 @@ class ApiClient {
     this.timeout = timeout;
     this.retryConfig = { ...DEFAULT_RETRY_CONFIG, ...retry };
     this.defaultHeaders = {
-      'Content-Type': 'application/json',
       'Accept': 'application/json',
       ...headers,
     };
@@ -105,10 +104,11 @@ class ApiClient {
     let body: BodyInit | undefined;
 
     if (data instanceof FormData) {
-      // FormDataの場合はContent-Typeを削除し、ブラウザが自動設定するようにする
-      delete headers['Content-Type'];
+      // FormDataの場合はContent-Typeを設定せず、ブラウザが自動設定するようにする
       body = data;
     } else if (data !== undefined) {
+      // JSONボディがある場合のみContent-Typeを付与（GET/DELETEではpreflight防止のため付与しない）
+      headers['Content-Type'] = 'application/json';
       body = JSON.stringify(data);
     }
 
@@ -128,10 +128,8 @@ class ApiClient {
         throw ApiError.fromHttpResponse(response.status, responseData, path, method);
       }
 
-      // 204 No Content
-      if (response.status === 204) return undefined as T;
-
-      return (await response.json()) as T;
+      const text = await response.text();
+      return (text ? (JSON.parse(text) as T) : undefined as T);
     } catch (error) {
       if (error instanceof ApiError) {
         // リトライ判定

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -68,7 +68,8 @@ class ApiClient {
       }
     }
     const qs = searchParams.toString();
-    return qs ? `${url}?${qs}` : url;
+    if (!qs) return url;
+    return `${url}${url.includes('?') ? '&' : '?'}${qs}`;
   }
 
   private async executeRequest<T>(
@@ -131,28 +132,12 @@ class ApiClient {
       const text = await response.text();
       return (text ? (JSON.parse(text) as T) : undefined as T);
     } catch (error) {
+      let apiError: ApiError;
       if (error instanceof ApiError) {
-        // リトライ判定
-        if (
-          retryCount < this.retryConfig.maxRetries &&
-          this.retryConfig.shouldRetry!(error)
-        ) {
-          const delay = this.retryConfig.retryDelay *
-            Math.pow(this.retryConfig.retryDelayMultiplier, retryCount);
-          console.warn(
-            `Retrying request (${retryCount + 1}/${this.retryConfig.maxRetries}) after ${delay}ms:`,
-            error.message
-          );
-          await new Promise(resolve => setTimeout(resolve, delay));
-          return this.executeRequest<T>(method, path, data, config, retryCount + 1);
-        }
-        throw error;
-      }
-
-      // AbortError: タイムアウトまたはキャンセル
-      if (error instanceof DOMException && error.name === 'AbortError') {
+        apiError = error;
+      } else if (error instanceof DOMException && error.name === 'AbortError') {
         const isTimeout = controller.signal.reason === 'timeout';
-        throw new ApiError(
+        apiError = new ApiError(
           isTimeout ? ApiErrorType.TIMEOUT_ERROR : ApiErrorType.REQUEST_ERROR,
           isTimeout ? 'リクエストがタイムアウトしました' : 'リクエストがキャンセルされました',
           undefined,
@@ -160,17 +145,32 @@ class ApiClient {
           path,
           method
         );
+      } else {
+        apiError = new ApiError(
+          ApiErrorType.NETWORK_ERROR,
+          'ネットワークエラーが発生しました',
+          undefined,
+          undefined,
+          path,
+          method
+        );
       }
 
-      // ネットワークエラー
-      throw new ApiError(
-        ApiErrorType.NETWORK_ERROR,
-        'ネットワークエラーが発生しました',
-        undefined,
-        undefined,
-        path,
-        method
-      );
+      // 統一リトライ判定
+      if (
+        retryCount < this.retryConfig.maxRetries &&
+        this.retryConfig.shouldRetry!(apiError)
+      ) {
+        const delay = this.retryConfig.retryDelay *
+          Math.pow(this.retryConfig.retryDelayMultiplier, retryCount);
+        console.warn(
+          `Retrying request (${retryCount + 1}/${this.retryConfig.maxRetries}) after ${delay}ms:`,
+          apiError.message
+        );
+        await new Promise(resolve => setTimeout(resolve, delay));
+        return this.executeRequest<T>(method, path, data, config, retryCount + 1);
+      }
+      throw apiError;
     } finally {
       clearTimeout(timeoutId);
       externalSignal?.removeEventListener('abort', onExternalAbort);

--- a/frontend/src/lib/types/api.ts
+++ b/frontend/src/lib/types/api.ts
@@ -1,5 +1,3 @@
-import { AxiosError, AxiosResponse } from 'axios';
-
 export enum ApiErrorType {
   REQUEST_ERROR = 'REQUEST_ERROR',
   NETWORK_ERROR = 'NETWORK_ERROR',
@@ -46,7 +44,7 @@ export class ApiError extends Error {
     this.name = 'ApiError';
     this.requestUrl = requestUrl;
     this.requestMethod = requestMethod;
-    
+
     // スタックトレースを保持
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, ApiError);
@@ -58,21 +56,21 @@ export class ApiError extends Error {
    */
   public toDetailedString(): string {
     const parts = [`[${this.type}] ${this.message}`];
-    
+
     if (this.statusCode) {
       parts.push(`Status: ${this.statusCode}`);
     }
-    
+
     if (this.requestUrl) {
       parts.push(`URL: ${this.requestMethod || 'GET'} ${this.requestUrl}`);
     }
-    
+
     if (this.details) {
       parts.push(`Details: ${JSON.stringify(this.details)}`);
     }
-    
+
     parts.push(`Timestamp: ${this.timestamp.toISOString()}`);
-    
+
     return parts.join(' | ');
   }
 
@@ -103,44 +101,21 @@ export class ApiError extends Error {
   }
 
   /**
-   * AxiosErrorからApiErrorを生成
+   * HTTPレスポンスからApiErrorを生成
    */
-  static fromAxiosError(error: AxiosError): ApiError {
-    const response = error.response as AxiosResponse | undefined;
-    const request = error.config;
-    
-    // ネットワークエラー
-    if (error.code === 'ECONNABORTED' || error.code === 'ETIMEDOUT') {
-      return new ApiError(
-        ApiErrorType.TIMEOUT_ERROR,
-        'リクエストがタイムアウトしました',
-        undefined,
-        { code: error.code },
-        request?.url,
-        request?.method?.toUpperCase()
-      );
-    }
-    
-    if (error.code === 'ERR_NETWORK' || !response) {
-      return new ApiError(
-        ApiErrorType.NETWORK_ERROR,
-        'ネットワークエラーが発生しました',
-        undefined,
-        { code: error.code },
-        request?.url,
-        request?.method?.toUpperCase()
-      );
-    }
-    
-    // HTTPステータスコードに基づくエラー分類
-    const statusCode = response.status;
+  static fromHttpResponse(
+    status: number,
+    data: unknown,
+    url?: string,
+    method?: string
+  ): ApiError {
     let errorType: ApiErrorType;
     let message: string;
-    
-    switch (statusCode) {
+
+    switch (status) {
       case 400: {
         errorType = ApiErrorType.VALIDATION_ERROR;
-        const data400 = response.data as { error?: { message?: string } } | null;
+        const data400 = data as { error?: { message?: string } } | null;
         message = data400?.error?.message ?? 'リクエストが不正です';
         break;
       }
@@ -165,29 +140,19 @@ export class ApiError extends Error {
         break;
       default:
         errorType = ApiErrorType.RESPONSE_ERROR;
-        message = `エラーが発生しました (ステータス: ${statusCode})`;
+        message = `エラーが発生しました (ステータス: ${status})`;
     }
-    
-    // レスポンスボディからエラー詳細を抽出
+
     const details: ApiErrorDetails = {};
-    if (response.data) {
-      if (typeof response.data === 'object') {
-        Object.assign(details, response.data);
+    if (data) {
+      if (typeof data === 'object') {
+        Object.assign(details, data);
       } else {
-        details.context = { responseData: response.data };
+        details.context = { responseData: data };
       }
     }
-    
-    const apiError = new ApiError(
-      errorType, 
-      message, 
-      statusCode, 
-      details,
-      request?.url,
-      request?.method?.toUpperCase()
-    );
-    
-    return apiError;
+
+    return new ApiError(errorType, message, status, details, url, method);
   }
 
   /**

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -27,12 +27,22 @@ export default defineConfig({
     outDir: 'dist',
     sourcemap: true,
     minify: 'terser',
+    terserOptions: {
+      compress: {
+        passes: 3,
+        drop_console: true,
+      },
+      mangle: {
+        toplevel: true,
+      },
+    },
     rollupOptions: {
       output: {
         manualChunks: (id: string) => {
           if (
             id.includes('/node_modules/react/') ||
             id.includes('/node_modules/react-dom/') ||
+            id.includes('/node_modules/react-router/')  ||
             id.includes('/node_modules/react-router-dom/')
           ) {
             return 'vendor';


### PR DESCRIPTION
## 概要

フロントエンドバンドルの gzip 合計サイズを **169.30 → 153.90 kB（-15.40 kB, -9.1%）** 削減。

## 変更種別
- [x] パフォーマンス改善
- [x] リファクタリング

## 主な変更内容

| 変更 | 削減量 |
|------|--------|
| axios → native fetch に置き換え | -13.94 kB gzip |
| terser オプション強化（passes=3, drop_console, toplevel） | -0.88 kB gzip |
| react-router を vendor チャンクに統合 | -0.44 kB gzip |
| **合計** | **-15.40 kB gzip** |

### 1. axios → native fetch（最大の削減）

- `lib/api/client.ts` を native `fetch` + `AbortController` で再実装
- `ApiError.fromAxiosError()` → `ApiError.fromHttpResponse(status, data, url?, method?)`
- axios 削除により `index` チャンクが 19.75 → 5.86 kB gzip に縮小
- リトライ・タイムアウト・キャンセル機能はすべて維持

### 2. J-Quants API 参照の UI 削除

- `DividendInfo` から `JQuantsBadge` を削除（embedded/standalone 両モード）
- ヒントテキストを「J-Quants APIから取得します」→「自動で取得されます」に変更

### 3. vite.config 最適化

- terser: `passes: 3`, `drop_console: true`, `mangle.toplevel: true`
- `react-router` を `vendor` チャンクに追加（react-dom との共通パターン gzip 圧縮）

## チャンク変化

| チャンク | 変更前 | 変更後 |
|---------|--------|--------|
| index.js | 19.75 kB | 5.86 kB |
| vendor | 57.56 kB | 85.93 kB（react-router を統合） |
| useAuth | 30.73 kB | 消滅（vendor に統合） |
| tanstack | 13.33 kB | 13.27 kB |

## テスト
- [x] 555 テスト全件パス
- [x] ビルド確認（gzip 153.90 kB）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 「一株配当」ラベルを常時表示、配当値の表示/入力を安定化
  * ヒント文を「自動で取得されます」に変更

* **Bug Fixes**
  * 外部バッジ表示を削除し、配当表示の一貫性を改善

* **Chores**
  * HTTP 通信基盤を刷新し、リクエスト/タイムアウト制御や再試行を改善
  * ビルド設定の圧縮とチャンク分割を最適化

* **Tests**
  * 表示・取得・エラー処理に関するテストを更新 and 整備
<!-- end of auto-generated comment: release notes by coderabbit.ai -->