### PR TITLE
refactor: delete_all ハンドラーの MessageResponse 型使用

### DIFF
--- a/backend/src/handlers/asset_balance.rs
+++ b/backend/src/handlers/asset_balance.rs
@@ -133,6 +133,8 @@ pub async fn delete_all(
     asset_balance_service::delete_all(&state.pool, auth_user.id()).await?;
     Ok((
         StatusCode::OK,
-        Json(serde_json::json!({"message": "全ての保有銘柄データを削除しました"})),
+        Json(MessageResponse {
+            message: "全ての保有銘柄データを削除しました".to_string(),
+        }),
     ))
 }

--- a/backend/src/handlers/dividend.rs
+++ b/backend/src/handlers/dividend.rs
@@ -108,6 +108,8 @@ pub async fn delete_all(
     dividend_service::delete_all(&state.pool, auth_user.id()).await?;
     Ok((
         StatusCode::OK,
-        Json(serde_json::json!({"message": "全ての配当金データを削除しました"})),
+        Json(MessageResponse {
+            message: "全ての配当金データを削除しました".to_string(),
+        }),
     ))
 }

--- a/backend/src/handlers/domestic_stock.rs
+++ b/backend/src/handlers/domestic_stock.rs
@@ -108,6 +108,8 @@ pub async fn delete_all(
     domestic_stock_service::delete_all(&state.pool, auth_user.id()).await?;
     Ok((
         StatusCode::OK,
-        Json(serde_json::json!({"message": "全ての国内株式取引データを削除しました"})),
+        Json(MessageResponse {
+            message: "全ての国内株式取引データを削除しました".to_string(),
+        }),
     ))
 }

--- a/backend/src/handlers/mutualfund.rs
+++ b/backend/src/handlers/mutualfund.rs
@@ -108,6 +108,8 @@ pub async fn delete_all(
     mutualfund_service::delete_all(&state.pool, auth_user.id()).await?;
     Ok((
         StatusCode::OK,
-        Json(serde_json::json!({"message": "全ての投資信託データを削除しました"})),
+        Json(MessageResponse {
+            message: "全ての投資信託データを削除しました".to_string(),
+        }),
     ))
 }


### PR DESCRIPTION
# タスク名

delete_all ハンドラーの MessageResponse 型使用

## 目的

4つの `delete_all` ハンドラーで `serde_json::json!` によるメッセージ返却をやめ、既存の `MessageResponse` 型に統一する。
OpenAPI 上のレスポンス定義と実装を一致させる。

## スコープ

- `backend/src/handlers/domestic_stock.rs` の `delete_all` を `MessageResponse` 返却に変更する
- `backend/src/handlers/dividend.rs` の `delete_all` を `MessageResponse` 返却に変更する
- `backend/src/handlers/mutualfund.rs` の `delete_all` を `MessageResponse` 返却に変更する
- `backend/src/handlers/asset_balance.rs` の `delete_all` を `MessageResponse` 返却に変更する
- 指定コマンドで `fmt` / `clippy` / `test` を実行する

## 非対象

- `delete_all` 以外のハンドラーのレスポンス変更
- API パス、メッセージ文言、認証、DB 挙動の変更
- OpenAPI や frontend 生成コードの更新

## 受け入れ条件

- [x] 4つの `delete_all` ハンドラーが `Json(MessageResponse { message: ... })` を返す
- [x] メッセージ文言は既存のまま維持する
- [x] `cd backend && cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test` が通る

## 変更候補ファイル

- backend/src/handlers/domestic_stock.rs
- backend/src/handlers/dividend.rs
- backend/src/handlers/mutualfund.rs
- backend/src/handlers/asset_balance.rs

## タスク固有コマンド

- `cd backend && cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test`

## 進捗

- [x] 調査
- [x] 実装
- [x] テスト
- [ ] PR 作成
- [ ] レビュー対応

## レビュー指摘

- なし

## メモ

- 指示された task file はリポジトリ内に存在しなかったため、PR 本文生成用にローカル作成した