### PR TITLE
test: Header・AuthContext の未カバーパスにテストを追加

### DIFF
--- a/frontend/src/components/organisms/__tests__/Header.test.tsx
+++ b/frontend/src/components/organisms/__tests__/Header.test.tsx
@@ -17,7 +17,7 @@ function createAuthState(overrides: Partial<AuthState> = {}): AuthState {
       id: '1',
       name: 'テストユーザー',
       email: 'test@example.com',
-      picture_url: null,
+      picture_url: undefined,
     },
     setUser: vi.fn(),
     login: vi.fn(),
@@ -216,7 +216,7 @@ describe('Header', () => {
           id: '1',
           name: '山田 太郎',
           email: 'yamada@example.com',
-          picture_url: null,
+          picture_url: undefined,
         },
       });
 
@@ -229,7 +229,7 @@ describe('Header', () => {
           id: '1',
           name: '田中',
           email: 'tanaka@example.com',
-          picture_url: null,
+          picture_url: undefined,
         },
       });
 
@@ -242,7 +242,7 @@ describe('Header', () => {
           id: '1',
           name: undefined,
           email: 'sample@example.com',
-          picture_url: null,
+          picture_url: undefined,
         },
       });
 
@@ -255,7 +255,7 @@ describe('Header', () => {
           id: '1',
           name: '',
           email: '',
-          picture_url: null,
+          picture_url: undefined,
         },
       });
 

--- a/frontend/src/components/organisms/__tests__/Header.test.tsx
+++ b/frontend/src/components/organisms/__tests__/Header.test.tsx
@@ -1,31 +1,58 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
-import { vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAuth } from '@/features/auth/hooks/useAuth';
 import { Header } from '../Header';
 
 vi.mock('@/features/auth/hooks/useAuth', () => ({
-  useAuth: () => ({
-    user: {
-      name: 'テストユーザー',
-      email: 'test@example.com',
-      picture: null,
-      picture_url: null,
-    },
-    login: vi.fn(),
-    logout: vi.fn(),
-    deleteAccount: vi.fn(),
-    isAuthenticated: true,
-    isLoading: false,
-  }),
+  useAuth: vi.fn(),
 }));
 
+type AuthState = ReturnType<typeof useAuth>;
+
+function createAuthState(overrides: Partial<AuthState> = {}): AuthState {
+  return {
+    user: {
+      id: '1',
+      name: 'テストユーザー',
+      email: 'test@example.com',
+      picture_url: null,
+    },
+    setUser: vi.fn(),
+    login: vi.fn(),
+    logout: vi.fn().mockResolvedValue(undefined),
+    deleteAccount: vi.fn().mockResolvedValue(undefined),
+    isAuthenticated: true,
+    isLoading: false,
+    onLogout: vi.fn(() => vi.fn()),
+    ...overrides,
+  };
+}
+
+function renderHeader(authOverrides: Partial<AuthState> = {}, route = '/') {
+  const authState = createAuthState(authOverrides);
+  vi.mocked(useAuth).mockReturnValue(authState);
+
+  const user = userEvent.setup();
+
+  render(
+    <MemoryRouter initialEntries={[route]}>
+      <Header />
+    </MemoryRouter>
+  );
+
+  return { user, authState };
+}
+
 describe('Header', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useAuth).mockReturnValue(createAuthState());
