### PR TITLE
chore: カバレッジ閾値を実績値に引き上げる

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -74,7 +74,10 @@ export default defineConfig({
       reporter: ['text', 'json', 'html'],
       exclude: ['node_modules/', 'src/test/'],
       thresholds: {
-        lines: 70,
+        lines: 97,
+        statements: 97,
+        functions: 97,
+        branches: 90,
       },
     },
     pool: 'forks',


### PR DESCRIPTION
# chore: カバレッジ閾値を実績値に引き上げる

## 概要

- `frontend/vite.config.ts` の `coverage.thresholds` が `lines: 70` のみで低すぎるため、現在の実績値に合わせて閾値を引き上げる

## 対応内容

- `lines` を `97` に変更
- `statements` を `97` に追加
- `functions` を `97` に追加
- `branches` を `90` に追加

## 確認

- `cd frontend && npm run test:coverage -- --run`
- 実績: `lines 98.51% / statements 97.98% / functions 98.41% / branches 94.05%`

## 完了条件

- カバレッジテストが更新後の閾値を通過する
- `frontend/vite.config.ts` のみをコミット対象に含める

## 進捗

- [x] `coverage.thresholds` を更新
- [x] カバレッジテストで閾値通過を確認
- [x] コミット対象が `frontend/vite.config.ts` のみであることを確認