### PR TITLE
chore: cargo fmt 正規化（iter 40）

### DIFF
--- a/autoresearch-results.tsv
+++ b/autoresearch-results.tsv
@@ -30,12 +30,4 @@ iteration	commit	metric	status	description
 28	840ed77	7881	kept	csv_util: テスト統合で 2 行削減
 29	20b7d2d	7878	kept	domestic_stock: テスト統合で 3 行削減
 30	956f903	7851	kept	rate_limit: テスト統合でさらに 27 行削減（172→145）
-31	ae39702	7743	kept	stock: リクエスト/JSON ヘルパー抽出で 51 行削減
-32	f1b1a04	7734	kept	auth handler: 未認証テスト統合で 9 行削減
-33	437921a	7723	kept	config: CORS テスト共通化で 11 行削減
-34	747138e	7712	kept	routes: 認証必須テスト配列化で 11 行削減
-35	-	7716	reverted	errors: status コード表の配列化で 4 行増のためリバート
-36	-	7720	reverted	security: ヘッダー検証共通化で 8 行増のためリバート
-37	98233e3	7707	kept	auth service: cookie テスト統合で 5 行削減
-38	540e0e1	7706	kept	csv_import: JSON レスポンス読み出し共通化で 1 行削減
-END	-	7706	done	削減候補が1行削減のみになったため終了
+31	464dd22	7794	kept	squash-merge 後の実測値（iter30記録と差異あり）

--- a/autoresearch-results.tsv
+++ b/autoresearch-results.tsv
@@ -31,3 +31,6 @@ iteration	commit	metric	status	description
 29	20b7d2d	7878	kept	domestic_stock: テスト統合で 3 行削減
 30	956f903	7851	kept	rate_limit: テスト統合でさらに 27 行削減（172→145）
 31	464dd22	7794	kept	squash-merge 後の実測値（iter30記録と差異あり）
+32	b7b480d	7706	kept	squash-merge #337（iter 32〜38: stock/auth/config/routes/csv_import で 88 行削減）
+39	98f63f9	7691	kept	security: ヘッダーテストのリクエスト構築共通化で 15 行削減
+40	(pending)	7857	fmt-cleanup	cargo fmt 正規化: 過去の assert 一行化を展開。errors.rs serde_err 型注釈削除で 1 行削減

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -200,7 +200,10 @@ mod tests {
             allowed_origin(&preflight(app.clone(), "https://shoken-webapp.vercel.app").await),
             Some("https://shoken-webapp.vercel.app")
         );
-        assert_eq!(allowed_origin(&preflight(app, "http://localhost:8080").await), None);
+        assert_eq!(
+            allowed_origin(&preflight(app, "http://localhost:8080").await),
+            None
+        );
     }
 
     #[tokio::test]

--- a/backend/src/errors.rs
+++ b/backend/src/errors.rs
@@ -216,8 +216,7 @@ mod tests {
             ApiError::OAuthError("認証エラー".to_string()),
             StatusCode::INTERNAL_SERVER_ERROR,
         );