+  });
+
   it('主要ナビゲーションリンクを表示する', () => {
-    render(
-      <MemoryRouter>
-        <Header />
-      </MemoryRouter>
-    );
+    renderHeader();
 
     expect(screen.getByRole('link', { name: '銘柄検索' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: '資産管理' })).toBeInTheDocument();
@@ -33,12 +60,206 @@ describe('Header', () => {
   });
 
   it('ログイン状態でユーザーアバターを表示する', () => {
-    render(
-      <MemoryRouter>
-        <Header />
-      </MemoryRouter>
-    );
+    renderHeader();
 
     expect(screen.getByLabelText('テストユーザー')).toBeInTheDocument();
+  });
+
+  it('未認証時にログインボタンを表示する', () => {
+    renderHeader({
+      user: null,
+      isAuthenticated: false,
+    });
+
+    expect(screen.getByRole('button', { name: 'ログイン' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'メニュー' })).not.toBeInTheDocument();
+  });
+
+  it('ローディング中に読み込み中を表示する', () => {
+    renderHeader({
+      user: null,
+      isAuthenticated: false,
+      isLoading: true,
+    });
+
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'ログイン' })).not.toBeInTheDocument();
+  });
+
+  it('メニューボタンをクリックするとドロップダウンが開く', async () => {
+    const { user } = renderHeader();
+
+    await user.click(screen.getByRole('button', { name: 'メニュー' }));
+
+    expect(screen.getByRole('menu', { name: 'ユーザーメニュー' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'ログアウト' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /アカウント削除/ })).toBeInTheDocument();
+  });
+
+  it('ログアウトボタンをクリックするとlogoutが呼ばれる', async () => {
+    const logout = vi.fn().mockResolvedValue(undefined);
+    const { user } = renderHeader({ logout });
+
+    await user.click(screen.getByRole('button', { name: 'メニュー' }));
+    await user.click(screen.getByRole('menuitem', { name: 'ログアウト' }));
+
+    await waitFor(() => {
+      expect(logout).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.queryByRole('menu', { name: 'ユーザーメニュー' })).not.toBeInTheDocument();
+  });
+
+  it('アカウント削除ボタンをクリックすると確認モーダルが開く', async () => {
+    const { user } = renderHeader();
+
+    await user.click(screen.getByRole('button', { name: 'メニュー' }));
+    await user.click(screen.getByRole('menuitem', { name: /アカウント削除/ }));
+
+    expect(await screen.findByRole('dialog', { name: 'アカウント削除の確認' })).toBeInTheDocument();
+  });
+
+  it('削除確認モーダルの削除するでdeleteAccountが呼ばれてモーダルが閉じる', async () => {
+    const deleteAccount = vi.fn().mockResolvedValue(undefined);
+    const { user } = renderHeader({ deleteAccount });
+
+    await user.click(screen.getByRole('button', { name: 'メニュー' }));
+    await user.click(screen.getByRole('menuitem', { name: /アカウント削除/ }));
+    await user.click(await screen.findByRole('button', { name: '削除する' }));
+
+    await waitFor(() => {
+      expect(deleteAccount).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: 'アカウント削除の確認' })).not.toBeInTheDocument();
+    });
+  });
+
+  it('削除確認モーダルのキャンセルでモーダルが閉じる', async () => {
+    const { user } = renderHeader();
+
+    await user.click(screen.getByRole('button', { name: 'メニュー' }));
+    await user.click(screen.getByRole('menuitem', { name: /アカウント削除/ }));
+    await user.click(await screen.findByRole('button', { name: 'キャンセル' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: 'アカウント削除の確認' })).not.toBeInTheDocument();
+    });
+  });
+
+  it('Escapeキーでドロップダウンが閉じる', async () => {
+    const { user } = renderHeader();
+
+    await user.click(screen.getByRole('button', { name: 'メニュー' }));
+    expect(screen.getByRole('menu', { name: 'ユーザーメニュー' })).toBeInTheDocument();
+
+    await user.keyboard('{Escape}');
+
+    await waitFor(() => {
+      expect(screen.queryByRole('menu', { name: 'ユーザーメニュー' })).not.toBeInTheDocument();
+    });
+  });
+
+  it('外部クリックでドロップダウンが閉じる', async () => {
+    const { user } = renderHeader();
+
+    await user.click(screen.getByRole('button', { name: 'メニュー' }));
+    expect(screen.getByRole('menu', { name: 'ユーザーメニュー' })).toBeInTheDocument();
+
+    fireEvent.mouseDown(document.body);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('menu', { name: 'ユーザーメニュー' })).not.toBeInTheDocument();
+    });
+  });
+
+  it('picture_urlがある場合はアバター画像を表示する', () => {
+    renderHeader({
+      user: {
+        id: '1',
+        name: '画像ユーザー',
+        email: 'image@example.com',
+        picture_url: 'http://example.com/avatar.png',
+      },
+    });
+
+    expect(screen.getByAltText('画像ユーザー')).toBeInTheDocument();
+  });
+
+  it('画像エラー時はイニシャルフォールバックを表示する', async () => {
+    renderHeader({
+      user: {
+        id: '1',
+        name: '画像エラー',
+        email: 'image-error@example.com',
+        picture_url: 'http://example.com/avatar.png',
+      },
+    });
+
+    fireEvent.error(screen.getByAltText('画像エラー'));
+
+    await waitFor(() => {
+      expect(screen.queryByAltText('画像エラー')).not.toBeInTheDocument();
+    });
+    expect(screen.getByLabelText('画像エラー')).toHaveTextContent('画像');
+  });
+
+  it('アクティブなリンクにaria-current=pageが付く', () => {
+    renderHeader({}, '/search');
+
+    expect(screen.getByRole('link', { name: '銘柄検索' })).toHaveAttribute('aria-current', 'page');
+  });
+
+  describe('イニシャル表示', () => {
+    it('スペース区切り2語の名前は実際の動作どおり2文字を表示する', () => {
+      renderHeader({
+        user: {
+          id: '1',
+          name: '山田 太郎',
+          email: 'yamada@example.com',
+          picture_url: null,
+        },
+      });
+
+      expect(screen.getByLabelText('山田 太郎')).toHaveTextContent('山太');
+    });
+
+    it('1語の名前は先頭2文字を表示する', () => {
+      renderHeader({
+        user: {
+          id: '1',
+          name: '田中',
+          email: 'tanaka@example.com',
+          picture_url: null,
+        },
+      });
+
+      expect(screen.getByLabelText('田中')).toHaveTextContent('田中');
+    });
+
+    it('名前なしでメールがある場合はメールの先頭2文字を表示する', () => {
+      renderHeader({
+        user: {
+          id: '1',
+          name: undefined,
+          email: 'sample@example.com',
+          picture_url: null,
+        },
+      });
+
+      expect(screen.getByLabelText('ユーザー')).toHaveTextContent('SA');
+    });
+
+    it('名前もメールもない場合はUを表示する', () => {
+      renderHeader({
+        user: {
+          id: '1',
+          name: '',
+          email: '',
+          picture_url: null,
+        },
+      });
+
+      expect(screen.getByLabelText('ユーザー')).toHaveTextContent('U');
+    });
   });
 });

