### PR TITLE
test: ApiClient の未カバーパス（タイムアウト・リトライ・シングルトン等）のテスト追加

### DIFF
--- a/frontend/src/lib/api/__tests__/client.test.ts
+++ b/frontend/src/lib/api/__tests__/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { createApiClient } from '../client';
+import { apiClient, createApiClient } from '../client';
 import { ApiError, ApiErrorType } from '../../types/api';
 
 const mockFetch = vi.fn();
@@ -119,6 +119,21 @@ describe('ApiClient', () => {
         expect.objectContaining({ method: 'DELETE' })
       );
     });
+
+    it('空ボディレスポンスのとき undefined を返す', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 204,
+        text: () => Promise.resolve(''),
+      });
+
+      const client = createApiClient({ baseURL: 'http://api.test' });
+      const resultPromise = client.get('/empty');
+      await vi.runAllTimersAsync();
+      const result = await resultPromise;
+
+      expect(result).toBeUndefined();
+    });
   });
 
   describe('エラーハンドリング', () => {
@@ -171,6 +186,100 @@ describe('ApiClient', () => {
         type: ApiErrorType.SERVER_ERROR,
       });
     });
+
+    it('タイムアウト時にTIMEOUT_ERRORをthrowする', async () => {
+      mockFetch.mockImplementation((_url: string, options?: RequestInit) => {
+        const signal = options?.signal as AbortSignal;
+
+        return new Promise((_resolve, reject) => {
+          signal.addEventListener('abort', () => {
+            const err = new DOMException('AbortError', 'AbortError');
+            reject(err);
+          });
+        });
+      });
+
+      const client = createApiClient({
+        baseURL: 'http://api.test',
+        timeout: 100,
+        retry: { maxRetries: 0 },
+      });
+
+      const resultPromise = client.get('/timeout');
+      const expectation = expect(resultPromise).rejects.toMatchObject({
+        type: ApiErrorType.TIMEOUT_ERROR,
+      });
+      await vi.runAllTimersAsync();
+      await expectation;
+    });
+
+    it('外部シグナルでキャンセルされた場合はREQUEST_ERRORをthrowする', async () => {
+      mockFetch.mockImplementation((_url: string, options?: RequestInit) => {
+        const signal = options?.signal as AbortSignal;
+
+        return new Promise((_resolve, reject) => {
+          signal.addEventListener('abort', () => {
+            const err = new DOMException('AbortError', 'AbortError');
+            reject(err);
+          });
+        });
+      });
+
+      const controller = new AbortController();
+      const client = createApiClient({
+        baseURL: 'http://api.test',
+        retry: { maxRetries: 0 },
+      });
+
+      const resultPromise = client.get('/cancel', { signal: controller.signal });
+      const expectation = expect(resultPromise).rejects.toMatchObject({
+        type: ApiErrorType.REQUEST_ERROR,
+      });
+      controller.abort();
+      await expectation;
+    });
+
+    it('外部シグナルが既にabort済みならfetch前にREQUEST_ERRORをthrowする', async () => {
+      const controller = new AbortController();
+      controller.abort();
+
+      const client = createApiClient({
+        baseURL: 'http://api.test',
+        retry: { maxRetries: 0 },
+      });
+
+      await expect(client.get('/already-aborted', { signal: controller.signal })).rejects.toMatchObject({
+        type: ApiErrorType.REQUEST_ERROR,
+      });
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('ネットワークエラー時に成功するまでリトライする', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const mockData = { success: true };
+
+      mockFetch
+        .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+        .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(JSON.stringify(mockData)),
+        });
+
+      const client = createApiClient({
+        baseURL: 'http://api.test',
+        retry: { maxRetries: 2, retryDelay: 100, retryDelayMultiplier: 1 },
+      });
+
+      const resultPromise = client.get('/retry');
+      await vi.runAllTimersAsync();
+      const result = await resultPromise;
+
+      expect(result).toEqual(mockData);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('バッチリクエスト', () => {
@@ -220,6 +329,17 @@ describe('ApiClient', () => {
 
       // キャンセルされたリクエストはエラーになるはず
       await expect(promise).rejects.toThrow();
+    });
+
+    it('abort以外のエラーはそのままrethrowする', async () => {
+      const client = createApiClient({ baseURL: 'http://api.test' });
+      const expectedError = new Error('Unexpected failure');
+
+      const { promise } = client.createCancelableRequest(async () => {
+        throw expectedError;
+      });
+
+      await expect(promise).rejects.toBe(expectedError);
     });
   });
 
@@ -320,6 +440,84 @@ describe('ApiClient', () => {
       await resultPromise;
 
       expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('baseURLに既存クエリがある場合は追加パラメータを&で連結する', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve('{}'),
+      });
+
+      const client = createApiClient({ baseURL: 'http://api.test/test?existing=1' });
+      const resultPromise = client.get('', {
+        params: { key: 'value' },
+      });
+      await vi.runAllTimersAsync();
+      await resultPromise;
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://api.test/test?existing=1&key=value',
+        expect.objectContaining({ method: 'GET' })
+      );
+    });
+  });
+
+  describe('シングルトンAPIクライアント', () => {
+    it('apiClientの各メソッドを正常に呼び出せる', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve('{}'),
+      });
+
+      const getPromise = apiClient.get('/singleton-get');
+      const postPromise = apiClient.post('/singleton-post', { name: 'post' });
+      const putPromise = apiClient.put('/singleton-put', { name: 'put' });
+      const patchPromise = apiClient.patch('/singleton-patch', { name: 'patch' });
+      const deletePromise = apiClient.delete('/singleton-delete');
+      const batchPromise = apiClient.batch([
+        () => apiClient.get('/singleton-batch-1'),
+        () => apiClient.get('/singleton-batch-2'),
+      ] as const);
+      const cancelableRequest = apiClient.createCancelableRequest(async () => 'singleton');
+
+      await vi.runAllTimersAsync();
+
+      await expect(getPromise).resolves.toEqual({});
+      await expect(postPromise).resolves.toEqual({});
+      await expect(putPromise).resolves.toEqual({});
+      await expect(patchPromise).resolves.toEqual({});
+      await expect(deletePromise).resolves.toEqual({});
+      await expect(batchPromise).resolves.toEqual([{}, {}]);
+      await expect(cancelableRequest.promise).resolves.toBe('singleton');
+
+      expect(mockFetch).toHaveBeenCalledTimes(7);
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        1,
+        expect.stringContaining('/singleton-get'),
+        expect.objectContaining({ method: 'GET' })
+      );
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining('/singleton-post'),
+        expect.objectContaining({ method: 'POST' })
+      );
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        3,
+        expect.stringContaining('/singleton-put'),
+        expect.objectContaining({ method: 'PUT' })
+      );
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        4,
+        expect.stringContaining('/singleton-patch'),
+        expect.objectContaining({ method: 'PATCH' })
+      );
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        5,
+        expect.stringContaining('/singleton-delete'),
+        expect.objectContaining({ method: 'DELETE' })
+      );
     });
   });
 });


