### PR TITLE
fix: /dividends/per-share/batch が本番で 401 を返す問題を修正

### DIFF
--- a/frontend/src/features/jquants/api/__tests__/dividendPerShareApi.test.ts
+++ b/frontend/src/features/jquants/api/__tests__/dividendPerShareApi.test.ts
@@ -29,7 +29,7 @@ describe('fetchDividendPerShareBatch', () => {
 
     expect(apiClient.post).toHaveBeenCalledWith('/dividends/per-share/batch', {
       security_codes: ['7203'],
-    });
+    }, { withCredentials: true });
     expect(result).toEqual(mockItems);
   });
 
@@ -40,7 +40,7 @@ describe('fetchDividendPerShareBatch', () => {
 
     expect(apiClient.post).toHaveBeenCalledWith('/dividends/per-share/batch', {
       security_codes: [],
-    });
+    }, { withCredentials: true });
     expect(result).toEqual([]);
   });
 
@@ -59,7 +59,7 @@ describe('fetchDividendPerShareBatch', () => {
 
     expect(apiClient.post).toHaveBeenCalledWith('/dividends/per-share/batch', {
       security_codes: securityCodes,
-    });
+    }, { withCredentials: true });
     expect(result).toEqual(mockItems);
   });
 });

--- a/frontend/src/features/jquants/api/dividendPerShareApi.ts
+++ b/frontend/src/features/jquants/api/dividendPerShareApi.ts
@@ -19,7 +19,8 @@ export async function fetchDividendPerShareBatch(
 ): Promise<DividendPerShareItem[]> {
   const response = await apiClient.post<BatchResponse>(
     '/dividends/per-share/batch',
-    { security_codes: securityCodes }
+    { security_codes: securityCodes },
+    { withCredentials: true }
   );
   return response.items;
 }


### PR DESCRIPTION
## 概要
本番環境で `/dividends/per-share/batch` 呼び出し時にセッション Cookie が送られず 401 になる問題を修正しました。

## 変更内容
- `fetchDividendPerShareBatch` の `apiClient.post(...)` に `{ withCredentials: true }` を追加
- 呼び出しオプションに合わせて既存テストの期待値を更新

## テスト
- [x] `cd frontend && vp lint && npm test -- --run && vp build`
