### PR TITLE
test: Receipts と Mutualfund のページテストを追加

### DIFF
--- a/frontend/src/pages/Receipt/__tests__/Mutualfund.test.tsx
+++ b/frontend/src/pages/Receipt/__tests__/Mutualfund.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import { Mutualfund } from '../Mutualfund';
+import { waitOpts } from '@/test/utils';
 
 // React Router DOM のモック
 vi.mock('react-router-dom', () => ({
@@ -39,6 +41,36 @@ describe('Mutualfund', () => {
             taxes: 6123000,
             realized_profit_and_loss_after_tax: 23877000,
         },
+        {
+            trade_date: new Date('2023-02-20'),
+            settlement_date: new Date('2023-02-24'),
+            fund_name: 'テストファンドB',
+            dividends: '0',
+            account: 'NISA',
+            shares: 5000,
+            exchange_rate: 1,
+            cancellation_unit_price_yen: 18000,
+            cancellation_amount_yen: 90000000,
+            average_acquisition_price_yen: 14000,
+            realized_profit_and_loss: 20000000,
+            taxes: 0,
+            realized_profit_and_loss_after_tax: 20000000,
+        },
+        {
+            trade_date: new Date('2024-03-10'),
+            settlement_date: new Date('2024-03-14'),
+            fund_name: 'テストファンドC',
+            dividends: '0',
+            account: '特定',
+            shares: 8000,
+            exchange_rate: 1,
+            cancellation_unit_price_yen: 12000,
+            cancellation_amount_yen: 96000000,
+            average_acquisition_price_yen: 12500,
+            realized_profit_and_loss: -4000000,
+            taxes: 0,
+            realized_profit_and_loss_after_tax: -4000000,
+        },
     ];
 
     it('空のデータでEmptyStateが表示される', () => {
@@ -60,5 +92,50 @@ describe('Mutualfund', () => {
 
         expect(screen.getByText('約定日')).toBeInTheDocument();
         expect(screen.getByText('ファンド名')).toBeInTheDocument();
+    });
+
+    it('ファンド名検索でフィルタリングされる', async () => {
+        const user = userEvent.setup();
+        const { container } = render(<Mutualfund data={mockData} />);
+
+        fireEvent.click(screen.getByTestId('search-card-header'));
+
+        await waitFor(() => {
+            expect(container.querySelector('#securities-search')).toBeInTheDocument();
+        }, waitOpts);
+
+        const securitiesSelect = container.querySelector('#securities-search') as HTMLSelectElement;
+        await user.selectOptions(securitiesSelect, 'テストファンドA');
+
+        const table = screen.getByRole('table');
+        await waitFor(() => {
+            expect(within(table).getAllByText('テストファンドA').length).toBeGreaterThanOrEqual(1);
+            expect(within(table).queryByText('テストファンドB')).not.toBeInTheDocument();
+            expect(within(table).queryByText('2023年1月')).not.toBeInTheDocument();
+        }, waitOpts);
+    });
+
+    it('年検索でフィルタリングされる', async () => {
+        const user = userEvent.setup();
+        const { container } = render(<Mutualfund data={mockData} />);
+
+        fireEvent.click(screen.getByTestId('search-card-header'));
+
+        await waitFor(() => {
+            expect(container.querySelector('#years-search')).toBeInTheDocument();
+        }, waitOpts);
+
+        const yearSelect = container.querySelector('#years-search') as HTMLSelectElement;
+        await user.selectOptions(yearSelect, '2023');
+
+        const table = screen.getByRole('table');
+        await waitFor(() => {
+            expect(within(table).getByText('テストファンドA')).toBeInTheDocument();
+            expect(within(table).getByText('テストファンドB')).toBeInTheDocument();
+            expect(within(table).queryByText('テストファンドC')).not.toBeInTheDocument();
+            expect(within(table).getByText('2023年1月')).toBeInTheDocument();
+            expect(within(table).getByText('2023年2月')).toBeInTheDocument();
+            expect(within(table).queryByText('2024年3月')).not.toBeInTheDocument();
+        }, waitOpts);
     });
 });

--- a/frontend/src/pages/__tests__/Receipts.test.tsx
+++ b/frontend/src/pages/__tests__/Receipts.test.tsx
@@ -6,7 +6,7 @@
  * - ReceiptsPage: タブ切替・ログアウト時データクリアの統合テスト
  */
 import React from 'react';
-import { screen, waitFor, act } from '@testing-library/react';
+import { screen, waitFor, act, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { makeQueryClient, renderWithQuery, waitOpts } from '@/test/utils';
@@ -234,6 +234,26 @@ describe('ReceiptsPage', () => {
     vi.clearAllMocks();
   });
 
+  async function setupKeyboardNavigationTest() {
+    vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({ isAuthenticated: true }));
+    vi.mocked(receiptApi.dividendApi.list).mockResolvedValue([] as never[]);
+    vi.mocked(receiptApi.domesticStockApi.list).mockResolvedValue([] as never[]);
+    vi.mocked(receiptApi.mutualfundApi.list).mockResolvedValue([] as never[]);
+
+    renderWithQuery(<ReceiptsPage />);
+
+    await waitFor(() => {
+      expect(receiptApi.dividendApi.list).toHaveBeenCalled();
+    }, waitOpts);
+
+    return {
+      user: userEvent.setup(),
+      getDividendTab: () => screen.getByRole('tab', { name: /^配当金/ }),
+      getDomesticStockTab: () => screen.getByRole('tab', { name: /^国内株式/ }),
+      getMutualfundTab: () => screen.getByRole('tab', { name: /^投資信託/ }),
+    };
+  }
+
   it('初期表示: 配当金タブが選択されている', () => {
     vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({}));
 
@@ -270,6 +290,130 @@ describe('ReceiptsPage', () => {
 
     expect(screen.getByTestId('mutualfund-view')).toBeInTheDocument();
     expect(screen.queryByTestId('dividend-view')).not.toBeInTheDocument();
+  });
+
+  describe('タブキーボードナビゲーション', () => {
+    it('ArrowRight でタブが次に移動する', async () => {
+      const { getDividendTab, getDomesticStockTab } = await setupKeyboardNavigationTest();
+
+      const dividendTab = getDividendTab();
+      dividendTab.focus();
+      fireEvent.keyDown(dividendTab, { key: 'ArrowRight' });
+
+      await waitFor(() => {
+        expect(screen.getByRole('tab', { selected: true, name: /^国内株式/ })).toBeInTheDocument();
+        expect(getDomesticStockTab()).toHaveFocus();
+      }, waitOpts);
+
+      expect(screen.getByTestId('domesticstock-view')).toBeInTheDocument();
+      expect(screen.queryByTestId('dividend-view')).not.toBeInTheDocument();
+    });
+
+    it('ArrowLeft でタブが前に移動する', async () => {
+      const { user, getDividendTab, getDomesticStockTab } = await setupKeyboardNavigationTest();
+
+      await user.click(getDomesticStockTab());
+      await waitFor(() => {
+        expect(screen.getByRole('tab', { selected: true, name: /^国内株式/ })).toBeInTheDocument();
+      }, waitOpts);
+
+      const domesticStockTab = getDomesticStockTab();
+      domesticStockTab.focus();
+      fireEvent.keyDown(domesticStockTab, { key: 'ArrowLeft' });
+
+      await waitFor(() => {
+        expect(screen.getByRole('tab', { selected: true, name: /^配当金/ })).toBeInTheDocument();
+        expect(getDividendTab()).toHaveFocus();
+      }, waitOpts);
+
+      expect(screen.getByTestId('dividend-view')).toBeInTheDocument();
+      expect(screen.queryByTestId('domesticstock-view')).not.toBeInTheDocument();
+    });
+
+    it('ArrowRight が最後のタブでラップアラウンドする', async () => {
+      const { user, getDividendTab, getMutualfundTab } = await setupKeyboardNavigationTest();
+
+      await user.click(getMutualfundTab());
+      await waitFor(() => {
+        expect(screen.getByRole('tab', { selected: true, name: /^投資信託/ })).toBeInTheDocument();
+      }, waitOpts);
+
+      const mutualfundTab = getMutualfundTab();
+      mutualfundTab.focus();
+      fireEvent.keyDown(mutualfundTab, { key: 'ArrowRight' });
+
+      await waitFor(() => {
+        expect(screen.getByRole('tab', { selected: true, name: /^配当金/ })).toBeInTheDocument();
+        expect(getDividendTab()).toHaveFocus();
+      }, waitOpts);
+
+      expect(screen.getByTestId('dividend-view')).toBeInTheDocument();
+      expect(screen.queryByTestId('mutualfund-view')).not.toBeInTheDocument();
+    });
+
+    it('ArrowLeft が最初のタブでラップアラウンドする', async () => {
+      const { getDividendTab, getMutualfundTab } = await setupKeyboardNavigationTest();
+
+      const dividendTab = getDividendTab();
+      dividendTab.focus();
+      fireEvent.keyDown(dividendTab, { key: 'ArrowLeft' });
+
+      await waitFor(() => {
+        expect(screen.getByRole('tab', { selected: true, name: /^投資信託/ })).toBeInTheDocument();
+        expect(getMutualfundTab()).toHaveFocus();
+      }, waitOpts);
+
+      expect(screen.getByTestId('mutualfund-view')).toBeInTheDocument();
+      expect(screen.queryByTestId('dividend-view')).not.toBeInTheDocument();
+    });
+
+    it('Home キーで最初のタブに移動する', async () => {
+      const { user, getDividendTab, getMutualfundTab } = await setupKeyboardNavigationTest();
+
+      await user.click(getMutualfundTab());
+      await waitFor(() => {
+        expect(screen.getByRole('tab', { selected: true, name: /^投資信託/ })).toBeInTheDocument();
+      }, waitOpts);
+
+      const mutualfundTab = getMutualfundTab();
+      mutualfundTab.focus();
+      fireEvent.keyDown(mutualfundTab, { key: 'Home' });
+
+      await waitFor(() => {
+        expect(screen.getByRole('tab', { selected: true, name: /^配当金/ })).toBeInTheDocument();
+        expect(getDividendTab()).toHaveFocus();
+      }, waitOpts);
+    });
+
+    it('End キーで最後のタブに移動する', async () => {
+      const { getDividendTab, getMutualfundTab } = await setupKeyboardNavigationTest();
+
+      const dividendTab = getDividendTab();
+      dividendTab.focus();
+      fireEvent.keyDown(dividendTab, { key: 'End' });
+
+      await waitFor(() => {
+        expect(screen.getByRole('tab', { selected: true, name: /^投資信託/ })).toBeInTheDocument();
+        expect(getMutualfundTab()).toHaveFocus();
+      }, waitOpts);
+    });
+
+    it('関係ないキーではタブが変わらない', async () => {
+      const { getDividendTab } = await setupKeyboardNavigationTest();
+
+      const dividendTab = getDividendTab();
+      dividendTab.focus();
+      fireEvent.keyDown(dividendTab, { key: 'Space' });
+
+      await waitFor(() => {
+        expect(screen.getByRole('tab', { selected: true, name: /^配当金/ })).toBeInTheDocument();
+      }, waitOpts);
+
+      expect(getDividendTab()).toHaveFocus();
+      expect(screen.getByTestId('dividend-view')).toBeInTheDocument();
+      expect(screen.queryByTestId('domesticstock-view')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('mutualfund-view')).not.toBeInTheDocument();
+    });
   });
 
   it('CSV読込→保存: uploadCsv API が呼ばれ保存ボタンが消える', async () => {


### PR DESCRIPTION
## 概要
- Receipts ページにタブのキーボードナビゲーションテストを追加
- Mutualfund ページにファンド名検索・年検索のテストを追加
- ページテストのカバレッジを改善

## 主な変更
- ArrowRight / ArrowLeft / Home / End / 非対象キーのタブ移動を検証
- Mutualfund の検索カード操作でファンド名検索と西暦検索の分岐を検証
- 既存の EmptyState テストは維持し、検索系の未カバー分岐を追加で検証

## テスト
- cd frontend && npx vitest run src/pages/__tests__/Receipts.test.tsx src/pages/Receipt/__tests__/Mutualfund.test.tsx
- cd frontend && npx vitest run --coverage --reporter=verbose
- cd frontend && npm run lint -- --max-warnings=0 src/pages/__tests__/Receipts.test.tsx src/pages/Receipt/__tests__/Mutualfund.test.tsx
- cd frontend && npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * 投資信託レシートの証券名および年度別フィルタリング機能の検証テストを追加しました。
  * レシートページのタブキーボードナビゲーション機能（矢印キー、Home/Endキー対応）の検証テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->