### PR TITLE
test: Receipts関連のテストカバレッジを補強

### DIFF
--- a/frontend/src/features/receipt/hooks/__tests__/useReceiptsData.test.ts
+++ b/frontend/src/features/receipt/hooks/__tests__/useReceiptsData.test.ts
@@ -326,6 +326,82 @@ describe('useReceiptsData: 認証境界・キャッシュ境界', () => {
     });
   });
 
+  it('previewCsv mutation: domesticstock で previewCsv が呼ばれる', async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+    const onSuccess = vi.fn();
+    const file = new File([''], 'domesticstock.csv');
+
+    vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({ isAuthenticated: true }));
+    vi.mocked(receiptApiModule.domesticStockApi.previewCsv).mockResolvedValue({
+      total_rows: 2,
+      valid_rows: 1,
+      errors: [{ row: 2, message: 'invalid' }],
+      rows: [{ id: 'ds-1' }],
+    } as never);
+
+    const { result } = renderHook(() => useReceiptsData(), { wrapper: makeWrapper(qc) });
+
+    act(() => {
+      result.current.previewCsv({
+        type: 'domesticstock',
+        file,
+        onSuccess,
+      });
+    });
+
+    await waitFor(() => {
+      expect(receiptApiModule.domesticStockApi.previewCsv).toHaveBeenCalledWith(file);
+    });
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith({
+        totalRows: 2,
+        validRows: 1,
+        errors: [{ row: 2, message: 'invalid' }],
+        rows: [{ id: 'ds-1' }],
+      });
+    });
+  });
+
+  it('previewCsv mutation: mutualfund で previewCsv が呼ばれる', async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+    const onSuccess = vi.fn();
+    const file = new File([''], 'mutualfund.csv');
+
+    vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({ isAuthenticated: true }));
+    vi.mocked(receiptApiModule.mutualfundApi.previewCsv).mockResolvedValue({
+      total_rows: 3,
+      valid_rows: 3,
+      errors: [],
+      rows: [{ id: 'mf-1' }, { id: 'mf-2' }],
+    } as never);
+
+    const { result } = renderHook(() => useReceiptsData(), { wrapper: makeWrapper(qc) });
+
+    act(() => {
+      result.current.previewCsv({
+        type: 'mutualfund',
+        file,
+        onSuccess,
+      });
+    });
+
+    await waitFor(() => {
+      expect(receiptApiModule.mutualfundApi.previewCsv).toHaveBeenCalledWith(file);
+    });
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith({
+        totalRows: 3,
+        validRows: 3,
+        errors: [],
+        rows: [{ id: 'mf-1' }, { id: 'mf-2' }],
+      });
+    });
+  });
+
   it('previewCsv mutation: エラー時に onError が呼ばれる', async () => {
     const qc = new QueryClient({
       defaultOptions: { queries: { retry: false, staleTime: Infinity } },
@@ -404,6 +480,94 @@ describe('useReceiptsData: 認証境界・キャッシュ境界', () => {
 
     await waitFor(() => {
       expect(result.current.dbError).toBe('アップロード失敗');
+    });
+  });
+
+  it('uploadCsv mutation: domesticstock で invalidate と onSuccess が実行される', async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+    const invalidateQueriesSpy = vi.spyOn(qc, 'invalidateQueries');
+    const onSuccess = vi.fn();
+
+    vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({ isAuthenticated: true }));
+    vi.mocked(receiptApiModule.domesticStockApi.uploadCsv).mockResolvedValue({
+      inserted: 4,
+      skipped: 1,
+      errors: [],
+    } as never);
+
+    const { result } = renderHook(() => useReceiptsData(), { wrapper: makeWrapper(qc) });
+
+    await waitFor(() => {
+      expect(qc.getQueryData(receiptQueryKeys.domesticstock('user-1'))).toEqual([]);
+    });
+
+    act(() => {
+      result.current.uploadCsv({
+        type: 'domesticstock',
+        file: new File([''], 'domesticstock.csv'),
+        onSuccess,
+      });
+    });
+
+    await waitFor(() => {
+      expect(receiptApiModule.domesticStockApi.uploadCsv).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith({ inserted: 4, skipped: 1, errors: [] });
+    });
+    await waitFor(() => {
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+        queryKey: receiptQueryKeys.domesticstock('user-1'),
+      });
+    });
+    await waitFor(() => {
+      expect(receiptApiModule.domesticStockApi.list).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('uploadCsv mutation: mutualfund で invalidate と onSuccess が実行される', async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+    const invalidateQueriesSpy = vi.spyOn(qc, 'invalidateQueries');
+    const onSuccess = vi.fn();
+
+    vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({ isAuthenticated: true }));
+    vi.mocked(receiptApiModule.mutualfundApi.uploadCsv).mockResolvedValue({
+      inserted: 5,
+      skipped: 0,
+      errors: [],
+    } as never);
+
+    const { result } = renderHook(() => useReceiptsData(), { wrapper: makeWrapper(qc) });
+
+    await waitFor(() => {
+      expect(qc.getQueryData(receiptQueryKeys.mutualfund('user-1'))).toEqual([]);
+    });
+
+    act(() => {
+      result.current.uploadCsv({
+        type: 'mutualfund',
+        file: new File([''], 'mutualfund.csv'),
+        onSuccess,
+      });
+    });
+
+    await waitFor(() => {
+      expect(receiptApiModule.mutualfundApi.uploadCsv).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith({ inserted: 5, skipped: 0, errors: [] });
+    });
+    await waitFor(() => {
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+        queryKey: receiptQueryKeys.mutualfund('user-1'),
+      });
+    });
+    await waitFor(() => {
+      expect(receiptApiModule.mutualfundApi.list).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/frontend/src/lib/utils/__tests__/formatters.test.ts
+++ b/frontend/src/lib/utils/__tests__/formatters.test.ts
@@ -181,6 +181,23 @@ describe('数値関連のフォーマット関数', () => {
       expect(formatNumber('abc')).toBe('-');
       expect(formatNumber(null)).toBe('-');
     });
+
+    it('フォーマット例外時に "-" を返す', () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const numberFormatSpy = vi
+        .spyOn(Intl, 'NumberFormat')
+        .mockImplementationOnce(() => ({
+          format: () => {
+            throw new Error('format failed');
+          },
+        }) as unknown as Intl.NumberFormat);
+
+      expect(formatNumber(100)).toBe('-');
+      expect(consoleErrorSpy).toHaveBeenCalled();
+
+      numberFormatSpy.mockRestore();
+      consoleErrorSpy.mockRestore();
+    });
   });
 
   describe('formatCurrency', () => {
@@ -207,6 +224,23 @@ describe('数値関連のフォーマット関数', () => {
     it('文字列でも数値でもない値でハイフンを返す', () => {
       expect(formatCurrency(true)).toBe('-');
       expect(formatCurrency(null)).toBe('-');
+    });
+
+    it('フォーマット例外時に "-" を返す', () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const numberFormatSpy = vi
+        .spyOn(Intl, 'NumberFormat')
+        .mockImplementationOnce(() => ({
+          format: () => {
+            throw new Error('format failed');
+          },
+        }) as unknown as Intl.NumberFormat);
+
+      expect(formatCurrency(100)).toBe('-');
+      expect(consoleErrorSpy).toHaveBeenCalled();
+
+      numberFormatSpy.mockRestore();
+      consoleErrorSpy.mockRestore();
     });
   });
 

--- a/frontend/src/pages/__tests__/Receipts.test.tsx
+++ b/frontend/src/pages/__tests__/Receipts.test.tsx
@@ -15,6 +15,7 @@ import { receiptsReducer, initialState } from '../receiptsReducer';
 import type { ReceiptsState } from '../receiptsReducer';
 import { ReceiptsPage } from '../Receipts';
 import { receiptQueryKeys } from '@/features/receipt/queryKeys';
+import * as receiptParsers from '@/features/receipt/parsers';
 
 // ────────────────────────────────────────────────────────
 // モック定義
@@ -54,13 +55,25 @@ vi.mock('@/components/molecules/ConfirmDeleteModal/ConfirmDeleteModal', () => ({
     isOpen,
     onConfirm,
     onCancel,
+    title,
+    description,
+    itemCount,
+    loading,
   }: {
     isOpen: boolean;
     onConfirm: () => void;
     onCancel: () => void;
+    title?: string;
+    description?: string;
+    itemCount?: number;
+    loading?: boolean;
   }) =>
     isOpen ? (
       <div data-testid="confirm-modal">
+        <div>{title}</div>
+        <div>{description}</div>
+        <div data-testid="confirm-item-count">{itemCount}</div>
+        <div data-testid="confirm-loading">{String(loading)}</div>
         <button data-testid="confirm-delete" onClick={onConfirm}>
           削除する
         </button>
@@ -73,28 +86,61 @@ vi.mock('@/components/molecules/ConfirmDeleteModal/ConfirmDeleteModal', () => ({
 
 // 子コンポーネント: data の長さ確認 + importResult が渡された場合は表示（回帰検知用）
 vi.mock('@/pages/Receipt/Dividend', () => ({
-  Dividend: ({ data, importResult, utilityRail }: { data: unknown[]; importResult?: { inserted: number }; utilityRail?: React.ReactNode }) => (
+  Dividend: ({
+    data,
+    previewData,
+    importResult,
+    utilityRail,
+  }: {
+    data: unknown[];
+    previewData?: unknown[];
+    importResult?: { inserted: number };
+    utilityRail?: React.ReactNode;
+  }) => (
     <div data-testid="dividend-view">
       {utilityRail}
       {data.length}
+      {previewData && <span data-testid="dividend-preview-count">{previewData.length}</span>}
       {importResult && <strong>{importResult.inserted}件登録</strong>}
     </div>
   ),
 }));
 vi.mock('@/pages/Receipt/DomesticStock', () => ({
-  DomesticStock: ({ data, importResult, utilityRail }: { data: unknown[]; importResult?: { inserted: number }; utilityRail?: React.ReactNode }) => (
+  DomesticStock: ({
+    data,
+    previewData,
+    importResult,
+    utilityRail,
+  }: {
+    data: unknown[];
+    previewData?: unknown[];
+    importResult?: { inserted: number };
+    utilityRail?: React.ReactNode;
+  }) => (
     <div data-testid="domesticstock-view">
       {utilityRail}
       {data.length}
+      {previewData && <span data-testid="domesticstock-preview-count">{previewData.length}</span>}
       {importResult && <strong>{importResult.inserted}件登録</strong>}
     </div>
   ),
 }));
 vi.mock('@/pages/Receipt/Mutualfund', () => ({
-  Mutualfund: ({ data, importResult, utilityRail }: { data: unknown[]; importResult?: { inserted: number }; utilityRail?: React.ReactNode }) => (
+  Mutualfund: ({
+    data,
+    previewData,
+    importResult,
+    utilityRail,
+  }: {
+    data: unknown[];
+    previewData?: unknown[];
+    importResult?: { inserted: number };
+    utilityRail?: React.ReactNode;
+  }) => (
     <div data-testid="mutualfund-view">
       {utilityRail}
       {data.length}
+      {previewData && <span data-testid="mutualfund-preview-count">{previewData.length}</span>}
       {importResult && <strong>{importResult.inserted}件登録</strong>}
     </div>
   ),
@@ -290,6 +336,124 @@ describe('ReceiptsPage', () => {
 
     expect(screen.getByTestId('mutualfund-view')).toBeInTheDocument();
     expect(screen.queryByTestId('dividend-view')).not.toBeInTheDocument();
+  });
+
+  it('CSV preview: 配当金のプレビュー行を Dividend に渡す', async () => {
+    vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({ isAuthenticated: true }));
+    vi.mocked(receiptApi.dividendApi.list).mockResolvedValue([] as never[]);
+    vi.mocked(receiptApi.domesticStockApi.list).mockResolvedValue([] as never[]);
+    vi.mocked(receiptApi.mutualfundApi.list).mockResolvedValue([] as never[]);
+    vi.mocked(receiptApi.dividendApi.previewCsv).mockResolvedValue({
+      total_rows: 2,
+      valid_rows: 2,
+      errors: [],
+      rows: [
+        { id: 'preview-dividend-1', payment_date: '2025-01-01' },
+        { id: 'preview-dividend-2', payment_date: '2025-02-01' },
+      ],
+    } as never);
+
+    renderWithQuery(<ReceiptsPage />);
+
+    await waitFor(() => {
+      expect(receiptApi.dividendApi.list).toHaveBeenCalled();
+    }, waitOpts);
+    await waitFor(() => {
+      expect(screen.getByTestId('csv-file-input')).toBeInTheDocument();
+    }, waitOpts);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('csv-file-input'));
+
+    await waitFor(() => {
+      expect(receiptApi.dividendApi.previewCsv).toHaveBeenCalled();
+    }, waitOpts);
+    await waitFor(() => {
+      expect(vi.mocked(receiptParsers.transformDBDividend)).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'preview-dividend-1' })
+      );
+      expect(vi.mocked(receiptParsers.transformDBDividend)).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'preview-dividend-2' })
+      );
+    }, waitOpts);
+
+    expect(screen.getByTestId('dividend-preview-count')).toHaveTextContent('2');
+  });
+
+  it('CSV preview: 国内株式タブで DomesticStock コンポーネントにプレビューが渡る', async () => {
+    vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({ isAuthenticated: true }));
+    vi.mocked(receiptApi.dividendApi.list).mockResolvedValue([] as never[]);
+    vi.mocked(receiptApi.domesticStockApi.list).mockResolvedValue([] as never[]);
+    vi.mocked(receiptApi.mutualfundApi.list).mockResolvedValue([] as never[]);
+    vi.mocked(receiptApi.domesticStockApi.previewCsv).mockResolvedValue({
+      total_rows: 1,
+      valid_rows: 1,
+      errors: [],
+      rows: [{ id: 'preview-domesticstock-1', trade_date: '2025-03-01' }],
+    } as never);
+
+    renderWithQuery(<ReceiptsPage />);
+
+    await waitFor(() => {
+      expect(receiptApi.dividendApi.list).toHaveBeenCalled();
+    }, waitOpts);
+    await waitFor(() => {
+      expect(screen.getByTestId('csv-file-input')).toBeInTheDocument();
+    }, waitOpts);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('tab', { name: /^国内株式/ }));
+    await user.click(screen.getByTestId('csv-file-input'));
+
+    await waitFor(() => {
+      expect(receiptApi.domesticStockApi.previewCsv).toHaveBeenCalled();
+    }, waitOpts);
+    await waitFor(() => {
+      expect(vi.mocked(receiptParsers.transformDBDomesticStock)).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'preview-domesticstock-1' })
+      );
+    }, waitOpts);
+
+    expect(screen.getByTestId('domesticstock-view')).toBeInTheDocument();
+    expect(screen.getByTestId('domesticstock-preview-count')).toHaveTextContent('1');
+  });
+
+  it('CSV preview: 投資信託タブで Mutualfund コンポーネントにプレビューが渡る', async () => {
+    vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({ isAuthenticated: true }));
+    vi.mocked(receiptApi.dividendApi.list).mockResolvedValue([] as never[]);
+    vi.mocked(receiptApi.domesticStockApi.list).mockResolvedValue([] as never[]);
+    vi.mocked(receiptApi.mutualfundApi.list).mockResolvedValue([] as never[]);
+    vi.mocked(receiptApi.mutualfundApi.previewCsv).mockResolvedValue({
+      total_rows: 1,
+      valid_rows: 1,
+      errors: [],
+      rows: [{ id: 'preview-mutualfund-1', trade_date: '2025-04-01' }],
+    } as never);
+
+    renderWithQuery(<ReceiptsPage />);
+
+    await waitFor(() => {
+      expect(receiptApi.dividendApi.list).toHaveBeenCalled();
+    }, waitOpts);
+    await waitFor(() => {
+      expect(screen.getByTestId('csv-file-input')).toBeInTheDocument();
+    }, waitOpts);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('tab', { name: /^投資信託/ }));
+    await user.click(screen.getByTestId('csv-file-input'));
+
+    await waitFor(() => {
+      expect(receiptApi.mutualfundApi.previewCsv).toHaveBeenCalled();
+    }, waitOpts);
+    await waitFor(() => {
+      expect(vi.mocked(receiptParsers.transformDBMutualfund)).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'preview-mutualfund-1' })
+      );
+    }, waitOpts);
+
+    expect(screen.getByTestId('mutualfund-view')).toBeInTheDocument();
+    expect(screen.getByTestId('mutualfund-preview-count')).toHaveTextContent('1');
   });
 
   describe('タブキーボードナビゲーション', () => {
@@ -521,6 +685,10 @@ describe('ReceiptsPage', () => {
     const user = userEvent.setup();
     await user.click(screen.getByText(/全件削除/));
     expect(screen.getByTestId('confirm-modal')).toBeInTheDocument();
+    expect(screen.getByText('配当金データの全件削除')).toBeInTheDocument();
+    expect(screen.getByText('【配当金】のデータをすべて削除します。')).toBeInTheDocument();
+    expect(screen.getByTestId('confirm-item-count')).toHaveTextContent('1');
+    expect(screen.getByTestId('confirm-loading')).toHaveTextContent('false');
 
     await user.click(screen.getByTestId('confirm-delete'));
 


### PR DESCRIPTION
## 概要
- `useReceiptsData` の `domesticstock` / `mutualfund` 向け preview/upload 分岐テストを追加
- `ReceiptsPage` の CSV preview 伝播と削除確認モーダル表示のテストを追加
- `formatters` の `formatNumber` / `formatCurrency` 例外ハンドリングのテストを追加

## カバレッジ
- `frontend/src/features/receipt/hooks/useReceiptsData.ts`: lines `100%`
- `frontend/src/pages/Receipts.tsx`: lines `98.07%`
- `frontend/src/lib/utils/formatters.ts`: lines `98.87%`

## 確認
- `cd frontend && npm run lint`
- `cd frontend && npx tsc --noEmit`
- `cd frontend && npm test -- --run`
- `cd frontend && npm run test:coverage -- src/features/receipt/hooks/__tests__/useReceiptsData.test.ts src/pages/__tests__/Receipts.test.tsx src/lib/utils/__tests__/formatters.test.ts`
