### PR TITLE
テスト: Search URLパラメータと useDividendBatch リトライのカバレッジを改善

### DIFF
--- a/frontend/src/features/jquants/hooks/__tests__/useDividendBatch.test.ts
+++ b/frontend/src/features/jquants/hooks/__tests__/useDividendBatch.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { useDividendBatch } from '../useDividendBatch';
 import * as api from '../../api/dividendPerShareApi';
 import { DividendPerShareItem } from '../../api/dividendPerShareApi';
@@ -19,12 +19,20 @@ const makeItem = (code: string, status: DividendPerShareItem['status'], div: num
   is_stale: false,
 });
 
+const flushAsyncUpdates = async () => {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+};
+
 describe('useDividendBatch', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -73,6 +81,57 @@ describe('useDividendBatch', () => {
     expect(result.current.fetchedCount).toBe(1);
     expect(result.current.totalCount).toBe(2);
     expect(result.current.dividendStatusMap.get('2222')).toBe('pending');
+  });
+
+  it('pending が返る場合はリトライタイマー経由で再フェッチする', async () => {
+    vi.useFakeTimers();
+
+    mockFetch
+      .mockResolvedValueOnce([makeItem('7203', 'pending', null)])
+      .mockResolvedValueOnce([makeItem('7203', 'ok', 50)]);
+
+    const { result } = renderHook(() => useDividendBatch(['7203'], true));
+
+    await flushAsyncUpdates();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(result.current.dividendStatusMap.get('7203')).toBe('pending');
+
+    await act(async () => {
+      await vi.runOnlyPendingTimersAsync();
+    });
+    await flushAsyncUpdates();
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(result.current.dividendStatusMap.get('7203')).toBe('ok');
+    expect(result.current.dividendPerShareMap.get('7203')).toBe(50);
+  });
+
+  it('pending が続いて maxRetries に達すると再フェッチを停止する', async () => {
+    vi.useFakeTimers();
+
+    mockFetch.mockResolvedValue([makeItem('7203', 'pending', null)]);
+
+    renderHook(() => useDividendBatch(['7203'], true));
+
+    await flushAsyncUpdates();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    for (let i = 0; i < 4; i += 1) {
+      await act(async () => {
+        await vi.runOnlyPendingTimersAsync();
+      });
+      await flushAsyncUpdates();
+    }
+
+    expect(mockFetch).toHaveBeenCalledTimes(5);
+
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+    await flushAsyncUpdates();
+
+    expect(mockFetch).toHaveBeenCalledTimes(5);
   });
 
   it('enabled=false のときは状態がクリアされ API が呼ばれない', async () => {

--- a/frontend/src/pages/__tests__/Search.test.tsx
+++ b/frontend/src/pages/__tests__/Search.test.tsx
@@ -67,6 +67,53 @@ describe('SearchPage', () => {
     });
   });
 
+  it('有効な ?code= パラメータがある場合に searchByCode を呼ぶ', () => {
+    const searchByCode = vi.fn();
+
+    mockUseStockSearch.mockReturnValue({
+      stockCode: '',
+      setStockCode: vi.fn(),
+      stockData: undefined,
+      error: null,
+      isLoading: false,
+      isError: false,
+      handleSearch: vi.fn(),
+      searchByCode,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/search?code=7203']}>
+        <SearchPage />
+      </MemoryRouter>
+    );
+
+    expect(searchByCode).toHaveBeenCalledWith('7203');
+  });
+
+  it('無効な ?code= パラメータの場合は警告を表示し searchByCode を呼ばない', () => {
+    const searchByCode = vi.fn();
+
+    mockUseStockSearch.mockReturnValue({
+      stockCode: '',
+      setStockCode: vi.fn(),
+      stockData: undefined,
+      error: null,
+      isLoading: false,
+      isError: false,
+      handleSearch: vi.fn(),
+      searchByCode,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/search?code=12*4']}>
+        <SearchPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('不正な銘柄コードが指定されています。')).toBeInTheDocument();
+    expect(searchByCode).not.toHaveBeenCalled();
+  });
+
   it('ApiError のユーザー向けメッセージを表示する', () => {
     mockUseStockSearch.mockReturnValue({
       stockCode: '',


### PR DESCRIPTION
## 概要
Search と useDividendBatch の未カバーパス向けテストを追加し、URL パラメータ自動検索と pending リトライ挙動の確認を強化しました。

## 変更内容
- `Search.test.tsx` に `?code=7203` で `searchByCode` が発火するケースを追加
- `Search.test.tsx` に不正な `?code=` パラメータで警告表示され、`searchByCode` が呼ばれないケースを追加
- `useDividendBatch.test.ts` に fake timers を使った pending 再試行テストを追加
- `useDividendBatch.test.ts` に maxRetries 到達後に再フェッチが停止するテストを追加
- `useDividendBatch.test.ts` の fake timers 利用後に `vi.useRealTimers()` へ戻す後始末を追加

## テスト
- `cd frontend && npx vitest run src/pages/__tests__/Search.test.tsx src/features/jquants/hooks/__tests__/useDividendBatch.test.ts 2>&1 | tail -10`
- `cd frontend && npx vitest run --coverage --reporter=verbose 2>&1 | grep -E "Search\.tsx|useDividendBatch"`
- `cd frontend && npm run lint -- --max-warnings=0 src/pages/__tests__/Search.test.tsx src/features/jquants/hooks/__tests__/useDividendBatch.test.ts`
- `cd frontend && npm test`

## 補足
- `Search.tsx` は lines 100% まで改善を確認
- `useDividendBatch.ts` は targeted coverage で lines 95.65%, branch 82.35% を確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

このプルリクエストはテストの改善のみを含み、エンドユーザーに対する目に見える変更はありません。

* **Tests**
  * テストのセットアップと実行環境を改善
  * リトライロジックの動作検証に関するテストケースを追加
  * 検索機能のクエリパラメータ処理に関するテストケースを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->