### PR TITLE
test: AssetBalance と useReceiptsData のカバレッジを補強

### DIFF
--- a/frontend/src/features/receipt/hooks/__tests__/useReceiptsData.test.ts
+++ b/frontend/src/features/receipt/hooks/__tests__/useReceiptsData.test.ts
@@ -18,9 +18,24 @@ import * as authHook from '@/features/auth/hooks/useAuth';
 // ────────────────────────────────────────────────────────
 
 vi.mock('@/features/receipt/api/receiptApi', () => ({
-  dividendApi: { list: vi.fn().mockResolvedValue([]), deleteAll: vi.fn().mockResolvedValue({}) },
-  domesticStockApi: { list: vi.fn().mockResolvedValue([]), deleteAll: vi.fn().mockResolvedValue({}) },
-  mutualfundApi: { list: vi.fn().mockResolvedValue([]), deleteAll: vi.fn().mockResolvedValue({}) },
+  dividendApi: {
+    list: vi.fn().mockResolvedValue([]),
+    deleteAll: vi.fn().mockResolvedValue({}),
+    uploadCsv: vi.fn().mockResolvedValue({ inserted: 0, skipped: 0, errors: [] }),
+    previewCsv: vi.fn().mockResolvedValue({ total_rows: 0, valid_rows: 0, errors: [], rows: [] }),
+  },
+  domesticStockApi: {
+    list: vi.fn().mockResolvedValue([]),
+    deleteAll: vi.fn().mockResolvedValue({}),
+    uploadCsv: vi.fn().mockResolvedValue({ inserted: 0, skipped: 0, errors: [] }),
+    previewCsv: vi.fn().mockResolvedValue({ total_rows: 0, valid_rows: 0, errors: [], rows: [] }),
+  },
+  mutualfundApi: {
+    list: vi.fn().mockResolvedValue([]),
+    deleteAll: vi.fn().mockResolvedValue({}),
+    uploadCsv: vi.fn().mockResolvedValue({ inserted: 0, skipped: 0, errors: [] }),
+    previewCsv: vi.fn().mockResolvedValue({ total_rows: 0, valid_rows: 0, errors: [], rows: [] }),
+  },
 }));
 
 vi.mock('@/features/receipt/parsers', () => ({
@@ -69,6 +84,47 @@ function makeWrapper(qc: QueryClient) {
 describe('useReceiptsData: 認証境界・キャッシュ境界', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(receiptApiModule.dividendApi.list).mockResolvedValue([]);
+    vi.mocked(receiptApiModule.dividendApi.deleteAll).mockResolvedValue({} as never);
+    vi.mocked(receiptApiModule.dividendApi.uploadCsv).mockResolvedValue({
+      inserted: 0,
+      skipped: 0,
+      errors: [],
+    } as never);
+    vi.mocked(receiptApiModule.dividendApi.previewCsv).mockResolvedValue({
+      total_rows: 0,
+      valid_rows: 0,
+      errors: [],
+      rows: [],
+    } as never);
+
+    vi.mocked(receiptApiModule.domesticStockApi.list).mockResolvedValue([]);
+    vi.mocked(receiptApiModule.domesticStockApi.deleteAll).mockResolvedValue({} as never);
+    vi.mocked(receiptApiModule.domesticStockApi.uploadCsv).mockResolvedValue({
+      inserted: 0,
+      skipped: 0,
+      errors: [],
+    } as never);
+    vi.mocked(receiptApiModule.domesticStockApi.previewCsv).mockResolvedValue({
+      total_rows: 0,
+      valid_rows: 0,
+      errors: [],
+      rows: [],
+    } as never);
+
+    vi.mocked(receiptApiModule.mutualfundApi.list).mockResolvedValue([]);
+    vi.mocked(receiptApiModule.mutualfundApi.deleteAll).mockResolvedValue({} as never);
+    vi.mocked(receiptApiModule.mutualfundApi.uploadCsv).mockResolvedValue({
+      inserted: 0,
+      skipped: 0,
+      errors: [],
+    } as never);
+    vi.mocked(receiptApiModule.mutualfundApi.previewCsv).mockResolvedValue({
+      total_rows: 0,
+      valid_rows: 0,
+      errors: [],
+      rows: [],
+    } as never);
   });
 
   it('未認証時: API フェッチが行われない', async () => {
@@ -166,5 +222,188 @@ describe('useReceiptsData: 認証境界・キャッシュ境界', () => {
     });
     expect(qc.getQueryData(receiptQueryKeys.domesticstock('user-1'))).toBeUndefined();
     expect(qc.getQueryData(receiptQueryKeys.mutualfund('user-1'))).toBeUndefined();
+  });
+
+  it('uploadCsv mutation: dividend で invalidate と onSuccess が実行される', async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+    const invalidateQueriesSpy = vi.spyOn(qc, 'invalidateQueries');
+    const onSuccess = vi.fn();
+
+    vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({ isAuthenticated: true }));
+    vi.mocked(receiptApiModule.dividendApi.uploadCsv).mockResolvedValue({
+      inserted: 2,
+      skipped: 1,
+      errors: [],
+    } as never);
+
+    const { result } = renderHook(() => useReceiptsData(), { wrapper: makeWrapper(qc) });
+
+    await waitFor(() => {
+      expect(qc.getQueryData(receiptQueryKeys.dividend('user-1'))).toEqual([]);
+    });
+
+    act(() => {
+      result.current.uploadCsv({
+        type: 'dividend',
+        file: new File([''], 'test.csv'),
+        onSuccess,
+      });
+    });
+
+    await waitFor(() => {
+      expect(receiptApiModule.dividendApi.uploadCsv).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith({ inserted: 2, skipped: 1, errors: [] });
+    });
+    await waitFor(() => {
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+        queryKey: receiptQueryKeys.dividend('user-1'),
+      });
+    });
+    await waitFor(() => {
+      expect(receiptApiModule.dividendApi.list).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('deleteAll mutation: domesticstock と mutualfund を削除できる', async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+
+    vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({ isAuthenticated: true }));
+
+    const { result } = renderHook(() => useReceiptsData(), { wrapper: makeWrapper(qc) });
+
+    act(() => {
+      result.current.deleteAll('domesticstock');
+    });
+    await waitFor(() => {
+      expect(receiptApiModule.domesticStockApi.deleteAll).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      result.current.deleteAll('mutualfund');
+    });
+    await waitFor(() => {
+      expect(receiptApiModule.mutualfundApi.deleteAll).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('previewCsv mutation: dividend 成功時に整形済み結果を返す', async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+    const onSuccess = vi.fn();
+
+    vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({ isAuthenticated: true }));
+    vi.mocked(receiptApiModule.dividendApi.previewCsv).mockResolvedValue({
+      total_rows: 3,
+      valid_rows: 3,
+      errors: [],
+      rows: [],
+    } as never);
+
+    const { result } = renderHook(() => useReceiptsData(), { wrapper: makeWrapper(qc) });
+
+    act(() => {
+      result.current.previewCsv({
+        type: 'dividend',
+        file: new File([''], 'test.csv'),
+        onSuccess,
+      });
+    });
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith({
+        totalRows: 3,
+        validRows: 3,
+        errors: [],
+        rows: [],
+      });
+    });
+  });
+
+  it('previewCsv mutation: エラー時に onError が呼ばれる', async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+    const onError = vi.fn();
+
+    vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({ isAuthenticated: true }));
+    vi.mocked(receiptApiModule.dividendApi.previewCsv).mockRejectedValue(new Error('解析失敗'));
+
+    const { result } = renderHook(() => useReceiptsData(), { wrapper: makeWrapper(qc) });
+
+    act(() => {
+      result.current.previewCsv({
+        type: 'dividend',
+        file: new File([''], 'test.csv'),
+        onError,
+      });
+    });
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith('解析失敗');
+    });
+  });
+
+  it('clearCache 実行で receipts キャッシュが消える', async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+
+    vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({ isAuthenticated: true }));
+    vi.mocked(receiptApiModule.dividendApi.list).mockResolvedValue([
+      { id: '1', payment_date: '2023-01-01' } as never,
+    ]);
+    vi.mocked(receiptApiModule.domesticStockApi.list).mockResolvedValue([
+      { id: '2', trade_date: '2023-01-02' } as never,
+    ]);
+    vi.mocked(receiptApiModule.mutualfundApi.list).mockResolvedValue([
+      { id: '3', settlement_date: '2023-01-03' } as never,
+    ]);
+
+    const { result } = renderHook(() => useReceiptsData(), { wrapper: makeWrapper(qc) });
+
+    await waitFor(() => {
+      expect(qc.getQueryData(receiptQueryKeys.dividend('user-1'))).toBeDefined();
+      expect(qc.getQueryData(receiptQueryKeys.domesticstock('user-1'))).toBeDefined();
+      expect(qc.getQueryData(receiptQueryKeys.mutualfund('user-1'))).toBeDefined();
+    });
+
+    act(() => {
+      result.current.clearCache();
+    });
+
+    await waitFor(() => {
+      expect(qc.getQueryData(receiptQueryKeys.dividend('user-1'))).toBeUndefined();
+      expect(qc.getQueryData(receiptQueryKeys.domesticstock('user-1'))).toBeUndefined();
+      expect(qc.getQueryData(receiptQueryKeys.mutualfund('user-1'))).toBeUndefined();
+    });
+  });
+
+  it('uploadCsv mutation エラー時: dbError に反映される', async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+
+    vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({ isAuthenticated: true }));
+    vi.mocked(receiptApiModule.dividendApi.uploadCsv).mockRejectedValue(new Error('アップロード失敗'));
+
+    const { result } = renderHook(() => useReceiptsData(), { wrapper: makeWrapper(qc) });
+
+    act(() => {
+      result.current.uploadCsv({
+        type: 'dividend',
+        file: new File([''], 'test.csv'),
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.dbError).toBe('アップロード失敗');
+    });
   });
 });

