### PR TITLE
test: ErrorBoundary カバレッジ改善

### DIFF
--- a/frontend/src/components/molecules/__tests__/ErrorBoundary.test.tsx
+++ b/frontend/src/components/molecules/__tests__/ErrorBoundary.test.tsx
@@ -1,11 +1,18 @@
+import { createRef } from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { ErrorBoundary, WithErrorBoundary } from '../ErrorBoundary';
 
 // エラーを発生させるコンポーネント
-const ThrowError = ({ shouldThrow }: { shouldThrow: boolean }) => {
+const ThrowError = ({
+  shouldThrow,
+  message = 'Test error',
+}: {
+  shouldThrow: boolean;
+  message?: string;
+}) => {
   if (shouldThrow) {
-    throw new Error('Test error');
+    throw new Error(message);
   }
   return <div>No error</div>;
 };
@@ -152,23 +159,77 @@ describe('ErrorBoundary', () => {
       expect(screen.getByText('No error')).toBeInTheDocument();
     });
 
-    it('resetOnPropsChangeが有効な場合、子要素の変更でリセットされる', () => {
+    it('resetOnPropsChangeが有効な場合、子要素の変更でresetErrorBoundaryが呼ばれる', () => {
+      const boundaryRef = createRef<ErrorBoundary>();
       const { rerender } = render(
-        <ErrorBoundary resetOnPropsChange={true}>
+        <ErrorBoundary ref={boundaryRef} resetOnPropsChange={true}>
           <ThrowError shouldThrow={true} />
         </ErrorBoundary>
       );
 
       expect(screen.getByText('エラーが発生しました')).toBeInTheDocument();
+      const resetSpy = vi.spyOn(boundaryRef.current!, 'resetErrorBoundary');
 
       // 子要素を変更
       rerender(
-        <ErrorBoundary resetOnPropsChange={true}>
+        <ErrorBoundary ref={boundaryRef} resetOnPropsChange={true}>
           <div>New child</div>
         </ErrorBoundary>
       );
 
+      expect(resetSpy).toHaveBeenCalledTimes(1);
       expect(screen.getByText('New child')).toBeInTheDocument();
+    });
+
+    it('resetOnPropsChangeが無効な場合、子要素が変わってもリセットされない', () => {
+      const boundaryRef = createRef<ErrorBoundary>();
+      const { rerender } = render(
+        <ErrorBoundary ref={boundaryRef} resetOnPropsChange={false}>
+          <ThrowError shouldThrow={true} />
+        </ErrorBoundary>
+      );
+
+      expect(screen.getByText('エラーが発生しました')).toBeInTheDocument();
+      const resetSpy = vi.spyOn(boundaryRef.current!, 'resetErrorBoundary');
+
+      rerender(
+        <ErrorBoundary ref={boundaryRef} resetOnPropsChange={false}>
+          <div>New child</div>
+        </ErrorBoundary>
+      );
+
+      expect(resetSpy).not.toHaveBeenCalled();
+      expect(screen.getByText('エラーが発生しました')).toBeInTheDocument();
+      expect(screen.queryByText('New child')).not.toBeInTheDocument();
+    });
+
+    it('resetKeysが不足している場合、hasResetKeyChangedはfalseを返す', () => {
+      const boundaryRef = createRef<ErrorBoundary>();
+
+      render(
+        <ErrorBoundary ref={boundaryRef}>
+          <div>Child component</div>
+        </ErrorBoundary>
+      );
+
+      expect(boundaryRef.current?.hasResetKeyChanged(['key1'])).toBe(false);
+    });
+
+    it('resetTimeoutIdが設定されている状態でunmountするとclearTimeoutが呼ばれる', () => {
+      const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+      const boundaryRef = createRef<ErrorBoundary>();
+      const { unmount } = render(
+        <ErrorBoundary ref={boundaryRef}>
+          <div>Child component</div>
+        </ErrorBoundary>
+      );
+      const timeoutId = window.setTimeout(() => undefined, 1000);
+
+      (boundaryRef.current as unknown as { resetTimeoutId: number | null }).resetTimeoutId = timeoutId;
+
+      unmount();
+
+      expect(clearTimeoutSpy).toHaveBeenCalledWith(timeoutId);
     });
   });
 
@@ -207,6 +268,53 @@ describe('ErrorBoundary', () => {
 
       expect(screen.getByText('エラーが頻発しています')).toBeInTheDocument();
       expect(screen.getByText('ページを再読み込み')).toBeInTheDocument();
+    });
+
+    it('ページ再読み込みボタンを押せる', () => {
+      const boundaryRef = createRef<ErrorBoundary>();
+
+      render(
+        <ErrorBoundary ref={boundaryRef}>
+          <div>Child component</div>
+        </ErrorBoundary>
+      );
+
+      act(() => {
+        boundaryRef.current?.setState({
+          hasError: true,
+          error: new Error('Too many errors'),
+          errorCount: 4,
+        });
+      });
+
+      expect(() => {
+        fireEvent.click(screen.getByText('ページを再読み込み'));
+      }).not.toThrow();
+    });
+  });
+
+  describe('追加のレンダリング分岐', () => {
+    it('isolateが有効な場合、デフォルトフォールバックにisolatedクラスが付く', () => {
+      render(
+        <ErrorBoundary isolate={true}>
+          <ThrowError shouldThrow={true} />
+        </ErrorBoundary>
+      );
+
+      expect(screen.getByRole('alert').parentElement).toHaveClass('isolated');
+    });
+
+    it('エラーメッセージが空文字の場合はUnknown errorをログ出力する', () => {
+      render(
+        <ErrorBoundary>
+          <ThrowError shouldThrow={true} message="" />
+        </ErrorBoundary>
+      );
+
+      expect(console.error).toHaveBeenCalledWith(
+        'ErrorBoundary caught an error:',
+        'Unknown error'
+      );
     });
   });
 