--- a/frontend/src/features/auth/context/AuthContext.tsx
+++ b/frontend/src/features/auth/context/AuthContext.tsx
@@ -3,6 +3,7 @@ import { UserInfo } from '../types';
 import { AuthContext } from './context';
 import { apiClient, createApiClient } from '@/lib/api/client';
 import { useIdleTimer } from '../hooks/useIdleTimer';
+import { locationAssigner } from './locationAssigner';
 
 // 認証確認専用クライアント設定
 // デフォルト設定(timeout=30s, retry=3回, 指数バックオフ)では
@@ -79,7 +80,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // バックエンドの認証エンドポイントに直接リダイレクト
     // バックエンドがGoogleの認証ページにリダイレクトする
     const apiBaseUrl = import.meta.env.VITE_SHOKEN_WEBAPI_API_URL;
-    window.location.assign(`${apiBaseUrl}/auth/google`);
+    locationAssigner.assign(`${apiBaseUrl}/auth/google`);
   };
 
   const logout = useCallback(async () => {

--- a/frontend/src/features/auth/context/__tests__/AuthContext.test.tsx
+++ b/frontend/src/features/auth/context/__tests__/AuthContext.test.tsx
@@ -1,19 +1,21 @@
+import { useRef, useState } from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AuthProvider } from '../AuthContext';
+import { locationAssigner } from '../locationAssigner';
 import { useAuth } from '../../hooks/useAuth';
+import { useIdleTimer } from '../../hooks/useIdleTimer';
+import { apiClient } from '@/lib/api/client';
 
-// アイドルタイマーのモック
 vi.mock('../../hooks/useIdleTimer', () => ({
   useIdleTimer: vi.fn(),
 }));
 
-// vi.hoisted でモック関数をホイスティング対応にする
 const { mockGet } = vi.hoisted(() => ({
   mockGet: vi.fn(),
 }));
 
-// APIクライアントのモック
 vi.mock('@/lib/api/client', () => ({
   apiClient: {
     post: vi.fn(),
@@ -24,25 +26,106 @@ vi.mock('@/lib/api/client', () => ({
   }),
 }));
 
-// テスト用コンシューマーコンポーネント
-function TestConsumer() {
-  const { user, isLoading, isAuthenticated } = useAuth();
+const mockUser = {
+  id: '1',
+  email: 'test@example.com',
+  name: 'テストユーザー',
+};
+
+function TestConsumer({ onLogoutCallback }: { onLogoutCallback?: () => void }) {
+  const { user, isLoading, isAuthenticated, login, logout, deleteAccount, onLogout } = useAuth();
+  const cleanupRef = useRef<(() => void) | null>(null);
+  const [error, setError] = useState('none');
+
+  const handleLogout = async () => {
+    try {
+      await logout();
+      setError('none');
+    } catch (caughtError) {
+      setError(caughtError instanceof Error ? caughtError.message : String(caughtError));
+    }
+  };
+
+  const handleDeleteAccount = async () => {
+    try {
+      await deleteAccount();
+      setError('none');
+    } catch (caughtError) {
+      setError(caughtError instanceof Error ? caughtError.message : String(caughtError));
+    }
+  };
+
   return (
     <div>
       <span data-testid="loading">{String(isLoading)}</span>
       <span data-testid="authenticated">{String(isAuthenticated)}</span>
       <span data-testid="user-name">{user?.name ?? 'none'}</span>
+      <span data-testid="error">{error}</span>
+      <button type="button" onClick={() => login()}>
+        login
+      </button>
+      <button type="button" onClick={handleLogout}>
+        logout
+      </button>
+      <button type="button" onClick={handleDeleteAccount}>
+        delete-account
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          cleanupRef.current = onLogout(() => onLogoutCallback?.());
+        }}
+      >
+        register-callback
+      </button>
+      <button type="button" onClick={() => cleanupRef.current?.()}>
+        unregister-callback
+      </button>
     </div>
   );
 }
 
+async function renderAuthProvider({
+  authenticated = true,
+  onLogoutCallback,
+}: {
+  authenticated?: boolean;
+  onLogoutCallback?: () => void;
+} = {}) {
+  if (authenticated) {
+    mockGet.mockResolvedValueOnce(mockUser);
+  } else {
+    mockGet.mockRejectedValueOnce(new Error('Unauthorized'));
+  }
+
+  const user = userEvent.setup();
+
+  render(
+    <AuthProvider>
+      <TestConsumer onLogoutCallback={onLogoutCallback} />
+    </AuthProvider>
+  );
+
+  await waitFor(() => {
+    expect(screen.getByTestId('loading').textContent).toBe('false');
+  });
+
+  return { user };
+}
+
 describe('AuthProvider', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    mockGet.mockReset();
+    vi.mocked(useIdleTimer).mockReset();
+    vi.mocked(apiClient.post).mockReset();
+    vi.mocked(apiClient.delete).mockReset();
+    vi.mocked(useIdleTimer).mockReturnValue({ resetTimer: vi.fn() });
+    vi.mocked(apiClient.post).mockResolvedValue(undefined);
+    vi.mocked(apiClient.delete).mockResolvedValue(undefined);
   });
 
   it('認証成功時にユーザー情報がセットされる', async () => {
-    const mockUser = { id: '1', email: 'test@example.com', name: 'テストユーザー' };
     mockGet.mockResolvedValueOnce(mockUser);
 
     render(
@@ -51,7 +134,6 @@ describe('AuthProvider', () => {
       </AuthProvider>
     );
 
-    // 初期状態: ローディング中
     expect(screen.getByTestId('loading').textContent).toBe('true');
 
     await waitFor(() => {
@@ -86,7 +168,6 @@ describe('AuthProvider', () => {
   });
 
   it('アンマウント時にAbortControllerでリクエストがキャンセルされる', async () => {
-    // signalのabortを検知するためのモック
     let capturedSignal: AbortSignal | undefined;
     mockGet.mockImplementation((_url: string, config?: { signal?: AbortSignal }) => {
       capturedSignal = config?.signal;
@@ -101,12 +182,10 @@ describe('AuthProvider', () => {
       </AuthProvider>
     );
 
-    // リクエスト発行を待つ
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalled();
     });
 
-    // アンマウント時にabortされる
     unmount();
     expect(capturedSignal?.aborted).toBe(true);
   });
@@ -124,10 +203,114 @@ describe('AuthProvider', () => {
       expect(screen.getByTestId('loading').textContent).toBe('false');
     });
 
-    // createApiClientで生成されたクライアントのgetがsignal付きで呼ばれていること
     expect(mockGet).toHaveBeenCalledWith('/auth/me', expect.objectContaining({
       withCredentials: true,
       signal: expect.any(AbortSignal),
     }));
+  });
+
+  it('logoutがauth/logoutを呼びuserをnullにする', async () => {
+    const { user } = await renderAuthProvider();
+
+    await user.click(screen.getByRole('button', { name: 'logout' }));
+
+    await waitFor(() => {
+      expect(apiClient.post).toHaveBeenCalledWith('/auth/logout', {}, {
+        withCredentials: true,
+      });
+    });
+    expect(screen.getByTestId('user-name').textContent).toBe('none');
+    expect(screen.getByTestId('authenticated').textContent).toBe('false');
+  });
+
+  it('logoutがAPIエラーの場合はthrowしてcatch可能', async () => {
+    vi.mocked(apiClient.post).mockRejectedValueOnce(new Error('logout failed'));
+    const { user } = await renderAuthProvider();
+
+    await user.click(screen.getByRole('button', { name: 'logout' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('error').textContent).toBe('logout failed');
+    });
+    expect(screen.getByTestId('user-name').textContent).toBe('none');
+  });
+
+  it('deleteAccountがauth/delete-accountを呼びuserをnullにする', async () => {
+    const { user } = await renderAuthProvider();
+
+    await user.click(screen.getByRole('button', { name: 'delete-account' }));
+
+    await waitFor(() => {
+      expect(apiClient.delete).toHaveBeenCalledWith('/auth/delete-account', {
+        withCredentials: true,
+      });
+    });
+    expect(screen.getByTestId('user-name').textContent).toBe('none');
+    expect(screen.getByTestId('authenticated').textContent).toBe('false');
+  });
+
+  it('deleteAccountがAPIエラーの場合はthrowしてcatch可能', async () => {
+    vi.mocked(apiClient.delete).mockRejectedValueOnce(new Error('delete failed'));
+    const { user } = await renderAuthProvider();
+
+    await user.click(screen.getByRole('button', { name: 'delete-account' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('error').textContent).toBe('delete failed');
+    });
+    expect(screen.getByTestId('user-name').textContent).toBe('none');
+  });
+
+  it('userがいる場合はアイドル時にlogoutが呼ばれる', async () => {
+    await renderAuthProvider();
+
+    await waitFor(() => {
+      expect(useIdleTimer).toHaveBeenLastCalledWith(expect.objectContaining({
+        timeout: expect.any(Number),
+        onIdle: expect.any(Function),
+        enabled: true,
+      }));
+    });
+
+    const idleOptions = vi.mocked(useIdleTimer).mock.lastCall?.[0];
+    idleOptions?.onIdle();
+
+    await waitFor(() => {
+      expect(apiClient.post).toHaveBeenCalledWith('/auth/logout', {}, {
+        withCredentials: true,
+      });
+    });
+  });
+
+  it('loginがwindow.location.assignを呼ぶ', async () => {
+    vi.stubEnv('VITE_SHOKEN_WEBAPI_API_URL', 'https://api.example.com');
+    const assignSpy = vi.spyOn(locationAssigner, 'assign').mockImplementation(vi.fn());
+    const { user } = await renderAuthProvider({ authenticated: false });
+
+    await user.click(screen.getByRole('button', { name: 'login' }));
+
+    expect(assignSpy).toHaveBeenCalledWith('https://api.example.com/auth/google');
+
+    assignSpy.mockRestore();
+  });
+
+  it('onLogoutでコールバックを登録解除できる', async () => {
+    const onLogoutCallback = vi.fn();
+    const { user } = await renderAuthProvider({ onLogoutCallback });
+
+    await user.click(screen.getByRole('button', { name: 'register-callback' }));
+    await user.click(screen.getByRole('button', { name: 'logout' }));
+
+    await waitFor(() => {
+      expect(onLogoutCallback).toHaveBeenCalledTimes(1);
+    });
+
+    await user.click(screen.getByRole('button', { name: 'unregister-callback' }));
+    await user.click(screen.getByRole('button', { name: 'logout' }));
+
+    await waitFor(() => {
+      expect(apiClient.post).toHaveBeenCalledTimes(2);
+    });
+    expect(onLogoutCallback).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/features/auth/context/locationAssigner.ts
+++ b/frontend/src/features/auth/context/locationAssigner.ts
@@ -1,0 +1,3 @@
+export const locationAssigner = {
+  assign: (url: string) => window.location.assign(url),
+};


### PR DESCRIPTION
## 概要
- Header の未認証、ローディング、ドロップダウン、削除モーダル、アバター表示、イニシャル分岐のテストを追加
- AuthContext の logout / deleteAccount / login / onLogout / idle 処理のテストを追加
- jsdom で location.assign を直接差し替えられないため、AuthContext のログイン遷移は薄い委譲を切り出してテスト可能にした

## 変更内容
- `frontend/src/components/organisms/__tests__/Header.test.tsx` を拡張し、指定された 16 ケースを追加
- `frontend/src/features/auth/context/__tests__/AuthContext.test.tsx` を拡張し、指定された 7 ケースを追加
- `frontend/src/features/auth/context/locationAssigner.ts` を追加し、`AuthContext.tsx` の login から利用

## テスト
- `cd frontend && npx vitest run src/components/organisms/__tests__/Header.test.tsx src/features/auth/context/__tests__/AuthContext.test.tsx 2>&1 | tail -10`
- `cd frontend && npx vitest run --coverage --reporter=verbose 2>&1 | grep -E \"Header\\.tsx|AuthContext\\.tsx\"`
- `cd frontend && npm run lint -- --max-warnings=0 src/components/organisms/__tests__/Header.test.tsx src/features/auth/context/__tests__/AuthContext.test.tsx`
- `cd frontend && npm test`

## カバレッジ抜粋
- `Header.tsx`: Lines 86.44 / Functions 86.95 / Branches 76.19 / Statements 90.38
- `AuthContext.tsx`: Lines 92.18 / Functions 75.00 / Branches 80.95 / Statements 94.91

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Tests**
  * 認証関連とヘッダー表示のテストを大幅に拡張し、ログイン/ログアウト、アカウント削除、メニュー挙動、アバター表示やエラーパスまでユーザー操作を模した検証を追加しました。

* **Refactor**
  * ログイン遷移処理を整理し、認証フローまわりの挙動とテストの保守性を向上させました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->