### PR TITLE
refactor: autoresearch ループ継続（iter 40〜）

### DIFF
--- a/autoresearch-results.tsv
+++ b/autoresearch-results.tsv
@@ -30,3 +30,4 @@ iteration	commit	metric	status	description
 28	840ed77	7881	kept	csv_util: テスト統合で 2 行削減
 29	20b7d2d	7878	kept	domestic_stock: テスト統合で 3 行削減
 30	956f903	7851	kept	rate_limit: テスト統合でさらに 27 行削減（172→145）
+31	ae39702	7743	kept	stock: リクエスト/JSON ヘルパー抽出で 51 行削減

--- a/autoresearch-results.tsv
+++ b/autoresearch-results.tsv
@@ -30,4 +30,12 @@ iteration	commit	metric	status	description
 28	840ed77	7881	kept	csv_util: テスト統合で 2 行削減
 29	20b7d2d	7878	kept	domestic_stock: テスト統合で 3 行削減
 30	956f903	7851	kept	rate_limit: テスト統合でさらに 27 行削減（172→145）
+32	f1b1a04	7734	kept	auth handler: 未認証テスト統合で 9 行削減
+33	437921a	7723	kept	config: CORS テスト共通化で 11 行削減
+34	747138e	7712	kept	routes: 認証必須テスト配列化で 11 行削減
+35	-	7716	reverted	errors: status コード表の配列化で 4 行増のためリバート
+36	-	7720	reverted	security: ヘッダー検証共通化で 8 行増のためリバート
+37	98233e3	7707	kept	auth service: cookie テスト統合で 5 行削減
+38	540e0e1	7706	kept	csv_import: JSON レスポンス読み出し共通化で 1 行削減
+END	-	7706	done	削減候補が1行削減のみになったため終了
 31	ae39702	7743	kept	stock: リクエスト/JSON ヘルパー抽出で 51 行削減

--- a/autoresearch-results.tsv
+++ b/autoresearch-results.tsv
@@ -30,6 +30,7 @@ iteration	commit	metric	status	description
 28	840ed77	7881	kept	csv_util: テスト統合で 2 行削減
 29	20b7d2d	7878	kept	domestic_stock: テスト統合で 3 行削減
 30	956f903	7851	kept	rate_limit: テスト統合でさらに 27 行削減（172→145）
+31	ae39702	7743	kept	stock: リクエスト/JSON ヘルパー抽出で 51 行削減
 32	f1b1a04	7734	kept	auth handler: 未認証テスト統合で 9 行削減
 33	437921a	7723	kept	config: CORS テスト共通化で 11 行削減
 34	747138e	7712	kept	routes: 認証必須テスト配列化で 11 行削減
@@ -38,4 +39,3 @@ iteration	commit	metric	status	description
 37	98233e3	7707	kept	auth service: cookie テスト統合で 5 行削減
 38	540e0e1	7706	kept	csv_import: JSON レスポンス読み出し共通化で 1 行削減
 END	-	7706	done	削減候補が1行削減のみになったため終了
-31	ae39702	7743	kept	stock: リクエスト/JSON ヘルパー抽出で 51 行削減

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -118,6 +118,23 @@ mod tests {
         app.oneshot(req).await.unwrap()
     }
 
