### PR TITLE
refactor: autoresearch ループ継続（iter 41〜）

### DIFF
--- a/autoresearch-results.tsv
+++ b/autoresearch-results.tsv
@@ -35,4 +35,5 @@ iteration	commit	metric	status	description
 39	98f63f9	7691	kept	security: ヘッダーテストのリクエスト構築共通化で 15 行削減
 40	(pending)	7857	fmt-cleanup	cargo fmt 正規化: 過去の assert 一行化を展開。errors.rs serde_err 型注釈削除で 1 行削減
 41	(no commit)	7857	reverted	security.rs: test_extract_origin のループ化は rustfmt 後に +4 行のため破棄
-42	(pending)	7852	kept	routes.rs: 認証必須テストの with_state をループ側へ集約して 5 行削減
+42	e77e5e2	7852	kept	routes.rs: 認証必須テストの with_state をループ側へ集約して 5 行削減
+43	(pending)	7843	kept	csv_util.rs: 小さい純関数テストを既存ユーティリティテストへ統合して 9 行削減

--- a/autoresearch-results.tsv
+++ b/autoresearch-results.tsv
@@ -37,4 +37,5 @@ iteration	commit	metric	status	description
 41	(no commit)	7857	reverted	security.rs: test_extract_origin のループ化は rustfmt 後に +4 行のため破棄
 42	e77e5e2	7852	kept	routes.rs: 認証必須テストの with_state をループ側へ集約して 5 行削減
 43	9e9cebc	7843	kept	csv_util.rs: 小さい純関数テストを既存ユーティリティテストへ統合して 9 行削減
-44	(pending)	7840	kept	domestic_stock.rs: preview_csv の異常系テストを統合して 3 行削減
+44	86814d7	7840	kept	domestic_stock.rs: preview_csv の異常系テストを統合して 3 行削減
+45	(pending)	7837	kept	asset_balance.rs: preview_csv の正常系と空入力テストを統合して 3 行削減

--- a/autoresearch-results.tsv
+++ b/autoresearch-results.tsv
@@ -34,3 +34,5 @@ iteration	commit	metric	status	description
 32	b7b480d	7706	kept	squash-merge #337（iter 32〜38: stock/auth/config/routes/csv_import で 88 行削減）
 39	98f63f9	7691	kept	security: ヘッダーテストのリクエスト構築共通化で 15 行削減
 40	(pending)	7857	fmt-cleanup	cargo fmt 正規化: 過去の assert 一行化を展開。errors.rs serde_err 型注釈削除で 1 行削減
+41	(no commit)	7857	reverted	security.rs: test_extract_origin のループ化は rustfmt 後に +4 行のため破棄
+42	(pending)	7852	kept	routes.rs: 認証必須テストの with_state をループ側へ集約して 5 行削減

--- a/autoresearch-results.tsv
+++ b/autoresearch-results.tsv
@@ -36,4 +36,5 @@ iteration	commit	metric	status	description
 40	(pending)	7857	fmt-cleanup	cargo fmt 正規化: 過去の assert 一行化を展開。errors.rs serde_err 型注釈削除で 1 行削減
 41	(no commit)	7857	reverted	security.rs: test_extract_origin のループ化は rustfmt 後に +4 行のため破棄
 42	e77e5e2	7852	kept	routes.rs: 認証必須テストの with_state をループ側へ集約して 5 行削減
