### PR TITLE
test: フロントエンドのブランチカバレッジを補強

### DIFF
--- a/frontend/src/components/atoms/__tests__/EmptyState.test.tsx
+++ b/frontend/src/components/atoms/__tests__/EmptyState.test.tsx
@@ -25,4 +25,10 @@ describe('EmptyState', () => {
 
     expect(screen.getByRole('heading', { level: 1, name: 'トップ見出し' })).toBeInTheDocument();
   });
+
+  it('icon を表示する', () => {
+    render(<EmptyState title="データなし" icon={<span data-testid="empty-icon">📭</span>} />);
+
+    expect(screen.getByTestId('empty-icon')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/atoms/__tests__/InputField.test.tsx
+++ b/frontend/src/components/atoms/__tests__/InputField.test.tsx
@@ -75,8 +75,36 @@ describe('InputField', () => {
 
   it('disabledプロパティが動作する', () => {
     render(<InputField label="テスト項目" disabled />);
-    
+
     const input = screen.getByLabelText('テスト項目');
     expect(input).toBeDisabled();
+  });
+
+  it('variant=filledのスタイルが適用される', () => {
+    render(<InputField label="テスト項目" variant="filled" />);
+
+    const input = screen.getByLabelText('テスト項目');
+    expect(input).toHaveClass('bg-gray-100');
+  });
+
+  it('variant=standardのスタイルが適用される', () => {
+    render(<InputField label="テスト項目" variant="standard" />);
+
+    const input = screen.getByLabelText('テスト項目');
+    expect(input).toHaveClass('border-0');
+  });
+
+  it('required=trueのときラベルにアスタリスクが表示される', () => {
+    render(<InputField label="必須項目" required />);
+
+    expect(screen.getByText('*')).toBeInTheDocument();
+    expect(screen.getByText('*')).toHaveClass('text-danger');
+    expect(screen.getByRole('textbox')).toBeRequired();
+  });
+
+  it('labelなしでもinputがレンダリングされる', () => {
+    render(<InputField placeholder="ラベルなし" />);
+
+    expect(screen.getByPlaceholderText('ラベルなし')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/atoms/__tests__/SecurityCodeLink.test.tsx
+++ b/frontend/src/components/atoms/__tests__/SecurityCodeLink.test.tsx
@@ -34,4 +34,14 @@ describe('SecurityCodeLink', () => {
     expect(screen.getByText('7203?')).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: '7203?' })).not.toBeInTheDocument();
   });
+
+  it('classNameを指定するとリンクに適用される', () => {
+    render(
+      <MemoryRouter>
+        <SecurityCodeLink value="7203" className="custom-class" />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('link', { name: '7203' })).toHaveClass('custom-class');
+  });
 });

--- a/frontend/src/components/molecules/ReceiptHeader/__tests__/ReceiptHeader.test.tsx
+++ b/frontend/src/components/molecules/ReceiptHeader/__tests__/ReceiptHeader.test.tsx
@@ -163,4 +163,30 @@ describe('ReceiptHeader', () => {
     expect(grid).toHaveClass('sm:grid-cols-2');
     expect(grid).toHaveClass('xl:grid-cols-3');
   });
+
+  it('compactモード+collapsibleでもヘッダークリックで開閉できる', () => {
+    render(<ReceiptHeader items={defaultItems} compact collapsible />);
+
+    const header = screen.getByTestId('receipt-header');
+    expect(screen.getByText('テスト項目1')).toBeVisible();
+
+    fireEvent.click(header);
+    expect(screen.getByText('テスト項目1')).not.toBeVisible();
+  });
+
+  it('マイナス値のitemにdata-negative属性が付く', () => {
+    const itemsWithNegative = [
+      {
+        title: '損益',
+        value: -500,
+        format: (value: number) => `¥${value}`,
+      },
+    ];
+
+    const { container } = render(<ReceiptHeader items={itemsWithNegative} />);
+
+    const valueEl = container.querySelector('[data-negative="true"]');
+    expect(valueEl).toBeInTheDocument();
+    expect(valueEl).toHaveTextContent('¥-500');
+  });
 });

--- a/frontend/src/components/molecules/__tests__/CSVFileInput.test.tsx
+++ b/frontend/src/components/molecules/__tests__/CSVFileInput.test.tsx
@@ -26,4 +26,32 @@ describe('CSVFileInput', () => {
 
     expect(handleFileSelect).toHaveBeenCalledWith(file);
   });
+
+  it('disabled=trueのときファイル変更イベントが無視される', () => {
+    const handleFileSelect = vi.fn();
+    render(<CSVFileInput onFileSelect={handleFileSelect} disabled />);
+
+    const input = screen.getByLabelText('CSVファイルを選択') as HTMLInputElement;
+    const file = new File(['test'], 'receipts.csv', { type: 'text/csv' });
+    fireEvent.change(input, { target: { files: [file] } });
+
+    expect(handleFileSelect).not.toHaveBeenCalled();
+  });
+
+  it('空のfilesリストではonFileSelectが呼ばれない', () => {
+    const handleFileSelect = vi.fn();
+    render(<CSVFileInput onFileSelect={handleFileSelect} />);
+
+    const input = screen.getByLabelText('CSVファイルを選択') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [] } });
+
+    expect(handleFileSelect).not.toHaveBeenCalled();
+  });
+
+  it('disabled=trueのとき不活性スタイルが適用される', () => {
+    render(<CSVFileInput onFileSelect={vi.fn()} disabled />);
+
+    expect(screen.getByTestId('csv-file-trigger')).toHaveClass('pointer-events-none');
+    expect(screen.getByTestId('csv-file-trigger')).toHaveClass('opacity-65');
+  });
 });