-        let serde_err: serde_json::Error =
-            serde_json::from_str::<serde_json::Value>("invalid json").unwrap_err();
+        let serde_err = serde_json::from_str::<serde_json::Value>("invalid json").unwrap_err();
         check_status(
             ApiError::Unauthorized("認証が必要です".to_string()),
             StatusCode::UNAUTHORIZED,

--- a/backend/src/middleware/security.rs
+++ b/backend/src/middleware/security.rs
@@ -202,36 +202,31 @@ mod tests {
         assert_eq!(oneshot_status(app, Method::DELETE, &[("origin", "https://evil.example.com")]).await, StatusCode::FORBIDDEN);
     }
 
+    async fn security_headers_response() -> axum::response::Response {
+        security_headers_app()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/test")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    }
+
     #[tokio::test]
     async fn test_security_headers_present() {
         let _lock = ENV_MUTEX.lock().await;
         let _secure_cookie = EnvGuard::set("SECURE_COOKIE", None);
         let _backend_url = EnvGuard::set("BACKEND_URL", None);
 
-        let app = security_headers_app();
-        let req = Request::builder()
-            .method(Method::POST)
-            .uri("/test")
-            .body(Body::empty())
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(
-            resp.headers().get("X-Content-Type-Options").unwrap(),
-            "nosniff"
-        );
+        let resp = security_headers_response().await;
+        assert_eq!(resp.headers().get("X-Content-Type-Options").unwrap(), "nosniff");
         assert_eq!(resp.headers().get("X-Frame-Options").unwrap(), "DENY");
-        assert_eq!(
-            resp.headers().get("Referrer-Policy").unwrap(),
-            "strict-origin-when-cross-origin"
-        );
-        assert_eq!(
-            resp.headers().get("Content-Security-Policy").unwrap(),
-            "default-src 'none'"
-        );
-        assert!(
-            resp.headers().get("Strict-Transport-Security").is_none(),
-            "secure cookie 無効時は HSTS を付与しない"
-        );
+        assert_eq!(resp.headers().get("Referrer-Policy").unwrap(), "strict-origin-when-cross-origin");
+        assert_eq!(resp.headers().get("Content-Security-Policy").unwrap(), "default-src 'none'");
+        assert!(resp.headers().get("Strict-Transport-Security").is_none(), "secure cookie 無効時は HSTS を付与しない");
     }
 
     #[tokio::test]
@@ -239,17 +234,7 @@ mod tests {
         let _lock = ENV_MUTEX.lock().await;
         let _secure_cookie = EnvGuard::set("SECURE_COOKIE", Some("true"));
 
-        let app = security_headers_app();
-        let req = Request::builder()
-            .method(Method::POST)
-            .uri("/test")
-            .body(Body::empty())
-            .unwrap();
-        let resp = app.oneshot(req).await.unwrap();
-
-        assert_eq!(
-            resp.headers().get("Strict-Transport-Security").unwrap(),
-            "max-age=31536000; includeSubDomains"
-        );
+        let resp = security_headers_response().await;
+        assert_eq!(resp.headers().get("Strict-Transport-Security").unwrap(), "max-age=31536000; includeSubDomains");
     }
 }

--- a/backend/src/middleware/security.rs
+++ b/backend/src/middleware/security.rs
@@ -133,10 +133,19 @@ mod tests {
 
     #[test]
     fn test_extract_origin() {
-        assert_eq!(extract_origin("http://localhost:8080/some/page"), Some("http://localhost:8080"));
-        assert_eq!(extract_origin("https://shoken-webapp.vercel.app"), Some("https://shoken-webapp.vercel.app"));
+        assert_eq!(
+            extract_origin("http://localhost:8080/some/page"),
+            Some("http://localhost:8080")
+        );
+        assert_eq!(
+            extract_origin("https://shoken-webapp.vercel.app"),
+            Some("https://shoken-webapp.vercel.app")
+        );
         // 許可ドメインを接頭辞に持つ偽装ドメインは別オリジンとして抽出される
-        assert_eq!(extract_origin("https://shoken-webapp.vercel.app.evil.com/steal"), Some("https://shoken-webapp.vercel.app.evil.com"));
+        assert_eq!(
+            extract_origin("https://shoken-webapp.vercel.app.evil.com/steal"),
+            Some("https://shoken-webapp.vercel.app.evil.com")
+        );
     }
 
     fn test_app() -> Router {
@@ -167,27 +176,53 @@ mod tests {
         for (name, value) in headers {
             builder = builder.header(*name, *value);
         }
-        app.oneshot(builder.body(Body::empty()).unwrap()).await.unwrap().status()
+        app.oneshot(builder.body(Body::empty()).unwrap())
+            .await
+            .unwrap()
+            .status()
     }
 
     #[tokio::test]
     async fn test_get_request_passes() {
         // GET はルート定義がないので 405 だが、ミドルウェアは通過
-        assert_ne!(oneshot_status(test_app(), Method::GET, &[]).await, StatusCode::FORBIDDEN);
+        assert_ne!(
+            oneshot_status(test_app(), Method::GET, &[]).await,
+            StatusCode::FORBIDDEN
+        );
     }
 
     #[tokio::test]
     async fn test_validate_origin() {
         let cases: &[(&[(&str, &str)], StatusCode)] = &[
             (&[("origin", "http://localhost:8080")], StatusCode::OK),
-            (&[("origin", "https://evil.example.com")], StatusCode::FORBIDDEN),
+            (
+                &[("origin", "https://evil.example.com")],
+                StatusCode::FORBIDDEN,
+            ),
             (&[], StatusCode::OK), // Origin なしは同一オリジンとみなし通過
-            (&[("referer", "http://localhost:8080/some/page")], StatusCode::OK), // Origin なし・許可済み Referer あり → 通過
-            (&[("referer", "https://evil.example.com/attack")], StatusCode::FORBIDDEN), // Origin なし・不正な Referer → 403
-            (&[("referer", "https://shoken-webapp.vercel.app.evil.com/steal")], StatusCode::FORBIDDEN), // 偽装ドメイン
-            (&[("origin", "https://shoken-webapp.vercel.app")], StatusCode::OK),
+            (
+                &[("referer", "http://localhost:8080/some/page")],
+                StatusCode::OK,
+            ), // Origin なし・許可済み Referer あり → 通過
+            (
+                &[("referer", "https://evil.example.com/attack")],
+                StatusCode::FORBIDDEN,
+            ), // Origin なし・不正な Referer → 403
+            (
+                &[("referer", "https://shoken-webapp.vercel.app.evil.com/steal")],
+                StatusCode::FORBIDDEN,
+            ), // 偽装ドメイン
+            (
+                &[("origin", "https://shoken-webapp.vercel.app")],
+                StatusCode::OK,
+            ),
         ];
-        for &(headers, expected) in cases { assert_eq!(oneshot_status(test_app(), Method::POST, headers).await, expected); }
+        for &(headers, expected) in cases {
+            assert_eq!(
+                oneshot_status(test_app(), Method::POST, headers).await,
+                expected
+            );
+        }
     }
 
     #[tokio::test]
@@ -199,7 +234,15 @@ mod tests {
                 let origins = allowed_origins.clone();
                 async move { validate_origin(origins, req, next).await }
             }));
-        assert_eq!(oneshot_status(app, Method::DELETE, &[("origin", "https://evil.example.com")]).await, StatusCode::FORBIDDEN);
+        assert_eq!(
+            oneshot_status(
+                app,
+                Method::DELETE,
+                &[("origin", "https://evil.example.com")]
+            )
+            .await,
+            StatusCode::FORBIDDEN
+        );
     }
 
     async fn security_headers_response() -> axum::response::Response {
@@ -222,11 +265,23 @@ mod tests {
         let _backend_url = EnvGuard::set("BACKEND_URL", None);
 
         let resp = security_headers_response().await;
-        assert_eq!(resp.headers().get("X-Content-Type-Options").unwrap(), "nosniff");
+        assert_eq!(
+            resp.headers().get("X-Content-Type-Options").unwrap(),
+            "nosniff"
+        );
         assert_eq!(resp.headers().get("X-Frame-Options").unwrap(), "DENY");
-        assert_eq!(resp.headers().get("Referrer-Policy").unwrap(), "strict-origin-when-cross-origin");
-        assert_eq!(resp.headers().get("Content-Security-Policy").unwrap(), "default-src 'none'");
-        assert!(resp.headers().get("Strict-Transport-Security").is_none(), "secure cookie 無効時は HSTS を付与しない");
+        assert_eq!(
+            resp.headers().get("Referrer-Policy").unwrap(),
+            "strict-origin-when-cross-origin"
+        );
+        assert_eq!(
+            resp.headers().get("Content-Security-Policy").unwrap(),
+            "default-src 'none'"
+        );
+        assert!(
+            resp.headers().get("Strict-Transport-Security").is_none(),
+            "secure cookie 無効時は HSTS を付与しない"
+        );
     }
 
     #[tokio::test]
@@ -235,6 +290,9 @@ mod tests {
         let _secure_cookie = EnvGuard::set("SECURE_COOKIE", Some("true"));
 
         let resp = security_headers_response().await;
-        assert_eq!(resp.headers().get("Strict-Transport-Security").unwrap(), "max-age=31536000; includeSubDomains");
+        assert_eq!(
+            resp.headers().get("Strict-Transport-Security").unwrap(),
+            "max-age=31536000; includeSubDomains"
+        );
     }
 }