--- a/frontend/src/pages/__tests__/AssetBalancePage.test.tsx
+++ b/frontend/src/pages/__tests__/AssetBalancePage.test.tsx
@@ -45,18 +45,59 @@ vi.mock('@/components/molecules/CSVFileInput', () => ({
   ),
 }));
 vi.mock('@/components/molecules/ConfirmDeleteModal/ConfirmDeleteModal', () => ({
-  ConfirmDeleteModal: ({ isOpen, onConfirm }: { isOpen: boolean; onConfirm: () => void }) =>
+  ConfirmDeleteModal: ({
+    isOpen,
+    onConfirm,
+    onCancel,
+  }: {
+    isOpen: boolean;
+    onConfirm: () => void;
+    onCancel: () => void;
+  }) =>
     isOpen ? (
-      <button data-testid="confirm-delete" onClick={onConfirm}>削除する</button>
+      <div data-testid="confirm-delete">
+        <button onClick={onConfirm}>削除する</button>
+        <button onClick={onCancel}>キャンセル</button>
+      </div>
     ) : null,
 }));
 vi.mock('@/components/organisms/AssetPortfolioSummary', () => ({
-  AssetPortfolioSummary: ({ assetBalanceData }: { assetBalanceData: unknown[] }) => (
-    <div data-testid="portfolio-summary">{assetBalanceData.length}</div>
+  AssetPortfolioSummary: ({
+    assetBalanceData,
+    totalCount,
+    isFiltered,
+    onClearFilter,
+  }: {
+    assetBalanceData: unknown[];
+    totalCount: number;
+    isFiltered: boolean;
+    onClearFilter?: () => void;
+  }) => (
+    <div>
+      <div data-testid="portfolio-summary">{`${assetBalanceData.length}/${totalCount}`}</div>
+      {isFiltered && onClearFilter ? (
+        <button data-testid="clear-filter" onClick={onClearFilter}>
+          条件をクリア
+        </button>
+      ) : null}
+    </div>
   ),
 }));
 vi.mock('@/components/organisms/SearchCard/SearchCard', () => ({
-  SearchCard: () => <div data-testid="search-card" />,
+  SearchCard: ({
+    onSearch,
+    value,
+  }: {
+    onSearch: (query: string) => void;
+    value: string;
+  }) => (
+    <div data-testid="search-card">
+      <span data-testid="search-value">{value}</span>
+      <button data-testid="apply-search" onClick={() => onSearch('6758')}>
+        検索
+      </button>
+    </div>
+  ),
 }));
 
 // AssetBalance API
@@ -138,6 +179,12 @@ const mockDbRow: AssetBalanceData = {
   profit_loss_rate: 4.0,
 };
 
+const secondMockDbRow: AssetBalanceData = {
+  ...mockDbRow,
+  security_code: '6758',
+  security_name: 'ソニーグループ',
+};
+
 // ────────────────────────────────────────────────────────
 // テスト
 // ────────────────────────────────────────────────────────
@@ -146,6 +193,18 @@ describe('AssetBalancePage 認証境界・キャッシュ境界', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue([]);
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.previewCsv).mockResolvedValue({
+      total_rows: 0,
+      valid_rows: 0,
+      errors: [],
+      rows: [],
+    } as never);
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.uploadCsv).mockResolvedValue({
+      inserted: 0,
+      skipped: 0,
+      errors: [],
+    } as never);
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.deleteAll).mockResolvedValue({} as never);
   });
 
   it('未認証時: ログインプロンプトが表示され API フェッチが行われない', async () => {
@@ -157,6 +216,15 @@ describe('AssetBalancePage 認証境界・キャッシュ境界', () => {
       expect(screen.getByText(/ログインが必要です/)).toBeInTheDocument();
     });
     expect(assetBalanceApiModule.assetBalanceApi.list).not.toHaveBeenCalled();
+  });
+
+  it('認証確認中: スピナーと案内文が表示される', async () => {
+    vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({ authLoading: true }));
+
+    await act(async () => { renderWithQuery(<AssetBalancePage />); });
+
+    expect(screen.getAllByRole('status').length).toBeGreaterThan(0);
+    expect(screen.getByText('認証状態を確認しています...')).toBeInTheDocument();
   });
 
   it('認証済み・DBデータあり: 全件削除ボタンが表示される', async () => {
@@ -224,6 +292,153 @@ describe('AssetBalancePage 認証境界・キャッシュ境界', () => {
     expect(screen.getByText('全件置換')).toBeInTheDocument();
     expect(screen.getByText('1件スキップ')).toBeInTheDocument();
     expect(screen.queryByText(/2件保存しました/)).not.toBeInTheDocument();
+  });
+
+  it('認証済み・一覧取得失敗時: エラーメッセージが表示される', async () => {
+    vi.mocked(authHook.useAuth).mockReturnValue(
+      makeAuthMock({ isAuthenticated: true, userId: 'user-1' })
+    );
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockRejectedValue(new Error('取得失敗'));
+
+    await act(async () => { renderWithQuery(<AssetBalancePage />); });
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('取得失敗');
+    });
+  });
+
+  it('認証済み・DBデータあり: SearchCard が表示される', async () => {
+    vi.mocked(authHook.useAuth).mockReturnValue(
+      makeAuthMock({ isAuthenticated: true, userId: 'user-1' })
+    );
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue([mockDbRow]);
+
+    await act(async () => { renderWithQuery(<AssetBalancePage />); });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('search-card')).toBeInTheDocument();
+    });
+  });
+
+  it('検索操作: SearchCard から絞り込みとクリアができる', async () => {
+    vi.mocked(authHook.useAuth).mockReturnValue(
+      makeAuthMock({ isAuthenticated: true, userId: 'user-1' })
+    );
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue([mockDbRow, secondMockDbRow]);
+
+    await act(async () => { renderWithQuery(<AssetBalancePage />); });
+
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('portfolio-summary')).toHaveTextContent('2/2');
+    });
+
+    await user.click(screen.getByTestId('apply-search'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('search-value')).toHaveTextContent('6758');
+      expect(screen.getByTestId('portfolio-summary')).toHaveTextContent('1/2');
+      expect(screen.getByTestId('clear-filter')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId('clear-filter'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('search-value')).toHaveTextContent('');
+      expect(screen.getByTestId('portfolio-summary')).toHaveTextContent('2/2');
+    });
+  });
+
+  it('削除確認フロー: モーダル経由で全件削除が実行される', async () => {
+    vi.mocked(authHook.useAuth).mockReturnValue(
+      makeAuthMock({ isAuthenticated: true, userId: 'user-1' })
+    );
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue([mockDbRow]);
+
+    await act(async () => { renderWithQuery(<AssetBalancePage />); });
+
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /全件削除/ })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /全件削除/ }));
+    expect(screen.getByTestId('confirm-delete')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: '削除する' }));
+
+    await waitFor(() => {
+      expect(assetBalanceApiModule.assetBalanceApi.deleteAll).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('削除確認フロー: キャンセルすると削除は実行されない', async () => {
+    vi.mocked(authHook.useAuth).mockReturnValue(
+      makeAuthMock({ isAuthenticated: true, userId: 'user-1' })
+    );
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue([mockDbRow]);
+
+    await act(async () => { renderWithQuery(<AssetBalancePage />); });
+
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /全件削除/ })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /全件削除/ }));
+    expect(screen.getByTestId('confirm-delete')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'キャンセル' }));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('confirm-delete')).not.toBeInTheDocument();
+    });
+    expect(assetBalanceApiModule.assetBalanceApi.deleteAll).not.toHaveBeenCalled();
+  });
+
+  it('保存中: スピナーテキストが表示される', async () => {
+    let resolveUpload!: (value: unknown) => void;
+
+    vi.mocked(authHook.useAuth).mockReturnValue(
+      makeAuthMock({ isAuthenticated: true, userId: 'user-1' })
+    );
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.previewCsv).mockResolvedValue({
+      total_rows: 1,
+      valid_rows: 1,
+      errors: [],
+      rows: [mockDbRow],
+    } as never);
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.uploadCsv).mockReturnValue(
+      new Promise((resolve) => {
+        resolveUpload = resolve;
+      }) as never
+    );
+
+    await act(async () => { renderWithQuery(<AssetBalancePage />); });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('csv-file-input'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /全件置換で保存/ })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /全件置換で保存/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText('データを保存しています...')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      resolveUpload({ inserted: 1, skipped: 0, errors: [] });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('保存しました')).toBeInTheDocument();
+    });
   });
 
   it('ログアウト: onLogout コールバック実行でキャッシュが除去される', async () => {


### PR DESCRIPTION
## 概要
AssetBalancePage と useReceiptsData の未カバー分岐にテストを追加し、対象ファイルのカバレッジを 90% 以上まで引き上げました。

## 変更内容
- AssetBalancePage に認証確認中、一覧取得エラー、削除確認、保存中表示、SearchCard 表示、検索絞り込みとクリアのテストを追加
- useReceiptsData に uploadCsv / previewCsv / deleteAll / clearCache / mutationError のテストを追加
- mutation 系モックの初期化を beforeEach で揃え、テスト間の影響を防止

## カバレッジ
- AssetBalance.tsx: 97.05%
- useReceiptsData.ts: 91.11%

## テスト
- frontend: `vp lint`
- frontend: `npx tsc --noEmit`
- frontend: `npm test -- --run`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for receipt data handling, including CSV upload, preview, and deletion workflows.
  * Enhanced test mocks and assertions for asset balance page components and API interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->