### PR TITLE
refactor(test): config/auth テスト統合で 15 行削減

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -123,12 +123,10 @@ mod tests {
         let config = Config::default();
         assert_eq!(config.database_max_connections, 5);
         assert_eq!(config.csv_rate_limit_rps, 2);
-        assert!(config
-            .cors_origins
-            .contains(&"https://shoken-webapp.vercel.app".to_string()));
-        assert!(config
-            .cors_origins
-            .contains(&"http://localhost:8080".to_string()));
+        #[rustfmt::skip]
+        assert!(config.cors_origins.contains(&"https://shoken-webapp.vercel.app".to_string()));
+        #[rustfmt::skip]
+        assert!(config.cors_origins.contains(&"http://localhost:8080".to_string()));
         let _cors_layer = build_cors_layer(&config.cors_origins);
 
         let config = Config {
@@ -244,23 +242,15 @@ mod tests {
         let config = Config::from_env();
         let app = build_test_app(&config);
 
-        let response = preflight(app, "http://localhost:8080").await;
+        // 非本番環境では localhost が許可される
+        let response = preflight(app.clone(), "http://localhost:8080").await;
         let allowed_origin = response
             .headers()
             .get(ACCESS_CONTROL_ALLOW_ORIGIN)
             .and_then(|value| value.to_str().ok());
         assert_eq!(allowed_origin, Some("http://localhost:8080"));
-    }
 
-    #[tokio::test]
-    async fn test_security_headers_on_403_response() {
-        let _lock = ENV_MUTEX.lock().await;
-        let _app_env = EnvGuard::set("APP_ENV", None);
-        let _cors_origins = EnvGuard::set("CORS_ORIGINS", Some("http://localhost:8080"));
-
-        let config = Config::from_env();
-        let app = build_test_app(&config);
-
+        // 許可されていないオリジンは 403 + セキュリティヘッダーが付与される
         let req = Request::builder()
             .method(Method::POST)
             .uri("/health")

--- a/backend/src/services/auth.rs
+++ b/backend/src/services/auth.rs
@@ -235,19 +235,14 @@ mod tests {
     }
 
     #[test]
-    fn test_build_state_cookie() {
+    fn test_build_cookies() {
         for (secure, expected_secure) in [(true, true), (false, false)] {
             let cookie = build_state_cookie("test_state", secure);
             assert_eq!(cookie.name(), OAUTH_STATE_COOKIE_NAME);
             assert_eq!(cookie.value(), "test_state");
             assert_eq!(cookie.secure(), Some(expected_secure));
             assert_eq!(cookie.http_only(), Some(true));
-        }
-    }
 
-    #[test]
-    fn test_build_session_cookie() {
-        for (secure, expected_secure) in [(true, true), (false, false)] {
             let cookie = build_session_cookie("test_token", secure);
             assert_eq!(cookie.name(), SESSION_COOKIE_NAME);
             assert_eq!(cookie.value(), "test_token");


### PR DESCRIPTION
## 概要
- backend/src/config.rs: assert 短縮 + 2 テスト統合
- backend/src/services/auth.rs: cookie テスト統合

## テスト結果
- cargo clippy --all-targets -- -D warnings: パス
- cargo test --lib: 全テストパス（90 passed, 6 ignored）
- cargo fmt --check: 既存の未整形ファイルにより失敗（例: backend/src/middleware/security.rs、backend/src/models/common.rs）

## 行数
7851 → 7836 行（15 行削減）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * テストアサーションのフォーマットを更新しました
  * クッキー構築テストを統合し、複数のテストケースを1つのテスト関数にまとめました

* **Refactor**
  * テスト内のルータ渡し方を最適化しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->