### PR DESCRIPTION
## 概要
`frontend/src/lib/api/client.ts` の未カバーパスに対するテストを追加し、タイムアウト、外部シグナルによるキャンセル、リトライ、空レスポンス、既存クエリ付き URL、`createCancelableRequest` の非 abort エラー、`apiClient` シングルトンの各メソッド呼び出しを検証できるようにしました。

これまで `client.ts` では `AbortError` の分岐、再試行処理、シングルトンラッパーなどの経路が十分にテストされておらず、回帰が入っても気付きにくい状態でした。今回の変更で該当経路を明示的にテストし、HTTP クライアントのエラーハンドリングと後方互換 API の挙動を固定しています。

## 変更内容
- タイムアウト発火時に `ApiErrorType.TIMEOUT_ERROR` へ変換されることを検証
- 外部 `AbortSignal` によるキャンセルと、事前 abort 済み signal の分岐を検証
- ネットワークエラー時の retry 成功パスを検証
- 空ボディレスポンスで `undefined` を返すことを検証
- 既存クエリ文字列付き `baseURL` に対して追加パラメータを `&` 連結することを検証
- `createCancelableRequest` が非 abort エラーをそのまま再送出することを検証
- `apiClient` シングルトンの `get/post/put/patch/delete/batch/createCancelableRequest` を検証

## テスト
- `cd frontend && npx vitest run src/lib/api/__tests__/client.test.ts`
- `cd frontend && npx vitest run --coverage --reporter=verbose 2>&1 | grep -A 5 'client.ts'`
  - `frontend/src/lib/api/client.ts`: lines 100%
- `cd frontend && npm run lint -- --max-warnings=0 src/lib/api/__tests__/client.test.ts`
- `cd frontend && npm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **Tests**
  * APIクライアントのテスト範囲を拡充しました。タイムアウト処理、リクエスト取消、ネットワークリトライ、クエリ文字列の合成などの動作を検証するテストを追加しました。エラーハンドリングと信頼性の向上を確認しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->