### PR TITLE
refactor: autoresearch ループ継続（iter 50）

### DIFF
--- a/autoresearch-results.tsv
+++ b/autoresearch-results.tsv
@@ -43,3 +43,4 @@ iteration	commit	metric	status	description
 47	59ae913	7824	kept	routes/csv_util/domestic_stock/asset_balance: テスト統合で 18 行削減
 48	eab4d45	7815	kept	csv_util/dividend/mutualfund: テスト統合で 9 行削減
 49	4dba61e	7802	kept	errors/csv_import/asset_balance/config: テスト統合で 13 行削減
+50	3028ee6	7792	kept	security/domestic_stock/asset_balance: テスト統合で 10 行削減

--- a/backend/src/middleware/security.rs
+++ b/backend/src/middleware/security.rs
@@ -131,23 +131,6 @@ mod tests {
     use axum::{middleware, routing::post, Router};
     use tower::ServiceExt;
 
-    #[test]
-    fn test_extract_origin() {
-        assert_eq!(
-            extract_origin("http://localhost:8080/some/page"),
-            Some("http://localhost:8080")
-        );
-        assert_eq!(
-            extract_origin("https://shoken-webapp.vercel.app"),
-            Some("https://shoken-webapp.vercel.app")
-        );
-        // 許可ドメインを接頭辞に持つ偽装ドメインは別オリジンとして抽出される
-        assert_eq!(
-            extract_origin("https://shoken-webapp.vercel.app.evil.com/steal"),
-            Some("https://shoken-webapp.vercel.app.evil.com")
-        );
-    }
-
     fn test_app() -> Router {
         let allowed_origins = Arc::new(vec![
             "https://shoken-webapp.vercel.app".to_string(),
@@ -184,6 +167,20 @@ mod tests {
 
     #[tokio::test]
     async fn test_validate_origin() {
+        assert_eq!(
+            extract_origin("http://localhost:8080/some/page"),
+            Some("http://localhost:8080")
+        );
+        assert_eq!(
+            extract_origin("https://shoken-webapp.vercel.app"),
+            Some("https://shoken-webapp.vercel.app")
+        );
+        // 許可ドメインを接頭辞に持つ偽装ドメインは別オリジンとして抽出される
+        assert_eq!(
+            extract_origin("https://shoken-webapp.vercel.app.evil.com/steal"),
+            Some("https://shoken-webapp.vercel.app.evil.com")
+        );
+
         // GET はルート定義がないので 405 だが、ミドルウェアは通過（403 にならない）
         assert_ne!(
             oneshot_status(test_app(), Method::GET, &[]).await,

--- a/backend/src/services/asset_balance.rs
+++ b/backend/src/services/asset_balance.rs
@@ -300,26 +300,6 @@ mod tests {
     }
 
     #[test]
-    fn test_preview_csv_valid() {
-        let csv = make_asset_balance_csv(&[INPEX_ROW, NINTENDO_ROW, ACCOUNT_SUMMARY_ROW]);
-        let preview = preview_csv(csv.as_bytes()).unwrap();
-        assert_eq!(
-            (preview.total_rows, preview.valid_rows, preview.rows.len()),
-            (2, 2, 2)
-        );
-        assert!(
-            preview.errors.is_empty(),
-            "unexpected errors: {:?}",
-            preview.errors
-        );
-
-        assert!(matches!(
-            preview_csv(b""),
-            Err(ApiError::ValidationError(_))
-        ));
-    }
-
-    #[test]
     fn test_parse_asset_balance_row() {
         for (row, expected) in [
             (
@@ -357,6 +337,23 @@ mod tests {
         ] {
             assert_row_error(row, expected_message);
         }
+
+        let csv = make_asset_balance_csv(&[INPEX_ROW, NINTENDO_ROW, ACCOUNT_SUMMARY_ROW]);
+        let preview = preview_csv(csv.as_bytes()).unwrap();
+        assert_eq!(
+            (preview.total_rows, preview.valid_rows, preview.rows.len()),
+            (2, 2, 2)
+        );
+        assert!(
+            preview.errors.is_empty(),
+            "unexpected errors: {:?}",
+            preview.errors
+        );
+
+        assert!(matches!(
+            preview_csv(b""),
+            Err(ApiError::ValidationError(_))
+        ));
 
         for (rows, expected_codes) in [
             (

--- a/backend/src/services/domestic_stock.rs
+++ b/backend/src/services/domestic_stock.rs
@@ -256,7 +256,7 @@ mod tests {
     }
 
     #[test]
-    fn test_preview_csv_valid_rows() {
+    fn test_preview_csv() {
         assert_eq!(
             assert_preview_ok(BASIC_ROW).rows[0]["security_name"],
             "ＥＮＥＯＳホールディングス"
@@ -269,10 +269,6 @@ mod tests {
             preview.rows[0]["realized_profit_and_loss_after_tax"],
             9100.0
         );
-    }
-
-    #[test]
-    fn test_preview_csv_row_errors() {
         for (header, row, expected_message) in [
             (MISSING_NAME_HEADER, MISSING_NAME_ROW, "銘柄名"),
             (HEADER, INVALID_PNL_ROW, "実現損益[円]"),


### PR DESCRIPTION
## 概要
- `backend/src/middleware/security.rs` の `test_extract_origin` を `test_validate_origin` に統合
- `backend/src/services/domestic_stock.rs` の CSV preview テスト 2 件を `test_preview_csv` に統合
- `backend/src/services/asset_balance.rs` の `test_preview_csv_valid` を `test_parse_asset_balance_row` に統合
- `autoresearch-results.tsv` に iter 50 の結果を追記

## 行数
- `backend/src`: 7802 -> 7792

## テスト
- `cd backend && cargo fmt --check`
- `cd backend && cargo clippy --all-targets -- -D warnings`
- `cd backend && cargo test --lib -q`