### PR TITLE
refactor: autoresearch ループでバックエンドテストコードを 882 行削減 (iter24-30)

### DIFF
--- a/autoresearch-results.tsv
+++ b/autoresearch-results.tsv
@@ -23,4 +23,8 @@ iteration	commit	metric	status	description
 21	b37b829	8054	kept	char_width_converter/cors: テスト統合で 32 行削減
 22	b2d17db	8032	kept	csv_import/asset_balance: 行テスト統合で 22 行削減
 23	2972c40	7999	kept	domestic_stock/dividend/mutualfund: preview_csv 基本テスト統合で 33 行削減
-24	-	8102	kept	csv_util: parse 系テストを 5→2 に統合し対象ファイル 18 行削減
+24	9484b2d	7981	kept	csv_util: parse 系テストを 5→2 に統合し対象ファイル 18 行削減
+25	16639ef	7886	kept	routes/rate_limit: assert_rate_limited ヘルパーでテスト 95 行削減
+26	c6e90af	7883	kept	asset_balance: テスト統合で 3 行削減
+27	f69c1b9	7885	reverted	domestic_stock: cherry-pick が逆に +2 行のためリバート（6f3ae50）
+28	840ed77	7881	kept	csv_util: テスト統合で 2 行削減

--- a/autoresearch-results.tsv
+++ b/autoresearch-results.tsv
@@ -28,3 +28,5 @@ iteration	commit	metric	status	description
 26	c6e90af	7883	kept	asset_balance: テスト統合で 3 行削減
 27	f69c1b9	7885	reverted	domestic_stock: cherry-pick が逆に +2 行のためリバート（6f3ae50）
 28	840ed77	7881	kept	csv_util: テスト統合で 2 行削減
+29	20b7d2d	7878	kept	domestic_stock: テスト統合で 3 行削減
+30	956f903	7851	kept	rate_limit: テスト統合でさらに 27 行削減（172→145）

--- a/autoresearch-results.tsv
+++ b/autoresearch-results.tsv
@@ -23,3 +23,4 @@ iteration	commit	metric	status	description
 21	b37b829	8054	kept	char_width_converter/cors: テスト統合で 32 行削減
 22	b2d17db	8032	kept	csv_import/asset_balance: 行テスト統合で 22 行削減
 23	2972c40	7999	kept	domestic_stock/dividend/mutualfund: preview_csv 基本テスト統合で 33 行削減
+24	-	8102	kept	csv_util: parse 系テストを 5→2 に統合し対象ファイル 18 行削減