--- a/frontend/src/components/molecules/__tests__/DividendInfo.test.tsx
+++ b/frontend/src/components/molecules/__tests__/DividendInfo.test.tsx
@@ -77,6 +77,84 @@ describe('DividendInfo', () => {
     expect(container.firstChild).toBeNull();
   });
 
+  it('embeddedモードでapiLoading=trueのとき取得中...が表示される', () => {
+    mockUseDividendBatch.mockReturnValue({
+      dividendPerShareMap: new Map(),
+      dividendStatusMap: new Map(),
+      loading: true,
+      fetchedCount: 0,
+      totalCount: 1,
+    });
+
+    render(<DividendInfo embedded searchQuery="7203: トヨタ自動車" summary={[]} />);
+
+    expect(screen.getByText('取得中...')).toBeInTheDocument();
+  });
+
+  it('embeddedモードでdividendPerShareが定義済みの場合---が表示されない', () => {
+    mockUseDividendBatch.mockReturnValue({
+      dividendPerShareMap: new Map([['7203', 100]]),
+      dividendStatusMap: new Map([['7203', 'ok']]),
+      loading: false,
+      fetchedCount: 1,
+      totalCount: 1,
+    });
+
+    render(<DividendInfo embedded searchQuery="7203: トヨタ自動車" summary={[]} />);
+
+    // 一株配当が定義されているので---は表示されない（自動で取得されますのヒントも消える）
+    expect(screen.queryByText('自動で取得されます')).not.toBeInTheDocument();
+  });
+
+  it('embeddedモードでsummaryが非ゼロの場合、配当利回りが表示される', () => {
+    mockUseAssetBalance.mockReturnValue({
+      assetBalanceData: [],
+      isLoading: false,
+      getAssetBalanceByCode: vi.fn(() => ({
+        average_purchase_price: 1000,
+        shares: 100,
+        security_code: '7203',
+      })),
+      getTotalMarketValue: vi.fn(() => 0),
+      refetch: vi.fn(),
+    });
+
+    render(
+      <DividendInfo
+        embedded
+        searchQuery="7203: トヨタ自動車"
+        summary={[
+          {
+            filter: '7203',
+            security_code: '7203',
+            net_amount_received: 4500,
+            dividends_before_tax: 5000,
+            taxes: 500,
+          },
+        ]}
+      />
+    );
+
+    // grossDividendReturnRate > 0 なので利回りのspanが表示される
+    // totalInvestment = 1000 * 100 = 100000, totalDividendsBeforeTax = 5000
+    // grossDividendReturnRate = 5000 / 100000 * 100 = 5.00%
+    expect(screen.getByText('(5.00%)')).toBeInTheDocument();
+  });
+
+  it('standaloneモードでapiLoading=trueのときplaceholderが設定される', () => {
+    mockUseDividendBatch.mockReturnValue({
+      dividendPerShareMap: new Map(),
+      dividendStatusMap: new Map(),
+      loading: true,
+      fetchedCount: 0,
+      totalCount: 1,
+    });
+
+    render(<DividendInfo searchQuery="7203: トヨタ自動車" summary={[]} />);
+
+    expect(screen.getByPlaceholderText('データ取得中...')).toBeInTheDocument();
+  });
+
   it('summaryデータがある場合、配当利回りが計算される', () => {
     mockUseAssetBalance.mockReturnValue({
       assetBalanceData: [],

--- a/frontend/src/components/organisms/AssetPortfolioSummary/__tests__/AssetPortfolioSummary.test.tsx
+++ b/frontend/src/components/organisms/AssetPortfolioSummary/__tests__/AssetPortfolioSummary.test.tsx
@@ -130,6 +130,48 @@ describe('AssetPortfolioSummary', () => {
     expect(matches.length).toBeGreaterThanOrEqual(1);
   });
 
+  it('security_nameが空の場合security_codeをグラフ名に使用する', () => {
+    const mockData: AssetBalanceData[] = [
+      {
+        security_code: '7203',
+        security_name: '',
+        shares: 100,
+        executing_shares: 0,
+        average_purchase_price: 2500,
+        total_purchase_amount: 250000,
+        current_price: 2600,
+        daily_change: 50,
+        market_value: 260000,
+        profit_loss_rate: 4.0,
+      },
+    ];
+    render(<AssetPortfolioSummary assetBalanceData={mockData} />);
+
+    // security_nameが空なのでsecurity_codeがグラフに使われる
+    expect(screen.getByTestId('asset-portfolio-summary')).toBeInTheDocument();
+  });
+
+  it('合計取得総額がマイナスの場合data-negative属性が付く', () => {
+    const mockData: AssetBalanceData[] = [
+      {
+        security_code: '7203',
+        security_name: 'テスト銘柄',
+        shares: 100,
+        executing_shares: 0,
+        average_purchase_price: 2500,
+        total_purchase_amount: -250000,
+        current_price: 2600,
+        daily_change: 50,
+        market_value: 260000,
+        profit_loss_rate: 4.0,
+      },
+    ];
+    const { container } = render(<AssetPortfolioSummary assetBalanceData={mockData} />);
+
+    const negativeEl = container.querySelector('[data-negative="true"]');
+    expect(negativeEl).toBeInTheDocument();
+  });
+
   it('data-testidが設定される', () => {
     const mockData = createMockData();
     render(<AssetPortfolioSummary assetBalanceData={mockData} />);
@@ -173,6 +215,24 @@ describe('AssetPortfolioSummary', () => {
       render(<AssetPortfolioSummary assetBalanceData={mockData} dividendPerShareMap={emptyMap} />);
 
       expect(screen.getByTestId('portfolio-dividend-yield')).toHaveTextContent('---');
+    });
+
+    it('dividendPerShareMapに一部の銘柄しかない場合は存在する銘柄のみ計算される', () => {
+      const mockData = createMockData();
+      // 7203のみマップに含める（6758は含めない）
+      const partialMap = new Map([['7203', 50]]);
+      render(<AssetPortfolioSummary assetBalanceData={mockData} dividendPerShareMap={partialMap} />);
+
+      // 50 * 100 = 5000
+      expect(screen.getByTestId('portfolio-annual-dividends')).toHaveTextContent(/5,000/);
+    });
+
+    it('dividendPerShareが0の場合は合計が0になり---が表示される', () => {
+      const mockData = createMockData();
+      const zeroMap = new Map([['7203', 0], ['6758', 0]]);
+      render(<AssetPortfolioSummary assetBalanceData={mockData} dividendPerShareMap={zeroMap} />);
+
+      expect(screen.getByTestId('portfolio-annual-dividends')).toHaveTextContent('---');
     });
 
     it('dividendStatusMap を渡すと pending 銘柄で取得中...が表示される', () => {

--- a/frontend/src/components/organisms/__tests__/Header.test.tsx
+++ b/frontend/src/components/organisms/__tests__/Header.test.tsx
@@ -209,6 +209,73 @@ describe('Header', () => {
     expect(screen.getByRole('link', { name: '銘柄検索' })).toHaveAttribute('aria-current', 'page');
   });
 
+  it('ログインボタンをクリックするとloginが呼ばれる', async () => {
+    const login = vi.fn();
+    const { user } = renderHeader({ user: null, isAuthenticated: false, login });
+
+    await user.click(screen.getByRole('button', { name: 'ログイン' }));
+
+    expect(login).toHaveBeenCalledTimes(1);
+  });
+
+  it('削除確認モーダルのバックドロップクリックでモーダルが閉じる', async () => {
+    const { user } = renderHeader();
+
+    await user.click(screen.getByRole('button', { name: 'メニュー' }));
+    await user.click(screen.getByRole('menuitem', { name: /アカウント削除/ }));
+    const dialog = await screen.findByRole('dialog', { name: 'アカウント削除の確認' });
+    expect(dialog).toBeInTheDocument();
+
+    // バックドロップ（dialog要素自体）をクリック
+    await user.click(dialog);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: 'アカウント削除の確認' })).not.toBeInTheDocument();
+    });
+  });
+
+  it('削除確認モーダルでEscapeキーを押すとモーダルが閉じる', async () => {
+    const { user } = renderHeader();
+
+    await user.click(screen.getByRole('button', { name: 'メニュー' }));
+    await user.click(screen.getByRole('menuitem', { name: /アカウント削除/ }));
+    const dialog = await screen.findByRole('dialog', { name: 'アカウント削除の確認' });
+
+    fireEvent.keyDown(dialog, { key: 'Escape' });
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: 'アカウント削除の確認' })).not.toBeInTheDocument();
+    });
+  });
+
+  it('削除確認モーダルの✕ボタンでモーダルが閉じる', async () => {
+    const { user } = renderHeader();
+
+    await user.click(screen.getByRole('button', { name: 'メニュー' }));
+    await user.click(screen.getByRole('menuitem', { name: /アカウント削除/ }));
+    await screen.findByRole('dialog', { name: 'アカウント削除の確認' });
+
+    await user.click(screen.getByRole('button', { name: '閉じる' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: 'アカウント削除の確認' })).not.toBeInTheDocument();
+    });
+  });
+
+  it('削除確認モーダル内でEscape以外のキーはstopPropagationで処理される', async () => {
+    const { user } = renderHeader();
+
+    await user.click(screen.getByRole('button', { name: 'メニュー' }));
+    await user.click(screen.getByRole('menuitem', { name: /アカウント削除/ }));
+    await screen.findByRole('dialog', { name: 'アカウント削除の確認' });
+
+    // inner presentationにEnterキーを発火 → stopPropagation()パスが実行されモーダルは閉じない
+    const presentation = screen.getByRole('presentation');
+    fireEvent.keyDown(presentation, { key: 'Enter' });
+
+    expect(screen.getByRole('dialog', { name: 'アカウント削除の確認' })).toBeInTheDocument();
+  });
+
   describe('イニシャル表示', () => {
     it('スペース区切り2語の名前は実際の動作どおり2文字を表示する', () => {
       renderHeader({

--- a/frontend/src/components/organisms/__tests__/StockInfo.test.tsx
+++ b/frontend/src/components/organisms/__tests__/StockInfo.test.tsx
@@ -46,6 +46,16 @@ describe('StockInfo', () => {
     expect(screen.getByText('プライム')).toBeInTheDocument();
   });
 
+  it('フィールドが空の場合は - を表示する', () => {
+    render(
+      <MemoryRouter>
+        <StockInfo stockData={{ ...mockStockData, size_category: '' }} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getAllByText('-').length).toBeGreaterThan(0);
+  });
+
   it('stockDataがnullの場合nullを返す', () => {
     const { container } = render(
       <MemoryRouter>

--- a/frontend/src/components/templates/__tests__/ReceiptTemplate.test.tsx
+++ b/frontend/src/components/templates/__tests__/ReceiptTemplate.test.tsx
@@ -225,6 +225,37 @@ describe('ReceiptTemplate', () => {
     expect(receiptContainer).toBeInTheDocument();
   });
 
+  test('utilityRailのみ指定時は自動的にworkspaceレイアウトになる', () => {
+    const railTools = <div data-testid="auto-rail">CSV操作</div>;
+
+    render(
+      <ReceiptTemplate
+        {...defaultProps}
+        utilityRail={railTools}
+      />
+    );
+
+    // layoutPropなしでもworkspaceレイアウトが選択される
+    expect(screen.getByTestId('receipt-workspace')).toBeInTheDocument();
+    expect(screen.getByTestId('auto-rail')).toBeInTheDocument();
+  });
+
+  test('workspaceレイアウトでフッターが表示される', () => {
+    const footerContent = <div data-testid="workspace-footer">フッター</div>;
+    const railTools = <div data-testid="rail">サイド</div>;
+
+    render(
+      <ReceiptTemplate
+        {...defaultProps}
+        layout="workspace"
+        utilityRail={railTools}
+        footer={footerContent}
+      />
+    );
+
+    expect(screen.getByTestId('workspace-footer')).toBeInTheDocument();
+  });
+
   test('workspaceレイアウトではヘッダーがmain stage上部に配置される', () => {
     const headerContent = <div data-testid="workspace-header">集計ヘッダー</div>;
     const railTools = <div data-testid="workspace-tools">CSV操作</div>;

--- a/frontend/src/components/templates/__tests__/WorkspaceShell.test.tsx
+++ b/frontend/src/components/templates/__tests__/WorkspaceShell.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { WorkspaceShell } from '../WorkspaceShell';
+
+describe('WorkspaceShell', () => {
+  it('mainとrailをレンダリングする', () => {
+    render(
+      <WorkspaceShell
+        main={<div>メインコンテンツ</div>}
+        rail={<div>サイドバー</div>}
+      />
+    );
+
+    expect(screen.getByText('メインコンテンツ')).toBeInTheDocument();
+    expect(screen.getByText('サイドバー')).toBeInTheDocument();
+  });
+
+  it('testIdPrefixを指定するとdata-testidにプレフィックスが付く', () => {
+    render(
+      <WorkspaceShell
+        main={<div>メイン</div>}
+        rail={<div>サイド</div>}
+        testIdPrefix="receipt"
+      />
+    );
+
+    expect(screen.getByTestId('receipt-workspace')).toBeInTheDocument();
+    expect(screen.getByTestId('receipt-main-stage')).toBeInTheDocument();
+    expect(screen.getByTestId('receipt-utility-rail')).toBeInTheDocument();
+  });
+
+  it('testIdPrefixなしのデフォルトdata-testidが付く', () => {
+    render(
+      <WorkspaceShell
+        main={<div>メイン</div>}
+        rail={<div>サイド</div>}
+      />
+    );
+
+    expect(screen.getByTestId('workspace')).toBeInTheDocument();
+    expect(screen.getByTestId('main-stage')).toBeInTheDocument();
+    expect(screen.getByTestId('utility-rail')).toBeInTheDocument();
+  });
+
+  it('mainClassNameがmainステージに適用される', () => {
+    render(
+      <WorkspaceShell
+        main={<div>メイン</div>}
+        rail={<div>サイド</div>}
+        mainClassName="custom-main"
+      />
+    );
+
+    expect(screen.getByTestId('main-stage')).toHaveClass('custom-main');
+  });
+});

--- a/frontend/src/features/assetBalance/hooks/__tests__/useAssetBalance.test.ts
+++ b/frontend/src/features/assetBalance/hooks/__tests__/useAssetBalance.test.ts
@@ -171,6 +171,36 @@ describe('useAssetBalance', () => {
     expect(result.current.getTotalMarketValue()).toBe(390000);
   });
 
+  it('未認証時はassetBalanceDataが空配列を返す', () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({ isAuthenticated: false }));
+
+    const { result } = renderHook(() => useAssetBalance(), { wrapper: makeWrapper(qc) });
+
+    expect(result.current.assetBalanceData).toEqual([]);
+  });
+
+  it('getTotalMarketValue は market_value が 0 のデータも正しく合計する', async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue([
+      makeAssetBalanceData({ security_code: '7203', market_value: 100000 }),
+      makeAssetBalanceData({ security_code: '6758', market_value: 0 }),
+    ]);
+
+    const { result } = renderHook(() => useAssetBalance(), { wrapper: makeWrapper(qc) });
+
+    await waitFor(() => {
+      expect(result.current.assetBalanceData).toHaveLength(2);
+    });
+
+    expect(result.current.getTotalMarketValue()).toBe(100000);
+  });
+
   it('refetch は assetBalance クエリを invalidate する', async () => {
     const qc = new QueryClient({
       defaultOptions: { queries: { retry: false, staleTime: Infinity } },

--- a/frontend/src/features/assetBalance/hooks/__tests__/useAssetBalanceDataSource.test.ts
+++ b/frontend/src/features/assetBalance/hooks/__tests__/useAssetBalanceDataSource.test.ts
@@ -63,6 +63,78 @@ function makeWrapper(qc: QueryClient) {
 // テスト
 // ────────────────────────────────────────────────────────
 
+describe('useAssetBalanceDataSource: 基本動作', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({}));
+  });
+
+  it('未認証時はhandleSaveToDBが早期リターンする', async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({ isAuthenticated: false }));
+
+    const { result } = renderHook(() => useAssetBalanceDataSource(), { wrapper: makeWrapper(qc) });
+
+    act(() => { result.current.handleSaveToDB(); });
+
+    expect(assetBalanceApiModule.assetBalanceApi.uploadCsv).not.toHaveBeenCalled();
+  });
+
+  it('未認証時はhandleDeleteAllが早期リターンする', async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({ isAuthenticated: false }));
+
+    const { result } = renderHook(() => useAssetBalanceDataSource(), { wrapper: makeWrapper(qc) });
+
+    await act(async () => { await result.current.handleDeleteAll(); });
+
+    expect(assetBalanceApiModule.assetBalanceApi.deleteAll).not.toHaveBeenCalled();
+  });
+
+  it('rawFileなしではhandleSaveToDBが早期リターンする', () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    const { result } = renderHook(() => useAssetBalanceDataSource(), { wrapper: makeWrapper(qc) });
+
+    // rawFile=null（初期状態）でhanleSaveToDB呼び出し
+    act(() => { result.current.handleSaveToDB(); });
+
+    expect(assetBalanceApiModule.assetBalanceApi.uploadCsv).not.toHaveBeenCalled();
+  });
+
+  it('previewMutationエラー時にerrorが設定される', async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.previewCsv).mockRejectedValueOnce(new Error('プレビュー失敗'));
+
+    const { result } = renderHook(() => useAssetBalanceDataSource(), { wrapper: makeWrapper(qc) });
+
+    await act(async () => {
+      result.current.handleFileSelect(new File([], 'test.csv'));
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).toBeTruthy();
+    });
+  });
+
+  it('deleteAll完了後にcacheキーが存在しない場合setQueryDataを呼ばない', async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: Infinity } } });
+    vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({}));
+    // DBデータを読み込まない（queryStateがundefined）ままdeleteAllを呼ぶ
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.deleteAll).mockResolvedValue({} as never);
+
+    const { result } = renderHook(() => useAssetBalanceDataSource(), { wrapper: makeWrapper(qc) });
+
+    // クエリが実行される前にキャッシュを削除
+    qc.removeQueries();
+
+    await act(async () => { await result.current.handleDeleteAll(); });
+
+    // エラーなく完了することを確認
+    expect(result.current.error).toBeNull();
+  });
+});
+
 describe('useAssetBalanceDataSource: キャッシュ境界', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/frontend/src/features/auth/context/__tests__/AuthContext.test.tsx
+++ b/frontend/src/features/auth/context/__tests__/AuthContext.test.tsx
@@ -294,6 +294,86 @@ describe('AuthProvider', () => {
     assignSpy.mockRestore();
   });
 
+  it('setUserを呼ぶとユーザー情報が更新される', async () => {
+    mockGet.mockResolvedValueOnce(mockUser);
+
+    function SetUserConsumer() {
+      const { user, setUser } = useAuth();
+      return (
+        <div>
+          <span data-testid="name">{user?.name ?? 'none'}</span>
+          <button type="button" onClick={() => setUser({ id: '2', name: '更新ユーザー', email: 'new@example.com' })}>
+            setUser
+          </button>
+        </div>
+      );
+    }
+
+    const user = userEvent.setup();
+    render(
+      <AuthProvider>
+        <SetUserConsumer />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('name').textContent).toBe('テストユーザー');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'setUser' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('name').textContent).toBe('更新ユーザー');
+    });
+  });
+
+  it('login=successパラメータがある場合にhistory.replaceStateでURLをクリアする', async () => {
+    const replaceStateSpy = vi.spyOn(window.history, 'replaceState').mockImplementation(vi.fn());
+    // URLSearchParamsがlogin=successを返すようにsearch文字列を差し替え
+    const originalSearch = window.location.search;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      get: () => ({ search: '?login=success', pathname: '/home' }),
+    });
+
+    mockGet.mockResolvedValueOnce(mockUser);
+
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('false');
+    });
+
+    expect(replaceStateSpy).toHaveBeenCalledWith({}, '', '/home');
+
+    // 後片付け
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      get: () => ({ search: originalSearch, pathname: '/' }),
+    });
+    replaceStateSpy.mockRestore();
+  });
+
+  it('userがnullの場合はアイドル時にlogoutが呼ばれない', async () => {
+    await renderAuthProvider({ authenticated: false });
+
+    await waitFor(() => {
+      expect(useIdleTimer).toHaveBeenLastCalledWith(expect.objectContaining({
+        enabled: false,
+      }));
+    });
+
+    const idleOptions = vi.mocked(useIdleTimer).mock.lastCall?.[0];
+    idleOptions?.onIdle();
+
+    // userがnullなのでlogoutは呼ばれない
+    expect(apiClient.post).not.toHaveBeenCalled();
+  });
+
   it('onLogoutでコールバックを登録解除できる', async () => {
     const onLogoutCallback = vi.fn();
     const { user } = await renderAuthProvider({ onLogoutCallback });

--- a/frontend/src/features/jquants/hooks/__tests__/useJQuantsDividend.test.ts
+++ b/frontend/src/features/jquants/hooks/__tests__/useJQuantsDividend.test.ts
@@ -222,6 +222,50 @@ describe('useJQuantsDividend', () => {
     expect(result.current.error).toBeNull();
   });
 
+  it('DiscDateがないデータを含む場合でもソートが失敗しない', async () => {
+    const mockResponse = {
+      data: [
+        { NxFDivAnn: '40.00' }, // DiscDateなし
+        { NxFDivAnn: '50.00' }, // DiscDateなし
+      ],
+    };
+
+    (jquantsApiClient.getStatements as Mock).mockResolvedValue(mockResponse);
+    (parseNumber as Mock).mockReturnValue(40);
+
+    const { result } = renderHook(() => useJQuantsDividend('1234', true));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.dividendPerShare).toBeDefined();
+    expect(result.current.error).toBeNull();
+  });
+
+  it('アンマウント時にstateを更新しない', async () => {
+    let resolvePromise!: (value: { data: unknown[] }) => void;
+    const pendingPromise = new Promise<{ data: unknown[] }>((resolve) => {
+      resolvePromise = resolve;
+    });
+
+    (jquantsApiClient.getStatements as Mock).mockReturnValue(pendingPromise);
+
+    const { result, unmount } = renderHook(() => useJQuantsDividend('1234', true));
+
+    expect(result.current.loading).toBe(true);
+
+    // アンマウント（isActive = false になる）
+    unmount();
+
+    // 非同期処理を解決してもstateは更新されない
+    resolvePromise({ data: [{ NxFDivAnn: '50.00' }] });
+
+    // stateが変わらないことを確認（エラー/警告なし）
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(result.current.loading).toBe(true); // unmount後は更新されない
+  });
+
   it('securityCodeが変更された場合、再取得する', async () => {
     const mockResponse = {
       data: [{ NxFDivAnn: '50.00' }],

--- a/frontend/src/hooks/__tests__/usePageTitle.test.ts
+++ b/frontend/src/hooks/__tests__/usePageTitle.test.ts
@@ -1,0 +1,30 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { usePageTitle } from '../usePageTitle';
+
+describe('usePageTitle', () => {
+  afterEach(() => {
+    document.title = '';
+  });
+
+  it('pageTitleを指定するとタイトルが設定される', () => {
+    renderHook(() => usePageTitle('銘柄検索'));
+
+    expect(document.title).toBe('銘柄検索 - 証券Web');
+  });
+
+  it('pageTitleを省略するとベースタイトルが設定される', () => {
+    renderHook(() => usePageTitle());
+
+    expect(document.title).toBe('証券Web');
+  });
+
+  it('アンマウント時にベースタイトルに戻る', () => {
+    const { unmount } = renderHook(() => usePageTitle('資産管理'));
+    expect(document.title).toBe('資産管理 - 証券Web');
+
+    unmount();
+
+    expect(document.title).toBe('証券Web');
+  });
+});

--- a/frontend/src/hooks/receipt/__tests__/useReceiptData.test.ts
+++ b/frontend/src/hooks/receipt/__tests__/useReceiptData.test.ts
@@ -1,0 +1,56 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { useReceiptBaseData, useReceiptCalculations } from '../useReceiptData';
+import { type FilterConfig } from '@/lib/utils/searchUtils';
+
+type Item = { id: number; name: string };
+
+const identity = (items: Item[]) => items;
+const filterConfig: FilterConfig<Item> = {
+  fields: ['name'],
+};
+
+describe('useReceiptBaseData', () => {
+  it('previewDataがある場合はpreviewDataを優先する', () => {
+    const data: Item[] = [{ id: 1, name: 'メインデータ' }];
+    const previewData: Item[] = [{ id: 2, name: 'プレビューデータ' }];
+
+    const { result } = renderHook(() =>
+      useReceiptBaseData(data, previewData, identity, filterConfig)
+    );
+
+    expect(result.current.sortedData).toEqual(previewData);
+  });
+
+  it('previewDataが空配列の場合はdataを使う', () => {
+    const data: Item[] = [{ id: 1, name: 'メインデータ' }];
+
+    const { result } = renderHook(() =>
+      useReceiptBaseData(data, [], identity, filterConfig)
+    );
+
+    expect(result.current.sortedData).toEqual(data);
+  });
+
+  it('previewDataがundefinedの場合はdataを使う', () => {
+    const data: Item[] = [{ id: 1, name: 'メインデータ' }];
+
+    const { result } = renderHook(() =>
+      useReceiptBaseData(data, undefined, identity, filterConfig)
+    );
+
+    expect(result.current.sortedData).toEqual(data);
+  });
+});
+
+describe('useReceiptCalculations', () => {
+  it('calculateFunctionの結果を返す', () => {
+    const data: Item[] = [{ id: 1, name: 'A' }, { id: 2, name: 'B' }];
+
+    const { result } = renderHook(() =>
+      useReceiptCalculations(data, (items) => items.length)
+    );
+
+    expect(result.current).toBe(2);
+  });
+});

--- a/frontend/src/hooks/receipt/__tests__/useReceiptData.test.ts
+++ b/frontend/src/hooks/receipt/__tests__/useReceiptData.test.ts
@@ -7,7 +7,7 @@ type Item = { id: number; name: string };
 
 const identity = (items: Item[]) => items;
 const filterConfig: FilterConfig<Item> = {
-  fields: ['name'],
+  stringFields: [(item: Item) => item.name],
 };
 
 describe('useReceiptBaseData', () => {

--- a/frontend/src/pages/__tests__/Search.test.tsx
+++ b/frontend/src/pages/__tests__/Search.test.tsx
@@ -114,6 +114,48 @@ describe('SearchPage', () => {
     expect(searchByCode).not.toHaveBeenCalled();
   });
 
+  it('通常のErrorオブジェクトのエラーメッセージを表示する', () => {
+    mockUseStockSearch.mockReturnValue({
+      stockCode: '',
+      setStockCode: vi.fn(),
+      stockData: undefined,
+      error: new Error('ネットワークエラーが発生しました'),
+      isLoading: false,
+      isError: true,
+      handleSearch: vi.fn(),
+      searchByCode: vi.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <SearchPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('ネットワークエラーが発生しました')).toBeInTheDocument();
+  });
+
+  it('messageなしのエラーの場合はフォールバックメッセージを表示する', () => {
+    mockUseStockSearch.mockReturnValue({
+      stockCode: '',
+      setStockCode: vi.fn(),
+      stockData: undefined,
+      error: { message: '' },
+      isLoading: false,
+      isError: true,
+      handleSearch: vi.fn(),
+      searchByCode: vi.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <SearchPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('銘柄情報の取得に失敗しました。')).toBeInTheDocument();
+  });
+
   it('ApiError のユーザー向けメッセージを表示する', () => {
     mockUseStockSearch.mockReturnValue({
       stockCode: '',


### PR DESCRIPTION
## 概要

フロントエンドのテストカバレッジ、特にブランチカバレッジを改善する。

## カバレッジ変化

| 種別 | 変更前 | 変更後 | 差分 |
|------|--------|--------|------|
| ブランチ | 89.66% | 91.85% | +2.19pt |
| ステートメント | 96.34% | 96.97% | +0.63pt |
| ファンクション | 95.84% | 97.23% | +1.39pt |
| 行 | 97.43% | 97.83% | +0.40pt |

## 主な変更内容

### コンポーネント（テスト追加）
- **InputField**: `variant=filled/standard`、`required=true`、`labelなし` の各ブランチ
- **Header**: ログインボタンクリック→login()呼び出し、バックドロップクリックでモーダル閉じる、Escapeキー、✕ボタン、削除モーダル内 keyDown（Escape 以外の stopPropagation）
- **SecurityCodeLink**: `className` prop 適用時のクラス結合
- **EmptyState**: `icon` prop 表示
- **CSVFileInput**: `disabled=true` 時のファイル変更無視、空の files リスト
- **StockInfo**: フィールド空時の `'-'` フォールバック
- **ReceiptHeader**: `compact+collapsible` での開閉、マイナス値の `data-negative='true'`

### テンプレート・フック（新規テストファイル含む）
- **WorkspaceShell** (新規): `testIdPrefix` あり/なし、`mainClassName` 適用
- **ReceiptTemplate**: `utilityRail` のみ指定時の workspace 自動検出、workspace レイアウト + footer
- **usePageTitle** (新規): `pageTitle` あり/なし、アンマウント時のタイトルリセット
- **useReceiptBaseData** (新規): `previewData` 空配列/undefined 時のフォールバック

### フィーチャーフック・コンテキスト
- **AuthContext**: `setUser` 呼び出し、`?login=success` URL パラメータによる `history.replaceState`、`handleIdle` when user=null
- **useAssetBalance**: 未認証時の空配列返却、`market_value=0` を含む合計計算
- **useJQuantsDividend**: `DiscDate` なしデータのソート（`|| ''` パス）、アンマウント中の state 更新抑制

### ページ
- **Search**: 通常 `Error` オブジェクトのメッセージ表示、`message` なし時のフォールバック文字列

## テスト結果

```
Test Files: 73 passed (73)
Tests:      693 passed (693)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * テストカバレッジを大幅に拡張し、UIコンポーネント（入力欄、EmptyState、SecurityCodeLink、CSVFileInput、ReceiptHeader、DividendInfo、AssetPortfolioSummary等）、テンプレート/ワークスペース、ヘッダー、検索ページのエラー表示を網羅しました
  * フック／認証／資産関連ロジック（useAssetBalance, useJQuantsDividend, useReceiptData 等）やモーダル・キーハンドリング、ファイル操作、レンダリング振る舞いのユニットテストを追加・強化しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->