### PR TITLE
test: Receipts カバレッジ改善

### DIFF
--- a/frontend/src/pages/__tests__/Receipts.test.tsx
+++ b/frontend/src/pages/__tests__/Receipts.test.tsx
@@ -660,6 +660,42 @@ describe('ReceiptsPage', () => {
     expect(screen.getAllByText('保存しました')).toHaveLength(1);
   }, 20000);
 
+  it('全削除: 確認モーダルを開いてキャンセルで閉じる', async () => {
+    vi.mocked(authHook.useAuth).mockReturnValue(
+      makeAuthMock({ isAuthenticated: true })
+    );
+
+    const mockDbRow = { id: '1', payment_date: '2023-01-01' };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(receiptApi.dividendApi.list).mockResolvedValue([mockDbRow] as any);
+    vi.mocked(receiptApi.domesticStockApi.list).mockResolvedValue([]);
+    vi.mocked(receiptApi.mutualfundApi.list).mockResolvedValue([]);
+    vi.mocked(receiptApi.dividendApi.deleteAll).mockResolvedValue({});
+
+    renderWithQuery(<ReceiptsPage />);
+
+    await waitFor(() => {
+      expect(receiptApi.dividendApi.list).toHaveBeenCalled();
+    }, waitOpts);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /全件削除/ })).toBeInTheDocument();
+    }, waitOpts);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /全件削除/ }));
+
+    expect(screen.getByTestId('confirm-modal')).toBeInTheDocument();
+    expect(screen.getByText('配当金データの全件削除')).toBeInTheDocument();
+
+    await user.click(screen.getByTestId('cancel-delete'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('confirm-modal')).not.toBeInTheDocument();
+    }, waitOpts);
+    expect(receiptApi.dividendApi.deleteAll).not.toHaveBeenCalled();
+  }, 20000);
+
   it('全削除: 確認モーダル経由で deleteAll API が呼ばれデータがクリアされる', async () => {
     vi.mocked(authHook.useAuth).mockReturnValue(
       makeAuthMock({ isAuthenticated: true })


### PR DESCRIPTION
# タスク名

Receipts カバレッジ改善

## 目的

`Receipts.tsx` の ConfirmDeleteModal にある `onCancel` 分岐をテストで通し、
ブランチカバレッジを改善する。

## スコープ

- `frontend/src/pages/__tests__/Receipts.test.tsx` にモーダル表示の確認を追加
- `frontend/src/pages/__tests__/Receipts.test.tsx` にキャンセルでモーダルが閉じるテストを追加

## 非対象

- `frontend/src/pages/Receipts.tsx` の実装変更
- 既存 UI や API ロジックの変更

## 受け入れ条件

- [x] 「全件削除」ボタン押下で削除確認モーダルが表示される
- [x] モーダルの「キャンセル」押下でモーダルが閉じる
- [x] `cd frontend && vp lint && npx tsc --noEmit && npm test -- --run && vp build` が通る

## 変更候補ファイル

- `frontend/src/pages/__tests__/Receipts.test.tsx`

## 進捗

- [x] 調査
- [x] 実装
- [x] テスト
- [x] PR 作成
- [ ] レビュー対応

## レビュー指摘

- なし

## メモ

- 既存の削除成功テストとは分けて、キャンセル分岐を独立して検証した