### PR TITLE
fix: 削除系エンドポイントと配当利回りAPIの認証を保証

### DIFF
--- a/backend/src/handlers/dividend_per_share.rs
+++ b/backend/src/handlers/dividend_per_share.rs
@@ -1,5 +1,6 @@
 use crate::{
     errors::{ApiError, ErrorResponse},
+    extractors::auth::AuthenticatedUser,
     extractors::validated_json::ValidatedJson,
     models::dividend_cache::{DividendPerShareBatchRequest, DividendPerShareBatchResponse},
     services::dividend_cache as dividend_cache_service,
@@ -11,7 +12,7 @@ pub fn dividend_per_share_routes() -> Router<AppState> {
     Router::new().route("/dividends/per-share/batch", post(batch))
 }
 
-/// 配当利回り一括取得（認証不要）
+/// 配当利回り一括取得
 #[utoipa::path(
     post,
     path = "/dividends/per-share/batch",
@@ -20,10 +21,13 @@ pub fn dividend_per_share_routes() -> Router<AppState> {
     responses(
         (status = 200, body = DividendPerShareBatchResponse),
         (status = 400, body = ErrorResponse),
+        (status = 401, body = ErrorResponse),
     ),
+    security(("cookieAuth" = []))
 )]
 pub async fn batch(
     State(state): State<AppState>,
+    _auth_user: AuthenticatedUser,
     ValidatedJson(data): ValidatedJson<DividendPerShareBatchRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
     let api_key = state.secrets.jquants_api_key.as_deref();

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -282,6 +282,118 @@ mod tests {
         assert_eq!(response.status(), axum::http::StatusCode::UNAUTHORIZED);
     }
 
+    /// 未認証時に DELETE /dividends が 401 を返すことを確認
+    #[tokio::test]
+    async fn test_dividend_delete_all_unauthorized() {
+        use axum::{body::Body, http::Request};
+        use tower::ServiceExt;
+
+        let app = handlers::dividend::dividend_routes().with_state(make_test_state());
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(axum::http::Method::DELETE)
+                    .uri("/dividends")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), axum::http::StatusCode::UNAUTHORIZED);
+    }
+
+    /// 未認証時に DELETE /domestic-stocks が 401 を返すことを確認
+    #[tokio::test]
+    async fn test_domestic_stock_delete_all_unauthorized() {
+        use axum::{body::Body, http::Request};
+        use tower::ServiceExt;
+
+        let app = handlers::domestic_stock::domestic_stock_routes().with_state(make_test_state());
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(axum::http::Method::DELETE)
+                    .uri("/domestic-stocks")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), axum::http::StatusCode::UNAUTHORIZED);
+    }
+
+    /// 未認証時に DELETE /mutualfunds が 401 を返すことを確認
+    #[tokio::test]
+    async fn test_mutualfund_delete_all_unauthorized() {
+        use axum::{body::Body, http::Request};
+        use tower::ServiceExt;
+
+        let app = handlers::mutualfund::mutualfund_routes().with_state(make_test_state());
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(axum::http::Method::DELETE)
+                    .uri("/mutualfunds")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), axum::http::StatusCode::UNAUTHORIZED);
+    }
+
+    /// 未認証時に DELETE /asset-balances が 401 を返すことを確認
+    #[tokio::test]
+    async fn test_asset_balance_delete_all_unauthorized() {
+        use axum::{body::Body, http::Request};
+        use tower::ServiceExt;
+
+        let app = handlers::asset_balance::asset_balance_routes().with_state(make_test_state());
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(axum::http::Method::DELETE)
+                    .uri("/asset-balances")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), axum::http::StatusCode::UNAUTHORIZED);
+    }
+
+    /// 未認証時に POST /dividends/per-share/batch が 401 を返すことを確認
+    #[tokio::test]
+    async fn test_dividend_per_share_batch_unauthorized() {
+        use axum::{body::Body, http::Request};
+        use tower::ServiceExt;
+
+        let app =
+            handlers::dividend_per_share::dividend_per_share_routes().with_state(make_test_state());
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(axum::http::Method::POST)
+                    .uri("/dividends/per-share/batch")
+                    .header(axum::http::header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"security_codes":["7203"]}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), axum::http::StatusCode::UNAUTHORIZED);
+    }
+
     /// CSV upload ルートだけが IP 単位レート制限の対象になることを確認
     #[tokio::test]
     async fn test_csv_upload_routes_rate_limit_returns_429() {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -548,7 +548,7 @@
         "tags": [
           "handlers::dividend_per_share"
         ],
-        "summary": "配当利回り一括取得（認証不要）",
+        "summary": "配当利回り一括取得",
         "operationId": "dividend_per_share_batch",
         "requestBody": {
           "content": {
@@ -580,8 +580,23 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
-        }
+        },
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ]
       }
     },
     "/domestic-stocks": {

--- a/frontend/src/generated/api.ts
+++ b/frontend/src/generated/api.ts
@@ -188,7 +188,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** 配当利回り一括取得（認証不要） */
+        /** 配当利回り一括取得 */
         post: operations["dividend_per_share_batch"];
         delete?: never;
         options?: never;
@@ -1229,6 +1229,14 @@ export interface operations {
                 };
             };
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            401: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
## 概要
削除系エンドポイントと配当利回り一括取得 API の未認証アクセスについて、401 を返すことをテストで保証しました。あわせて、`POST /dividends/per-share/batch` は実装上まだ未認証だったため、認証必須に修正し、OpenAPI と生成型も同期しています。

## 変更内容
- `backend/src/routes.rs` の `#[cfg(test)] mod tests` に未認証時の 401 テストを 5 件追加
- `backend/src/handlers/dividend_per_share.rs` に `AuthenticatedUser` を追加して `/dividends/per-share/batch` を認証必須化
- `docs/openapi.json` と `frontend/src/generated/api.ts` を再生成して契約を同期

## ユーザー影響
未認証状態では、対象の削除 API と配当利回り一括取得 API が一貫して 401 を返すようになります。フロントエンド側の型定義も最新の認証要件に追従しています。

## 確認内容
- `cd backend && cargo fmt --check`
- `cd backend && cargo clippy -- -D warnings`
- `cd backend && cargo test`
- `bash scripts/check-openapi.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **セキュリティ改善**
  * 配当利回り一括取得エンドポイント（POST /dividends/per-share/batch）がクッキー認証を要求するようになりました。未認証リクエストは401エラーを返します。

* **テスト**
  * 複数のエンドポイントに対する認証要件の検証テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->