### PR TITLE
feat: CSV アップロードエンドポイントへのレート制限追加

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -4,7 +4,9 @@ pub mod cors;
 pub mod environment;
 
 pub use cors::{build_cors_layer, is_localhost_origin, parse_cors_origins};
-pub use environment::{backend_url, is_production_env, is_secure_cookie, server_addr};
+pub use environment::{
+    backend_url, csv_rate_limit_rps, is_production_env, is_secure_cookie, server_addr,
+};
 
 pub struct Config {
     pub cors_origins: Vec<String>,
@@ -13,6 +15,8 @@ pub struct Config {
     pub auth_rate_limit_rps: u32,
     /// `/jquants/*` ルートへのレート制限（リクエスト/秒）。0 は無制限
     pub jquants_rate_limit_rps: u32,
+    /// CSV アップロードルートへの IP 単位レート制限（リクエスト/秒）。0 は無制限
+    pub csv_rate_limit_rps: u32,
 }
 
 impl Default for Config {
@@ -28,6 +32,7 @@ impl Default for Config {
             database_max_connections: 5,
             auth_rate_limit_rps: 10,
             jquants_rate_limit_rps: 5,
+            csv_rate_limit_rps: 2,
         }
     }
 }
@@ -54,6 +59,8 @@ impl Config {
                 config.jquants_rate_limit_rps = v;
             }
         }
