### PR TITLE
refactor: APIパス命名を複数形に統一

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -33,22 +33,22 @@
 
 | メソッド | パス | 説明 | 認証 |
 |---------|------|------|------|
-| GET | `/stock/{query}` | 株式情報を検索 | 不要 |
-| POST | `/stock` | 株式情報を追加 | **必須** |
+| GET | `/stocks/{query}` | 株式情報を検索 | 不要 |
+| POST | `/stocks` | 株式情報を追加 | **必須** |
 
 ### データ管理（すべて認証必須）
 
 | メソッド | パス | 説明 |
 |---------|------|------|
 | GET | `/dividends` | 配当金一覧を取得 |
-| DELETE | `/dividends/all` | 配当金を全削除 |
+| DELETE | `/dividends` | 配当金を全削除 |
 | GET | `/domestic-stocks` | 国内株式一覧を取得 |
-| DELETE | `/domestic-stocks/all` | 国内株式を全削除 |
+| DELETE | `/domestic-stocks` | 国内株式を全削除 |
 | GET | `/mutualfunds` | 投資信託一覧を取得 |
-| DELETE | `/mutualfunds/all` | 投資信託を全削除 |
+| DELETE | `/mutualfunds` | 投資信託を全削除 |
 | GET | `/asset-balances` | 保有銘柄一覧を取得 |
 | POST | `/asset-balances/bulk` | 保有銘柄を一括登録（全削除→再挿入） |
-| DELETE | `/asset-balances/all` | 保有銘柄を全削除 |
+| DELETE | `/asset-balances` | 保有銘柄を全削除 |
 
 ### J-Quants API
 