--- a/backend/src/middleware/rate_limit.rs
+++ b/backend/src/middleware/rate_limit.rs
@@ -104,24 +104,20 @@ mod tests {
     }
 
     fn test_request(ip: Option<&str>) -> Request<Body> {
-        let mut req = Request::builder()
+        let req = Request::builder()
             .method(axum::http::Method::POST)
             .uri("/test");
-        if let Some(ip) = ip {
-            req = req.header("fly-client-ip", ip);
+        match ip {
+            Some(ip) => req.header("fly-client-ip", ip),
+            None => req,
         }
-        req.body(Body::empty()).unwrap()
+        .body(Body::empty())
+        .unwrap()
     }
 
-    async fn assert_not_rate_limited(router: Router, ip: Option<&str>) {
+    async fn assert_status(router: Router, ip: Option<&str>, expected: StatusCode) {
         let resp = router.oneshot(test_request(ip)).await.unwrap();
-        assert_ne!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
-    }
-
-    async fn assert_rate_limited(router: Router, ip: Option<&str>) {
-        assert_not_rate_limited(router.clone(), ip).await;
-        let resp = router.oneshot(test_request(ip)).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(resp.status(), expected);
     }
 
     #[test]
@@ -133,40 +129,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_rate_limit_allows_within_quota() {
-        assert_not_rate_limited(direct_app(build_rate_limiter(100).unwrap()), None).await;
+    async fn test_rate_limit() {
+        let router = direct_app(build_rate_limiter(1).unwrap());
+        assert_status(router.clone(), None, StatusCode::OK).await;
+        assert_status(router, None, StatusCode::TOO_MANY_REQUESTS).await;
     }
 
     #[tokio::test]
-    async fn test_rate_limit_blocks_excess_requests() {
-        // rps=1 で複数回リクエストを送ると 429 が返る
-        assert_rate_limited(direct_app(build_rate_limiter(1).unwrap()), None).await;
-    }
-
-    #[tokio::test]
-    async fn test_keyed_rate_limit_allows_within_quota() {
-        assert_not_rate_limited(
-            keyed_app(build_keyed_rate_limiter(100).unwrap()),
-            Some("1.2.3.4"),
-        )
-        .await;
-    }
-
-    #[tokio::test]
-    async fn test_keyed_rate_limit_blocks_same_ip() {
-        // rps=1: 同一 IP からの 2 回目は 429
-        assert_rate_limited(
-            keyed_app(build_keyed_rate_limiter(1).unwrap()),
-            Some("1.2.3.4"),
-        )
-        .await;
-    }
-
-    #[tokio::test]
-    async fn test_keyed_rate_limit_different_ips_independent() {
-        // rps=1: 異なる IP は独立したバケット
-        let limiter = build_keyed_rate_limiter(1).unwrap();
-        assert_not_rate_limited(keyed_app(limiter.clone()), Some("1.2.3.4")).await;
-        assert_not_rate_limited(keyed_app(limiter), Some("5.6.7.8")).await;
+    async fn test_keyed_rate_limit() {
+        let router = keyed_app(build_keyed_rate_limiter(1).unwrap());
+        assert_status(router.clone(), Some("1.2.3.4"), StatusCode::OK).await;
+        assert_status(router.clone(), Some("5.6.7.8"), StatusCode::OK).await;
+        assert_status(router, Some("1.2.3.4"), StatusCode::TOO_MANY_REQUESTS).await;
     }
 }

--- a/backend/src/middleware/rate_limit.rs
+++ b/backend/src/middleware/rate_limit.rs
@@ -85,6 +85,45 @@ mod tests {
     use axum::{middleware, routing::post, Router};
     use tower::ServiceExt;
 
+    fn test_route() -> Router {
+        Router::new().route("/test", post(|| async { "ok" }))
+    }
+
+    fn direct_app(limiter: Arc<DefaultDirectRateLimiter>) -> Router {
+        test_route().layer(middleware::from_fn(move |req, next| {
+            let limiter = limiter.clone();
+            async move { rate_limit(limiter, req, next).await }
+        }))
+    }
+
+    fn keyed_app(limiter: Arc<DefaultKeyedRateLimiter<std::net::IpAddr>>) -> Router {
+        test_route().layer(middleware::from_fn(move |req, next| {
+            let limiter = limiter.clone();
+            async move { keyed_rate_limit(limiter, req, next).await }
+        }))
+    }
+
+    fn test_request(ip: Option<&str>) -> Request<Body> {
+        let mut req = Request::builder()
+            .method(axum::http::Method::POST)
+            .uri("/test");
+        if let Some(ip) = ip {
+            req = req.header("fly-client-ip", ip);
+        }
+        req.body(Body::empty()).unwrap()
+    }
+
+    async fn assert_not_rate_limited(router: Router, ip: Option<&str>) {
+        let resp = router.oneshot(test_request(ip)).await.unwrap();
+        assert_ne!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    async fn assert_rate_limited(router: Router, ip: Option<&str>) {
+        assert_not_rate_limited(router.clone(), ip).await;
+        let resp = router.oneshot(test_request(ip)).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+    }
+
     #[test]
     fn test_build_rate_limiters() {
         assert!(build_rate_limiter(0).is_none());
@@ -95,134 +134,39 @@ mod tests {
 
     #[tokio::test]
     async fn test_rate_limit_allows_within_quota() {
-        let limiter = build_rate_limiter(100).unwrap();
-        let app = Router::new()
-            .route("/test", post(|| async { "ok" }))
-            .layer(middleware::from_fn(move |req, next| {
-                let l = limiter.clone();
-                async move { rate_limit(l, req, next).await }
-            }));
-        let req = Request::builder()
-            .method(axum::http::Method::POST)
-            .uri("/test")
-            .body(Body::empty())
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_ne!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_not_rate_limited(direct_app(build_rate_limiter(100).unwrap()), None).await;
     }
 
     #[tokio::test]
     async fn test_rate_limit_blocks_excess_requests() {
         // rps=1 で複数回リクエストを送ると 429 が返る
-        let limiter = build_rate_limiter(1).unwrap();
-        let make_app = || {
-            let l = limiter.clone();
-            Router::new()
-                .route("/test", post(|| async { "ok" }))
-                .layer(middleware::from_fn(move |req, next| {
-                    let l = l.clone();
-                    async move { rate_limit(l, req, next).await }
-                }))
-        };
-        // 1回目は通過
-        let req = Request::builder()
-            .method(axum::http::Method::POST)
-            .uri("/test")
-            .body(Body::empty())
-            .unwrap();
-        let resp = make_app().oneshot(req).await.unwrap();
-        assert_ne!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
-        // 2回目は超過
-        let req = Request::builder()
-            .method(axum::http::Method::POST)
-            .uri("/test")
-            .body(Body::empty())
-            .unwrap();
-        let resp = make_app().oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_rate_limited(direct_app(build_rate_limiter(1).unwrap()), None).await;
     }
 
     #[tokio::test]
     async fn test_keyed_rate_limit_allows_within_quota() {
-        let limiter = build_keyed_rate_limiter(100).unwrap();
-        let app = Router::new()
-            .route("/test", post(|| async { "ok" }))
-            .layer(middleware::from_fn(move |req, next| {
-                let l = limiter.clone();
-                async move { keyed_rate_limit(l, req, next).await }
-            }));
-        let req = Request::builder()
-            .method(axum::http::Method::POST)
-            .uri("/test")
-            .header("fly-client-ip", "1.2.3.4")
-            .body(Body::empty())
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_ne!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_not_rate_limited(
+            keyed_app(build_keyed_rate_limiter(100).unwrap()),
+            Some("1.2.3.4"),
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn test_keyed_rate_limit_blocks_same_ip() {
         // rps=1: 同一 IP からの 2 回目は 429
-        let limiter = build_keyed_rate_limiter(1).unwrap();
-        let make_app = || {
-            let l = limiter.clone();
-            Router::new()
-                .route("/test", post(|| async { "ok" }))
-                .layer(middleware::from_fn(move |req, next| {
-                    let l = l.clone();
-                    async move { keyed_rate_limit(l, req, next).await }
-                }))
-        };
-        let req = Request::builder()
-            .method(axum::http::Method::POST)
-            .uri("/test")
-            .header("fly-client-ip", "1.2.3.4")
-            .body(Body::empty())
-            .unwrap();
-        let resp = make_app().oneshot(req).await.unwrap();
-        assert_ne!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
-        // 2回目（同一 IP）は超過
-        let req = Request::builder()
-            .method(axum::http::Method::POST)
-            .uri("/test")
-            .header("fly-client-ip", "1.2.3.4")
-            .body(Body::empty())
-            .unwrap();
-        let resp = make_app().oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_rate_limited(
+            keyed_app(build_keyed_rate_limiter(1).unwrap()),
+            Some("1.2.3.4"),
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn test_keyed_rate_limit_different_ips_independent() {
         // rps=1: 異なる IP は独立したバケット
         let limiter = build_keyed_rate_limiter(1).unwrap();
-        let make_app = || {
-            let l = limiter.clone();
-            Router::new()
-                .route("/test", post(|| async { "ok" }))
-                .layer(middleware::from_fn(move |req, next| {
-                    let l = l.clone();
-                    async move { keyed_rate_limit(l, req, next).await }
-                }))
-        };
-        // IP1 が 1 回消費
-        let req = Request::builder()
-            .method(axum::http::Method::POST)
-            .uri("/test")
-            .header("fly-client-ip", "1.2.3.4")
-            .body(Body::empty())
-            .unwrap();
-        let resp = make_app().oneshot(req).await.unwrap();
-        assert_ne!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
-        // IP2 はまだ許可される（独立したバケット）
-        let req = Request::builder()
-            .method(axum::http::Method::POST)
-            .uri("/test")
-            .header("fly-client-ip", "5.6.7.8")
-            .body(Body::empty())
-            .unwrap();
-        let resp = make_app().oneshot(req).await.unwrap();
-        assert_ne!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_not_rate_limited(keyed_app(limiter.clone()), Some("1.2.3.4")).await;
+        assert_not_rate_limited(keyed_app(limiter), Some("5.6.7.8")).await;
     }
 }

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -176,25 +176,7 @@ mod tests {
         }
         .with_state(state);
 
-        // 1 回目は通過（ルートが見つからず 200/401/500 になるが 429 ではない）
-        let req = Request::builder()
-            .method(axum::http::Method::GET)
-            .uri("/auth/me")
-            .header("fly-client-ip", "1.2.3.4")
-            .body(Body::empty())
-            .unwrap();
-        let resp = router.clone().oneshot(req).await.unwrap();
-        assert_ne!(resp.status(), axum::http::StatusCode::TOO_MANY_REQUESTS);
-
-        // 2 回目（同一 IP）は 429
-        let req = Request::builder()
-            .method(axum::http::Method::GET)
-            .uri("/auth/me")
-            .header("fly-client-ip", "1.2.3.4")
-            .body(Body::empty())
-            .unwrap();
-        let resp = router.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), axum::http::StatusCode::TOO_MANY_REQUESTS);
+        assert_rate_limited(router, axum::http::Method::GET, "/auth/me", Some("1.2.3.4")).await;
     }
 
     /// jquants ルートが rps=1 制限を超えると 429 を返すことを確認
@@ -211,23 +193,24 @@ mod tests {
             handlers::jquants::jquants_routes()
         }
         .with_state(state);
+        assert_rate_limited(router, axum::http::Method::GET, "/jquants/fins/summary", None).await;
+    }
 
-        // 1 回目は通過
-        let req = Request::builder()
-            .method(axum::http::Method::GET)
-            .uri("/jquants/fins/summary")
-            .body(Body::empty())
-            .unwrap();
-        let resp = router.clone().oneshot(req).await.unwrap();
+    /// rps=1 ルーターに同一条件で 2 回リクエストし、2 回目が 429 になることを検証するヘルパー
+    async fn assert_rate_limited(
+        router: axum::Router,
+        method: axum::http::Method,
+        uri: &str,
+        ip: Option<&str>,
+    ) {
+        let make_req = || {
+            let mut b = Request::builder().method(method.clone()).uri(uri);
+            if let Some(ip) = ip { b = b.header("fly-client-ip", ip); }
+            b.body(Body::empty()).unwrap()
+        };
+        let resp = router.clone().oneshot(make_req()).await.unwrap();
         assert_ne!(resp.status(), axum::http::StatusCode::TOO_MANY_REQUESTS);
-
-        // 2 回目は 429
-        let req = Request::builder()
-            .method(axum::http::Method::GET)
-            .uri("/jquants/fins/summary")
-            .body(Body::empty())
-            .unwrap();
-        let resp = router.oneshot(req).await.unwrap();
+        let resp = router.oneshot(make_req()).await.unwrap();
         assert_eq!(resp.status(), axum::http::StatusCode::TOO_MANY_REQUESTS);
     }
 
@@ -353,40 +336,18 @@ mod tests {
             ("/mutualfunds/csv", "1.2.3.6"),
             ("/asset-balances/csv", "1.2.3.7"),
         ] {
-            let state = make_test_state();
-            let config = Config::from_env();
-            let router = app_router(state, &config);
-
-            let req = Request::builder()
-                .method(axum::http::Method::POST)
-                .uri(path)
-                .header("fly-client-ip", ip)
-                .body(Body::empty())
-                .unwrap();
-            let resp = router.clone().oneshot(req).await.unwrap();
-            assert_ne!(resp.status(), axum::http::StatusCode::TOO_MANY_REQUESTS);
-
-            let req = Request::builder()
-                .method(axum::http::Method::POST)
-                .uri(path)
-                .header("fly-client-ip", ip)
-                .body(Body::empty())
-                .unwrap();
-            let resp = router.oneshot(req).await.unwrap();
-            assert_eq!(resp.status(), axum::http::StatusCode::TOO_MANY_REQUESTS);
+            let router = app_router(make_test_state(), &Config::from_env());
+            assert_rate_limited(router, axum::http::Method::POST, path, Some(ip)).await;
         }
 
-        let state = make_test_state();
-        let config = Config::from_env();
-        let router = app_router(state, &config);
-
+        // プレビューエンドポイントはレート制限対象外
         let req = Request::builder()
             .method(axum::http::Method::POST)
             .uri("/domestic-stocks/csv/preview")
             .header("fly-client-ip", "1.2.3.4")
             .body(Body::empty())
             .unwrap();
-        let resp = router.oneshot(req).await.unwrap();
+        let resp = app_router(make_test_state(), &Config::from_env()).oneshot(req).await.unwrap();
         assert_ne!(resp.status(), axum::http::StatusCode::TOO_MANY_REQUESTS);
     }
 

--- a/backend/src/services/asset_balance.rs
+++ b/backend/src/services/asset_balance.rs
@@ -243,45 +243,67 @@ mod tests {
     use super::*;
     use rust_decimal_macros::dec;
 
-    fn make_csv(header: &str, row: &str) -> String {
-        format!("{}\n{}\n", header, row)
-    }
-
-    fn parse_row_csv(row: &str) -> (Vec<CreateAssetBalanceRequest>, Vec<CsvRowError>) {
-        parse_csv(make_csv(HEADER, row).as_bytes(), parse_asset_balance_row).unwrap()
-    }
-
     const HEADER: &str =
         "銘柄コード,銘柄名,保有数量［株］,執行中［株］,平均取得価額［円］,取得総額［円］,現在値［円］,現在値（前日比）［円］,時価評価額［円］,評価損益［％］";
-    const ASSET_BALANCE_CSV_HEADER: &str =
-        "銘柄コード,銘柄名,保有数量［株］,執行中［株］,(内訳　通常数量[株]),(内訳　積立数量[株]),平均取得価額［円］,取得総額［円］,現在値［円］,現在値（前日比）［円］,時価評価額［円］,評価損益［％］";
+    const ASSET_BALANCE_CSV_HEADER: &str = "銘柄コード,銘柄名,保有数量［株］,執行中［株］,(内訳　通常数量[株]),(内訳　積立数量[株]),平均取得価額［円］,取得総額［円］,現在値［円］,現在値（前日比）［円］,時価評価額［円］,評価損益［％］";
+    const TEST_ROW_1: &str =
+        "1234,テスト株式会社,100,0,100,0,1500,150000,1600,10,160000,6.67";
+    const TEST_ROW_2: &str =
+        "5678,サンプル株式会社,200,0,200,0,1800,360000,1900,15,380000,5.56";
+    const INPEX_ROW: &str =
+        "\"1605\",\"ＩＮＰＥＸ\",\"200\",\"0\",\"200\",\"0\",\"2,355.00\",\"471,000\",\"3,685.0\",\"65.0\",\"737,000\",\"56.47\"";
+    const NINTENDO_ROW: &str =
+        "\"7974\",\"任天堂\",\"1,000\",\"0\",\"1,000\",\"0\",\"5,997.60\",\"5,997,600\",\"8,737.0\",\"223.0\",\"8,737,000\",\"45.67\"";
+    const ACCOUNT_SUMMARY_ROW: &str =
+        ",,,,,,特定口座合計,\"11,245,249\",,,\"14,517,240\",\"29.09\"";
+
+    fn parse_row_csv(row: &str) -> (Vec<CreateAssetBalanceRequest>, Vec<CsvRowError>) {
+        parse_csv(format!("{HEADER}\n{row}\n").as_bytes(), parse_asset_balance_row).unwrap()
+    }
+
+    fn make_asset_balance_csv(rows: &[&str]) -> String {
+        format!(
+            "■現在の評価額合計［円］,,\"9,474,000\"\n■評価損益合計,前日比［円］,\"288,000\"\n,前月比［円］,\"-120,000\"\n,評価損益［円］,\"2,005,900\"\n■特定口座\n\n{ASSET_BALANCE_CSV_HEADER}\n{}",
+            rows.join("\n")
+        )
+    }
+
+    fn assert_row_ok(row: &str, expected: (&str, Decimal, Decimal, Decimal, Decimal, Decimal, Decimal)) {
+        let (items, errors) = parse_row_csv(row);
+        assert!(errors.is_empty(), "unexpected errors for {row}: {errors:?}");
+        assert_eq!(items.len(), 1, "row should produce one item: {row}");
+        let item = &items[0];
+        assert_eq!(
+            (
+                item.security_code.as_str(),
+                item.shares,
+                item.executing_shares,
+                item.average_purchase_price,
+                item.current_price,
+                item.daily_change,
+                item.profit_loss_rate,
+            ),
+            expected
+        );
+    }
+
+    fn assert_row_error(row: &str, expected_message: &str) {
+        let (items, errors) = parse_row_csv(row);
+        assert!(items.is_empty(), "invalid row must not be parsed: {row}");
+        assert_eq!(errors.len(), 1, "row should produce one error: {row}");
+        assert!(errors[0].message.contains(expected_message), "{errors:?}");
+    }
 
     #[test]
     fn test_preview_csv_valid() {
-        let csv = [
-            "■現在の評価額合計［円］,,\"9,474,000\"",
-            "■評価損益合計,前日比［円］,\"288,000\"",
-            ",前月比［円］,\"-120,000\"",
-            ",評価損益［円］,\"2,005,900\"",
-            "■特定口座",
-            "",
-            ASSET_BALANCE_CSV_HEADER,
-            "\"1605\",\"ＩＮＰＥＸ\",\"200\",\"0\",\"200\",\"0\",\"2,355.00\",\"471,000\",\"3,685.0\",\"65.0\",\"737,000\",\"56.47\"",
-            "\"7974\",\"任天堂\",\"1,000\",\"0\",\"1,000\",\"0\",\"5,997.60\",\"5,997,600\",\"8,737.0\",\"223.0\",\"8,737,000\",\"45.67\"",
-            ",,,,,,特定口座合計,\"11,245,249\",,,\"14,517,240\",\"29.09\"",
-        ]
-        .join("\n");
-
+        let csv = make_asset_balance_csv(&[INPEX_ROW, NINTENDO_ROW, ACCOUNT_SUMMARY_ROW]);
         let preview = preview_csv(csv.as_bytes()).unwrap();
-
-        assert_eq!(preview.total_rows, 2);
-        assert_eq!(preview.valid_rows, 2);
+        assert_eq!((preview.total_rows, preview.valid_rows, preview.rows.len()), (2, 2, 2));
         assert!(
             preview.errors.is_empty(),
             "unexpected errors: {:?}",
             preview.errors
         );
-        assert_eq!(preview.rows.len(), 2);
     }
 
     #[test]
@@ -294,82 +316,57 @@ mod tests {
 
     #[test]
     fn test_parse_asset_balance_row() {
-        // 正常行
-        let (items, errors) =
-            parse_row_csv("1234,テスト株式会社,100,-,1500,150000,1600,10,160000,6.67");
-        assert!(errors.is_empty(), "unexpected errors: {errors:?}");
-        assert_eq!(items.len(), 1);
-        assert_eq!(items[0].security_code, "1234");
-        assert_eq!(items[0].shares, dec!(100));
-        assert_eq!(items[0].executing_shares, Decimal::ZERO);
-        assert_eq!(items[0].average_purchase_price, dec!(1500));
-        assert_eq!(items[0].current_price, dec!(1600));
+        for (row, expected) in [
+            (
+                "1234,テスト株式会社,100,-,1500,150000,1600,10,160000,6.67",
+                (
+                    "1234",
+                    dec!(100),
+                    Decimal::ZERO,
+                    dec!(1500),
+                    dec!(1600),
+                    dec!(10),
+                    dec!(6.67),
+                ),
+            ),
+            (
+                "5678,ファンド,50,-,2000,100000,2100,-,105000,-",
+                (
+                    "5678",
+                    dec!(50),
+                    Decimal::ZERO,
+                    dec!(2000),
+                    dec!(2100),
+                    Decimal::ZERO,
+                    Decimal::ZERO,
+                ),
+            ),
+        ] {
+            assert_row_ok(row, expected);
+        }
 
-        // 不正な値（保有数量 N/A）
-        let (items, errors) = parse_row_csv("1234,テスト,N/A,-,1500,150000,1600,0,160000,0");
-        assert!(items.is_empty(), "不正行はアイテムに含まれてはいけない");
-        assert_eq!(errors.len(), 1);
-        assert!(errors[0].message.contains("保有数量"));
-
-        // 必須列が '-'
-        let (items, errors) = parse_row_csv("1234,テスト,-,-,1500,150000,1600,0,160000,0");
-        assert!(items.is_empty(), "必須列が '-' の行はアイテムに含まれてはいけない");
-        assert_eq!(errors.len(), 1);
-        assert!(errors[0].message.contains("保有数量"));
-
-        // 現在値が不正
-        let (items, errors) = parse_row_csv("1234,テスト,100,-,1500,150000,N/A,0,160000,0");
-        assert!(items.is_empty());
-        assert_eq!(errors.len(), 1);
-        assert!(errors[0].message.contains("現在値"));
-
-        // オプション列が '-' → Decimal::ZERO
-        let (items, errors) = parse_row_csv("5678,ファンド,50,-,2000,100000,2100,-,105000,-");
-        assert!(errors.is_empty(), "unexpected errors: {errors:?}");
-        assert_eq!(items[0].daily_change, Decimal::ZERO);
-        assert_eq!(items[0].profit_loss_rate, Decimal::ZERO);
+        for (row, expected_message) in [
+            ("1234,テスト,N/A,-,1500,150000,1600,0,160000,0", "保有数量"),
+            ("1234,テスト,-,-,1500,150000,1600,0,160000,0", "保有数量"),
+            ("1234,テスト,100,-,1500,150000,N/A,0,160000,0", "現在値"),
+        ] {
+            assert_row_error(row, expected_message);
+        }
     }
 
     #[test]
     fn test_parse_asset_balance_csv_skips_non_data_rows() {
-        // 空行をスキップするケース
-        let csv = [
-            "■現在の評価額合計［円］,,\"3,588,300\"",
-            "■評価損益合計,前日比［円］,\"59,700\"",
-            ",前月比［円］,\"45,000\"",
-            ",評価損益［円］,\"684,900\"",
-            "■特定口座",
-            "",
-            ASSET_BALANCE_CSV_HEADER,
-            "1234,テスト株式会社,100,0,100,0,1500,150000,1600,10,160000,6.67",
-            ",,,,,,,,,,,",
-            "5678,サンプル株式会社,200,0,200,0,1800,360000,1900,15,380000,5.56",
-        ]
-        .join("\n");
-        let (items, errors) = parse_asset_balance_csv(csv.as_bytes()).unwrap();
-        assert!(errors.is_empty(), "unexpected errors: {errors:?}");
-        assert_eq!(items.len(), 2);
-        assert_eq!(items[0].security_code, "1234");
-        assert_eq!(items[1].security_code, "5678");
-
-        // 口座合計行をスキップするケース
-        let csv = [
-            "■現在の評価額合計［円］,,\"9,474,000\"",
-            "■評価損益合計,前日比［円］,\"288,000\"",
-            ",前月比［円］,\"-120,000\"",
-            ",評価損益［円］,\"2,005,900\"",
-            "■特定口座",
-            "",
-            ASSET_BALANCE_CSV_HEADER,
-            "\"1605\",\"ＩＮＰＥＸ\",\"200\",\"0\",\"200\",\"0\",\"2,355.00\",\"471,000\",\"3,685.0\",\"65.0\",\"737,000\",\"56.47\"",
-            "\"7974\",\"任天堂\",\"1,000\",\"0\",\"1,000\",\"0\",\"5,997.60\",\"5,997,600\",\"8,737.0\",\"223.0\",\"8,737,000\",\"45.67\"",
-            ",,,,,,特定口座合計,\"11,245,249\",,,\"14,517,240\",\"29.09\"",
-        ]
-        .join("\n");
-        let (items, errors) = parse_asset_balance_csv(csv.as_bytes()).unwrap();
-        assert!(errors.is_empty(), "unexpected errors: {errors:?}");
-        assert_eq!(items.len(), 2);
-        assert_eq!(items[0].security_code, "1605");
-        assert_eq!(items[1].security_code, "7974");
+        for (rows, expected_codes) in [
+            (&[TEST_ROW_1, ",,,,,,,,,,,", TEST_ROW_2][..], &["1234", "5678"][..]),
+            (&[INPEX_ROW, NINTENDO_ROW, ACCOUNT_SUMMARY_ROW][..], &["1605", "7974"][..]),
+        ] {
+            let csv = make_asset_balance_csv(rows);
+            let (items, errors) = parse_asset_balance_csv(csv.as_bytes()).unwrap();
+            assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+            assert_eq!(
+                items.iter().map(|item| item.security_code.as_str()).collect::<Vec<_>>(),
+                expected_codes
+            );
+        }
     }
 }

--- a/backend/src/services/csv_util.rs
+++ b/backend/src/services/csv_util.rs
@@ -161,33 +161,21 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_number_normal() {
+    fn test_parse_utilities() {
         assert_eq!(parse_number("1,234").unwrap(), dec!(1234));
         assert_eq!(parse_number("500").unwrap(), dec!(500));
         assert_eq!(parse_number("(500)").unwrap(), dec!(-500));
         assert_eq!(parse_number("").unwrap(), Decimal::ZERO);
         // ハイフン単独は「値なし」として 0
         assert_eq!(parse_number("-").unwrap(), Decimal::ZERO);
-    }
-
-    #[test]
-    fn test_parse_optional_string() {
         let record = csv::StringRecord::from(vec!["", "value"]);
         let mut header_map = HashMap::new();
         header_map.insert("empty".to_string(), 0);
         header_map.insert("filled".to_string(), 1);
-
         assert_eq!(parse_optional_string(&record, &header_map, "empty"), "");
-        assert_eq!(
-            parse_optional_string(&record, &header_map, "filled"),
-            "value"
-        );
+        assert_eq!(parse_optional_string(&record, &header_map, "filled"), "value");
         // 存在しない列は空文字
         assert_eq!(parse_optional_string(&record, &header_map, "missing"), "");
-    }
-
-    #[test]
-    fn test_parse_date() {
         assert_eq!(
             parse_date("2024/01/15").unwrap(),
             NaiveDate::from_ymd_opt(2024, 1, 15).unwrap()
@@ -224,22 +212,16 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_required_string_empty() {
+    fn test_parse_required() {
         let record = csv::StringRecord::from(vec!["", "value"]);
         let mut header_map = HashMap::new();
         header_map.insert("col_a".to_string(), 0);
         header_map.insert("col_b".to_string(), 1);
-
         let err = parse_required_string(&record, &header_map, "col_a", 3).unwrap_err();
         assert_eq!(err.row, 3);
         assert!(err.message.contains("col_a"));
-
         let ok = parse_required_string(&record, &header_map, "col_b", 1).unwrap();
         assert_eq!(ok, "value");
-    }
-
-    #[test]
-    fn test_parse_required_invalid() {
         let record = csv::StringRecord::from(vec!["abc", "1,234"]);
         let mut hm = HashMap::new();
         hm.insert("bad".to_string(), 0);

--- a/backend/src/services/csv_util.rs
+++ b/backend/src/services/csv_util.rs
@@ -160,43 +160,48 @@ mod tests {
         println!("[timing] {} × {}回: {:.2}ms", label, n, start.elapsed().as_secs_f64() * 1000.0);
     }
 
+    fn make_header_map(cols: &[&str]) -> HashMap<String, usize> {
+        cols.iter()
+            .enumerate()
+            .map(|(i, col)| ((*col).to_string(), i))
+            .collect()
+    }
+
     #[test]
     fn test_parse_utilities() {
-        assert_eq!(parse_number("1,234").unwrap(), dec!(1234));
-        assert_eq!(parse_number("500").unwrap(), dec!(500));
-        assert_eq!(parse_number("(500)").unwrap(), dec!(-500));
-        assert_eq!(parse_number("").unwrap(), Decimal::ZERO);
-        // ハイフン単独は「値なし」として 0
-        assert_eq!(parse_number("-").unwrap(), Decimal::ZERO);
+        for (input, expected) in [
+            ("1,234", dec!(1234)),
+            ("500", dec!(500)),
+            ("(500)", dec!(-500)),
+            ("", Decimal::ZERO),
+            // ハイフン単独は「値なし」として 0
+            ("-", Decimal::ZERO),
+        ] {
+            assert_eq!(parse_number(input).unwrap(), expected);
+        }
+
         let record = csv::StringRecord::from(vec!["", "value"]);
-        let mut header_map = HashMap::new();
-        header_map.insert("empty".to_string(), 0);
-        header_map.insert("filled".to_string(), 1);
-        assert_eq!(parse_optional_string(&record, &header_map, "empty"), "");
-        assert_eq!(parse_optional_string(&record, &header_map, "filled"), "value");
-        // 存在しない列は空文字
-        assert_eq!(parse_optional_string(&record, &header_map, "missing"), "");
-        assert_eq!(
-            parse_date("2024/01/15").unwrap(),
-            NaiveDate::from_ymd_opt(2024, 1, 15).unwrap()
-        );
-        assert_eq!(
-            parse_date("2024-01-15").unwrap(),
-            NaiveDate::from_ymd_opt(2024, 1, 15).unwrap()
-        );
+        let header_map = make_header_map(&["empty", "filled"]);
+        for (col, expected) in [("empty", ""), ("filled", "value"), ("missing", "")] {
+            assert_eq!(parse_optional_string(&record, &header_map, col), expected);
+        }
+
+        let expected_date = NaiveDate::from_ymd_opt(2024, 1, 15).unwrap();
+        for input in ["2024/01/15", "2024-01-15"] {
+            assert_eq!(parse_date(input).unwrap(), expected_date);
+        }
     }
 
     #[test]
     fn test_compute_taxes() {
-        let (taxes, after) = compute_taxes("特定", dec!(10000));
-        assert_eq!(taxes, dec!(2031)); // floor(10000 * 0.20315)
-        assert_eq!(after, dec!(7969));
-        let (taxes, after) = compute_taxes("特定", dec!(-5000));
-        assert_eq!(taxes, Decimal::ZERO);
-        assert_eq!(after, dec!(-5000));
-        let (taxes, after) = compute_taxes("NISA", dec!(10000));
-        assert_eq!(taxes, Decimal::ZERO);
-        assert_eq!(after, dec!(10000));
+        for (account, realized_pnl, expected_taxes, expected_after) in [
+            ("特定", dec!(10000), dec!(2031), dec!(7969)), // floor(10000 * 0.20315)
+            ("特定", dec!(-5000), Decimal::ZERO, dec!(-5000)),
+            ("NISA", dec!(10000), Decimal::ZERO, dec!(10000)),
+        ] {
+            let (taxes, after) = compute_taxes(account, realized_pnl);
+            assert_eq!((taxes, after), (expected_taxes, expected_after));
+        }
     }
 
     #[test]
@@ -212,30 +217,53 @@ mod tests {
     }
 
     #[test]
+    fn test_get_cell() {
+        let record = csv::StringRecord::from(vec!["value"]);
+        let header_map = make_header_map(&["present"]);
+        assert_eq!(get_cell(&record, &header_map, "present"), "value");
+        assert_eq!(get_cell(&record, &header_map, "missing"), "");
+    }
+
+    #[test]
     fn test_parse_required() {
         let record = csv::StringRecord::from(vec!["", "value"]);
-        let mut header_map = HashMap::new();
-        header_map.insert("col_a".to_string(), 0);
-        header_map.insert("col_b".to_string(), 1);
+        let header_map = make_header_map(&["col_a", "col_b"]);
         let err = parse_required_string(&record, &header_map, "col_a", 3).unwrap_err();
         assert_eq!(err.row, 3);
         assert!(err.message.contains("col_a"));
         let ok = parse_required_string(&record, &header_map, "col_b", 1).unwrap();
         assert_eq!(ok, "value");
-        let record = csv::StringRecord::from(vec!["abc", "1,234"]);
-        let mut hm = HashMap::new();
-        hm.insert("bad".to_string(), 0);
-        hm.insert("good".to_string(), 1);
-        assert_eq!(parse_required_number(&record, &hm, "bad", 5).unwrap_err().row, 5);
-        assert_eq!(parse_required_number(&record, &hm, "good", 1).unwrap(), dec!(1234));
 
-        let record = csv::StringRecord::from(vec!["not-a-date", "2024/03/01"]);
-        let mut hm = HashMap::new();
-        hm.insert("bad".to_string(), 0);
-        hm.insert("good".to_string(), 1);
-        assert_eq!(parse_required_date(&record, &hm, "bad", 2).unwrap_err().row, 2);
-        let ok = parse_required_date(&record, &hm, "good", 1).unwrap();
+        let record = csv::StringRecord::from(vec!["abc", "1,234", ""]);
+        let hm = make_header_map(&["invalid", "valid", "empty"]);
+        assert_eq!(parse_required_number(&record, &hm, "invalid", 5).unwrap_err().row, 5);
+        assert_eq!(parse_required_number(&record, &hm, "valid", 1).unwrap(), dec!(1234));
+        let err = parse_required_number(&record, &hm, "empty", 7).unwrap_err();
+        assert_eq!(err.row, 7);
+        assert!(err.message.contains("empty"));
+
+        let record = csv::StringRecord::from(vec!["not-a-date", "2024/03/01", "2024/13/40"]);
+        let hm = make_header_map(&["invalid", "valid", "out_of_range"]);
+        assert_eq!(parse_required_date(&record, &hm, "invalid", 2).unwrap_err().row, 2);
+        let ok = parse_required_date(&record, &hm, "valid", 1).unwrap();
         assert_eq!(ok, NaiveDate::from_ymd_opt(2024, 3, 1).unwrap());
+        let err = parse_required_date(&record, &hm, "out_of_range", 9).unwrap_err();
+        assert_eq!(err.row, 9);
+        assert!(err.message.contains("out_of_range"));
+    }
+
+    #[test]
+    fn test_normalize_security_name() {
+        for (input, expected) in [
+            ("K D D I", "KDDI"),
+            ("I N P E X", "INPEX"),
+            ("eMAXIS Slim 全世界株式", "eMAXIS Slim 全世界株式"),
+            ("任天堂", "任天堂"),
+            ("  KDDI  ", "KDDI"),
+            ("", ""),
+        ] {
+            assert_eq!(normalize_security_name(input), expected);
+        }
     }
 
     /// CSV パース処理の所要時間を計測するタイミングテスト。
@@ -276,35 +304,5 @@ mod tests {
         time_n("parse_date", 10_000, || {
             for s in &date_samples { let _ = std::hint::black_box(parse_date(std::hint::black_box(s))); }
         });
-    }
-
-    #[test]
-    fn test_normalize_security_name() {
-        assert_eq!(normalize_security_name("K D D I"), "KDDI");
-        assert_eq!(normalize_security_name("I N P E X"), "INPEX");
-        assert_eq!(
-            normalize_security_name("eMAXIS Slim 全世界株式"),
-            "eMAXIS Slim 全世界株式"
-        );
-        assert_eq!(normalize_security_name("任天堂"), "任天堂");
-        assert_eq!(normalize_security_name("  KDDI  "), "KDDI");
-        assert_eq!(normalize_security_name(""), "");
-    }
-
-    #[test]
-    fn test_parse_required_empty_or_invalid_is_error() {
-        let record = csv::StringRecord::from(vec![""]);
-        let mut hm = HashMap::new();
-        hm.insert("required".to_string(), 0);
-        let err = parse_required_number(&record, &hm, "required", 7).unwrap_err();
-        assert_eq!(err.row, 7);
-        assert!(err.message.contains("required"));
-
-        let record = csv::StringRecord::from(vec!["2024/13/40"]);
-        let mut hm = HashMap::new();
-        hm.insert("date".to_string(), 0);
-        let err = parse_required_date(&record, &hm, "date", 9).unwrap_err();
-        assert_eq!(err.row, 9);
-        assert!(err.message.contains("date"));
     }
 }

--- a/backend/src/services/domestic_stock.rs
+++ b/backend/src/services/domestic_stock.rs
@@ -221,34 +221,42 @@ mod tests {
     use chrono::NaiveDate;
     use rust_decimal_macros::dec;
 
-    #[test]
-    fn test_preview_csv_basic() {
-        let csv = [
-            "約定日,受渡日,銘柄コード,銘柄名,口座,信用区分,取引,数量[株],売却/決済単価[円],売却/決済額[円],平均取得価額[円],実現損益[円]",
-            "\"2026/02/09\",\"2026/02/12\",\"5020\",\"ＥＮＥＯＳホールディングス\",\"特定\",\"-\",\"売付\",\"100\",\"1,441.0\",\"144,100\",\"1,350.00\",\"9,100\"",
-        ]
-        .join("\n");
+    const HEADER: &str = "約定日,受渡日,銘柄コード,銘柄名,口座,信用区分,取引,数量[株],売却/決済単価[円],売却/決済額[円],平均取得価額[円],実現損益[円]";
+    const BASIC_ROW: &str = "\"2026/02/09\",\"2026/02/12\",\"5020\",\"ＥＮＥＯＳホールディングス\",\"特定\",\"-\",\"売付\",\"100\",\"1,441.0\",\"144,100\",\"1,350.00\",\"9,100\"";
+    const NISA_ROW: &str = "\"2026/02/09\",\"2026/02/12\",\"9433\",\"K D D I\",\"NISA\",\"-\",\"売付\",\"100\",\"1441.0\",\"144100\",\"1350.00\",\"9100\"";
+    const MISSING_NAME_HEADER: &str = "約定日,受渡日,銘柄コード,口座,信用区分,取引,数量[株],売却/決済単価[円],売却/決済額[円],平均取得価額[円],実現損益[円]";
+    const MISSING_NAME_ROW: &str = "\"2026/02/09\",\"2026/02/12\",\"5020\",\"特定\",\"-\",\"売付\",\"100\",\"1,441.0\",\"144,100\",\"1,350.00\",\"9,100\"";
+    const INVALID_PNL_ROW: &str = "\"2026/02/09\",\"2026/02/12\",\"5020\",\"ＥＮＥＯＳ\",\"特定\",\"-\",\"売付\",\"100\",\"1441.0\",\"144100\",\"1350.00\",\"N/A\"";
 
-        let preview = preview_csv(csv.as_bytes()).unwrap();
+    fn preview_with_header(header: &str, row: &str) -> CsvPreviewResponse {
+        preview_csv(format!("{header}\n{row}").as_bytes()).unwrap()
+    }
 
-        assert_eq!(preview.total_rows, 1);
-        assert_eq!(preview.valid_rows, 1);
-        assert!(preview.errors.is_empty(), "unexpected errors: {:?}", preview.errors);
-        assert_eq!(preview.rows.len(), 1);
-        assert!(matches!(preview_csv(b""), Err(ApiError::ValidationError(_))));
+    fn assert_preview_ok(row: &str) -> CsvPreviewResponse {
+        let preview = preview_with_header(HEADER, row);
+        assert_eq!((preview.total_rows, preview.valid_rows, preview.rows.len()), (1, 1, 1));
+        assert!(
+            preview.errors.is_empty(),
+            "unexpected errors: {:?}",
+            preview.errors
+        );
+        preview
+    }
+
+    fn assert_preview_error(header: &str, row: &str, expected_message: &str) {
+        let preview = preview_with_header(header, row);
+        assert_eq!((preview.total_rows, preview.valid_rows, preview.errors.len()), (1, 0, 1));
+        assert!(preview.errors[0].message.contains(expected_message));
     }
 
     #[test]
-    fn test_preview_csv_normalizes_name_and_keeps_nisa_profit_untaxed() {
-        let csv = [
-            "約定日,受渡日,銘柄コード,銘柄名,口座,信用区分,取引,数量[株],売却/決済単価[円],売却/決済額[円],平均取得価額[円],実現損益[円]",
-            "\"2026/02/09\",\"2026/02/12\",\"9433\",\"K D D I\",\"NISA\",\"-\",\"売付\",\"100\",\"1441.0\",\"144100\",\"1350.00\",\"9100\"",
-        ]
-        .join("\n");
+    fn test_preview_csv_valid_rows() {
+        assert_eq!(
+            assert_preview_ok(BASIC_ROW).rows[0]["security_name"],
+            "ＥＮＥＯＳホールディングス"
+        );
 
-        let preview = preview_csv(csv.as_bytes()).unwrap();
-
-        assert_eq!(preview.valid_rows, 1);
+        let preview = assert_preview_ok(NISA_ROW);
         assert_eq!(preview.rows[0]["security_name"], "KDDI");
         assert_eq!(preview.rows[0]["taxes"], 0.0);
         assert_eq!(
@@ -259,28 +267,17 @@ mod tests {
 
     #[test]
     fn test_preview_csv_row_errors() {
-        let cases = [
-            (
-                "約定日,受渡日,銘柄コード,口座,信用区分,取引,数量[株],売却/決済単価[円],売却/決済額[円],平均取得価額[円],実現損益[円]",
-                "\"2026/02/09\",\"2026/02/12\",\"5020\",\"特定\",\"-\",\"売付\",\"100\",\"1,441.0\",\"144,100\",\"1,350.00\",\"9,100\"",
-                "銘柄名",
-            ),
-            (
-                "約定日,受渡日,銘柄コード,銘柄名,口座,信用区分,取引,数量[株],売却/決済単価[円],売却/決済額[円],平均取得価額[円],実現損益[円]",
-                "\"2026/02/09\",\"2026/02/12\",\"5020\",\"ＥＮＥＯＳ\",\"特定\",\"-\",\"売付\",\"100\",\"1441.0\",\"144100\",\"1350.00\",\"N/A\"",
-                "実現損益[円]",
-            ),
-        ];
-
-        for (header, row, expected_message) in cases {
-            let csv = [header, row].join("\n");
-            let preview = preview_csv(csv.as_bytes()).unwrap();
-
-            assert_eq!(preview.total_rows, 1);
-            assert_eq!(preview.valid_rows, 0);
-            assert_eq!(preview.errors.len(), 1);
-            assert!(preview.errors[0].message.contains(expected_message));
+        for (header, row, expected_message) in [
+            (MISSING_NAME_HEADER, MISSING_NAME_ROW, "銘柄名"),
+            (HEADER, INVALID_PNL_ROW, "実現損益[円]"),
+        ] {
+            assert_preview_error(header, row, expected_message);
         }
+    }
+
+    #[test]
+    fn test_preview_csv_empty() {
+        assert!(matches!(preview_csv(b""), Err(ApiError::ValidationError(_))));
     }
 
     fn make_test_item() -> CreateDomesticStockRequest {

--- a/backend/src/services/domestic_stock.rs
+++ b/backend/src/services/domestic_stock.rs
@@ -221,40 +221,58 @@ mod tests {
     use chrono::NaiveDate;
     use rust_decimal_macros::dec;
 
-    #[test]
-    fn test_preview_csv_basic() {
-        let csv = [
-            "約定日,受渡日,銘柄コード,銘柄名,口座,信用区分,取引,数量[株],売却/決済単価[円],売却/決済額[円],平均取得価額[円],実現損益[円]",
-            "\"2026/02/09\",\"2026/02/12\",\"5020\",\"ＥＮＥＯＳホールディングス\",\"特定\",\"-\",\"売付\",\"100\",\"1,441.0\",\"144,100\",\"1,350.00\",\"9,100\"",
-        ]
-        .join("\n");
+    const PREVIEW_HEADER: &str = "約定日,受渡日,銘柄コード,銘柄名,口座,信用区分,取引,数量[株],売却/決済単価[円],売却/決済額[円],平均取得価額[円],実現損益[円]";
+    fn preview_from_csv(header: &str, row: &str) -> CsvPreviewResponse {
+        preview_csv([header, row].join("\n").as_bytes()).unwrap()
+    }
 
-        let preview = preview_csv(csv.as_bytes()).unwrap();
+    fn assert_valid_row(row: &str) -> CsvPreviewResponse {
+        let preview = preview_from_csv(PREVIEW_HEADER, row);
+        assert_eq!(
+            (
+                preview.total_rows,
+                preview.valid_rows,
+                preview.rows.len(),
+                preview.errors.len()
+            ),
+            (1, 1, 1, 0)
+        );
+        preview
+    }
 
-        assert_eq!(preview.total_rows, 1);
-        assert_eq!(preview.valid_rows, 1);
-        assert!(preview.errors.is_empty(), "unexpected errors: {:?}", preview.errors);
-        assert_eq!(preview.rows.len(), 1);
-        assert!(matches!(preview_csv(b""), Err(ApiError::ValidationError(_))));
+    fn assert_single_row_error(header: &str, row: &str, expected_message: &str) {
+        let preview = preview_from_csv(header, row);
+        assert_eq!(
+            (preview.total_rows, preview.valid_rows, preview.errors.len()),
+            (1, 0, 1)
+        );
+        assert!(
+            preview.errors[0].message.contains(expected_message),
+            "unexpected errors: {:?}",
+            preview.errors
+        );
     }
 
     #[test]
-    fn test_preview_csv_normalizes_name_and_keeps_nisa_profit_untaxed() {
-        let csv = [
-            "約定日,受渡日,銘柄コード,銘柄名,口座,信用区分,取引,数量[株],売却/決済単価[円],売却/決済額[円],平均取得価額[円],実現損益[円]",
-            "\"2026/02/09\",\"2026/02/12\",\"9433\",\"K D D I\",\"NISA\",\"-\",\"売付\",\"100\",\"1441.0\",\"144100\",\"1350.00\",\"9100\"",
-        ]
-        .join("\n");
-
-        let preview = preview_csv(csv.as_bytes()).unwrap();
-
-        assert_eq!(preview.valid_rows, 1);
-        assert_eq!(preview.rows[0]["security_name"], "KDDI");
-        assert_eq!(preview.rows[0]["taxes"], 0.0);
-        assert_eq!(
-            preview.rows[0]["realized_profit_and_loss_after_tax"],
-            9100.0
+    fn test_preview_csv_valid_rows() {
+        assert_valid_row(
+            "\"2026/02/09\",\"2026/02/12\",\"5020\",\"ＥＮＥＯＳホールディングス\",\"特定\",\"-\",\"売付\",\"100\",\"1,441.0\",\"144,100\",\"1,350.00\",\"9,100\"",
         );
+        let preview = assert_valid_row(
+            "\"2026/02/09\",\"2026/02/12\",\"9433\",\"K D D I\",\"NISA\",\"-\",\"売付\",\"100\",\"1441.0\",\"144100\",\"1350.00\",\"9100\"",
+        );
+        let row = &preview.rows[0];
+        assert_eq!(row["security_name"], "KDDI");
+        assert_eq!(row["taxes"], 0.0);
+        assert_eq!(row["realized_profit_and_loss_after_tax"], 9100.0);
+    }
+
+    #[test]
+    fn test_preview_csv_empty_input() {
+        assert!(matches!(
+            preview_csv(b""),
+            Err(ApiError::ValidationError(_))
+        ));
     }
 
     #[test]
@@ -266,42 +284,17 @@ mod tests {
                 "銘柄名",
             ),
             (
-                "約定日,受渡日,銘柄コード,銘柄名,口座,信用区分,取引,数量[株],売却/決済単価[円],売却/決済額[円],平均取得価額[円],実現損益[円]",
+                PREVIEW_HEADER,
                 "\"2026/02/09\",\"2026/02/12\",\"5020\",\"ＥＮＥＯＳ\",\"特定\",\"-\",\"売付\",\"100\",\"1441.0\",\"144100\",\"1350.00\",\"N/A\"",
                 "実現損益[円]",
             ),
         ];
 
         for (header, row, expected_message) in cases {
-            let csv = [header, row].join("\n");
-            let preview = preview_csv(csv.as_bytes()).unwrap();
-
-            assert_eq!(preview.total_rows, 1);
-            assert_eq!(preview.valid_rows, 0);
-            assert_eq!(preview.errors.len(), 1);
-            assert!(preview.errors[0].message.contains(expected_message));
+            assert_single_row_error(header, row, expected_message);
         }
     }
 
-    fn make_test_item() -> CreateDomesticStockRequest {
-        CreateDomesticStockRequest {
-            trade_date: NaiveDate::from_ymd_opt(2026, 2, 12).unwrap(),
-            settlement_date: NaiveDate::from_ymd_opt(2026, 2, 16).unwrap(),
-            security_code: "9508".to_string(),
-            security_name: "九州電力".to_string(),
-            account: "特定".to_string(),
-            shares: dec!(100),
-            asked_price: dec!(1880),
-            proceeds: dec!(188000),
-            purchase_price: dec!(1770),
-            realized_profit_and_loss: dec!(11000),
-            taxes: dec!(2234),
-            realized_profit_and_loss_after_tax: dec!(8766),
-        }
-    }
-
-    /// 1回目アップロード → 全件挿入、2回目同一CSV → 全件スキップ（再アップロード防止）
-    /// Docker が必要なため通常テストでは skip する（実行: cargo test -- --ignored）
     #[tokio::test]
     #[ignore = "requires Docker"]
     async fn test_bulk_create_reupload_deduplication() {
@@ -317,7 +310,6 @@ mod tests {
         let pool = sqlx::PgPool::connect(&url).await.unwrap();
         sqlx::migrate!("./migrations").run(&pool).await.unwrap();
 
-        // FK制約のためユーザーを事前作成
         let user_id = Uuid::new_v4();
         sqlx::query("INSERT INTO users (id, google_id, email) VALUES ($1, $2, $3)")
             .bind(user_id)
@@ -327,16 +319,26 @@ mod tests {
             .await
             .unwrap();
 
-        let items = vec![make_test_item(); 5];
-
-        // 1回目: 全件挿入
+        let items = vec![
+            CreateDomesticStockRequest {
+                trade_date: NaiveDate::from_ymd_opt(2026, 2, 12).unwrap(),
+                settlement_date: NaiveDate::from_ymd_opt(2026, 2, 16).unwrap(),
+                security_code: "9508".to_string(),
+                security_name: "九州電力".to_string(),
+                account: "特定".to_string(),
+                shares: dec!(100),
+                asked_price: dec!(1880),
+                proceeds: dec!(188000),
+                purchase_price: dec!(1770),
+                realized_profit_and_loss: dec!(11000),
+                taxes: dec!(2234),
+                realized_profit_and_loss_after_tax: dec!(8766),
+            };
+            5
+        ];
         let first = bulk_create(&pool, user_id, &items).await.unwrap();
-        assert_eq!(first.inserted, 5);
-        assert_eq!(first.skipped, 0);
-
-        // 2回目（同一CSV再アップロード）: 全件スキップ
+        assert_eq!((first.inserted, first.skipped), (5, 0));
         let second = bulk_create(&pool, user_id, &items).await.unwrap();
-        assert_eq!(second.inserted, 0);
-        assert_eq!(second.skipped, 5);
+        assert_eq!((second.inserted, second.skipped), (0, 5));
     }
 }

--- a/backend/src/services/domestic_stock.rs
+++ b/backend/src/services/domestic_stock.rs
@@ -221,58 +221,40 @@ mod tests {
     use chrono::NaiveDate;
     use rust_decimal_macros::dec;
 
-    const PREVIEW_HEADER: &str = "約定日,受渡日,銘柄コード,銘柄名,口座,信用区分,取引,数量[株],売却/決済単価[円],売却/決済額[円],平均取得価額[円],実現損益[円]";
-    fn preview_from_csv(header: &str, row: &str) -> CsvPreviewResponse {
-        preview_csv([header, row].join("\n").as_bytes()).unwrap()
-    }
-
-    fn assert_valid_row(row: &str) -> CsvPreviewResponse {
-        let preview = preview_from_csv(PREVIEW_HEADER, row);
-        assert_eq!(
-            (
-                preview.total_rows,
-                preview.valid_rows,
-                preview.rows.len(),
-                preview.errors.len()
-            ),
-            (1, 1, 1, 0)
-        );
-        preview
-    }
-
-    fn assert_single_row_error(header: &str, row: &str, expected_message: &str) {
-        let preview = preview_from_csv(header, row);
-        assert_eq!(
-            (preview.total_rows, preview.valid_rows, preview.errors.len()),
-            (1, 0, 1)
-        );
-        assert!(
-            preview.errors[0].message.contains(expected_message),
-            "unexpected errors: {:?}",
-            preview.errors
-        );
-    }
-
     #[test]
-    fn test_preview_csv_valid_rows() {
-        assert_valid_row(
+    fn test_preview_csv_basic() {
+        let csv = [
+            "約定日,受渡日,銘柄コード,銘柄名,口座,信用区分,取引,数量[株],売却/決済単価[円],売却/決済額[円],平均取得価額[円],実現損益[円]",
             "\"2026/02/09\",\"2026/02/12\",\"5020\",\"ＥＮＥＯＳホールディングス\",\"特定\",\"-\",\"売付\",\"100\",\"1,441.0\",\"144,100\",\"1,350.00\",\"9,100\"",
-        );
-        let preview = assert_valid_row(
-            "\"2026/02/09\",\"2026/02/12\",\"9433\",\"K D D I\",\"NISA\",\"-\",\"売付\",\"100\",\"1441.0\",\"144100\",\"1350.00\",\"9100\"",
-        );
-        let row = &preview.rows[0];
-        assert_eq!(row["security_name"], "KDDI");
-        assert_eq!(row["taxes"], 0.0);
-        assert_eq!(row["realized_profit_and_loss_after_tax"], 9100.0);
+        ]
+        .join("\n");
+
+        let preview = preview_csv(csv.as_bytes()).unwrap();
+
+        assert_eq!(preview.total_rows, 1);
+        assert_eq!(preview.valid_rows, 1);
+        assert!(preview.errors.is_empty(), "unexpected errors: {:?}", preview.errors);
+        assert_eq!(preview.rows.len(), 1);
+        assert!(matches!(preview_csv(b""), Err(ApiError::ValidationError(_))));
     }
 
     #[test]
-    fn test_preview_csv_empty_input() {
-        assert!(matches!(
-            preview_csv(b""),
-            Err(ApiError::ValidationError(_))
-        ));
+    fn test_preview_csv_normalizes_name_and_keeps_nisa_profit_untaxed() {
+        let csv = [
+            "約定日,受渡日,銘柄コード,銘柄名,口座,信用区分,取引,数量[株],売却/決済単価[円],売却/決済額[円],平均取得価額[円],実現損益[円]",
+            "\"2026/02/09\",\"2026/02/12\",\"9433\",\"K D D I\",\"NISA\",\"-\",\"売付\",\"100\",\"1441.0\",\"144100\",\"1350.00\",\"9100\"",
+        ]
+        .join("\n");
+
+        let preview = preview_csv(csv.as_bytes()).unwrap();
+
+        assert_eq!(preview.valid_rows, 1);
+        assert_eq!(preview.rows[0]["security_name"], "KDDI");
+        assert_eq!(preview.rows[0]["taxes"], 0.0);
+        assert_eq!(
+            preview.rows[0]["realized_profit_and_loss_after_tax"],
+            9100.0
+        );
     }
 
     #[test]
@@ -284,17 +266,42 @@ mod tests {
                 "銘柄名",
             ),
             (
-                PREVIEW_HEADER,
+                "約定日,受渡日,銘柄コード,銘柄名,口座,信用区分,取引,数量[株],売却/決済単価[円],売却/決済額[円],平均取得価額[円],実現損益[円]",
                 "\"2026/02/09\",\"2026/02/12\",\"5020\",\"ＥＮＥＯＳ\",\"特定\",\"-\",\"売付\",\"100\",\"1441.0\",\"144100\",\"1350.00\",\"N/A\"",
                 "実現損益[円]",
             ),
         ];
 
         for (header, row, expected_message) in cases {
-            assert_single_row_error(header, row, expected_message);
+            let csv = [header, row].join("\n");
+            let preview = preview_csv(csv.as_bytes()).unwrap();
+
+            assert_eq!(preview.total_rows, 1);
+            assert_eq!(preview.valid_rows, 0);
+            assert_eq!(preview.errors.len(), 1);
+            assert!(preview.errors[0].message.contains(expected_message));
         }
     }
 
+    fn make_test_item() -> CreateDomesticStockRequest {
+        CreateDomesticStockRequest {
+            trade_date: NaiveDate::from_ymd_opt(2026, 2, 12).unwrap(),
+            settlement_date: NaiveDate::from_ymd_opt(2026, 2, 16).unwrap(),
+            security_code: "9508".to_string(),
+            security_name: "九州電力".to_string(),
+            account: "特定".to_string(),
+            shares: dec!(100),
+            asked_price: dec!(1880),
+            proceeds: dec!(188000),
+            purchase_price: dec!(1770),
+            realized_profit_and_loss: dec!(11000),
+            taxes: dec!(2234),
+            realized_profit_and_loss_after_tax: dec!(8766),
+        }
+    }
+
+    /// 1回目アップロード → 全件挿入、2回目同一CSV → 全件スキップ（再アップロード防止）
+    /// Docker が必要なため通常テストでは skip する（実行: cargo test -- --ignored）
     #[tokio::test]
     #[ignore = "requires Docker"]
     async fn test_bulk_create_reupload_deduplication() {
@@ -310,6 +317,7 @@ mod tests {
         let pool = sqlx::PgPool::connect(&url).await.unwrap();
         sqlx::migrate!("./migrations").run(&pool).await.unwrap();
 
+        // FK制約のためユーザーを事前作成
         let user_id = Uuid::new_v4();
         sqlx::query("INSERT INTO users (id, google_id, email) VALUES ($1, $2, $3)")
             .bind(user_id)
@@ -319,26 +327,16 @@ mod tests {
             .await
             .unwrap();
 
-        let items = vec![
-            CreateDomesticStockRequest {
-                trade_date: NaiveDate::from_ymd_opt(2026, 2, 12).unwrap(),
-                settlement_date: NaiveDate::from_ymd_opt(2026, 2, 16).unwrap(),
-                security_code: "9508".to_string(),
-                security_name: "九州電力".to_string(),
-                account: "特定".to_string(),
-                shares: dec!(100),
-                asked_price: dec!(1880),
-                proceeds: dec!(188000),
-                purchase_price: dec!(1770),
-                realized_profit_and_loss: dec!(11000),
-                taxes: dec!(2234),
-                realized_profit_and_loss_after_tax: dec!(8766),
-            };
-            5
-        ];
+        let items = vec![make_test_item(); 5];
+
+        // 1回目: 全件挿入
         let first = bulk_create(&pool, user_id, &items).await.unwrap();
-        assert_eq!((first.inserted, first.skipped), (5, 0));
+        assert_eq!(first.inserted, 5);
+        assert_eq!(first.skipped, 0);
+
+        // 2回目（同一CSV再アップロード）: 全件スキップ
         let second = bulk_create(&pool, user_id, &items).await.unwrap();
-        assert_eq!((second.inserted, second.skipped), (0, 5));
+        assert_eq!(second.inserted, 0);
+        assert_eq!(second.skipped, 5);
     }
 }


### PR DESCRIPTION
## 概要

autoresearch ループ（iter24〜30）でバックエンド `.rs` ファイルのテストコードを継続的に削減。

## 変更内容

| iter | 対象ファイル | 削減行数 | 手法 |
|------|------------|---------|------|
| 24 | `services/csv_util.rs` | -18 | parse 系テストを 5→2 に統合 |
| 25 | `routes.rs` + `middleware/rate_limit.rs` | -95 | `assert_rate_limited` ヘルパー追加、テスト圧縮 |
| 26 | `services/asset_balance.rs` | -3 | テスト統合 |
| 28 | `services/csv_util.rs` | -2 | テスト再整理 |
| 29 | `services/domestic_stock.rs` | -3 | preview_csv テスト統合 |
| 30 | `middleware/rate_limit.rs` | -27 | `assert_status` ヘルパー追加、テストさらに統合 |

**合計: -148 行（今回分）**
**累積: ベースライン 8733 → 7851（882 行削減）**

## テスト結果

```
cargo test --lib
92 passed; 0 failed; 6 ignored
```

※ rate_limit テスト統合により 95→92 に減少（テスト関数をマージ、カバレッジは維持）

## 確認コマンド

```bash
cd backend && cargo test --lib
```