+
+        config.csv_rate_limit_rps = csv_rate_limit_rps();
 
         if is_production_env() {
             config
@@ -115,6 +122,7 @@ mod tests {
     fn test_config_default() {
         let config = Config::default();
         assert_eq!(config.database_max_connections, 5);
+        assert_eq!(config.csv_rate_limit_rps, 2);
         assert!(config
             .cors_origins
             .contains(&"https://shoken-webapp.vercel.app".to_string()));
@@ -137,11 +145,23 @@ mod tests {
             database_max_connections: 10,
             auth_rate_limit_rps: 10,
             jquants_rate_limit_rps: 5,
+            csv_rate_limit_rps: 2,
         };
 
         assert_eq!(config.database_max_connections, 10);
         assert_eq!(config.cors_origins.len(), 1);
         assert_eq!(config.cors_origins[0], "http://example.com");
+        assert_eq!(config.csv_rate_limit_rps, 2);
+    }
+
+    #[tokio::test]
+    async fn test_config_from_env_reads_csv_rate_limit_rps() {
+        let _lock = ENV_MUTEX.lock().await;
+        let _csv_rate_limit_rps = EnvGuard::set("CSV_RATE_LIMIT_RPS", Some("7"));
+
+        let config = Config::from_env();
+
+        assert_eq!(config.csv_rate_limit_rps, 7);
     }
 
     #[test]

--- a/backend/src/config/environment.rs
+++ b/backend/src/config/environment.rs
@@ -40,3 +40,11 @@ pub fn is_secure_cookie() -> bool {
         .map(|url| url.starts_with("https://"))
         .unwrap_or(false)
 }
+
+/// CSV アップロード系ルートへのレート制限（リクエスト/秒）。0 は無制限
+pub fn csv_rate_limit_rps() -> u32 {
+    env::var("CSV_RATE_LIMIT_RPS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(2)
+}

--- a/backend/src/handlers/asset_balance.rs
+++ b/backend/src/handlers/asset_balance.rs
@@ -22,9 +22,12 @@ pub fn asset_balance_routes() -> Router<AppState> {
     Router::new()
         .route("/asset-balances", get(list))
         .route("/asset-balances/bulk", post(bulk_create))
-        .route("/asset-balances/csv", post(upload_csv))
         .route("/asset-balances/csv/preview", post(preview_csv))
         .route("/asset-balances/all", delete(delete_all))
+}
+
+pub fn asset_balance_csv_upload_routes() -> Router<AppState> {
+    Router::new().route("/asset-balances/csv", post(upload_csv))
 }
 
 /// 認証ユーザーの保有銘柄一覧を取得

--- a/backend/src/handlers/dividend.rs
+++ b/backend/src/handlers/dividend.rs
@@ -20,9 +20,12 @@ use axum::{
 pub fn dividend_routes() -> Router<AppState> {
     Router::new()
         .route("/dividends", get(list))
-        .route("/dividends/csv", post(upload_csv))
         .route("/dividends/csv/preview", post(preview_csv))
         .route("/dividends/all", delete(delete_all))
+}
+
+pub fn dividend_csv_upload_routes() -> Router<AppState> {
+    Router::new().route("/dividends/csv", post(upload_csv))
 }
 
 /// 認証ユーザーの配当金一覧を取得

--- a/backend/src/handlers/domestic_stock.rs
+++ b/backend/src/handlers/domestic_stock.rs
@@ -20,9 +20,12 @@ use axum::{
 pub fn domestic_stock_routes() -> Router<AppState> {
     Router::new()
         .route("/domestic-stocks", get(list))
-        .route("/domestic-stocks/csv", post(upload_csv))
         .route("/domestic-stocks/csv/preview", post(preview_csv))
         .route("/domestic-stocks/all", delete(delete_all))
+}
+
+pub fn domestic_stock_csv_upload_routes() -> Router<AppState> {
+    Router::new().route("/domestic-stocks/csv", post(upload_csv))
 }
 
 /// 認証ユーザーの国内株式取引一覧を取得

--- a/backend/src/handlers/mutualfund.rs
+++ b/backend/src/handlers/mutualfund.rs
@@ -20,9 +20,12 @@ use axum::{
 pub fn mutualfund_routes() -> Router<AppState> {
     Router::new()
         .route("/mutualfunds", get(list))
-        .route("/mutualfunds/csv", post(upload_csv))
         .route("/mutualfunds/csv/preview", post(preview_csv))
         .route("/mutualfunds/all", delete(delete_all))
+}
+
+pub fn mutualfund_csv_upload_routes() -> Router<AppState> {
+    Router::new().route("/mutualfunds/csv", post(upload_csv))
 }
 
 /// 認証ユーザーの投資信託一覧を取得

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -22,11 +22,10 @@ use crate::{
 /// リクエストボディの上限サイズ（10MB）
 const REQUEST_BODY_LIMIT: usize = 10 * 1024 * 1024;
 
-pub fn app_router(state: AppState, config: &Config) -> Router {
-    // auth は IP 単位の keyed limiter（ブルートフォース/DoS 対策）
-    let auth_limiter = build_keyed_rate_limiter(config.auth_rate_limit_rps);
-    let jquants_limiter = build_rate_limiter(config.jquants_rate_limit_rps);
-    if let Some(ref limiter) = auth_limiter {
+fn spawn_keyed_limiter_cleanup(
+    limiter: &Option<Arc<governor::DefaultKeyedRateLimiter<std::net::IpAddr>>>,
+) {
+    if let Some(limiter) = limiter {
         let limiter = limiter.clone();
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
@@ -36,9 +35,18 @@ pub fn app_router(state: AppState, config: &Config) -> Router {
             }
         });
     }
+}
+
+pub fn app_router(state: AppState, config: &Config) -> Router {
+    // auth は IP 単位の keyed limiter（ブルートフォース/DoS 対策）
+    let auth_limiter = build_keyed_rate_limiter(config.auth_rate_limit_rps);
+    let csv_limiter = build_keyed_rate_limiter(config.csv_rate_limit_rps);
+    let jquants_limiter = build_rate_limiter(config.jquants_rate_limit_rps);
+    spawn_keyed_limiter_cleanup(&auth_limiter);
+    spawn_keyed_limiter_cleanup(&csv_limiter);
 
     let allowed_origins = Arc::new(config.cors_origins.clone());
-    domain_routes(jquants_limiter, auth_limiter)
+    domain_routes(jquants_limiter, auth_limiter, csv_limiter)
         .merge(
             Router::new()
                 .route("/health", get(|| async { "OK" }))
@@ -68,6 +76,7 @@ pub fn app_router(state: AppState, config: &Config) -> Router {
 fn domain_routes(
     jquants_limiter: Option<Arc<governor::DefaultDirectRateLimiter>>,
     auth_limiter: Option<Arc<governor::DefaultKeyedRateLimiter<std::net::IpAddr>>>,
+    csv_limiter: Option<Arc<governor::DefaultKeyedRateLimiter<std::net::IpAddr>>>,
 ) -> Router<AppState> {
     let jquants_routes = if let Some(l) = jquants_limiter {
         handlers::jquants::jquants_routes().layer(middleware::from_fn(move |req, next| {
@@ -85,12 +94,21 @@ fn domain_routes(
     } else {
         handlers::auth::auth_routes()
     };
+    let csv_upload_routes = if let Some(l) = csv_limiter {
+        csv_upload_routes().layer(middleware::from_fn(move |req, next| {
+            let l = l.clone();
+            async move { keyed_rate_limit(l, req, next).await }
+        }))
+    } else {
+        csv_upload_routes()
+    };
 
     Router::new()
         .merge(handlers::auth::stock_routes())
         .merge(jquants_routes)
         .merge(handlers::dividend_per_share::dividend_per_share_routes())
         .merge(auth_routes)
+        .merge(csv_upload_routes)
         .merge(handlers::dividend::dividend_routes())
         .merge(handlers::domestic_stock::domestic_stock_routes())
         .merge(handlers::mutualfund::mutualfund_routes())
@@ -98,9 +116,18 @@ fn domain_routes(
         .merge(handlers::csv_import::csv_import_routes())
 }
 
+fn csv_upload_routes() -> Router<AppState> {
+    Router::new()
+        .merge(handlers::dividend::dividend_csv_upload_routes())
+        .merge(handlers::domestic_stock::domestic_stock_csv_upload_routes())
+        .merge(handlers::mutualfund::mutualfund_csv_upload_routes())
+        .merge(handlers::asset_balance::asset_balance_csv_upload_routes())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_env::{EnvGuard, ENV_MUTEX};
     use std::sync::Arc;
 
     fn make_test_state() -> AppState {
@@ -230,6 +257,58 @@ mod tests {
             .unwrap();
         let resp = router.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), axum::http::StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    /// CSV upload ルートだけが IP 単位レート制限の対象になることを確認
+    #[tokio::test]
+    async fn test_csv_upload_routes_rate_limit_returns_429() {
+        use axum::{body::Body, http::Request};
+        use tower::ServiceExt;
+
+        let _lock = ENV_MUTEX.lock().await;
+        let _csv_rate_limit_rps = EnvGuard::set("CSV_RATE_LIMIT_RPS", Some("1"));
+
+        for (path, ip) in [
+            ("/domestic-stocks/csv", "1.2.3.4"),
+            ("/dividends/csv", "1.2.3.5"),
+            ("/mutualfunds/csv", "1.2.3.6"),
+            ("/asset-balances/csv", "1.2.3.7"),
+        ] {
+            let state = make_test_state();
+            let config = Config::from_env();
+            let router = app_router(state, &config);
+
+            let req = Request::builder()
+                .method(axum::http::Method::POST)
+                .uri(path)
+                .header("fly-client-ip", ip)
+                .body(Body::empty())
+                .unwrap();
+            let resp = router.clone().oneshot(req).await.unwrap();
+            assert_ne!(resp.status(), axum::http::StatusCode::TOO_MANY_REQUESTS);
+
+            let req = Request::builder()
+                .method(axum::http::Method::POST)
+                .uri(path)
+                .header("fly-client-ip", ip)
+                .body(Body::empty())
+                .unwrap();
+            let resp = router.oneshot(req).await.unwrap();
+            assert_eq!(resp.status(), axum::http::StatusCode::TOO_MANY_REQUESTS);
+        }
+
+        let state = make_test_state();
+        let config = Config::from_env();
+        let router = app_router(state, &config);
+
+        let req = Request::builder()
+            .method(axum::http::Method::POST)
+            .uri("/domestic-stocks/csv/preview")
+            .header("fly-client-ip", "1.2.3.4")
+            .body(Body::empty())
+            .unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_ne!(resp.status(), axum::http::StatusCode::TOO_MANY_REQUESTS);
     }
 
     /// x-request-id がレスポンスに伝播されることを確認


### PR DESCRIPTION
# CSV アップロードエンドポイントへのレート制限追加

## 目的

CSV アップロードエンドポイントに IP 単位のレート制限を追加し、
短時間の連続アップロードによる負荷集中を抑える。

## スコープ

- `CSV_RATE_LIMIT_RPS` の環境変数追加
- `Config` に CSV 用レート制限設定を追加
- CSV upload 4 エンドポイントに keyed rate limit を適用
- backend の fmt / clippy / test 実行

## 非対象

- preview エンドポイントへの制限追加
- auth / jquants 以外の既存レート制限の見直し
- OpenAPI 契約の変更

## 受け入れ条件

- [x] `Config::from_env()` が `CSV_RATE_LIMIT_RPS` を読み取る
- [x] `POST /domestic-stocks/csv` が IP 単位レート制限の対象になる
- [x] `POST /dividends/csv` が IP 単位レート制限の対象になる
- [x] `POST /mutualfunds/csv` が IP 単位レート制限の対象になる
- [x] `POST /asset-balances/csv` が IP 単位レート制限の対象になる
- [x] preview エンドポイントはレート制限の対象外のまま

## 変更候補ファイル

- backend/src/config/environment.rs
- backend/src/config.rs
- backend/src/routes.rs
- backend/src/handlers/domestic_stock.rs
- backend/src/handlers/dividend.rs
- backend/src/handlers/mutualfund.rs
- backend/src/handlers/asset_balance.rs

## タスク固有コマンド

- `cd backend && cargo fmt --check`
- `cd backend && cargo clippy --all-targets -- -D warnings`
- `cd backend && cargo test`

## 進捗

- [x] 調査
- [x] 実装
- [x] テスト
- [ ] PR 作成
- [ ] レビュー対応

## レビュー指摘

- なし

## メモ

- task file はローカル運用のみとし、コミット対象に含めない