+    async fn post_with_origin(app: Router, origin: &str) -> axum::response::Response {
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/health")
+            .header("origin", origin)
+            .body(Body::empty())
+            .unwrap();
+        app.oneshot(req).await.unwrap()
+    }
+
+    fn allowed_origin(response: &axum::response::Response) -> Option<&str> {
+        response
+            .headers()
+            .get(ACCESS_CONTROL_ALLOW_ORIGIN)
+            .and_then(|value| value.to_str().ok())
+    }
+
     #[test]
     fn test_config_creation() {
         let config = Config::default();
@@ -179,19 +196,11 @@ mod tests {
         let config = Config::from_env();
         let app = build_test_app(&config);
 
-        let response = preflight(app.clone(), "https://shoken-webapp.vercel.app").await;
-        let allowed_origin = response
-            .headers()
-            .get(ACCESS_CONTROL_ALLOW_ORIGIN)
-            .and_then(|value| value.to_str().ok());
-        assert_eq!(allowed_origin, Some("https://shoken-webapp.vercel.app"));
-
-        let response = preflight(app, "http://localhost:8080").await;
-        let allowed_origin = response
-            .headers()
-            .get(ACCESS_CONTROL_ALLOW_ORIGIN)
-            .and_then(|value| value.to_str().ok());
-        assert_eq!(allowed_origin, None);
+        assert_eq!(
+            allowed_origin(&preflight(app.clone(), "https://shoken-webapp.vercel.app").await),
+            Some("https://shoken-webapp.vercel.app")
+        );
+        assert_eq!(allowed_origin(&preflight(app, "http://localhost:8080").await), None);
     }
 
     #[tokio::test]
@@ -206,26 +215,14 @@ mod tests {
         let config = Config::from_env();
         let app = build_test_app(&config);
 
-        let req = Request::builder()
-            .method(Method::POST)
-            .uri("/health")
-            .header("origin", "http://custom-origin.example.com:8080")
-            .body(Body::empty())
-            .unwrap();
-        let resp = app.clone().oneshot(req).await.unwrap();
+        let resp = post_with_origin(app.clone(), "http://custom-origin.example.com:8080").await;
         assert_ne!(
             resp.status(),
             StatusCode::FORBIDDEN,
             "許可されたカスタムオリジンは通過すべき"
         );
 
-        let req = Request::builder()
-            .method(Method::POST)
-            .uri("/health")
-            .header("origin", "http://disallowed-origin.example.com")
-            .body(Body::empty())
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
+        let resp = post_with_origin(app, "http://disallowed-origin.example.com").await;
         assert_eq!(
             resp.status(),
             StatusCode::FORBIDDEN,
@@ -243,21 +240,13 @@ mod tests {
         let app = build_test_app(&config);
 
         // 非本番環境では localhost が許可される
-        let response = preflight(app.clone(), "http://localhost:8080").await;
-        let allowed_origin = response
-            .headers()
-            .get(ACCESS_CONTROL_ALLOW_ORIGIN)
-            .and_then(|value| value.to_str().ok());
-        assert_eq!(allowed_origin, Some("http://localhost:8080"));
+        assert_eq!(
+            allowed_origin(&preflight(app.clone(), "http://localhost:8080").await),
+            Some("http://localhost:8080")
+        );
 
         // 許可されていないオリジンは 403 + セキュリティヘッダーが付与される
-        let req = Request::builder()
-            .method(Method::POST)
-            .uri("/health")
-            .header("origin", "http://evil.example.com")
-            .body(Body::empty())
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
+        let resp = post_with_origin(app, "http://evil.example.com").await;
         assert_eq!(resp.status(), StatusCode::FORBIDDEN);
         assert_eq!(
             resp.headers().get("X-Content-Type-Options").unwrap(),

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -276,40 +276,31 @@ mod tests {
         serde_json::from_slice(&body).unwrap()
     }
 
-    #[tokio::test]
-    async fn test_get_current_user_no_cookie() {
+    async fn request_json<T: DeserializeOwned>(method: &str, uri: &str) -> (StatusCode, T) {
         let response = test_app()
             .oneshot(
                 Request::builder()
-                    .method("GET")
-                    .uri("/auth/me")
+                    .method(method)
+                    .uri(uri)
                     .body(Body::empty())
                     .unwrap(),
             )
             .await
             .unwrap();
-
-        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
-        let error: ErrorResponse = read_json_response(response).await;
-        assert_eq!(error.error.code, "UNAUTHORIZED");
-        assert!(error.error.message.contains("ログインが必要"));
+        let status = response.status();
+        (status, read_json_response(response).await)
     }
 
     #[tokio::test]
-    async fn test_logout_no_cookie() {
-        let response = test_app()
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri("/auth/logout")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
+    async fn test_auth_endpoints_without_cookie() {
+        let (status, error): (StatusCode, ErrorResponse) = request_json("GET", "/auth/me").await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(error.error.code, "UNAUTHORIZED");
+        assert!(error.error.message.contains("ログインが必要"));
 
-        assert_eq!(response.status(), StatusCode::OK);
-        let message: MessageResponse = read_json_response(response).await;
+        let (status, message): (StatusCode, MessageResponse) =
+            request_json("POST", "/auth/logout").await;
+        assert_eq!(status, StatusCode::OK);
         assert_eq!(message.message, "ログアウトしました");
     }
 }

--- a/backend/src/handlers/csv_import.rs
+++ b/backend/src/handlers/csv_import.rs
@@ -68,6 +68,7 @@ mod tests {
         routing::post,
         Router,
     };
+    use serde::de::DeserializeOwned;
     use sqlx::postgres::PgPoolOptions;
     use tower::ServiceExt;
     use uuid::Uuid;
@@ -152,7 +153,7 @@ mod tests {
             .unwrap()
     }
 
-    async fn read_error_response(response: axum::response::Response) -> ErrorResponse {
+    async fn read_json_response<T: DeserializeOwned>(response: axum::response::Response) -> T {
         let body = to_bytes(response.into_body(), BODY_LIMIT).await.unwrap();
         serde_json::from_slice(&body).unwrap()
     }
@@ -209,7 +210,7 @@ mod tests {
                 .unwrap();
 
             assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-            let error = read_error_response(response).await;
+            let error: ErrorResponse = read_json_response(response).await;
             assert_eq!(error.error.code, "VALIDATION_ERROR");
             if let Some(fragment) = msg_fragment {
                 assert!(error.error.message.contains(fragment));
@@ -225,8 +226,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
-        let body = to_bytes(response.into_body(), BODY_LIMIT).await.unwrap();
-        let preview: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let preview: serde_json::Value = read_json_response(response).await;
         assert_eq!(preview["valid_rows"], 1);
         assert_eq!(preview["rows"].as_array().unwrap().len(), 1);
     }
@@ -239,8 +239,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::CREATED);
-        let body = to_bytes(response.into_body(), BODY_LIMIT).await.unwrap();
-        let upload: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let upload: serde_json::Value = read_json_response(response).await;
         assert_eq!(upload["inserted"], 1);
         assert_eq!(upload["skipped"], 0);
     }

--- a/backend/src/handlers/stock/tests.rs
+++ b/backend/src/handlers/stock/tests.rs
@@ -17,6 +17,8 @@ use testcontainers_modules::postgres::Postgres as PgImage;
 use tokio::time::{sleep, timeout, Duration};
 use tower::ServiceExt;
 
+const BODY_LIMIT: usize = 100;
+
 /// testcontainers 経由で Postgres を起動し、マイグレーション + テストデータを投入する
 /// 戻り値: (pool, _node) で _node を drop すると停止する
 async fn setup_test_db() -> (Pool<Postgres>, impl Drop) {
@@ -98,6 +100,45 @@ fn setup_test_app(pool: Pool<Postgres>) -> Router {
         .with_state(app_state)
 }
 
+async fn call(
+    app: Router,
+    method: &str,
+    uri: &str,
+    body: Option<Value>,
+) -> axum::response::Response {
+    let mut request = Request::builder().method(method).uri(uri);
+    let body = if let Some(payload) = body {
+        request = request.header("content-type", "application/json");
+        Body::from(payload.to_string())
+    } else {
+        Body::empty()
+    };
+
+    app.oneshot(request.body(body).unwrap()).await.unwrap()
+}
+
+async fn read_json(response: axum::response::Response) -> Value {
+    let body = axum::body::to_bytes(response.into_body(), BODY_LIMIT)
+        .await
+        .unwrap();
+    serde_json::from_slice(&body).unwrap()
+}
+
+fn stock_payload(code: &str, name: &str) -> Value {
+    json!({
+        "date": "2025-03-25",
+        "code": code,
+        "name": name,
+        "market_category": "スタンダード",
+        "industry_code_33": "456",
+        "industry_category_33": "製造業",
+        "industry_code_17": "45",
+        "industry_category_17": "製造",
+        "size_code": "20",
+        "size_category": "中型株"
+    })
+}
+
 #[tokio::test]
 #[ignore = "requires Docker to run Postgres container"]
 async fn test_search_stock() {
@@ -105,128 +146,51 @@ async fn test_search_stock() {
     let app = setup_test_app(pool);
 
     // コードによる検索テスト
-    let response = app
-        .clone()
-        .oneshot(
-            Request::builder()
-                .uri("/stocks/1234")
-                .method("GET")
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
+    let response = call(app.clone(), "GET", "/stocks/1234", None).await;
     assert_eq!(response.status(), StatusCode::OK);
-
-    let body = axum::body::to_bytes(response.into_body(), 100)
-        .await
-        .unwrap();
-    let stock: Value = serde_json::from_slice(&body).unwrap();
-
+    let stock = read_json(response).await;
     assert_eq!(stock["code"], "1234");
     assert_eq!(stock["name"], "テスト株式会社");
 
     // 銘柄名による検索テスト
-    let response = app
-        .clone()
-        .oneshot(
-            Request::builder()
-                .uri("/stocks/テスト")
-                .method("GET")
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
-    assert_eq!(response.status(), StatusCode::OK);
-
-    // 存在しない銘柄コードのテスト
-    let response = app
-        .clone()
-        .oneshot(
-            Request::builder()
-                .uri("/stocks/9999")
-                .method("GET")
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
-    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    for (uri, expected_status) in [
+        ("/stocks/テスト", StatusCode::OK),
+        ("/stocks/9999", StatusCode::NOT_FOUND),
+    ] {
+        assert_eq!(
+            call(app.clone(), "GET", uri, None).await.status(),
+            expected_status
+        );
+    }
 }
 
 #[tokio::test]
 #[ignore = "requires Docker to run Postgres container"]
 async fn test_create_stock() {
     let (pool, _node) = setup_test_db().await;
-    let app = setup_test_app(pool.clone());
+    let app = setup_test_app(pool);
 
-    let stock_data = json!({
-        "date": "2025-03-25",
-        "code": "5678",
-        "name": "新規テスト株式会社",
-        "market_category": "スタンダード",
-        "industry_code_33": "456",
-        "industry_category_33": "製造業",
-        "industry_code_17": "45",
-        "industry_category_17": "製造",
-        "size_code": "20",
-        "size_category": "中型株"
-    });
-
-    let response = app
-        .clone()
-        .oneshot(
-            Request::builder()
-                .uri("/stocks")
-                .method("POST")
-                .header("content-type", "application/json")
-                .body(Body::from(stock_data.to_string()))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
+    let response = call(
+        app.clone(),
+        "POST",
+        "/stocks",
+        Some(stock_payload("5678", "新規テスト株式会社")),
+    )
+    .await;
 
     assert_eq!(response.status(), StatusCode::CREATED);
-
-    let body = axum::body::to_bytes(response.into_body(), 100)
-        .await
-        .unwrap();
-    let stock: Value = serde_json::from_slice(&body).unwrap();
-
+    let stock = read_json(response).await;
     assert_eq!(stock["code"], "5678");
     assert_eq!(stock["name"], "新規テスト株式会社");
 
-    let invalid_data = json!({
-        "date": "2025-03-25",
-        "code": "",
-        "name": "新規テスト株式会社",
-        "market_category": "スタンダード",
-        "industry_code_33": "456",
-        "industry_category_33": "製造業",
-        "industry_code_17": "45",
-        "industry_category_17": "製造",
-        "size_code": "20",
-        "size_category": "中型株"
-    });
-
-    let response = app
-        .clone()
-        .oneshot(
-            Request::builder()
-                .uri("/stocks")
-                .method("POST")
-                .header("content-type", "application/json")
-                .body(Body::from(invalid_data.to_string()))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let mut invalid_data = stock_payload("5678", "新規テスト株式会社");
+    invalid_data["code"] = json!("");
+    assert_eq!(
+        call(app, "POST", "/stocks", Some(invalid_data))
+            .await
+            .status(),
+        StatusCode::BAD_REQUEST
+    );
 }
 
 /// 未認証時に POST /stocks が 401 を返すことを確認
@@ -237,31 +201,16 @@ async fn test_create_stock_unauthorized() {
         .unwrap();
     let app = setup_test_app(pool);
 
-    let stock_data = json!({
-        "date": "2025-03-25",
-        "code": "9999",
-        "name": "未認証テスト",
-        "market_category": "プライム",
-        "industry_code_33": null,
-        "industry_category_33": null,
-        "industry_code_17": null,
-        "industry_category_17": null,
-        "size_code": null,
-        "size_category": null
-    });
-
     // セッション Cookie なしでリクエスト
-    let response = app
-        .oneshot(
-            Request::builder()
-                .uri("/stocks")
-                .method("POST")
-                .header("content-type", "application/json")
-                .body(Body::from(stock_data.to_string()))
-                .unwrap(),
+    assert_eq!(
+        call(
+            app,
+            "POST",
+            "/stocks",
+            Some(stock_payload("9999", "未認証テスト"))
         )
         .await
-        .unwrap();
-
-    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        .status(),
+        StatusCode::UNAUTHORIZED
+    );
 }

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -127,7 +127,7 @@ fn csv_upload_routes() -> Router<AppState> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum::{body::Body, http::Request};
+    use axum::{body::Body, http::{Method, Request}};
     use crate::test_env::{EnvGuard, ENV_MUTEX};
     use std::sync::Arc;
     use tower::ServiceExt;
@@ -176,7 +176,7 @@ mod tests {
         }
         .with_state(state);
 
-        assert_rate_limited(router, axum::http::Method::GET, "/auth/me", Some("1.2.3.4")).await;
+        assert_rate_limited(router, Method::GET, "/auth/me", Some("1.2.3.4")).await;
     }
 
     /// jquants ルートが rps=1 制限を超えると 429 を返すことを確認
@@ -193,13 +193,13 @@ mod tests {
             handlers::jquants::jquants_routes()
         }
         .with_state(state);
-        assert_rate_limited(router, axum::http::Method::GET, "/jquants/fins/summary", None).await;
+        assert_rate_limited(router, Method::GET, "/jquants/fins/summary", None).await;
     }
 
     /// rps=1 ルーターに同一条件で 2 回リクエストし、2 回目が 429 になることを検証するヘルパー
     async fn assert_rate_limited(
         router: axum::Router,
-        method: axum::http::Method,
+        method: Method,
         uri: &str,
         ip: Option<&str>,
     ) {
@@ -215,7 +215,7 @@ mod tests {
     }
 
     /// セッション Cookie なしでルーターにリクエストを送り、401 が返ることを検証するヘルパー
-    async fn check_unauthorized(router: axum::Router, method: axum::http::Method, uri: &str) {
+    async fn check_unauthorized(router: axum::Router, method: Method, uri: &str) {
         let response = router
             .oneshot(
                 Request::builder()
@@ -231,97 +231,86 @@ mod tests {
 
     #[tokio::test]
     async fn test_all_endpoints_require_auth() {
-        check_unauthorized(
-            handlers::jquants::jquants_routes().with_state(make_test_state()),
-            axum::http::Method::GET,
-            "/jquants/fins/summary?code=7203",
-        )
-        .await;
-        check_unauthorized(
-            handlers::dividend::dividend_routes().with_state(make_test_state()),
-            axum::http::Method::DELETE,
-            "/dividends",
-        )
-        .await;
-        check_unauthorized(
-            handlers::dividend::dividend_routes().with_state(make_test_state()),
-            axum::http::Method::GET,
-            "/dividends",
-        )
-        .await;
-        check_unauthorized(
-            handlers::dividend::dividend_routes().with_state(make_test_state()),
-            axum::http::Method::POST,
-            "/dividends/csv/preview",
-        )
-        .await;
-        check_unauthorized(
-            handlers::domestic_stock::domestic_stock_routes().with_state(make_test_state()),
-            axum::http::Method::DELETE,
-            "/domestic-stocks",
-        )
-        .await;
-        check_unauthorized(
-            handlers::domestic_stock::domestic_stock_routes().with_state(make_test_state()),
-            axum::http::Method::GET,
-            "/domestic-stocks",
-        )
-        .await;
-        check_unauthorized(
-            handlers::domestic_stock::domestic_stock_routes().with_state(make_test_state()),
-            axum::http::Method::POST,
-            "/domestic-stocks/csv/preview",
-        )
-        .await;
-        check_unauthorized(
-            handlers::mutualfund::mutualfund_routes().with_state(make_test_state()),
-            axum::http::Method::DELETE,
-            "/mutualfunds",
-        )
-        .await;
-        check_unauthorized(
-            handlers::mutualfund::mutualfund_routes().with_state(make_test_state()),
-            axum::http::Method::GET,
-            "/mutualfunds",
-        )
-        .await;
-        check_unauthorized(
-            handlers::mutualfund::mutualfund_routes().with_state(make_test_state()),
-            axum::http::Method::POST,
-            "/mutualfunds/csv/preview",
-        )
-        .await;
-        check_unauthorized(
-            handlers::asset_balance::asset_balance_routes().with_state(make_test_state()),
-            axum::http::Method::DELETE,
-            "/asset-balances",
-        )
-        .await;
-        check_unauthorized(
-            handlers::asset_balance::asset_balance_routes().with_state(make_test_state()),
-            axum::http::Method::POST,
-            "/asset-balances/bulk",
-        )
-        .await;
-        check_unauthorized(
-            handlers::asset_balance::asset_balance_routes().with_state(make_test_state()),
-            axum::http::Method::POST,
-            "/asset-balances/csv/preview",
-        )
-        .await;
-        check_unauthorized(
-            csv_upload_routes().with_state(make_test_state()),
-            axum::http::Method::POST,
-            "/dividends/csv",
-        )
-        .await;
-        check_unauthorized(
-            handlers::dividend_per_share::dividend_per_share_routes()
-                .with_state(make_test_state()),
-            axum::http::Method::POST,
-            "/dividends/per-share/batch",
-        )
-        .await;
+        for (router, method, uri) in [
+            (
+                handlers::jquants::jquants_routes().with_state(make_test_state()),
+                Method::GET,
+                "/jquants/fins/summary?code=7203",
+            ),
+            (
+                handlers::dividend::dividend_routes().with_state(make_test_state()),
+                Method::DELETE,
+                "/dividends",
+            ),
+            (
+                handlers::dividend::dividend_routes().with_state(make_test_state()),
+                Method::GET,
+                "/dividends",
+            ),
+            (
+                handlers::dividend::dividend_routes().with_state(make_test_state()),
+                Method::POST,
+                "/dividends/csv/preview",
+            ),
+            (
+                handlers::domestic_stock::domestic_stock_routes().with_state(make_test_state()),
+                Method::DELETE,
+                "/domestic-stocks",
+            ),
+            (
+                handlers::domestic_stock::domestic_stock_routes().with_state(make_test_state()),
+                Method::GET,
+                "/domestic-stocks",
+            ),
+            (
+                handlers::domestic_stock::domestic_stock_routes().with_state(make_test_state()),
+                Method::POST,
+                "/domestic-stocks/csv/preview",
+            ),
+            (
+                handlers::mutualfund::mutualfund_routes().with_state(make_test_state()),
+                Method::DELETE,
+                "/mutualfunds",
+            ),
+            (
+                handlers::mutualfund::mutualfund_routes().with_state(make_test_state()),
+                Method::GET,
+                "/mutualfunds",
+            ),
+            (
+                handlers::mutualfund::mutualfund_routes().with_state(make_test_state()),
+                Method::POST,
+                "/mutualfunds/csv/preview",
+            ),
+            (
+                handlers::asset_balance::asset_balance_routes().with_state(make_test_state()),
+                Method::DELETE,
+                "/asset-balances",
+            ),
+            (
+                handlers::asset_balance::asset_balance_routes().with_state(make_test_state()),
+                Method::POST,
+                "/asset-balances/bulk",
+            ),
+            (
+                handlers::asset_balance::asset_balance_routes().with_state(make_test_state()),
+                Method::POST,
+                "/asset-balances/csv/preview",
+            ),
+            (
+                csv_upload_routes().with_state(make_test_state()),
+                Method::POST,
+                "/dividends/csv",
+            ),
+            (
+                handlers::dividend_per_share::dividend_per_share_routes()
+                    .with_state(make_test_state()),
+                Method::POST,
+                "/dividends/per-share/batch",
+            ),
+        ] {
+            check_unauthorized(router, method, uri).await;
+        }
     }
 
     /// CSV upload ルートだけが IP 単位レート制限の対象になることを確認
@@ -337,12 +326,12 @@ mod tests {
             ("/asset-balances/csv", "1.2.3.7"),
         ] {
             let router = app_router(make_test_state(), &Config::from_env());
-            assert_rate_limited(router, axum::http::Method::POST, path, Some(ip)).await;
+            assert_rate_limited(router, Method::POST, path, Some(ip)).await;
         }
 
         // プレビューエンドポイントはレート制限対象外
         let req = Request::builder()
-            .method(axum::http::Method::POST)
+            .method(Method::POST)
             .uri("/domestic-stocks/csv/preview")
             .header("fly-client-ip", "1.2.3.4")
             .body(Body::empty())
@@ -364,7 +353,7 @@ mod tests {
 
         // x-request-id ヘッダーなし → 自動生成されてレスポンスに付与される
         let req = Request::builder()
-            .method(axum::http::Method::GET)
+            .method(Method::GET)
             .uri("/health")
             .body(Body::empty())
             .unwrap();
@@ -376,7 +365,7 @@ mod tests {
 
         // x-request-id ヘッダーあり → 既存値がそのままレスポンスに伝播される
         let req = Request::builder()
-            .method(axum::http::Method::GET)
+            .method(Method::GET)
             .uri("/health")
             .header("x-request-id", "my-custom-id")
             .body(Body::empty())

--- a/backend/src/services/auth.rs
+++ b/backend/src/services/auth.rs
@@ -252,16 +252,6 @@ mod tests {
     }
 
     #[test]
-    fn test_clear_cookies() {
-        let s = clear_state_cookie(true);
-        assert_eq!(s.name(), OAUTH_STATE_COOKIE_NAME);
-        assert_eq!(s.value(), "");
-        let c = clear_session_cookie(true);
-        assert_eq!(c.name(), SESSION_COOKIE_NAME);
-        assert_eq!(c.value(), "");
-    }
-
-    #[test]
     fn test_get_session_id_from_jar() {
         assert!(get_session_id_from_jar(&CookieJar::new()).is_err());
 
@@ -270,13 +260,18 @@ mod tests {
 
         let uuid = uuid::Uuid::new_v4();
         let jar = CookieJar::new().add(Cookie::new(SESSION_COOKIE_NAME, uuid.to_string()));
-        let result = get_session_id_from_jar(&jar);
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), uuid);
+        assert_eq!(get_session_id_from_jar(&jar).unwrap(), uuid);
     }
 
     #[test]
-    fn test_simple_auth_functions() {
+    fn test_cookie_helpers_and_constants() {
+        for (cookie, expected_name) in [
+            (clear_state_cookie(true), OAUTH_STATE_COOKIE_NAME),
+            (clear_session_cookie(true), SESSION_COOKIE_NAME),
+        ] {
+            assert_eq!(cookie.name(), expected_name);
+            assert_eq!(cookie.value(), "");
+        }
         assert_eq!(same_site(true), SameSite::None);
         assert_eq!(same_site(false), SameSite::Lax);
         assert_eq!(SESSION_COOKIE_NAME, "session_token");


### PR DESCRIPTION
## 概要
backend/src/**/*.rs の autoresearch ループを継続し、#[cfg(test)] 内の統合だけで総行数を削減しました。

## 今回の keep
- handlers/auth.rs: 未認証テスト統合で 9 行削減
- config.rs: CORS テスト共通化で 11 行削減
- routes.rs: 認証必須テスト配列化で 11 行削減
- services/auth.rs: cookie テスト統合で 5 行削減
- handlers/csv_import.rs: JSON レスポンス読み出し共通化で 1 行削減

## 結果
- 総行数: 7743 -> 7706
- 終了理由: 削減候補が 1 行削減のみになったため終了
- 進捗記録: autoresearch-results.tsv に iter 32〜38 と END を追記

## テスト
- cd backend && cargo test --lib -q
- pre-push hook による openapi/api.ts 同期確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

本PR変更により、エンドユーザーに対する新機能、バグ修正、またはその他の影響はありません。

* **Tests**
  * テストコードを整理・統合し、共通ヘルパーを導入して可読性と保守性を向上しました（複数のテストケースをループ化・共通化）。
* **Chores**
  * テスト内の繰り返し処理を簡素化し、期待値チェックを統一しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->