--- a/backend/src/models/common.rs
+++ b/backend/src/models/common.rs
@@ -20,14 +20,19 @@ mod tests {
 
     #[test]
     fn test_serde_round_trips() {
-        let r = BulkCreateResponse { inserted: 3, skipped: 2 };
+        let r = BulkCreateResponse {
+            inserted: 3,
+            skipped: 2,
+        };
         let json = serde_json::to_string(&r).expect("BulkCreateResponse should serialize");
         let d: BulkCreateResponse =
             serde_json::from_str(&json).expect("BulkCreateResponse should deserialize");
         assert_eq!(d.inserted, r.inserted);
         assert_eq!(d.skipped, r.skipped);
 
-        let r = MessageResponse { message: "ok".to_string() };
+        let r = MessageResponse {
+            message: "ok".to_string(),
+        };
         let json = serde_json::to_string(&r).expect("MessageResponse should serialize");
         let d: MessageResponse =
             serde_json::from_str(&json).expect("MessageResponse should deserialize");

--- a/backend/src/models/stock.rs
+++ b/backend/src/models/stock.rs
@@ -49,8 +49,12 @@ mod tests {
 
     #[test]
     fn test_stock_validation() {
-        assert!(make_stock("1234", "テスト株式会社", "プライム").validate().is_ok());
-        assert!(make_stock("", "テスト株式会社", "プライム").validate().is_err());
+        assert!(make_stock("1234", "テスト株式会社", "プライム")
+            .validate()
+            .is_ok());
+        assert!(make_stock("", "テスト株式会社", "プライム")
+            .validate()
+            .is_err());
         assert!(make_stock("1234", "", "プライム").validate().is_err());
         assert!(make_stock("1234", "テスト株式会社", "").validate().is_err());
     }

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -127,8 +127,11 @@ fn csv_upload_routes() -> Router<AppState> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum::{body::Body, http::{Method, Request}};
     use crate::test_env::{EnvGuard, ENV_MUTEX};
+    use axum::{
+        body::Body,
+        http::{Method, Request},
+    };
     use std::sync::Arc;
     use tower::ServiceExt;
 
@@ -205,7 +208,9 @@ mod tests {
     ) {
         let make_req = || {
             let mut b = Request::builder().method(method.clone()).uri(uri);
-            if let Some(ip) = ip { b = b.header("fly-client-ip", ip); }
+            if let Some(ip) = ip {
+                b = b.header("fly-client-ip", ip);
+            }
             b.body(Body::empty()).unwrap()
         };
         let resp = router.clone().oneshot(make_req()).await.unwrap();
@@ -336,7 +341,10 @@ mod tests {
             .header("fly-client-ip", "1.2.3.4")
             .body(Body::empty())
             .unwrap();
-        let resp = app_router(make_test_state(), &Config::from_env()).oneshot(req).await.unwrap();
+        let resp = app_router(make_test_state(), &Config::from_env())
+            .oneshot(req)
+            .await
+            .unwrap();
         assert_ne!(resp.status(), axum::http::StatusCode::TOO_MANY_REQUESTS);
     }
 

--- a/backend/src/services/asset_balance.rs
+++ b/backend/src/services/asset_balance.rs
@@ -246,10 +246,8 @@ mod tests {
     const HEADER: &str =
         "銘柄コード,銘柄名,保有数量［株］,執行中［株］,平均取得価額［円］,取得総額［円］,現在値［円］,現在値（前日比）［円］,時価評価額［円］,評価損益［％］";
     const ASSET_BALANCE_CSV_HEADER: &str = "銘柄コード,銘柄名,保有数量［株］,執行中［株］,(内訳　通常数量[株]),(内訳　積立数量[株]),平均取得価額［円］,取得総額［円］,現在値［円］,現在値（前日比）［円］,時価評価額［円］,評価損益［％］";
-    const TEST_ROW_1: &str =
-        "1234,テスト株式会社,100,0,100,0,1500,150000,1600,10,160000,6.67";
-    const TEST_ROW_2: &str =
-        "5678,サンプル株式会社,200,0,200,0,1800,360000,1900,15,380000,5.56";
+    const TEST_ROW_1: &str = "1234,テスト株式会社,100,0,100,0,1500,150000,1600,10,160000,6.67";
+    const TEST_ROW_2: &str = "5678,サンプル株式会社,200,0,200,0,1800,360000,1900,15,380000,5.56";
     const INPEX_ROW: &str =
         "\"1605\",\"ＩＮＰＥＸ\",\"200\",\"0\",\"200\",\"0\",\"2,355.00\",\"471,000\",\"3,685.0\",\"65.0\",\"737,000\",\"56.47\"";
     const NINTENDO_ROW: &str =
@@ -258,7 +256,11 @@ mod tests {
         ",,,,,,特定口座合計,\"11,245,249\",,,\"14,517,240\",\"29.09\"";
 
     fn parse_row_csv(row: &str) -> (Vec<CreateAssetBalanceRequest>, Vec<CsvRowError>) {
-        parse_csv(format!("{HEADER}\n{row}\n").as_bytes(), parse_asset_balance_row).unwrap()
+        parse_csv(
+            format!("{HEADER}\n{row}\n").as_bytes(),
+            parse_asset_balance_row,
+        )
+        .unwrap()
     }
 
     fn make_asset_balance_csv(rows: &[&str]) -> String {
@@ -268,7 +270,10 @@ mod tests {
         )
     }
 
-    fn assert_row_ok(row: &str, expected: (&str, Decimal, Decimal, Decimal, Decimal, Decimal, Decimal)) {
+    fn assert_row_ok(
+        row: &str,
+        expected: (&str, Decimal, Decimal, Decimal, Decimal, Decimal, Decimal),
+    ) {
         let (items, errors) = parse_row_csv(row);
         assert!(errors.is_empty(), "unexpected errors for {row}: {errors:?}");
         assert_eq!(items.len(), 1, "row should produce one item: {row}");
@@ -298,7 +303,10 @@ mod tests {
     fn test_preview_csv_valid() {
         let csv = make_asset_balance_csv(&[INPEX_ROW, NINTENDO_ROW, ACCOUNT_SUMMARY_ROW]);
         let preview = preview_csv(csv.as_bytes()).unwrap();
-        assert_eq!((preview.total_rows, preview.valid_rows, preview.rows.len()), (2, 2, 2));
+        assert_eq!(
+            (preview.total_rows, preview.valid_rows, preview.rows.len()),
+            (2, 2, 2)
+        );
         assert!(
             preview.errors.is_empty(),
             "unexpected errors: {:?}",
@@ -357,14 +365,23 @@ mod tests {
     #[test]
     fn test_parse_asset_balance_csv_skips_non_data_rows() {
         for (rows, expected_codes) in [
-            (&[TEST_ROW_1, ",,,,,,,,,,,", TEST_ROW_2][..], &["1234", "5678"][..]),
-            (&[INPEX_ROW, NINTENDO_ROW, ACCOUNT_SUMMARY_ROW][..], &["1605", "7974"][..]),
+            (
+                &[TEST_ROW_1, ",,,,,,,,,,,", TEST_ROW_2][..],
+                &["1234", "5678"][..],
+            ),
+            (
+                &[INPEX_ROW, NINTENDO_ROW, ACCOUNT_SUMMARY_ROW][..],
+                &["1605", "7974"][..],
+            ),
         ] {
             let csv = make_asset_balance_csv(rows);
             let (items, errors) = parse_asset_balance_csv(csv.as_bytes()).unwrap();
             assert!(errors.is_empty(), "unexpected errors: {errors:?}");
             assert_eq!(
-                items.iter().map(|item| item.security_code.as_str()).collect::<Vec<_>>(),
+                items
+                    .iter()
+                    .map(|item| item.security_code.as_str())
+                    .collect::<Vec<_>>(),
                 expected_codes
             );
         }

--- a/backend/src/services/csv_domain.rs
+++ b/backend/src/services/csv_domain.rs
@@ -110,7 +110,12 @@ mod tests {
                 "\"2025/12/09\",\"国内株式\",\"特定・一般\",\"8591\",\"オリックス\",\"円\",\"93.76\",\"200\",\"18,752\",\"3,808\",\"14,944\"",
             ]
             .join("\n");
-            assert_eq!(DividendDomain::preview_csv(csv.as_bytes()).unwrap().valid_rows, 1);
+            assert_eq!(
+                DividendDomain::preview_csv(csv.as_bytes())
+                    .unwrap()
+                    .valid_rows,
+                1
+            );
         }
         {
             let csv = [
@@ -131,7 +136,12 @@ mod tests {
                 "\"2022/10/28\",\"2022/11/2\",\"eMAXIS Slim 米国株式(S&P500)\",\"再投資型\",\"特定\",\"解約\",\"3,721,147\",\"-\",\"19,661\",\"7,316,147\",\"18,005.20\",\"615,849\"",
             ]
             .join("\n");
-            assert_eq!(MutualfundDomain::preview_csv(csv.as_bytes()).unwrap().valid_rows, 1);
+            assert_eq!(
+                MutualfundDomain::preview_csv(csv.as_bytes())
+                    .unwrap()
+                    .valid_rows,
+                1
+            );
         }
         {
             let csv = [
@@ -147,7 +157,12 @@ mod tests {
                 ",,,,,,特定口座合計,\"11,245,249\",,,\"14,517,240\",\"29.09\"",
             ]
             .join("\n");
-            assert_eq!(AssetBalanceDomain::preview_csv(csv.as_bytes()).unwrap().valid_rows, 2);
+            assert_eq!(
+                AssetBalanceDomain::preview_csv(csv.as_bytes())
+                    .unwrap()
+                    .valid_rows,
+                2
+            );
         }
     }
 }

--- a/backend/src/services/csv_util.rs
+++ b/backend/src/services/csv_util.rs
@@ -157,7 +157,12 @@ mod tests {
         for _ in 0..n {
             f();
         }
-        println!("[timing] {} × {}回: {:.2}ms", label, n, start.elapsed().as_secs_f64() * 1000.0);
+        println!(
+            "[timing] {} × {}回: {:.2}ms",
+            label,
+            n,
+            start.elapsed().as_secs_f64() * 1000.0
+        );
     }
 
     fn make_header_map(cols: &[&str]) -> HashMap<String, usize> {
@@ -210,7 +215,10 @@ mod tests {
         // UTF-8
         assert_eq!(decode_bytes("テスト".as_bytes()), "テスト");
         // UTF-8 with BOM
-        assert_eq!(decode_bytes(b"\xEF\xBB\xBF\xE3\x83\x86\xE3\x82\xB9\xE3\x83\x88"), "テスト");
+        assert_eq!(
+            decode_bytes(b"\xEF\xBB\xBF\xE3\x83\x86\xE3\x82\xB9\xE3\x83\x88"),
+            "テスト"
+        );
         // Shift-JIS フォールバック（証券会社の CSV で使われることがある）
         let (bytes, _, _) = SHIFT_JIS.encode("テスト");
         assert_eq!(decode_bytes(&bytes), "テスト");
@@ -236,15 +244,28 @@ mod tests {
 
         let record = csv::StringRecord::from(vec!["abc", "1,234", ""]);
         let hm = make_header_map(&["invalid", "valid", "empty"]);
-        assert_eq!(parse_required_number(&record, &hm, "invalid", 5).unwrap_err().row, 5);
-        assert_eq!(parse_required_number(&record, &hm, "valid", 1).unwrap(), dec!(1234));
+        assert_eq!(
+            parse_required_number(&record, &hm, "invalid", 5)
+                .unwrap_err()
+                .row,
+            5
+        );
+        assert_eq!(
+            parse_required_number(&record, &hm, "valid", 1).unwrap(),
+            dec!(1234)
+        );
         let err = parse_required_number(&record, &hm, "empty", 7).unwrap_err();
         assert_eq!(err.row, 7);
         assert!(err.message.contains("empty"));
 
         let record = csv::StringRecord::from(vec!["not-a-date", "2024/03/01", "2024/13/40"]);
         let hm = make_header_map(&["invalid", "valid", "out_of_range"]);
-        assert_eq!(parse_required_date(&record, &hm, "invalid", 2).unwrap_err().row, 2);
+        assert_eq!(
+            parse_required_date(&record, &hm, "invalid", 2)
+                .unwrap_err()
+                .row,
+            2
+        );
         let ok = parse_required_date(&record, &hm, "valid", 1).unwrap();
         assert_eq!(ok, NaiveDate::from_ymd_opt(2024, 3, 1).unwrap());
         let err = parse_required_date(&record, &hm, "out_of_range", 9).unwrap_err();
@@ -281,7 +302,12 @@ mod tests {
         let csv_utf8: String = {
             let mut s = String::from("日付,銘柄コード,金額\n");
             for i in 0..ROWS {
-                s.push_str(&format!("2024/{:02}/{:02},1234,{}\n", (i % 12) + 1, (i % 28) + 1, i * 100));
+                s.push_str(&format!(
+                    "2024/{:02}/{:02},1234,{}\n",
+                    (i % 12) + 1,
+                    (i % 28) + 1,
+                    i * 100
+                ));
             }
             s
         };
@@ -293,16 +319,24 @@ mod tests {
         time_n(&format!("decode_bytes (UTF-8, {}行)", ROWS), 10, || {
             std::hint::black_box(decode_bytes(std::hint::black_box(bytes_utf8)));
         });
-        time_n(&format!("decode_bytes (Shift-JIS フォールバック, {}行)", ROWS), 10, || {
-            std::hint::black_box(decode_bytes(std::hint::black_box(bytes_sjis.as_slice())));
-        });
+        time_n(
+            &format!("decode_bytes (Shift-JIS フォールバック, {}行)", ROWS),
+            10,
+            || {
+                std::hint::black_box(decode_bytes(std::hint::black_box(bytes_sjis.as_slice())));
+            },
+        );
         let samples = ["1,234,567", "0", "(1,000)", "3.14159", "-"];
         time_n("parse_number", 10_000, || {
-            for s in &samples { let _ = std::hint::black_box(parse_number(std::hint::black_box(s))); }
+            for s in &samples {
+                let _ = std::hint::black_box(parse_number(std::hint::black_box(s)));
+            }
         });
         let date_samples = ["2024/03/01", "2024-12-31", "2023/01/01"];
         time_n("parse_date", 10_000, || {
-            for s in &date_samples { let _ = std::hint::black_box(parse_date(std::hint::black_box(s))); }
+            for s in &date_samples {
+                let _ = std::hint::black_box(parse_date(std::hint::black_box(s)));
+            }
         });
     }
 }

--- a/backend/src/services/dividend.rs
+++ b/backend/src/services/dividend.rs
@@ -167,9 +167,16 @@ mod tests {
 
         assert_eq!(preview.total_rows, 2);
         assert_eq!(preview.valid_rows, 2);
-        assert!(preview.errors.is_empty(), "unexpected errors: {:?}", preview.errors);
+        assert!(
+            preview.errors.is_empty(),
+            "unexpected errors: {:?}",
+            preview.errors
+        );
         assert_eq!(preview.rows.len(), 2);
-        assert!(matches!(preview_csv(b""), Err(ApiError::ValidationError(_))));
+        assert!(matches!(
+            preview_csv(b""),
+            Err(ApiError::ValidationError(_))
+        ));
     }
 
     #[test]

--- a/backend/src/services/domestic_stock.rs
+++ b/backend/src/services/domestic_stock.rs
@@ -234,7 +234,10 @@ mod tests {
 
     fn assert_preview_ok(row: &str) -> CsvPreviewResponse {
         let preview = preview_with_header(HEADER, row);
-        assert_eq!((preview.total_rows, preview.valid_rows, preview.rows.len()), (1, 1, 1));
+        assert_eq!(
+            (preview.total_rows, preview.valid_rows, preview.rows.len()),
+            (1, 1, 1)
+        );
         assert!(
             preview.errors.is_empty(),
             "unexpected errors: {:?}",
@@ -245,7 +248,10 @@ mod tests {
 
     fn assert_preview_error(header: &str, row: &str, expected_message: &str) {
         let preview = preview_with_header(header, row);
-        assert_eq!((preview.total_rows, preview.valid_rows, preview.errors.len()), (1, 0, 1));
+        assert_eq!(
+            (preview.total_rows, preview.valid_rows, preview.errors.len()),
+            (1, 0, 1)
+        );
         assert!(preview.errors[0].message.contains(expected_message));
     }
 
@@ -277,7 +283,10 @@ mod tests {
 
     #[test]
     fn test_preview_csv_empty() {
-        assert!(matches!(preview_csv(b""), Err(ApiError::ValidationError(_))));
+        assert!(matches!(
+            preview_csv(b""),
+            Err(ApiError::ValidationError(_))
+        ));
     }
 
     fn make_test_item() -> CreateDomesticStockRequest {

--- a/backend/src/services/mutualfund.rs
+++ b/backend/src/services/mutualfund.rs
@@ -200,9 +200,16 @@ mod tests {
 
         assert_eq!(preview.total_rows, 1);
         assert_eq!(preview.valid_rows, 1);
-        assert!(preview.errors.is_empty(), "unexpected errors: {:?}", preview.errors);
+        assert!(
+            preview.errors.is_empty(),
+            "unexpected errors: {:?}",
+            preview.errors
+        );
         assert_eq!(preview.rows.len(), 1);
-        assert!(matches!(preview_csv(b""), Err(ApiError::ValidationError(_))));
+        assert!(matches!(
+            preview_csv(b""),
+            Err(ApiError::ValidationError(_))
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## 変更内容

過去のautoresearchイテレーションで導入した `assert_eq!` 一行化が
`cargo fmt --check` を通過しないことが判明。

`cargo fmt` を適用して全ファイルを正規化。合わせて `errors.rs` の
`serde_err` 型注釈を削除し 1 行削減。

正規化後の行数: 7857（fmt-clean ベースライン）

## テスト

- `cargo fmt --check`: ✅ 通過
- `cargo test --lib`: 80 passed, 0 failed ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **Tests**
  * テストコードの可読性を向上させるため、複数のアサーション文を整形しました。
  * セキュリティ検証機能に対するテストカバレッジを拡張し、追加のユースケースをカバーするようにしました。

* **Chores**
  * テスト関連のコード構造を統一し、保守性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->