### PR DESCRIPTION
# タスク名

ErrorBoundary のテストカバレッジ改善

## 目的

`frontend/src/components/molecules/ErrorBoundary.tsx` の未カバーブランチを、
テスト追加のみでカバーし、既存挙動を変えずに検証を厚くする。

## スコープ

- `ErrorBoundary.test.tsx` に未カバーブランチ向けのテストを追加する
- lint / 型チェック / テスト / ビルドで変更を検証する
- 作業ブランチから PR を作成する

## 非対象

- `ErrorBoundary.tsx` の実装修正
- 他コンポーネントへの波及修正

## 受け入れ条件

- [x] `resetOnPropsChange=true` と `false` の分岐をテストで検証する
- [x] `clearTimeout` と追加レンダリング分岐をテストで検証する
- [x] 指定されたフロントエンド検証コマンドが通る
- [ ] コミット・push・PR 作成が完了している

## 変更候補ファイル

- frontend/src/components/molecules/__tests__/ErrorBoundary.test.tsx

## タスク固有コマンド（任意）

- `cd frontend && vp lint`
- `cd frontend && npx tsc --noEmit`
- `cd frontend && npm test -- --run`
- `cd frontend && vp build`

## 検証結果

- `cd frontend && vp lint && npx tsc --noEmit && npm test -- --run && vp build` が成功
- `cd frontend && npm test -- --run src/components/molecules/__tests__/ErrorBoundary.test.tsx --coverage` の結果、`ErrorBoundary.tsx` は `100% lines / 97.22% branches`

## 進捗

- [x] 調査
- [x] 実装
- [x] テスト
- [ ] PR 作成
- [ ] レビュー対応

## レビュー指摘

- なし

## メモ

- `resetTimeoutId` は実装上 `componentWillUnmount` でのみ参照されるため、その分岐を直接テストする
- `import.meta.env.DEV` が `false` の分岐のみ、現行テスト実行環境では未到達

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * ErrorBoundaryコンポーネントのテストカバレッジを拡張しました。ユーザーに直接影響のない内部品質保証の改善です。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->