### PR TITLE
refactor: autoresearch ループ継続（iter 49）

### DIFF
--- a/autoresearch-results.tsv
+++ b/autoresearch-results.tsv
@@ -42,3 +42,4 @@ iteration	commit	metric	status	description
 46	e1a39d7	7842	fmt-cleanup	cargo fmt 正規化: iter 43-45 の一行化を展開（+15 行、実行削減数は -15）
 47	59ae913	7824	kept	routes/csv_util/domestic_stock/asset_balance: テスト統合で 18 行削減
 48	eab4d45	7815	kept	csv_util/dividend/mutualfund: テスト統合で 9 行削減
+49	4dba61e	7802	kept	errors/csv_import/asset_balance/config: テスト統合で 13 行削減

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -154,20 +154,7 @@ mod tests {
         assert_eq!(config.cors_origins.len(), 1);
         assert_eq!(config.cors_origins[0], "http://example.com");
         assert_eq!(config.csv_rate_limit_rps, 2);
-    }
 
-    #[tokio::test]
-    async fn test_config_from_env_reads_csv_rate_limit_rps() {
-        let _lock = ENV_MUTEX.lock().await;
-        let _csv_rate_limit_rps = EnvGuard::set("CSV_RATE_LIMIT_RPS", Some("7"));
-
-        let config = Config::from_env();
-
-        assert_eq!(config.csv_rate_limit_rps, 7);
-    }
-
-    #[test]
-    fn test_utility_functions() {
         let url = backend_url();
         if let Ok(expected) = env::var("BACKEND_URL") {
             assert_eq!(url, expected);
@@ -178,6 +165,16 @@ mod tests {
         }
         assert!(server_addr().starts_with("0.0.0.0:"));
         let _ = is_secure_cookie();
+    }
+
+    #[tokio::test]
+    async fn test_config_from_env_reads_csv_rate_limit_rps() {
+        let _lock = ENV_MUTEX.lock().await;
+        let _csv_rate_limit_rps = EnvGuard::set("CSV_RATE_LIMIT_RPS", Some("7"));
+
+        let config = Config::from_env();
+
+        assert_eq!(config.csv_rate_limit_rps, 7);
     }
 
     #[tokio::test]

--- a/backend/src/errors.rs
+++ b/backend/src/errors.rs
@@ -233,10 +233,6 @@ mod tests {
             ApiError::SerdeJsonError(serde_err),
             StatusCode::INTERNAL_SERVER_ERROR,
         );
-    }
-
-    #[test]
-    fn test_simple_error_helper() {
         let (status, details) = simple_error(
             StatusCode::BAD_REQUEST,
             "TEST_CODE",

--- a/backend/src/handlers/csv_import.rs
+++ b/backend/src/handlers/csv_import.rs
@@ -219,7 +219,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_handle_preview_csv_returns_json_preview() {
+    async fn test_handle_csv_endpoints() {
         let response = preview_app()
             .oneshot(multipart_request("file", Some("preview.csv"), "a,b\n1,2\n"))
             .await
@@ -229,10 +229,7 @@ mod tests {
         let preview: serde_json::Value = read_json_response(response).await;
         assert_eq!(preview["valid_rows"], 1);
         assert_eq!(preview["rows"].as_array().unwrap().len(), 1);
-    }
 
-    #[tokio::test]
-    async fn test_handle_upload_csv_returns_created_response() {
         let response = upload_app()
             .oneshot(multipart_request("file", Some("upload.csv"), "a,b\n1,2\n"))
             .await

--- a/backend/src/services/asset_balance.rs
+++ b/backend/src/services/asset_balance.rs
@@ -357,10 +357,7 @@ mod tests {
         ] {
             assert_row_error(row, expected_message);
         }
-    }
 
-    #[test]
-    fn test_parse_asset_balance_csv_skips_non_data_rows() {
         for (rows, expected_codes) in [
             (
                 &[TEST_ROW_1, ",,,,,,,,,,,", TEST_ROW_2][..],


### PR DESCRIPTION
## 概要
backend のテスト関数 4 件を既存テストへ統合し、挙動を変えずに行数を削減しました。

## 変更内容
- `backend/src/errors.rs` で `test_simple_error_helper` を `test_all_error_status_codes` に統合
- `backend/src/handlers/csv_import.rs` で preview/upload のエンドポイントテストを `test_handle_csv_endpoints` に統合
- `backend/src/services/asset_balance.rs` で CSV の非データ行スキップ検証を `test_parse_asset_balance_row` に統合
- `backend/src/config.rs` で utility 系の確認を `test_config_creation` に統合
- `autoresearch-results.tsv` に iter 49 の実測値を追記

## 計測結果
- `backend/src` 行数: 7815 -> 7802
- 削減行数: 13

## テスト
- `cd backend && cargo fmt --check`
- `cd backend && cargo clippy --all-targets -- -D warnings`
- `cd backend && cargo test --lib -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * テストの再構成と統合により、テスト構造を改善しました
  * 複数のバックエンドモジュールにおけるテストカバレッジを最適化しました

**注記:** これらの変更はテスト基盤の改善であり、ユーザー向け機能への影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->