### PR TITLE
[codex] chore: frontend lint 警告を解消

### DIFF
--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -101,7 +101,7 @@ class ApiClient {
     const onExternalAbort = () => controller.abort(externalSignal?.reason);
     externalSignal?.addEventListener('abort', onExternalAbort);
 
-    const headers: Record<string, string> = { ...this.defaultHeaders, ...(config.headers ?? {}) };
+    const headers: Record<string, string> = { ...this.defaultHeaders, ...config.headers };
     let body: BodyInit | undefined;
 
     if (data instanceof FormData) {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,10 +10,10 @@ export default defineConfig({
   plugins: [
     react({
       babel: {
-        plugins: [
-          // Vitest / Playwright 実行時は React Compiler を無効化（dev/prod のみ有効）
-          ...(process.env.VITEST || process.env.PLAYWRIGHT_TEST ? [] : [['babel-plugin-react-compiler', {}] as const]),
-        ],
+        // Vitest / Playwright 実行時は React Compiler を無効化（dev/prod のみ有効）
+        plugins: process.env.VITEST || process.env.PLAYWRIGHT_TEST
+          ? []
+          : [['babel-plugin-react-compiler', {}] as const],
       },
     }),
     tailwindcss(),


### PR DESCRIPTION
## 概要
frontend の lint 警告 2 件を解消しました。`vite.config.ts` の `babel.plugins` では不要な spread を外し、API クライアントの header merge では object spread が `undefined` を許容する前提に合わせて冗長な nullish fallback を削除しています。

## 影響と原因
今回の差分はどちらも挙動変更ではなく、lint が警告する書き方をより単純な形に揃えるものです。`vite.config.ts` では条件式の結果を配列に spread しており、`client.ts` では `config.headers` に対して不要な `?? {}` を挟んでいました。いずれも保守性には影響しませんが、警告を放置すると `vp lint` がクリーンにならず、継続的な品質確認のノイズになります。

## 修正内容
`frontend/vite.config.ts` では `babel.plugins` に条件式の結果を直接代入する形へ変更しました。`frontend/src/lib/api/client.ts` では `...(config.headers ?? {})` を `...config.headers` に置き換え、同じ結果をより簡潔に表現しています。

## 確認内容
`cd frontend && vp lint` を実行し、`Found 0 warnings and 0 errors.` を確認しました。あわせて `cd frontend && npx tsc --noEmit`、`cd frontend && npm test -- --run`、`cd frontend && vp build` を順に実行し、型チェック、テスト、ビルドがすべて成功することを確認しています。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **内部改善**
  * APIクライアントのリクエストヘッダー処理を最適化しました
  * ビルド設定の構成を改善しました
  
これらは内部的なコード品質向上の改善であり、ユーザーに直接的な影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->