### PR TITLE
refactor: csv_import.rs のバリデーションエラーテストを統合で 17 行削減

### DIFF
--- a/backend/src/handlers/csv_import.rs
+++ b/backend/src/handlers/csv_import.rs
@@ -197,41 +197,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_read_csv_file_bytes_no_file_field() {
-        let response = test_app()
-            .oneshot(multipart_request("other", Some("positions.csv"), "dummy"))
-            .await
-            .unwrap();
+    async fn test_read_csv_file_bytes_validation_errors() {
+        for (field, filename, msg_fragment) in [
+            ("other", Some("positions.csv"), Some("fileフィールド")),
+            ("file", Some("positions.txt"), Some(".csv")),
+            ("file", Some(""), None),
+        ] {
+            let response = test_app()
+                .oneshot(multipart_request(field, filename, "dummy"))
+                .await
+                .unwrap();
 
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-        let error = read_error_response(response).await;
-        assert_eq!(error.error.code, "VALIDATION_ERROR");
-        assert!(error.error.message.contains("fileフィールド"));
-    }
-
-    #[tokio::test]
-    async fn test_read_csv_file_bytes_wrong_extension() {
-        let response = test_app()
-            .oneshot(multipart_request("file", Some("positions.txt"), "dummy"))
-            .await
-            .unwrap();
-
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-        let error = read_error_response(response).await;
-        assert_eq!(error.error.code, "VALIDATION_ERROR");
-        assert!(error.error.message.contains(".csv"));
-    }
-
-    #[tokio::test]
-    async fn test_read_csv_file_bytes_no_filename() {
-        let response = test_app()
-            .oneshot(multipart_request("file", Some(""), "dummy"))
-            .await
-            .unwrap();
-
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-        let error = read_error_response(response).await;
-        assert_eq!(error.error.code, "VALIDATION_ERROR");
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            let error = read_error_response(response).await;
+            assert_eq!(error.error.code, "VALIDATION_ERROR");
+            if let Some(fragment) = msg_fragment {
+                assert!(error.error.message.contains(fragment));
+            }
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## 概要
- backend/src/handlers/csv_import.rs: 3つの VALIDATION_ERROR テストを1つのパラメータ化テストに統合

## テスト結果
- cargo test --lib: 82 passed, 6 ignored
- cargo clippy --all-targets -- -D warnings: パス

## 行数
- 7811 → 7794 行（17 行削減）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * CSV インポート機能のバリデーションテストを改善し、複数のテストケースをひとつのパラメータ化テストに統合しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->