### PR TITLE
refactor: J-Quants エンドポイント命名の整理と認証追加

### DIFF
--- a/backend/src/handlers/jquants.rs
+++ b/backend/src/handlers/jquants.rs
@@ -1,4 +1,5 @@
 use crate::errors::{ApiError, ErrorResponse};
+use crate::extractors::auth::AuthenticatedUser;
 use crate::models::jquants::{FinSummaryQuery, FinSummaryResponse};
 use crate::services::jquants::JQuantsService;
 use crate::state::AppState;
@@ -10,14 +11,13 @@ use axum::{
 };
 
 pub fn jquants_routes() -> Router<AppState> {
-    Router::new().route("/jquants/fins/statements", get(get_fin_summary))
+    Router::new().route("/jquants/fins/summary", get(get_fin_summary))
 }
 
 /// 決算サマリーを取得（J-Quants API V2）
-/// V2では fins/statements → fins/summary に変更
 #[utoipa::path(
     get,
-    path = "/jquants/fins/statements",
+    path = "/jquants/fins/summary",
     operation_id = "jquants_fin_summary",
     params(
         ("code" = String, Query, description = "銘柄コード"),
@@ -35,6 +35,7 @@ pub fn jquants_routes() -> Router<AppState> {
 )]
 pub async fn get_fin_summary(
     State(state): State<AppState>,
+    _auth_user: AuthenticatedUser,
     Query(params): Query<FinSummaryQuery>,
 ) -> Result<Json<FinSummaryResponse>, ApiError> {
     tracing::info!("決算サマリー取得パラメータ: {:?}", params);

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -216,7 +216,7 @@ mod tests {
         // 1 回目は通過
         let req = Request::builder()
             .method(axum::http::Method::GET)
-            .uri("/jquants/fins/statements")
+            .uri("/jquants/fins/summary")
             .body(Body::empty())
             .unwrap();
         let resp = router.clone().oneshot(req).await.unwrap();
@@ -225,11 +225,34 @@ mod tests {
         // 2 回目は 429
         let req = Request::builder()
             .method(axum::http::Method::GET)
-            .uri("/jquants/fins/statements")
+            .uri("/jquants/fins/summary")
             .body(Body::empty())
             .unwrap();
         let resp = router.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), axum::http::StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    /// 未認証時に GET /jquants/fins/summary が 401 を返すことを確認
+    /// セッション Cookie なしでは認証エクストラクターが先に失敗するため DB クエリは発生しない
+    #[tokio::test]
+    async fn test_jquants_fin_summary_unauthorized() {
+        use axum::{body::Body, http::Request};
+        use tower::ServiceExt;
+
+        let app = handlers::jquants::jquants_routes().with_state(make_test_state());
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(axum::http::Method::GET)
+                    .uri("/jquants/fins/summary?code=7203")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), axum::http::StatusCode::UNAUTHORIZED);
     }
 
     /// x-request-id がレスポンスに伝播されることを確認

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -775,12 +775,12 @@
         ]
       }
     },
