### PR TITLE
test: useJQuantsDividendBatch カバレッジ改善

### DIFF
--- a/frontend/src/features/jquants/hooks/__tests__/useJQuantsDividendBatch.test.ts
+++ b/frontend/src/features/jquants/hooks/__tests__/useJQuantsDividendBatch.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { useJQuantsDividendBatch } from '../useJQuantsDividendBatch';
+import * as dividendHook from '../useJQuantsDividend';
 import { jquantsApiClient } from '../../api/client';
 import { parseNumber } from '@/lib/utils/formatters';
 
@@ -18,10 +19,35 @@ vi.mock('@/lib/utils/formatters', async (importOriginal) => {
   };
 });
 
+vi.mock('../useJQuantsDividend', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../useJQuantsDividend')>();
+  return {
+    ...actual,
+    extractDividendFromSummary: vi.fn(actual.extractDividendFromSummary),
+  };
+});
+
+const flushAsyncUpdates = async () => {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+};
+
 describe('useJQuantsDividendBatch', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (parseNumber as Mock).mockImplementation((val) => Number(val) || 0);
+    (dividendHook.extractDividendFromSummary as Mock).mockImplementation((summary) => {
+      if (summary.NxFDivAnn && summary.NxFDivAnn !== '') return summary.NxFDivAnn;
+      if (summary.FDivAnn && summary.FDivAnn !== '') return summary.FDivAnn;
+      if (summary.DivAnn && summary.DivAnn !== '') return summary.DivAnn;
+      return null;
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('同時実行数を3件以下に制限する', async () => {
@@ -63,5 +89,90 @@ describe('useJQuantsDividendBatch', () => {
 
     expect(maxInFlight).toBeLessThanOrEqual(3);
     expect(result.current.dividendPerShareMap.size).toBe(6);
+  });
+
+  it('value=null の銘柄がある場合は 60 秒待機後に再試行し、回復後に map へ追加する', async () => {
+    vi.useFakeTimers();
+    const codes = ['1605', '2933'];
+
+    const extractionCount: Record<string, number> = {};
+
+    (jquantsApiClient.getStatements as Mock).mockImplementation((code: string) =>
+      Promise.resolve({
+        data: [{ DiscDate: '2025-01-01', NxFDivAnn: code === '1605' ? '30.0' : '15.5', Code: code }],
+      })
+    );
+
+    (dividendHook.extractDividendFromSummary as Mock).mockImplementation((summary) => {
+      extractionCount[summary.Code] = (extractionCount[summary.Code] ?? 0) + 1;
+      if (summary.Code === '2933' && extractionCount[summary.Code] === 1) {
+        return null;
+      }
+      return summary.NxFDivAnn;
+    });
+
+    const { result } = renderHook(() => useJQuantsDividendBatch(codes, true));
+
+    await flushAsyncUpdates();
+
+    expect(jquantsApiClient.getStatements).toHaveBeenCalledTimes(2);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.dividendPerShareMap.get('1605')).toBe(30);
+    expect(result.current.dividendPerShareMap.has('2933')).toBe(false);
+
+    await act(async () => {
+      vi.advanceTimersByTime(60_001);
+    });
+    await flushAsyncUpdates();
+
+    expect(jquantsApiClient.getStatements).toHaveBeenCalledTimes(4);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.dividendPerShareMap.get('2933')).toBe(15.5);
+  });
+
+  it('抽出処理の失敗が続く銘柄は MAX_RETRIES 超過後に再試行を停止する', async () => {
+    vi.useFakeTimers();
+    const codes = ['1605', '2933'];
+
+    (jquantsApiClient.getStatements as Mock).mockImplementation((code: string) =>
+      Promise.resolve({
+        data: [{ DiscDate: '2025-01-01', NxFDivAnn: code === '1605' ? '30.0' : '15.5', Code: code }],
+      })
+    );
+
+    (dividendHook.extractDividendFromSummary as Mock).mockImplementation((summary) => {
+      if (summary.Code === '2933') {
+        throw new Error('forced failure');
+      }
+      return summary.NxFDivAnn;
+    });
+
+    const { result } = renderHook(() => useJQuantsDividendBatch(codes, true));
+
+    await flushAsyncUpdates();
+
+    expect(jquantsApiClient.getStatements).toHaveBeenCalledTimes(2);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.dividendPerShareMap.get('1605')).toBe(30);
+    expect(result.current.dividendPerShareMap.has('2933')).toBe(false);
+
+    for (let i = 0; i < 3; i += 1) {
+      await act(async () => {
+        vi.advanceTimersByTime(60_001);
+      });
+      await flushAsyncUpdates();
+    }
+
+    expect(jquantsApiClient.getStatements).toHaveBeenCalledTimes(8);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.dividendPerShareMap.get('1605')).toBe(30);
+    expect(result.current.dividendPerShareMap.has('2933')).toBe(false);
+
+    await act(async () => {
+      vi.advanceTimersByTime(60_001);
+    });
+    await flushAsyncUpdates();
+
+    expect(jquantsApiClient.getStatements).toHaveBeenCalledTimes(8);
   });
 });


### PR DESCRIPTION
# test: useJQuantsDividendBatch カバレッジ改善

## タスク名

`useJQuantsDividendBatch` の retry / max retry 分岐にテストを追加する。

## 目的

`frontend/src/features/jquants/hooks/useJQuantsDividendBatch.ts` の
`MAX_RETRIES=3` / `RETRY_DELAY_MS=60000` 周辺の未カバーブランチを
テストで通し、退行を防ぐ。

## スコープ

- `fulfilled(value=null)` の再試行分岐をテストする
- `rejected` の再試行分岐と上限到達後の停止をテストする
- `vi.useFakeTimers()` と `vi.advanceTimersByTime(60001)` で待機をスキップする

## 非対象

- `useJQuantsDividendBatch.ts` 本体の変更
- `useDividendBatch.ts` や API 実装の変更

## 受け入れ条件

- [x] `value === null` を返した銘柄が 60 秒後の再試行で回復するテストがある
- [x] 失敗が続く銘柄が `MAX_RETRIES` 超過後に再試行停止するテストがある
- [x] `cd frontend && vp lint && npx tsc --noEmit && npm test -- --run && vp build` を通す

## 変更候補ファイル

- `frontend/src/features/jquants/hooks/__tests__/useJQuantsDividendBatch.test.ts`

## タスク固有コマンド（任意）

- `cd frontend && npm test -- --run src/features/jquants/hooks/__tests__/useJQuantsDividendBatch.test.ts`
- `cd frontend && npm test -- --run src/features/jquants/hooks/__tests__/useJQuantsDividendBatch.test.ts --coverage`

## 進捗

- [x] 調査
- [x] 実装
- [x] テスト
- [ ] PR 作成
- [ ] レビュー対応

## レビュー指摘

- なし

## メモ

- 対象 hook は `error` ステータスを返さないため、失敗継続時は `Map` 未登録と再試行停止で確認した
- 既存の専用テストファイル `useJQuantsDividendBatch.test.ts` に追加した