-43	(pending)	7843	kept	csv_util.rs: 小さい純関数テストを既存ユーティリティテストへ統合して 9 行削減
+43	9e9cebc	7843	kept	csv_util.rs: 小さい純関数テストを既存ユーティリティテストへ統合して 9 行削減
+44	(pending)	7840	kept	domestic_stock.rs: preview_csv の異常系テストを統合して 3 行削減

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -238,83 +238,78 @@ mod tests {
     async fn test_all_endpoints_require_auth() {
         for (router, method, uri) in [
             (
-                handlers::jquants::jquants_routes().with_state(make_test_state()),
+                handlers::jquants::jquants_routes(),
                 Method::GET,
                 "/jquants/fins/summary?code=7203",
             ),
             (
-                handlers::dividend::dividend_routes().with_state(make_test_state()),
+                handlers::dividend::dividend_routes(),
                 Method::DELETE,
                 "/dividends",
             ),
             (
-                handlers::dividend::dividend_routes().with_state(make_test_state()),
+                handlers::dividend::dividend_routes(),
                 Method::GET,
                 "/dividends",
             ),
             (
-                handlers::dividend::dividend_routes().with_state(make_test_state()),
+                handlers::dividend::dividend_routes(),
                 Method::POST,
                 "/dividends/csv/preview",
             ),
             (
-                handlers::domestic_stock::domestic_stock_routes().with_state(make_test_state()),
+                handlers::domestic_stock::domestic_stock_routes(),
                 Method::DELETE,
                 "/domestic-stocks",
             ),
             (
-                handlers::domestic_stock::domestic_stock_routes().with_state(make_test_state()),
+                handlers::domestic_stock::domestic_stock_routes(),
                 Method::GET,
                 "/domestic-stocks",
             ),
             (
-                handlers::domestic_stock::domestic_stock_routes().with_state(make_test_state()),
+                handlers::domestic_stock::domestic_stock_routes(),
                 Method::POST,
                 "/domestic-stocks/csv/preview",
             ),
             (
-                handlers::mutualfund::mutualfund_routes().with_state(make_test_state()),
+                handlers::mutualfund::mutualfund_routes(),
                 Method::DELETE,
                 "/mutualfunds",
             ),
             (
-                handlers::mutualfund::mutualfund_routes().with_state(make_test_state()),
+                handlers::mutualfund::mutualfund_routes(),
                 Method::GET,
                 "/mutualfunds",
             ),
             (
-                handlers::mutualfund::mutualfund_routes().with_state(make_test_state()),
+                handlers::mutualfund::mutualfund_routes(),
                 Method::POST,
                 "/mutualfunds/csv/preview",
             ),
             (
-                handlers::asset_balance::asset_balance_routes().with_state(make_test_state()),
+                handlers::asset_balance::asset_balance_routes(),
                 Method::DELETE,
                 "/asset-balances",
             ),
             (
-                handlers::asset_balance::asset_balance_routes().with_state(make_test_state()),
+                handlers::asset_balance::asset_balance_routes(),
                 Method::POST,
                 "/asset-balances/bulk",
             ),
             (
-                handlers::asset_balance::asset_balance_routes().with_state(make_test_state()),
+                handlers::asset_balance::asset_balance_routes(),
                 Method::POST,
                 "/asset-balances/csv/preview",
             ),
+            (csv_upload_routes(), Method::POST, "/dividends/csv"),
             (
-                csv_upload_routes().with_state(make_test_state()),
-                Method::POST,
-                "/dividends/csv",
-            ),
-            (
-                handlers::dividend_per_share::dividend_per_share_routes()
-                    .with_state(make_test_state()),
+                handlers::dividend_per_share::dividend_per_share_routes(),
                 Method::POST,
                 "/dividends/per-share/batch",
             ),
         ] {
-            check_unauthorized(router, method, uri).await;
+            check_unauthorized(router.with_state(make_test_state()), method, uri).await;
         }
     }
 

--- a/backend/src/services/asset_balance.rs
+++ b/backend/src/services/asset_balance.rs
@@ -300,7 +300,7 @@ mod tests {
     }
 
     #[test]
-    fn test_preview_csv_valid() {
+    fn test_preview_csv() {
         let csv = make_asset_balance_csv(&[INPEX_ROW, NINTENDO_ROW, ACCOUNT_SUMMARY_ROW]);
         let preview = preview_csv(csv.as_bytes()).unwrap();
         assert_eq!(
@@ -312,10 +312,7 @@ mod tests {
             "unexpected errors: {:?}",
             preview.errors
         );
-    }
 
-    #[test]
-    fn test_preview_csv_empty() {
         assert!(matches!(
             preview_csv(b""),
             Err(ApiError::ValidationError(_))

--- a/backend/src/services/csv_util.rs
+++ b/backend/src/services/csv_util.rs
@@ -195,10 +195,7 @@ mod tests {
         for input in ["2024/01/15", "2024-01-15"] {
             assert_eq!(parse_date(input).unwrap(), expected_date);
         }
-    }
 
-    #[test]
-    fn test_compute_taxes() {
         for (account, realized_pnl, expected_taxes, expected_after) in [
             ("特定", dec!(10000), dec!(2031), dec!(7969)), // floor(10000 * 0.20315)
             ("特定", dec!(-5000), Decimal::ZERO, dec!(-5000)),
@@ -207,10 +204,7 @@ mod tests {
             let (taxes, after) = compute_taxes(account, realized_pnl);
             assert_eq!((taxes, after), (expected_taxes, expected_after));
         }
-    }
 
-    #[test]
-    fn test_decode_bytes() {
         use encoding_rs::SHIFT_JIS;
         // UTF-8
         assert_eq!(decode_bytes("テスト".as_bytes()), "テスト");
@@ -222,10 +216,7 @@ mod tests {
         // Shift-JIS フォールバック（証券会社の CSV で使われることがある）
         let (bytes, _, _) = SHIFT_JIS.encode("テスト");
         assert_eq!(decode_bytes(&bytes), "テスト");
-    }
 
-    #[test]
-    fn test_get_cell() {
         let record = csv::StringRecord::from(vec!["value"]);
         let header_map = make_header_map(&["present"]);
         assert_eq!(get_cell(&record, &header_map, "present"), "value");

--- a/backend/src/services/domestic_stock.rs
+++ b/backend/src/services/domestic_stock.rs
@@ -272,17 +272,14 @@ mod tests {
     }
 
     #[test]
-    fn test_preview_csv_row_errors() {
+    fn test_preview_csv_invalid_inputs() {
         for (header, row, expected_message) in [
             (MISSING_NAME_HEADER, MISSING_NAME_ROW, "銘柄名"),
             (HEADER, INVALID_PNL_ROW, "実現損益[円]"),
         ] {
             assert_preview_error(header, row, expected_message);
         }
-    }
 
-    #[test]
-    fn test_preview_csv_empty() {
         assert!(matches!(
             preview_csv(b""),
             Err(ApiError::ValidationError(_))


### PR DESCRIPTION
## 概要
autoresearch ループ iter 41〜45 を実施し、backend/src/**/*.rs の fmt-clean 行数を削減しました。

## 変更内容
- routes.rs: 認証必須テストの with_state 適用をループ側へ集約
- csv_util.rs: 小さい純関数テストを既存ユーティリティテストへ統合
- domestic_stock.rs: preview_csv の異常系テストを統合
- asset_balance.rs: preview_csv の正常系と空入力テストを統合
- security.rs はループ化を試したが rustfmt 後に増行したためリバート

## 結果
- fmt-clean 行数: 7857 -> 7837 (-20)
- 記録: autoresearch-results.tsv に iter 41〜45 を追記

## テスト
- cd backend && cargo fmt --check
- cd backend && cargo test --lib -q
- 最終結果: test result: ok. 75 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 0.85s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * テストスイートの構造を最適化し、複数のテストケースを統合して保守性を向上させました。
  * エンドポイント認証テストとCSV処理テストの組織体系を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->