-    "/jquants/fins/statements": {
+    "/jquants/fins/summary": {
       "get": {
         "tags": [
           "handlers::jquants"
         ],
-        "summary": "決算サマリーを取得（J-Quants API V2）\nV2では fins/statements → fins/summary に変更",
+        "summary": "決算サマリーを取得（J-Quants API V2）",
         "operationId": "jquants_fin_summary",
         "parameters": [
           {

--- a/frontend/src/features/jquants/api/__tests__/client.test.ts
+++ b/frontend/src/features/jquants/api/__tests__/client.test.ts
@@ -17,8 +17,8 @@ describe('JQuantsApiClient', () => {
     client = new JQuantsApiClient();
   });
 
-  describe('getStatements', () => {
-    it('財務諸表を正常に取得できる', async () => {
+  describe('getSummary', () => {
+    it('決算サマリーを正常に取得できる', async () => {
       const mockResponse = {
         data: [
           { NxFDivAnn: '100' },
@@ -26,9 +26,9 @@ describe('JQuantsApiClient', () => {
       };
       (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue(mockResponse);
 
-      const result = await client.getStatements('1234');
+      const result = await client.getSummary('1234');
 
-      expect(apiClient.get).toHaveBeenCalledWith('/jquants/fins/statements', {
+      expect(apiClient.get).toHaveBeenCalledWith('/jquants/fins/summary', {
         params: { code: '1234' },
       });
       expect(result).toEqual(mockResponse);
@@ -38,9 +38,9 @@ describe('JQuantsApiClient', () => {
       const mockResponse = { data: [] };
       (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue(mockResponse);
 
-      await client.getStatements('1234', '2024-01-01', '2024-12-31');
+      await client.getSummary('1234', '2024-01-01', '2024-12-31');
 
-      expect(apiClient.get).toHaveBeenCalledWith('/jquants/fins/statements', {
+      expect(apiClient.get).toHaveBeenCalledWith('/jquants/fins/summary', {
         params: { code: '1234', from: '2024-01-01', to: '2024-12-31' },
       });
     });
@@ -49,14 +49,14 @@ describe('JQuantsApiClient', () => {
       const apiError = new ApiError(ApiErrorType.NETWORK_ERROR, 'Network Error');
       (apiClient.get as ReturnType<typeof vi.fn>).mockRejectedValue(apiError);
 
-      await expect(client.getStatements('1234')).rejects.toBe(apiError);
+      await expect(client.getSummary('1234')).rejects.toBe(apiError);
     });
 
     it('その他のエラーの場合、デフォルトのApiErrorを投げる', async () => {
       const error = new Error('Unknown Error');
       (apiClient.get as ReturnType<typeof vi.fn>).mockRejectedValue(error);
 
-      await expect(client.getStatements('1234')).rejects.toThrow('財務諸表の取得に失敗しました');
+      await expect(client.getSummary('1234')).rejects.toThrow('決算サマリーの取得に失敗しました');
     });
   });
 });

--- a/frontend/src/features/jquants/api/client.ts
+++ b/frontend/src/features/jquants/api/client.ts
@@ -1,4 +1,4 @@
-import { JQuantsStatementsResponse } from './types';
+import { JQuantsFinSummaryResponse } from './types';
 import { apiClient } from '@/lib/api/client';
 import { ApiError, ApiErrorType } from '@/lib/types/api';
 
@@ -8,23 +8,23 @@ import { ApiError, ApiErrorType } from '@/lib/types/api';
  */
 export class JQuantsApiClient {
   /**
-   * 財務諸表を取得
+   * 決算サマリーを取得
    * @param code 銘柄コード
    * @param from 開始日付（YYYY-MM-DD形式）
    * @param to 終了日付（YYYY-MM-DD形式）
    */
-  async getStatements(
+  async getSummary(
     code: string,
     from?: string,
     to?: string
-  ): Promise<JQuantsStatementsResponse> {
+  ): Promise<JQuantsFinSummaryResponse> {
     try {
       const params: Record<string, string> = { code };
       if (from) params.from = from;
       if (to) params.to = to;
 
-      const response = await apiClient.get<JQuantsStatementsResponse>(
-        '/jquants/fins/statements',
+      const response = await apiClient.get<JQuantsFinSummaryResponse>(
+        '/jquants/fins/summary',
         { params }
       );
 
@@ -35,7 +35,7 @@ export class JQuantsApiClient {
       }
       throw new ApiError(
         ApiErrorType.DESERIALIZATION_ERROR,
-        '財務諸表の取得に失敗しました'
+        '決算サマリーの取得に失敗しました'
       );
     }
   }

--- a/frontend/src/features/jquants/api/types.ts
+++ b/frontend/src/features/jquants/api/types.ts
@@ -143,8 +143,7 @@ export interface JQuantsStatementData {
  * J-Quants API V2 決算サマリーレスポンス
  * V2では fins/summary を使用し、ルートフィールドは "data"
  */
-export interface JQuantsStatementsResponse {
+export interface JQuantsFinSummaryResponse {
   data: JQuantsStatementData[];
   pagination_key?: string;
 }
-

--- a/frontend/src/features/jquants/hooks/__tests__/useJQuantsDividend.test.ts
+++ b/frontend/src/features/jquants/hooks/__tests__/useJQuantsDividend.test.ts
@@ -6,7 +6,7 @@ import { parseNumber } from '@/lib/utils/formatters';
 
 vi.mock('../../api/client', () => ({
   jquantsApiClient: {
-    getStatements: vi.fn(),
+    getSummary: vi.fn(),
   },
 }));
 
@@ -30,7 +30,7 @@ describe('useJQuantsDividend', () => {
     expect(result.current.dividendPerShare).toBeUndefined();
     expect(result.current.loading).toBe(false);
     expect(result.current.error).toBeNull();
-    expect(jquantsApiClient.getStatements).not.toHaveBeenCalled();
+    expect(jquantsApiClient.getSummary).not.toHaveBeenCalled();
   });
 
   it('securityCodeが空の場合、配当情報を取得しない', () => {
@@ -39,7 +39,7 @@ describe('useJQuantsDividend', () => {
     expect(result.current.dividendPerShare).toBeUndefined();
     expect(result.current.loading).toBe(false);
     expect(result.current.error).toBeNull();
-    expect(jquantsApiClient.getStatements).not.toHaveBeenCalled();
+    expect(jquantsApiClient.getSummary).not.toHaveBeenCalled();
   });
 
   it('最新の決算データから配当情報を取得する（開示日でソート）', async () => {
@@ -52,7 +52,7 @@ describe('useJQuantsDividend', () => {
       ],
     };
 
-    (jquantsApiClient.getStatements as Mock).mockResolvedValue(mockResponse);
+    (jquantsApiClient.getSummary as Mock).mockResolvedValue(mockResponse);
     (parseNumber as Mock).mockReturnValue(70);
 
     const { result } = renderHook(() => useJQuantsDividend('1234', true));
@@ -64,7 +64,7 @@ describe('useJQuantsDividend', () => {
       expect(result.current.loading).toBe(false);
     });
 
-    expect(jquantsApiClient.getStatements).toHaveBeenCalledWith('1234');
+    expect(jquantsApiClient.getSummary).toHaveBeenCalledWith('1234');
     // 最新データ（2024-07-15）の70.00が取得されること
     expect(parseNumber).toHaveBeenCalledWith('70.00');
     expect(result.current.dividendPerShare).toBe(70);
@@ -82,7 +82,7 @@ describe('useJQuantsDividend', () => {
       ],
     };
 
-    (jquantsApiClient.getStatements as Mock).mockResolvedValue(mockResponse);
+    (jquantsApiClient.getSummary as Mock).mockResolvedValue(mockResponse);
     (parseNumber as Mock).mockReturnValue(45);
 
     const { result } = renderHook(() => useJQuantsDividend('1234', true));
@@ -107,7 +107,7 @@ describe('useJQuantsDividend', () => {
       ],
     };
 
-    (jquantsApiClient.getStatements as Mock).mockResolvedValue(mockResponse);
+    (jquantsApiClient.getSummary as Mock).mockResolvedValue(mockResponse);
     (parseNumber as Mock).mockReturnValue(40);
 
     const { result } = renderHook(() => useJQuantsDividend('1234', true));
@@ -128,7 +128,7 @@ describe('useJQuantsDividend', () => {
       ],
     };
 
-    (jquantsApiClient.getStatements as Mock).mockResolvedValue(mockResponse);
+    (jquantsApiClient.getSummary as Mock).mockResolvedValue(mockResponse);
     (parseNumber as Mock).mockReturnValue(50);
 
     const { result } = renderHook(() => useJQuantsDividend('1234', true));
@@ -151,7 +151,7 @@ describe('useJQuantsDividend', () => {
       ],
     };
 
-    (jquantsApiClient.getStatements as Mock).mockResolvedValue(mockResponse);
+    (jquantsApiClient.getSummary as Mock).mockResolvedValue(mockResponse);
     (parseNumber as Mock).mockReturnValue(0);
 
     const { result } = renderHook(() => useJQuantsDividend('1234', true));
@@ -167,7 +167,7 @@ describe('useJQuantsDividend', () => {
   it('エラーが発生した場合、エラーメッセージを設定する', async () => {
     const mockError = new Error('API Error');
 
-    (jquantsApiClient.getStatements as Mock).mockRejectedValue(mockError);
+    (jquantsApiClient.getSummary as Mock).mockRejectedValue(mockError);
 
     const { result } = renderHook(() => useJQuantsDividend('1234', true));
 
@@ -180,7 +180,7 @@ describe('useJQuantsDividend', () => {
   });
 
   it('非Errorオブジェクトのエラーの場合、デフォルトメッセージを設定する', async () => {
-    (jquantsApiClient.getStatements as Mock).mockRejectedValue('string error');
+    (jquantsApiClient.getSummary as Mock).mockRejectedValue('string error');
 
     const { result } = renderHook(() => useJQuantsDividend('1234', true));
 
@@ -195,7 +195,7 @@ describe('useJQuantsDividend', () => {
   it('response.dataがundefinedの場合、undefinedを返す', async () => {
     const mockResponse = { data: undefined };
 
-    (jquantsApiClient.getStatements as Mock).mockResolvedValue(mockResponse);
+    (jquantsApiClient.getSummary as Mock).mockResolvedValue(mockResponse);
 
     const { result } = renderHook(() => useJQuantsDividend('1234', true));
 
@@ -210,7 +210,7 @@ describe('useJQuantsDividend', () => {
   it('response.dataが配列でない場合、undefinedを返す', async () => {
     const mockResponse = { data: { some: 'object' } };
 
-    (jquantsApiClient.getStatements as Mock).mockResolvedValue(mockResponse);
+    (jquantsApiClient.getSummary as Mock).mockResolvedValue(mockResponse);
 
     const { result } = renderHook(() => useJQuantsDividend('1234', true));
 
@@ -230,7 +230,7 @@ describe('useJQuantsDividend', () => {
       ],
     };
 
-    (jquantsApiClient.getStatements as Mock).mockResolvedValue(mockResponse);
+    (jquantsApiClient.getSummary as Mock).mockResolvedValue(mockResponse);
     (parseNumber as Mock).mockReturnValue(40);
 
     const { result } = renderHook(() => useJQuantsDividend('1234', true));
@@ -249,7 +249,7 @@ describe('useJQuantsDividend', () => {
       resolvePromise = resolve;
     });
 
-    (jquantsApiClient.getStatements as Mock).mockReturnValue(pendingPromise);
+    (jquantsApiClient.getSummary as Mock).mockReturnValue(pendingPromise);
 
     const { result, unmount } = renderHook(() => useJQuantsDividend('1234', true));
 
@@ -271,7 +271,7 @@ describe('useJQuantsDividend', () => {
       data: [{ NxFDivAnn: '50.00' }],
     };
 
-    (jquantsApiClient.getStatements as Mock).mockResolvedValue(mockResponse);
+    (jquantsApiClient.getSummary as Mock).mockResolvedValue(mockResponse);
     (parseNumber as Mock).mockReturnValue(50);
 
     const { result, rerender } = renderHook(
@@ -283,14 +283,14 @@ describe('useJQuantsDividend', () => {
       expect(result.current.loading).toBe(false);
     }, { timeout: 5000 });
 
-    expect(jquantsApiClient.getStatements).toHaveBeenCalledWith('1234');
+    expect(jquantsApiClient.getSummary).toHaveBeenCalledWith('1234');
     expect(result.current.dividendPerShare).toBe(50);
 
     // securityCodeを変更
     rerender({ code: '5678', enabled: true });
 
     await waitFor(() => {
-      expect(jquantsApiClient.getStatements).toHaveBeenCalledWith('5678');
+      expect(jquantsApiClient.getSummary).toHaveBeenCalledWith('5678');
     }, { timeout: 5000 });
   }, 15000);
 });

--- a/frontend/src/features/jquants/hooks/__tests__/useJQuantsDividendBatch.test.ts
+++ b/frontend/src/features/jquants/hooks/__tests__/useJQuantsDividendBatch.test.ts
@@ -7,7 +7,7 @@ import { parseNumber } from '@/lib/utils/formatters';
 
 vi.mock('../../api/client', () => ({
   jquantsApiClient: {
-    getStatements: vi.fn(),
+    getSummary: vi.fn(),
   },
 }));
 
@@ -56,7 +56,7 @@ describe('useJQuantsDividendBatch', () => {
     let maxInFlight = 0;
     const resolvers: Array<() => void> = [];
 
-    (jquantsApiClient.getStatements as Mock).mockImplementation((code: string) => {
+    (jquantsApiClient.getSummary as Mock).mockImplementation((code: string) => {
       inFlight += 1;
       maxInFlight = Math.max(maxInFlight, inFlight);
       return new Promise((resolve) => {
@@ -72,13 +72,13 @@ describe('useJQuantsDividendBatch', () => {
     const { result } = renderHook(() => useJQuantsDividendBatch(codes, true));
 
     await waitFor(() => {
-      expect(jquantsApiClient.getStatements).toHaveBeenCalledTimes(3);
+      expect(jquantsApiClient.getSummary).toHaveBeenCalledTimes(3);
     });
 
     resolvers.splice(0, 3).forEach((resolve) => resolve());
 
     await waitFor(() => {
-      expect(jquantsApiClient.getStatements).toHaveBeenCalledTimes(6);
+      expect(jquantsApiClient.getSummary).toHaveBeenCalledTimes(6);
     });
 
     resolvers.splice(0).forEach((resolve) => resolve());
@@ -97,7 +97,7 @@ describe('useJQuantsDividendBatch', () => {
 
     const extractionCount: Record<string, number> = {};
 
-    (jquantsApiClient.getStatements as Mock).mockImplementation((code: string) =>
+    (jquantsApiClient.getSummary as Mock).mockImplementation((code: string) =>
       Promise.resolve({
         data: [{ DiscDate: '2025-01-01', NxFDivAnn: code === '1605' ? '30.0' : '15.5', Code: code }],
       })
@@ -115,7 +115,7 @@ describe('useJQuantsDividendBatch', () => {
 
     await flushAsyncUpdates();
 
-    expect(jquantsApiClient.getStatements).toHaveBeenCalledTimes(2);
+    expect(jquantsApiClient.getSummary).toHaveBeenCalledTimes(2);
     expect(result.current.loading).toBe(false);
     expect(result.current.dividendPerShareMap.get('1605')).toBe(30);
     expect(result.current.dividendPerShareMap.has('2933')).toBe(false);
@@ -125,7 +125,7 @@ describe('useJQuantsDividendBatch', () => {
     });
     await flushAsyncUpdates();
 
-    expect(jquantsApiClient.getStatements).toHaveBeenCalledTimes(4);
+    expect(jquantsApiClient.getSummary).toHaveBeenCalledTimes(4);
     expect(result.current.loading).toBe(false);
     expect(result.current.dividendPerShareMap.get('2933')).toBe(15.5);
   });
@@ -134,7 +134,7 @@ describe('useJQuantsDividendBatch', () => {
     vi.useFakeTimers();
     const codes = ['1605', '2933'];
 
-    (jquantsApiClient.getStatements as Mock).mockImplementation((code: string) =>
+    (jquantsApiClient.getSummary as Mock).mockImplementation((code: string) =>
       Promise.resolve({
         data: [{ DiscDate: '2025-01-01', NxFDivAnn: code === '1605' ? '30.0' : '15.5', Code: code }],
       })
@@ -151,7 +151,7 @@ describe('useJQuantsDividendBatch', () => {
 
     await flushAsyncUpdates();
 
-    expect(jquantsApiClient.getStatements).toHaveBeenCalledTimes(2);
+    expect(jquantsApiClient.getSummary).toHaveBeenCalledTimes(2);
     expect(result.current.loading).toBe(false);
     expect(result.current.dividendPerShareMap.get('1605')).toBe(30);
     expect(result.current.dividendPerShareMap.has('2933')).toBe(false);
@@ -163,7 +163,7 @@ describe('useJQuantsDividendBatch', () => {
       await flushAsyncUpdates();
     }
 
-    expect(jquantsApiClient.getStatements).toHaveBeenCalledTimes(8);
+    expect(jquantsApiClient.getSummary).toHaveBeenCalledTimes(8);
     expect(result.current.loading).toBe(false);
     expect(result.current.dividendPerShareMap.get('1605')).toBe(30);
     expect(result.current.dividendPerShareMap.has('2933')).toBe(false);
@@ -173,6 +173,6 @@ describe('useJQuantsDividendBatch', () => {
     });
     await flushAsyncUpdates();
 
-    expect(jquantsApiClient.getStatements).toHaveBeenCalledTimes(8);
+    expect(jquantsApiClient.getSummary).toHaveBeenCalledTimes(8);
   });
 });

--- a/frontend/src/features/jquants/hooks/useJQuantsDividend.ts
+++ b/frontend/src/features/jquants/hooks/useJQuantsDividend.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { jquantsApiClient } from '../api/client';
-import { JQuantsStatementData } from '../api/types';
+import { JQuantsFinSummaryResponse, JQuantsStatementData } from '../api/types';
 import { parseNumber } from '@/lib/utils/formatters';
 
 /**
@@ -50,7 +50,8 @@ export const useJQuantsDividend = (
 
       try {
         // V2 API では data フィールドを使用
-        const response = await jquantsApiClient.getStatements(securityCode);
+        const response: JQuantsFinSummaryResponse =
+          await jquantsApiClient.getSummary(securityCode);
         if (!isActive) return;
 
         // レスポンスの data フィールドが配列でない場合はスキップ

--- a/frontend/src/features/jquants/hooks/useJQuantsDividendBatch.ts
+++ b/frontend/src/features/jquants/hooks/useJQuantsDividendBatch.ts
@@ -42,7 +42,7 @@ export const useJQuantsDividendBatch = (
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
 
     const fetchOneCode = async (code: string) => {
-      const response = await jquantsApiClient.getStatements(code);
+      const response = await jquantsApiClient.getSummary(code);
       if (!response?.data || !Array.isArray(response.data)) return { code, value: null };
 
       // 開示日で降順ソート（最新データを優先）

--- a/frontend/src/generated/api.ts
+++ b/frontend/src/generated/api.ts
@@ -296,17 +296,14 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/jquants/fins/statements": {
+    "/jquants/fins/summary": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        /**
-         * 決算サマリーを取得（J-Quants API V2）
-         *     V2では fins/statements → fins/summary に変更
-         */
+        /** 決算サマリーを取得（J-Quants API V2） */
         get: operations["jquants_fin_summary"];
         put?: never;
         post?: never;


### PR DESCRIPTION
# タスク名

J-Quants エンドポイント命名の整理と認証追加

## 目的

J-Quants の決算サマリー API を `fins/summary` に統一し、backend の認証チェック漏れを解消する。
OpenAPI と frontend 側の hand-written/generated 型、呼び出し箇所を同時に同期する。

## スコープ

- backend の J-Quants 決算サマリー API を `/jquants/fins/summary` に変更する
- `get_fin_summary` に `AuthenticatedUser` を追加して未認証アクセスを 401 にする
- frontend の型名、API client、hook 呼び出しを `summary` 系に統一する
- OpenAPI と generated types を再生成して同期する

## 非対象

- J-Quants の他エンドポイント名変更
- 配当抽出ロジック自体の仕様変更
- UI 表示や文言の追加改善

## 受け入れ条件

- [x] backend の J-Quants ルートが `/jquants/fins/summary` になっている
- [x] 未認証で `/jquants/fins/summary` を叩くと 401 になる
- [x] frontend が `getSummary` / `JQuantsFinSummaryResponse` を使う
- [x] `docs/openapi.json` と `frontend/src/generated/api.ts` が同期している
- [x] 指定コマンドが通る

## 変更候補ファイル

- backend/src/handlers/jquants.rs
- backend/src/routes.rs
- frontend/src/features/jquants/api/types.ts
- frontend/src/features/jquants/api/client.ts
- frontend/src/features/jquants/hooks/useJQuantsDividend.ts
- frontend/src/features/jquants/hooks/useJQuantsDividendBatch.ts
- frontend/src/features/jquants/api/__tests__/client.test.ts
- frontend/src/features/jquants/hooks/__tests__/useJQuantsDividend.test.ts
- frontend/src/features/jquants/hooks/__tests__/useJQuantsDividendBatch.test.ts
- docs/openapi.json
- frontend/src/generated/api.ts

## タスク固有コマンド

- `cd backend && cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test`
- `bash scripts/check-openapi.sh`
- `cd frontend && vp lint && npx tsc --noEmit && npm test -- --run && vp build`

## 進捗

- [x] 調査
- [x] 実装
- [x] テスト
- [ ] PR 作成
- [ ] レビュー対応

## レビュー指摘

- なし

## メモ

- ユーザー指定の task file が存在しなかったため、このファイルをローカル作業メモとして新規作成した

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * J-Quants 財務サマリー API エンドポイントに認証が追加されました

* **リファクタ**
  * API クライアントのメソッド名と各エンドポイント構成を整備しました
  * API ドキュメントを更新しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->