### PR TITLE
test: CORS設定のユニットテスト追加

### DIFF
--- a/backend/src/config/cors.rs
+++ b/backend/src/config/cors.rs
@@ -63,3 +63,81 @@ pub fn is_localhost_origin(origin: &str) -> bool {
     let host = origin.split(':').next().unwrap_or(origin);
     matches!(host, "localhost" | "localhost." | "127.0.0.1")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{is_localhost_origin, parse_cors_origins};
+
+    #[test]
+    fn accepts_localhost_origin_variants() {
+        let cases = [
+            "http://localhost",
+            "https://localhost:3000",
+            "http://localhost.:5173",
+            "http://127.0.0.1:8080",
+            "https://[::1]:3000",
+            "http://[0:0:0:0:0:0:0:1]:5173/path",
+        ];
+
+        for origin in cases {
+            assert!(
+                is_localhost_origin(origin),
+                "expected {origin} to be treated as localhost"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_spoofed_and_production_origins() {
+        let cases = [
+            "https://localhost.example.com",
+            "https://127.0.0.1.example.com:3000",
+            "https://frontend.example.com",
+        ];
+
+        for origin in cases {
+            assert!(
+                !is_localhost_origin(origin),
+                "expected {origin} to be rejected as non-localhost"
+            );
+        }
+    }
+
+    #[test]
+    fn parses_comma_separated_cors_origins() {
+        assert_eq!(
+            parse_cors_origins("https://app.example.com,http://localhost:3000"),
+            vec![
+                "https://app.example.com".to_string(),
+                "http://localhost:3000".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn trims_whitespace_when_parsing_cors_origins() {
+        assert_eq!(
+            parse_cors_origins(" https://app.example.com , http://localhost:3000 "),
+            vec![
+                "https://app.example.com".to_string(),
+                "http://localhost:3000".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn returns_empty_vec_for_empty_cors_origins() {
+        assert!(parse_cors_origins("").is_empty());
+    }
+
+    #[test]
+    fn ignores_trailing_commas_when_parsing_cors_origins() {
+        assert_eq!(
+            parse_cors_origins("https://app.example.com,http://localhost:3000,"),
+            vec![
+                "https://app.example.com".to_string(),
+                "http://localhost:3000".to_string(),
+            ]
+        );
+    }
+}


### PR DESCRIPTION
# タスク名

CORS 設定ユニットテスト追加

## 目的

`backend/src/config/cors.rs` の `is_localhost_origin` と
`parse_cors_origins` の振る舞いをユニットテストで固定する。

## スコープ

- `is_localhost_origin` の localhost, 127.0.0.1, `[::1]`, port 付き判定を検証
- `is_localhost_origin` の subdomain 偽装と本番ドメイン拒否を検証
- `parse_cors_origins` の通常入力、空白トリム、空文字、末尾カンマを検証

## 非対象

- CORS 本体ロジックの変更
- 本件に無関係な設定変更やリファクタ

## 受け入れ条件

- [x] `backend/src/config/cors.rs` に `#[cfg(test)]` ブロックが追加されている
- [x] `is_localhost_origin` の主要ケースがテストされている
- [x] `parse_cors_origins` の主要ケースがテストされている
- [x] `cargo fmt --check` が通る
- [x] `cargo clippy --all-targets -- -D warnings` が通る
- [x] `cargo test` が通る

## 変更ファイル

- `backend/src/config/cors.rs`

## 検証コマンド

```bash
cd backend && cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test
```

## メモ

- task file は当初リポジトリ内に存在しなかったため、PR 本文生成のために今回の指示内容から補完した

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * CORS設定の検証テストを追加しました。既存の公開機能に対して包括的なテストケースが実装され、ローカルホストオリジンの識別とオリジン設定の解析処理の正確性が確保されました。本番コードに変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->