### PR TITLE
chore(skill): codex exec に --sandbox danger-full-access を追加

### DIFF
--- a/.claude/skills/claude-codex-handoff/SKILL.md
+++ b/.claude/skills/claude-codex-handoff/SKILL.md
@@ -9,7 +9,7 @@ description: |
 # Claude Codex Handoff
 
 ## Goal
-Codex が最短で実装に着手できる依頼文を作成し、`codex exec "<依頼文>"` で渡す。
+Codex が最短で実装に着手できる依頼文を作成し、`codex exec --sandbox danger-full-access "<依頼文>"` で渡す。
 
 ## Workflow
 
@@ -88,7 +88,7 @@ cd backend && cargo fmt --check && cargo clippy --all-targets -- -D warnings && 
 依頼文を作成したら以下で実行:
 
 ```bash
-codex exec "<依頼文をここに貼る>"
+codex exec --sandbox danger-full-access "<依頼文をここに貼る>"
 ```
 
 非対話モードで実行するため `exec` サブコマンドを必ず使う（`codex "..."` は TTY なしで失敗する）。


### PR DESCRIPTION
## 概要
.agents が .claude への symlink になっているため、Codex の bwrap サンドボックスが起動時にクラッシュする問題を修正。

claude-codex-handoff スキルの `codex exec` 呼び出しに `--sandbox danger-full-access` を追加した。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Codex handoff命令のサンドボックスモード設定を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->