### PR TITLE
test: useAuth・ReceiptsAlerts・InputField・useAssetBalance の未カバーパスにテストを追加

### DIFF
--- a/frontend/src/components/atoms/__tests__/InputField.test.tsx
+++ b/frontend/src/components/atoms/__tests__/InputField.test.tsx
@@ -17,10 +17,12 @@ describe('InputField', () => {
   });
 
   it('ヘルプテキストを表示する', () => {
-    render(<InputField label="テスト項目" helpText="数値を入力してください" />);
+    render(<InputField id="amount" label="テスト項目" helpText="半角数字で入力" />);
     
-    expect(screen.getByText('数値を入力してください')).toBeInTheDocument();
-    expect(screen.getByText('数値を入力してください')).toHaveClass('text-secondary');
+    const input = screen.getByLabelText('テスト項目');
+    expect(screen.getByText('半角数字で入力')).toBeInTheDocument();
+    expect(screen.getByText('半角数字で入力')).toHaveClass('text-secondary');
+    expect(input).toHaveAttribute('aria-describedby', 'amount-help');
   });
 
   it('ヘルプテキストとしてReactコンポーネントを表示する', () => {
@@ -34,21 +36,34 @@ describe('InputField', () => {
   it('エラーとヘルプテキストの両方を表示する', () => {
     render(
       <InputField
+        id="amount"
         label="テスト項目"
         error="必須項目です"
-        helpText="数値を入力してください"
+        helpText="半角数字で入力"
       />
     );
     
+    const input = screen.getByLabelText('テスト項目');
     expect(screen.getByText('必須項目です')).toBeInTheDocument();
-    expect(screen.getByText('数値を入力してください')).toBeInTheDocument();
+    expect(screen.getByText('半角数字で入力')).toBeInTheDocument();
+    expect(input).toHaveAttribute('aria-describedby', 'amount-error amount-help');
   });
 
   it('フルワイドオプションが動作する', () => {
     const { container } = render(<InputField label="テスト項目" fullWidth />);
     
     const wrapper = container.querySelector('div.w-full');
+    const input = screen.getByLabelText('テスト項目');
     expect(wrapper).toBeInTheDocument();
+    expect(input).toHaveClass('w-full');
+  });
+
+  it('fullWidth のデフォルト値では w-full クラスが付かない', () => {
+    const { container } = render(<InputField label="テスト項目" />);
+
+    const input = screen.getByLabelText('テスト項目');
+    expect(container.firstChild).not.toHaveClass('w-full');
+    expect(input).not.toHaveClass('w-full');
   });
 
   it('追加のクラス名が適用される', () => {

--- a/frontend/src/features/assetBalance/hooks/__tests__/useAssetBalance.test.ts
+++ b/frontend/src/features/assetBalance/hooks/__tests__/useAssetBalance.test.ts
@@ -12,6 +12,7 @@ import { useAssetBalance } from '../useAssetBalance';
 import { assetBalanceQueryKeys } from '../../queryKeys';
 import * as assetBalanceApiModule from '@/features/assetBalance/api/assetBalanceApi';
 import * as authHook from '@/features/auth/hooks/useAuth';
+import type { AssetBalanceData } from '@/lib/interfaces/assetBalance';
 
 // ────────────────────────────────────────────────────────
 // モック
@@ -54,13 +55,31 @@ function makeWrapper(qc: QueryClient) {
   return Wrapper;
 }
 
+function makeAssetBalanceData(overrides: Partial<AssetBalanceData> = {}): AssetBalanceData {
+  return {
+    security_code: '7203',
+    security_name: 'トヨタ自動車',
+    shares: 100,
+    executing_shares: 0,
+    average_purchase_price: 2000,
+    total_purchase_amount: 200000,
+    current_price: 2100,
+    daily_change: 10,
+    market_value: 210000,
+    profit_loss_rate: 5,
+    ...overrides,
+  };
+}
+
 // ────────────────────────────────────────────────────────
 // テスト
 // ────────────────────────────────────────────────────────
 
-describe('useAssetBalance: ログアウト時キャッシュクリア', () => {
+describe('useAssetBalance', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({}));
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue([]);
   });
 
   it('onLogout コールバック実行で assetBalance キャッシュが除去される', async () => {
@@ -91,6 +110,81 @@ describe('useAssetBalance: ログアウト時キャッシュクリア', () => {
 
     await waitFor(() => {
       expect(qc.getQueryData(assetBalanceQueryKeys.all('user-1'))).toBeUndefined();
+    });
+  });
+
+  it('getAssetBalanceByCode は空文字コードに undefined を返す', () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+
+    const { result } = renderHook(() => useAssetBalance(), { wrapper: makeWrapper(qc) });
+
+    expect(result.current.getAssetBalanceByCode('')).toBeUndefined();
+  });
+
+  it('getAssetBalanceByCode は正規化後に一致する銘柄を返す', async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue([
+      makeAssetBalanceData({ security_code: '7203' }),
+      makeAssetBalanceData({
+        security_code: '6758',
+        security_name: 'ソニーグループ',
+      }),
+    ]);
+
+    const { result } = renderHook(() => useAssetBalance(), { wrapper: makeWrapper(qc) });
+
+    await waitFor(() => {
+      expect(result.current.assetBalanceData).toHaveLength(2);
+    });
+
+    expect(result.current.getAssetBalanceByCode(' 7203 ')).toMatchObject({
+      security_code: '7203',
+      security_name: 'トヨタ自動車',
+    });
+  });
+
+  it('getTotalMarketValue は market_value の合計を返す', async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue([
+      makeAssetBalanceData({ security_code: '7203', market_value: 210000 }),
+      makeAssetBalanceData({
+        security_code: '6758',
+        security_name: 'ソニーグループ',
+        market_value: 180000,
+      }),
+    ]);
+
+    const { result } = renderHook(() => useAssetBalance(), { wrapper: makeWrapper(qc) });
+
+    await waitFor(() => {
+      expect(result.current.assetBalanceData).toHaveLength(2);
+    });
+
+    expect(result.current.getTotalMarketValue()).toBe(390000);
+  });
+
+  it('refetch は assetBalance クエリを invalidate する', async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries');
+
+    const { result } = renderHook(() => useAssetBalance(), { wrapper: makeWrapper(qc) });
+
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: assetBalanceQueryKeys.all('user-1'),
     });
   });
 });