--- a/backend/src/handlers/asset_balance.rs
+++ b/backend/src/handlers/asset_balance.rs
@@ -14,16 +14,15 @@ use axum::{
     extract::State,
     http::StatusCode,
     response::IntoResponse,
-    routing::{delete, get, post},
+    routing::{get, post},
     Json, Router,
 };
 
 pub fn asset_balance_routes() -> Router<AppState> {
     Router::new()
-        .route("/asset-balances", get(list))
+        .route("/asset-balances", get(list).delete(delete_all))
         .route("/asset-balances/bulk", post(bulk_create))
         .route("/asset-balances/csv/preview", post(preview_csv))
-        .route("/asset-balances/all", delete(delete_all))
 }
 
 pub fn asset_balance_csv_upload_routes() -> Router<AppState> {
@@ -121,7 +120,7 @@ pub async fn upload_csv(
 /// 認証ユーザーの保有銘柄を全削除
 #[utoipa::path(
     delete,
-    path = "/asset-balances/all",
+    path = "/asset-balances",
     operation_id = "asset_balance_delete_all",
     responses(
         (status = 200, body = MessageResponse),

--- a/backend/src/handlers/dividend.rs
+++ b/backend/src/handlers/dividend.rs
@@ -13,15 +13,14 @@ use axum::{
     extract::State,
     http::StatusCode,
     response::IntoResponse,
-    routing::{delete, get, post},
+    routing::{get, post},
     Json, Router,
 };
 
 pub fn dividend_routes() -> Router<AppState> {
     Router::new()
-        .route("/dividends", get(list))
+        .route("/dividends", get(list).delete(delete_all))
         .route("/dividends/csv/preview", post(preview_csv))
-        .route("/dividends/all", delete(delete_all))
 }
 
 pub fn dividend_csv_upload_routes() -> Router<AppState> {
@@ -96,7 +95,7 @@ pub async fn upload_csv(
 /// 認証ユーザーの配当金を全削除
 #[utoipa::path(
     delete,
-    path = "/dividends/all",
+    path = "/dividends",
     operation_id = "dividend_delete_all",
     responses(
         (status = 200, body = MessageResponse),

--- a/backend/src/handlers/domestic_stock.rs
+++ b/backend/src/handlers/domestic_stock.rs
@@ -13,15 +13,14 @@ use axum::{
     extract::State,
     http::StatusCode,
     response::IntoResponse,
-    routing::{delete, get, post},
+    routing::{get, post},
     Json, Router,
 };
 
 pub fn domestic_stock_routes() -> Router<AppState> {
     Router::new()
-        .route("/domestic-stocks", get(list))
+        .route("/domestic-stocks", get(list).delete(delete_all))
         .route("/domestic-stocks/csv/preview", post(preview_csv))
-        .route("/domestic-stocks/all", delete(delete_all))
 }
 
 pub fn domestic_stock_csv_upload_routes() -> Router<AppState> {
@@ -96,7 +95,7 @@ pub async fn upload_csv(
 /// 認証ユーザーの国内株式取引を全削除
 #[utoipa::path(
     delete,
-    path = "/domestic-stocks/all",
+    path = "/domestic-stocks",
     operation_id = "domestic_stock_delete_all",
     responses(
         (status = 200, body = MessageResponse),

--- a/backend/src/handlers/mutualfund.rs
+++ b/backend/src/handlers/mutualfund.rs
@@ -13,15 +13,14 @@ use axum::{
     extract::State,
     http::StatusCode,
     response::IntoResponse,
-    routing::{delete, get, post},
+    routing::{get, post},
     Json, Router,
 };
 
 pub fn mutualfund_routes() -> Router<AppState> {
     Router::new()
-        .route("/mutualfunds", get(list))
+        .route("/mutualfunds", get(list).delete(delete_all))
         .route("/mutualfunds/csv/preview", post(preview_csv))
-        .route("/mutualfunds/all", delete(delete_all))
 }
 
 pub fn mutualfund_csv_upload_routes() -> Router<AppState> {
@@ -96,7 +95,7 @@ pub async fn upload_csv(
 /// 認証ユーザーの投資信託を全削除
 #[utoipa::path(
     delete,
-    path = "/mutualfunds/all",
+    path = "/mutualfunds",
     operation_id = "mutualfund_delete_all",
     responses(
         (status = 200, body = MessageResponse),

--- a/backend/src/handlers/stock.rs
+++ b/backend/src/handlers/stock.rs
@@ -15,14 +15,14 @@ use axum::{
 
 pub fn stock_routes() -> Router<AppState> {
     Router::new()
-        .route("/stock", post(create_stock))
-        .route("/stock/{query}", get(search_stock))
+        .route("/stocks", post(create_stock))
+        .route("/stocks/{query}", get(search_stock))
 }
 
 /// 銘柄情報を検索（コードまたは名前）
 #[utoipa::path(
     get,
-    path = "/stock/{query}",
+    path = "/stocks/{query}",
     operation_id = "stock_search",
     params(
         ("query" = String, Path, description = "銘柄コードまたは銘柄名")
@@ -43,7 +43,7 @@ pub async fn search_stock(
 /// 銘柄情報を追加（認証必須）
 #[utoipa::path(
     post,
-    path = "/stock",
+    path = "/stocks",
     operation_id = "stock_create",
     request_body = Stock,
     responses(

--- a/backend/src/handlers/stock/tests.rs
+++ b/backend/src/handlers/stock/tests.rs
@@ -93,8 +93,8 @@ fn setup_test_app(pool: Pool<Postgres>) -> Router {
     };
 
     Router::new()
-        .route("/stock/{search_query}", get(search_stock))
-        .route("/stock", post(create_stock))
+        .route("/stocks/{search_query}", get(search_stock))
+        .route("/stocks", post(create_stock))
         .with_state(app_state)
 }
 
@@ -109,7 +109,7 @@ async fn test_search_stock() {
         .clone()
         .oneshot(
             Request::builder()
-                .uri("/stock/1234")
+                .uri("/stocks/1234")
                 .method("GET")
                 .body(Body::empty())
                 .unwrap(),
@@ -132,7 +132,7 @@ async fn test_search_stock() {
         .clone()
         .oneshot(
             Request::builder()
-                .uri("/stock/テスト")
+                .uri("/stocks/テスト")
                 .method("GET")
                 .body(Body::empty())
                 .unwrap(),
@@ -147,7 +147,7 @@ async fn test_search_stock() {
         .clone()
         .oneshot(
             Request::builder()
-                .uri("/stock/9999")
+                .uri("/stocks/9999")
                 .method("GET")
                 .body(Body::empty())
                 .unwrap(),
@@ -181,7 +181,7 @@ async fn test_create_stock() {
         .clone()
         .oneshot(
             Request::builder()
-                .uri("/stock")
+                .uri("/stocks")
                 .method("POST")
                 .header("content-type", "application/json")
                 .body(Body::from(stock_data.to_string()))
@@ -217,7 +217,7 @@ async fn test_create_stock() {
         .clone()
         .oneshot(
             Request::builder()
-                .uri("/stock")
+                .uri("/stocks")
                 .method("POST")
                 .header("content-type", "application/json")
                 .body(Body::from(invalid_data.to_string()))
@@ -229,7 +229,7 @@ async fn test_create_stock() {
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
 
-/// 未認証時に POST /stock が 401 を返すことを確認
+/// 未認証時に POST /stocks が 401 を返すことを確認
 /// セッション検証はハンドラー入口で実行され DB クエリは発生しないため DB 不要
 #[tokio::test]
 async fn test_create_stock_unauthorized() {
@@ -254,7 +254,7 @@ async fn test_create_stock_unauthorized() {
     let response = app
         .oneshot(
             Request::builder()
-                .uri("/stock")
+                .uri("/stocks")
                 .method("POST")
                 .header("content-type", "application/json")
                 .body(Body::from(stock_data.to_string()))

--- a/backend/tests/db_integration.rs
+++ b/backend/tests/db_integration.rs
@@ -129,7 +129,7 @@ async fn db_integration_with_docker_and_migrations() {
 
     let req = Request::builder()
         .method(Method::GET)
-        .uri("/stock/1234")
+        .uri("/stocks/1234")
         .body(Body::empty())
         .unwrap();
     let resp = app.clone().oneshot(req).await.unwrap();

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -46,9 +46,7 @@
             "cookieAuth": []
           }
         ]
-      }
-    },
-    "/asset-balances/all": {
+      },
       "delete": {
         "tags": [
           "handlers::asset_balance"
@@ -397,9 +395,7 @@
             "cookieAuth": []
           }
         ]
-      }
-    },
-    "/dividends/all": {
+      },
       "delete": {
         "tags": [
           "handlers::dividend"
@@ -625,9 +621,7 @@
             "cookieAuth": []
           }
         ]
-      }
-    },
-    "/domestic-stocks/all": {
+      },
       "delete": {
         "tags": [
           "handlers::domestic_stock"
@@ -907,9 +901,7 @@
             "cookieAuth": []
           }
         ]
-      }
-    },
-    "/mutualfunds/all": {
+      },
       "delete": {
         "tags": [
           "handlers::mutualfund"
@@ -1057,7 +1049,7 @@
         ]
       }
     },
-    "/stock": {
+    "/stocks": {
       "post": {
         "tags": [
           "handlers::stock"
@@ -1113,7 +1105,7 @@
         ]
       }
     },
-    "/stock/{query}": {
+    "/stocks/{query}": {
       "get": {
         "tags": [
           "handlers::stock"

--- a/frontend/e2e/a11y.spec.ts
+++ b/frontend/e2e/a11y.spec.ts
@@ -18,7 +18,7 @@ const ROUTES = {
   domesticStocks: /\/domestic-stocks$/,
   mutualfunds: /\/mutualfunds$/,
   assetBalances: /\/asset-balances$/,
-  stock: /\/stock\/[^/]+$/,
+  stock: /\/stocks\/[^/]+$/,
 };
 
 async function setupAuthMocks(page: import('@playwright/test').Page) {

--- a/frontend/e2e/search-flow.spec.ts
+++ b/frontend/e2e/search-flow.spec.ts
@@ -22,7 +22,7 @@ const MOCK_STOCK = {
 const ROUTES = {
   authMe: /\/auth\/me$/,
   // API エンドポイントのみ一致させる（Vite のソースファイルパスと衝突しないよう末尾を限定）
-  stock: /\/stock\/\d+$/,
+  stock: /\/stocks\/\d+$/,
 };
 
 async function setupAuthMocks(page: Page) {

--- a/frontend/src/features/assetBalance/api/__tests__/assetBalanceApi.test.ts
+++ b/frontend/src/features/assetBalance/api/__tests__/assetBalanceApi.test.ts
@@ -49,7 +49,7 @@ describe('assetBalanceApi', () => {
   it('deleteAll() は全件削除 API を呼ぶ', async () => {
     await assetBalanceApi.deleteAll();
 
-    expect(apiClient.delete).toHaveBeenCalledWith('/asset-balances/all', {
+    expect(apiClient.delete).toHaveBeenCalledWith('/asset-balances', {
       withCredentials: true,
     });
   });

--- a/frontend/src/features/assetBalance/api/assetBalanceApi.ts
+++ b/frontend/src/features/assetBalance/api/assetBalanceApi.ts
@@ -11,5 +11,5 @@ export const assetBalanceApi = {
   uploadCsv: (file: File) => uploadCsvFile('/asset-balances/csv', file),
 
   deleteAll: async () =>
-    apiClient.delete('/asset-balances/all', { withCredentials: true }),
+    apiClient.delete('/asset-balances', { withCredentials: true }),
 };

--- a/frontend/src/features/receipt/api/receiptApi.ts
+++ b/frontend/src/features/receipt/api/receiptApi.ts
@@ -14,7 +14,7 @@ export const dividendApi = {
   uploadCsv: (file: File) => uploadCsvFile('/dividends/csv', file),
 
   deleteAll: async () =>
-    apiClient.delete('/dividends/all', { withCredentials: true }),
+    apiClient.delete('/dividends', { withCredentials: true }),
 };
 
 // 国内株式API
@@ -27,7 +27,7 @@ export const domesticStockApi = {
   uploadCsv: (file: File) => uploadCsvFile('/domestic-stocks/csv', file),
 
   deleteAll: async () =>
-    apiClient.delete('/domestic-stocks/all', { withCredentials: true }),
+    apiClient.delete('/domestic-stocks', { withCredentials: true }),
 };
 
 // 投資信託API
@@ -40,5 +40,5 @@ export const mutualfundApi = {
   uploadCsv: (file: File) => uploadCsvFile('/mutualfunds/csv', file),
 
   deleteAll: async () =>
-    apiClient.delete('/mutualfunds/all', { withCredentials: true }),
+    apiClient.delete('/mutualfunds', { withCredentials: true }),
 };

--- a/frontend/src/features/stock/api.ts
+++ b/frontend/src/features/stock/api.ts
@@ -9,7 +9,7 @@ import { ApiError, ApiErrorType } from '../../lib/types/api';
  */
 export async function fetchStockData(query: string): Promise<StockData> {
   try {
-    const response = await apiClient.get<StockData>(`/stock/${query}`);
+    const response = await apiClient.get<StockData>(`/stocks/${query}`);
     return response;
   } catch (error) {
     if (error instanceof ApiError) {

--- a/frontend/src/generated/api.ts
+++ b/frontend/src/generated/api.ts
@@ -15,22 +15,6 @@ export interface paths {
         get: operations["asset_balance_list"];
         put?: never;
         post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/asset-balances/all": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
         /** 認証ユーザーの保有銘柄を全削除 */
         delete: operations["asset_balance_delete_all"];
         options?: never;
@@ -154,22 +138,6 @@ export interface paths {
         get: operations["dividend_list"];
         put?: never;
         post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/dividends/all": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
         /** 認証ユーザーの配当金を全削除 */
         delete: operations["dividend_delete_all"];
         options?: never;
@@ -237,22 +205,6 @@ export interface paths {
         };
         /** 認証ユーザーの国内株式取引一覧を取得 */
         get: operations["domestic_stock_list"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/domestic-stocks/all": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
         put?: never;
         post?: never;
         /** 認証ユーザーの国内株式取引を全削除 */
@@ -324,22 +276,6 @@ export interface paths {
         get: operations["mutualfund_list"];
         put?: never;
         post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/mutualfunds/all": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
         /** 認証ユーザーの投資信託を全削除 */
         delete: operations["mutualfund_delete_all"];
         options?: never;
@@ -381,7 +317,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/stock": {
+    "/stocks": {
         parameters: {
             query?: never;
             header?: never;
@@ -398,7 +334,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/stock/{query}": {
+    "/stocks/{query}": {
         parameters: {
             query?: never;
             header?: never;


### PR DESCRIPTION
## 概要
API パス命名を整理し、一覧リソースの削除系エンドポイントから `/all` を廃止しました。あわせて stock 系の単数パスを複数形へ統一し、backend と frontend の呼び出し、および OpenAPI 生成物を同期しています。

## 変更内容
- `DELETE /dividends/all` を `DELETE /dividends` に変更
- `DELETE /domestic-stocks/all` を `DELETE /domestic-stocks` に変更
- `DELETE /mutualfunds/all` を `DELETE /mutualfunds` に変更
- `DELETE /asset-balances/all` を `DELETE /asset-balances` に変更
- `GET /stock/{query}` を `GET /stocks/{query}` に変更
- `POST /stock` を `POST /stocks` に変更
- backend のルート定義、README、テストを更新
- frontend の API クライアント、E2E モック、生成 API 型を更新
- `docs/openapi.json` と `frontend/src/generated/api.ts` を再生成

## 影響
旧パスを直接叩いていたクライアントは新パスへの追従が必要です。この PR ではリポジトリ内の frontend 呼び出しと生成物はすべて新パスへ合わせています。

## 確認
- `bash scripts/check-openapi.sh`
- `cd backend && cargo clippy -- -D warnings`
- `cd backend && cargo test`
- `cd backend && cargo build`
- `cd frontend && vp lint`
- `cd frontend && npx tsc --noEmit`
- `cd frontend && npm test -- --run`
- `cd frontend && vp build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * OpenAPI仕様書とAPIドキュメントを更新しました。

* **Refactor**
  * APIエンドポイント構造を最適化。リソースパスを複数化し、削除操作のエンドポイント設計を簡素化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->