### PR TITLE
test: PortfolioPieChart カバレッジ改善

### DIFF
--- a/frontend/src/components/molecules/PortfolioPieChart/__tests__/PortfolioPieChart.test.tsx
+++ b/frontend/src/components/molecules/PortfolioPieChart/__tests__/PortfolioPieChart.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { vi, describe, it, expect } from 'vitest';
 import { PortfolioPieChart, PortfolioItem } from '../PortfolioPieChart';
 
@@ -13,6 +14,19 @@ describe('PortfolioPieChart', () => {
     { name: 'ソニーグループ', value: 600000, securityCode: '6758', shares: 50, averagePrice: 12000 },
     { name: '任天堂', value: 150000, securityCode: '7974', shares: 30, averagePrice: 5000 },
   ];
+  const createLargeData = (count: number): PortfolioItem[] =>
+    Array.from({ length: count }, (_, index) => {
+      const itemNumber = index + 1;
+      const paddedNumber = String(itemNumber).padStart(2, '0');
+
+      return {
+        name: `銘柄${paddedNumber}`,
+        value: (count - index) * 1000,
+        securityCode: `${1000 + itemNumber}`,
+        shares: itemNumber * 10,
+        averagePrice: itemNumber * 100,
+      };
+    });
 
   it('横棒グラフが表示される', () => {
     render(<PortfolioPieChart data={mockData} />);
@@ -79,6 +93,40 @@ describe('PortfolioPieChart', () => {
 
     const chartContainer = screen.getByTestId('portfolio-pie-chart');
     expect(chartContainer).toHaveClass('custom-chart');
+  });
+
+  describe('上位20件表示トグル', () => {
+    it('21件以上のとき初期表示では上位20件とその他にまとめ、全件表示ボタンを出す', () => {
+      const largeData = createLargeData(21);
+
+      render(<PortfolioPieChart data={largeData} />);
+
+      expect(screen.getAllByTestId('portfolio-card-code')).toHaveLength(20);
+      expect(screen.getByText('その他 1銘柄')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '残り1銘柄を表示（全21）' })).toBeInTheDocument();
+      expect(screen.queryByText('銘柄21')).not.toBeInTheDocument();
+    });
+
+    it('全件表示ボタンのクリックで showAll が切り替わり、全件表示と折りたたみ表示を往復できる', async () => {
+      const largeData = createLargeData(21);
+      const user = userEvent.setup();
+
+      render(<PortfolioPieChart data={largeData} />);
+
+      await user.click(screen.getByRole('button', { name: '残り1銘柄を表示（全21）' }));
+
+      expect(screen.getAllByTestId('portfolio-card-code')).toHaveLength(21);
+      expect(screen.getByText('銘柄21')).toBeInTheDocument();
+      expect(screen.queryByText('その他 1銘柄')).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '上位20件のみ表示' })).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: '上位20件のみ表示' }));
+
+      expect(screen.getAllByTestId('portfolio-card-code')).toHaveLength(20);
+      expect(screen.queryByText('銘柄21')).not.toBeInTheDocument();
+      expect(screen.getByText('その他 1銘柄')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '残り1銘柄を表示（全21）' })).toBeInTheDocument();
+    });
   });
 
   describe('配当金額・配当利回り', () => {


### PR DESCRIPTION
# PortfolioPieChart カバレッジ改善

## タスク名

PortfolioPieChart の 21 件超え表示分岐のテスト追加

## 目的

`PortfolioPieChart` の `TOP_N=20` 周辺ロジックについて、未カバーだった折りたたみ表示と全件表示トグルの分岐をテストで担保する。

## スコープ

- 21件以上のデータを使った折りたたみ表示のテスト追加
- 全件表示ボタンと `showAll` 切り替えのテスト追加
- 既存フロントエンド検証コマンドの実行

## 非対象

- `PortfolioPieChart.tsx` 本体の実装変更
- 関連コンポーネントのリファクタ

## 受け入れ条件

- [x] 21件以上で初期表示が上位20件 + 「その他」になることを確認できる
- [x] 21件以上で全件表示ボタンが出ることを確認できる
- [x] ボタンクリックで全件表示と折りたたみ表示を往復できる
- [x] `vp lint` / `npx tsc --noEmit` / `npm test -- --run` / `vp build` が通る

## 変更候補ファイル

- `frontend/src/components/molecules/PortfolioPieChart/__tests__/PortfolioPieChart.test.tsx`

## タスク固有コマンド

- `cd frontend && vp lint`
- `cd frontend && npx tsc --noEmit`
- `cd frontend && npm test -- --run`
- `cd frontend && vp build`

## 進捗

- [x] 調査
- [x] 実装
- [x] テスト
- [ ] PR 作成
- [ ] レビュー対応

## レビュー指摘

- なし