--- a/frontend/src/features/auth/hooks/__tests__/useAuth.test.tsx
+++ b/frontend/src/features/auth/hooks/__tests__/useAuth.test.tsx
@@ -1,0 +1,17 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useAuth } from '../useAuth';
+
+describe('useAuth', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('AuthProvider の外で useAuth を呼ぶと Error を throw する', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => renderHook(() => useAuth())).toThrow(
+      'useAuth must be used within an AuthProvider'
+    );
+  });
+});

--- a/frontend/src/pages/__tests__/ReceiptsAlerts.test.tsx
+++ b/frontend/src/pages/__tests__/ReceiptsAlerts.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ReceiptsAlerts } from '../ReceiptsAlerts';
+import type { CsvPreview } from '../receiptsReducer';
+
+function makeCsvPreview(overrides: Partial<CsvPreview> = {}): CsvPreview {
+  return {
+    totalRows: 1,
+    validRows: 1,
+    errors: [],
+    rows: [],
+    ...overrides,
+  };
+}
+
+describe('ReceiptsAlerts', () => {
+  it('csvPreview.errors があるとエラーリストを表示する', () => {
+    render(
+      <ReceiptsAlerts
+        dbError={null}
+        hasCsvFile
+        previewing={false}
+        csvPreview={makeCsvPreview({
+          errors: [{ row: 2, message: '金額が不正です' }],
+        })}
+      />
+    );
+
+    expect(screen.getByText('2行目: 金額が不正です')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveClass('bg-warning/15');
+  });
+
+  it('csvPreview.errors が空なら warning バリアントを使わない', () => {
+    render(
+      <ReceiptsAlerts
+        dbError={null}
+        hasCsvFile
+        previewing={false}
+        csvPreview={makeCsvPreview()}
+      />
+    );
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveClass('bg-info/10');
+    expect(alert).not.toHaveClass('bg-warning/15');
+  });
+
+  it('dbError があるとエラーメッセージを表示する', () => {
+    render(
+      <ReceiptsAlerts
+        dbError="保存に失敗しました"
+        hasCsvFile={false}
+        previewing={false}
+        csvPreview={null}
+      />
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent('エラー: 保存に失敗しました');
+  });
+
+  it('hasCsvFile=false なら csvPreview セクションを表示しない', () => {
+    render(
+      <ReceiptsAlerts
+        dbError={null}
+        hasCsvFile={false}
+        previewing={false}
+        csvPreview={makeCsvPreview()}
+      />
+    );
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    expect(screen.queryByText('1件 追加で保存されます')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
- useAuth の AuthProvider 外呼び出しエラーパスのテストを追加
- ReceiptsAlerts の csvPreview エラー表示、warning 分岐、dbError、非表示条件のテストを追加
- InputField の helpText、aria-describedby、fullWidth 分岐のテストを追加
- useAssetBalance の getAssetBalanceByCode、getTotalMarketValue、refetch のテストを追加

## テスト
- cd frontend && npx vitest run src/features/auth/hooks/__tests__/useAuth.test.tsx src/pages/__tests__/ReceiptsAlerts.test.tsx src/components/atoms/__tests__/InputField.test.tsx src/features/assetBalance/hooks/__tests__/useAssetBalance.test.ts
- cd frontend && npx vitest run --coverage --reporter=verbose 2>&1 | grep -E \"useAuth\\.ts|ReceiptsAlerts|InputField|useAssetBalance\"
- cd frontend && npm run lint -- --max-warnings=0 src/features/auth/hooks/__tests__/useAuth.test.tsx src/pages/__tests__/ReceiptsAlerts.test.tsx src/components/atoms/__tests__/InputField.test.tsx src/features/assetBalance/hooks/__tests__/useAssetBalance.test.ts
- cd frontend && npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

このリリースに含まれる変更はすべて内部品質向上を目的とした変更です。

* **Tests**
  * 入力フィールドのアクセシビリティ検証を強化
  * 資産残高機能のテストカバレッジを拡大
  * 認証フックのエラーハンドリングテストを追加
  * 領収書アラートコンポーネントのテストを追加

**ユーザーへの影響はありません。**

<!-- end of auto-generated comment: release notes by coderabbit.ai -->