### PR TITLE
fix: 配当検索とCSVエンコーディングのカバレッジを改善

### DIFF
--- a/frontend/src/features/jquants/api/__tests__/dividendPerShareApi.test.ts
+++ b/frontend/src/features/jquants/api/__tests__/dividendPerShareApi.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { apiClient } from '@/lib/api/client';
+import { fetchDividendPerShareBatch } from '../dividendPerShareApi';
+
+vi.mock('@/lib/api/client', () => ({
+  apiClient: {
+    post: vi.fn(),
+  },
+}));
+
+describe('fetchDividendPerShareBatch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('security_codes を POST して items を返す', async () => {
+    const mockItems = [
+      {
+        security_code: '7203',
+        dividend_per_share: 100,
+        status: 'ok' as const,
+        fetched_at: '2024-01-01',
+        is_stale: false,
+      },
+    ];
+    (apiClient.post as ReturnType<typeof vi.fn>).mockResolvedValue({ items: mockItems });
+
+    const result = await fetchDividendPerShareBatch(['7203']);
+
+    expect(apiClient.post).toHaveBeenCalledWith('/dividends/per-share/batch', {
+      security_codes: ['7203'],
+    });
+    expect(result).toEqual(mockItems);
+  });
+
+  it('空配列でも POST して空配列を返す', async () => {
+    (apiClient.post as ReturnType<typeof vi.fn>).mockResolvedValue({ items: [] });
+
+    const result = await fetchDividendPerShareBatch([]);
+
+    expect(apiClient.post).toHaveBeenCalledWith('/dividends/per-share/batch', {
+      security_codes: [],
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('複数銘柄コードを正しいペイロードで送信する', async () => {
+    const securityCodes = ['7203', '6758'];
+    const mockItems = securityCodes.map((securityCode, index) => ({
+      security_code: securityCode,
+      dividend_per_share: 100 + index,
+      status: 'ok' as const,
+      fetched_at: '2024-01-01',
+      is_stale: false,
+    }));
+    (apiClient.post as ReturnType<typeof vi.fn>).mockResolvedValue({ items: mockItems });
+
+    const result = await fetchDividendPerShareBatch(securityCodes);
+
+    expect(apiClient.post).toHaveBeenCalledWith('/dividends/per-share/batch', {
+      security_codes: securityCodes,
+    });
+    expect(result).toEqual(mockItems);
+  });
+});

--- a/frontend/src/lib/csv/__tests__/encoding.test.ts
+++ b/frontend/src/lib/csv/__tests__/encoding.test.ts
@@ -1,12 +1,17 @@
-import { describe, it, expect } from 'vitest';
-import { 
-  detectMojibake, 
-  calculateEncodingConfidence, 
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  detectMojibake,
+  calculateEncodingConfidence,
   removeBOM,
-  tryDecodeWithMultipleEncodings 
+  tryDecodeWithMultipleEncodings
 } from '../encoding';
 
 describe('encoding utilities', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
   describe('detectMojibake', () => {
     it('文字化けを検出する', () => {
       expect(detectMojibake('正常なテキスト')).toBe(false);
@@ -138,5 +143,105 @@ describe('encoding utilities', () => {
       expect(result.text).toBeDefined();
     });
 
+    it('未サポートのエンコーディングはスキップして他の結果を使う', () => {
+      const originalTextDecoder = TextDecoder;
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      class MockTextDecoder {
+        private readonly decoder: TextDecoder;
+
+        constructor(encoding = 'utf-8', options?: TextDecoderOptions) {
+          if (encoding === 'shift-jis') {
+            throw new TypeError('unsupported encoding');
+          }
+          this.decoder = new originalTextDecoder(encoding, options);
+        }
+
+        decode(input?: Uint8Array) {
+          return this.decoder.decode(input);
+        }
+      }
+      vi.stubGlobal('TextDecoder', MockTextDecoder as unknown as typeof TextDecoder);
+
+      const result = tryDecodeWithMultipleEncodings(new TextEncoder().encode('こんにちは世界'));
+
+      expect(result.encoding).toBe('utf-8');
+      expect(warnSpy).toHaveBeenCalled();
+    });
+
+    it('decode で例外が発生したエンコーディングはスキップする', () => {
+      const originalTextDecoder = TextDecoder;
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      class MockTextDecoder {
+        private readonly decoder?: TextDecoder;
+        private readonly shouldThrow: boolean;
+
+        constructor(encoding = 'utf-8', options?: TextDecoderOptions) {
+          this.shouldThrow = encoding === 'iso-8859-1';
+          if (!this.shouldThrow) {
+            this.decoder = new originalTextDecoder(encoding, options);
+          }
+        }
+
+        decode(input?: Uint8Array) {
+          if (this.shouldThrow) {
+            throw new TypeError('decode failed');
+          }
+          return this.decoder!.decode(input);
+        }
+      }
+      vi.stubGlobal('TextDecoder', MockTextDecoder as unknown as typeof TextDecoder);
+
+      const result = tryDecodeWithMultipleEncodings(new TextEncoder().encode('こんにちは世界'));
+
+      expect(result.encoding).toBe('utf-8');
+      expect(warnSpy).toHaveBeenCalled();
+    });
+
+    it('予期しない例外は外側の catch で握りつぶして継続する', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      vi.spyOn(Math, 'max').mockImplementationOnce(() => {
+        throw new Error('unexpected failure');
+      });
+
+      const result = tryDecodeWithMultipleEncodings(new TextEncoder().encode('hello'));
+
+      expect(result.text).toBeTruthy();
+      expect(warnSpy).toHaveBeenCalledWith(
+        'utf-8 でのデコードに失敗しました:',
+        'unexpected failure'
+      );
+    });
+
+    it('全エンコーディングの信頼度が低い場合は utf-8 fallback を返す', () => {
+      class MockTextDecoder {
+        decode() {
+          return '�\u0000';
+        }
+      }
+      vi.stubGlobal('TextDecoder', MockTextDecoder as unknown as typeof TextDecoder);
+
+      const result = tryDecodeWithMultipleEncodings(new Uint8Array([0x00]));
+
+      expect(result).toEqual({
+        text: '�\u0000',
+        encoding: 'utf-8',
+        confidence: 0.3
+      });
+    });
+
+    it('utf-8 fallback も失敗した場合はバイト列から文字列を組み立てる', () => {
+      const textDecoderMock = vi.fn().mockImplementation(() => {
+        throw new TypeError('always fail');
+      });
+      vi.stubGlobal('TextDecoder', textDecoderMock as unknown as typeof TextDecoder);
+
+      const result = tryDecodeWithMultipleEncodings(new Uint8Array([65, 66, 67]));
+
+      expect(result).toEqual({
+        text: 'ABC',
+        encoding: 'unknown',
+        confidence: 0.1
+      });
+    });
   });
 });

--- a/frontend/src/pages/Receipt/Dividend.tsx
+++ b/frontend/src/pages/Receipt/Dividend.tsx
@@ -124,7 +124,7 @@ export const Dividend: React.FC<DividendProps> = ({ data, previewData, utilityRa
     const searchSecurityCode = (() => {
         if (!searchQuery) return '';
         const normalizedQuery = searchQuery.toLowerCase();
-        const labelMatch = searchQuery.match(/^\\s*([0-9A-Za-z]+)\\s*[:：]/);
+        const labelMatch = searchQuery.match(/^\s*([0-9A-Za-z]+)\s*[:：]/);
         if (labelMatch) {
             return labelMatch[1];
         }

--- a/frontend/src/pages/Receipt/__tests__/Dividend.test.tsx
+++ b/frontend/src/pages/Receipt/__tests__/Dividend.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
+import * as receiptHooks from '@/hooks/receipt/useReceiptData';
 import { Dividend } from '../Dividend';
 
 // React Router DOM のモック
@@ -286,5 +287,91 @@ describe('Dividend', () => {
 
         // 入力フォーム（spinbutton）は表示されない（embedded モードは read-only）
         expect(screen.queryAllByRole('spinbutton').length).toBe(0);
+    });
+
+    it('商品で検索すると商品名でグループ化される', async () => {
+        const user = userEvent.setup();
+        render(<Dividend data={mockData} />);
+
+        await user.click(screen.getByTestId('search-card-header'));
+        await user.click(await screen.findByRole('button', { name: '株式' }));
+
+        await waitFor(() => {
+            const summaryCell = screen.getByRole('table').querySelector('tbody tr td');
+            expect(summaryCell).toHaveTextContent('株式');
+            expect(summaryCell).toHaveTextContent('2件');
+        });
+    });
+
+    it('口座で検索すると口座名でグループ化される', async () => {
+        const user = userEvent.setup();
+        render(<Dividend data={mockData} />);
+
+        await user.click(screen.getByTestId('search-card-header'));
+        await user.click(await screen.findByRole('button', { name: '特定口座' }));
+
+        await waitFor(() => {
+            const summaryCell = screen.getByRole('table').querySelector('tbody tr td');
+            expect(summaryCell).toHaveTextContent('特定口座');
+            expect(summaryCell).toHaveTextContent('2件');
+        });
+    });
+
+    it('年で検索すると年月単位のグループが維持される', async () => {
+        const user = userEvent.setup();
+        const { container } = render(<Dividend data={mockData} />);
+
+        const searchCardHeader = screen.getByTestId('search-card-header');
+        fireEvent.click(searchCardHeader);
+        await waitFor(() => {
+            expect(container.querySelector('#years-search')).toBeInTheDocument();
+        });
+
+        const yearSelect = container.querySelector('#years-search') as HTMLSelectElement;
+        await user.selectOptions(yearSelect, '2023');
+
+        await waitFor(() => {
+            expect(screen.getByText('2023年1月')).toBeInTheDocument();
+            expect(screen.getByText('2023年2月')).toBeInTheDocument();
+        });
+    });
+
+    it('年月検索クエリでは年月単位でグループ化される', () => {
+        const useReceiptBaseDataSpy = vi.spyOn(receiptHooks, 'useReceiptBaseData').mockReturnValue({
+            sortedData: mockData,
+            searchQuery: '2023-01',
+            setSearchQuery: vi.fn(),
+            filteredData: [mockData[0]],
+        } as ReturnType<typeof receiptHooks.useReceiptBaseData>);
+
+        try {
+            render(<Dividend data={mockData} />);
+
+            expect(screen.getByText('2023年1月')).toBeInTheDocument();
+            expect(screen.queryByText('2023年2月')).not.toBeInTheDocument();
+        } finally {
+            useReceiptBaseDataSpy.mockRestore();
+        }
+    });
+
+    it('コード付きラベル形式の検索クエリでも銘柄詳細ヘッダーが表示される', async () => {
+        const useReceiptBaseDataSpy = vi.spyOn(receiptHooks, 'useReceiptBaseData').mockReturnValue({
+            sortedData: mockData,
+            searchQuery: '1234: テスト株式1',
+            setSearchQuery: vi.fn(),
+            filteredData: [],
+        } as ReturnType<typeof receiptHooks.useReceiptBaseData>);
+
+        try {
+            render(<Dividend data={mockData} />);
+
+            await waitFor(() => {
+                expect(screen.getByText('平均取得価格')).toBeVisible();
+                expect(screen.getByText('一株配当')).toBeVisible();
+                expect(screen.getByText('受取金額 (累積利回り)')).toBeVisible();
+            });
+        } finally {
+            useReceiptBaseDataSpy.mockRestore();
+        }
     });
 });


### PR DESCRIPTION
## 概要
配当一覧の検索分岐と CSV エンコーディング判定の未カバー分岐をテストで補強しました。
あわせて、`1234: テスト株式1` のようなラベル形式クエリで銘柄コード補完が効かない不具合を修正しました。

## 変更内容
- `Dividend.test.tsx` に商品・口座・年・年月・ラベル形式検索のケースを追加
- `Dividend.tsx` の `labelMatch` 正規表現を修正
- `dividendPerShareApi.test.ts` を新規追加し、単一・空配列・複数コードの POST を検証
- `encoding.test.ts` に `TextDecoder` の constructor/decode 例外、低信頼度 fallback、最終バイト fallback のケースを追加

## カバレッジ
- `Dividend.tsx`: 98.14%
- `dividendPerShareApi.ts`: 100%
- `encoding.ts`: 100%

## テスト
- `cd frontend && vp lint`
- `cd frontend && npx tsc --noEmit`
- `cd frontend && npm test -- --run`
- `cd frontend && npx vitest run --coverage src/pages/Receipt/__tests__/Dividend.test.tsx src/features/jquants/api/__tests__/dividendPerShareApi.test.ts src/lib/csv/__tests__/encoding.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 配当金検索時の検索クエリからセキュリティコードを抽出する処理を改善しました。

* **Tests**
  * 配当金バッチ取得機能のテストスイートを追加しました。
  * ファイルエンコーディング処理とUIグループ化動作に関するテストカバレッジを拡張しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->