### PR TITLE
refactor: autoresearch ループ継続（iter 51）

### DIFF
--- a/autoresearch-results.tsv
+++ b/autoresearch-results.tsv
@@ -44,3 +44,4 @@ iteration	commit	metric	status	description
 48	eab4d45	7815	kept	csv_util/dividend/mutualfund: テスト統合で 9 行削減
 49	4dba61e	7802	kept	errors/csv_import/asset_balance/config: テスト統合で 13 行削減
 50	3028ee6	7792	kept	security/domestic_stock/asset_balance: テスト統合で 10 行削減
+51	975070f	7773	kept	auth/security/csv_util: テスト統合で 19 行削減

--- a/backend/src/middleware/security.rs
+++ b/backend/src/middleware/security.rs
@@ -217,10 +217,6 @@ mod tests {
                 expected
             );
         }
-    }
-
-    #[tokio::test]
-    async fn test_delete_with_disallowed_origin() {
         let allowed_origins = Arc::new(vec!["http://localhost:8080".to_string()]);
         let app = Router::new()
             .route("/test", axum::routing::delete(|| async { "ok" }))

--- a/backend/src/services/auth.rs
+++ b/backend/src/services/auth.rs
@@ -235,7 +235,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_cookies() {
+    fn test_auth_helpers() {
         for (secure, expected_secure) in [(true, true), (false, false)] {
             let cookie = build_state_cookie("test_state", secure);
             assert_eq!(cookie.name(), OAUTH_STATE_COOKIE_NAME);
@@ -249,22 +249,12 @@ mod tests {
             assert_eq!(cookie.secure(), Some(expected_secure));
             assert_eq!(cookie.http_only(), Some(true));
         }
-    }
-
-    #[test]
-    fn test_get_session_id_from_jar() {
         assert!(get_session_id_from_jar(&CookieJar::new()).is_err());
-
         let jar = CookieJar::new().add(Cookie::new(SESSION_COOKIE_NAME, "invalid-uuid"));
         assert!(get_session_id_from_jar(&jar).is_err());
-
         let uuid = uuid::Uuid::new_v4();
         let jar = CookieJar::new().add(Cookie::new(SESSION_COOKIE_NAME, uuid.to_string()));
         assert_eq!(get_session_id_from_jar(&jar).unwrap(), uuid);
-    }
-
-    #[test]
-    fn test_cookie_helpers_and_constants() {
         for (cookie, expected_name) in [
             (clear_state_cookie(true), OAUTH_STATE_COOKIE_NAME),
             (clear_session_cookie(true), SESSION_COOKIE_NAME),

--- a/backend/src/services/csv_util.rs
+++ b/backend/src/services/csv_util.rs
@@ -220,6 +220,16 @@ mod tests {
         let header_map = make_header_map(&["present"]);
         assert_eq!(get_cell(&record, &header_map, "present"), "value");
         assert_eq!(get_cell(&record, &header_map, "missing"), "");
+        for (input, expected) in [
+            ("K D D I", "KDDI"),
+            ("I N P E X", "INPEX"),
+            ("eMAXIS Slim 全世界株式", "eMAXIS Slim 全世界株式"),
+            ("任天堂", "任天堂"),
+            ("  KDDI  ", "KDDI"),
+            ("", ""),
+        ] {
+            assert_eq!(normalize_security_name(input), expected);
+        }
     }
 
     #[test]
@@ -262,21 +272,6 @@ mod tests {
         assert_eq!(err.row, 9);
         assert!(err.message.contains("out_of_range"));
     }
-
-    #[test]
-    fn test_normalize_security_name() {
-        for (input, expected) in [
-            ("K D D I", "KDDI"),
-            ("I N P E X", "INPEX"),
-            ("eMAXIS Slim 全世界株式", "eMAXIS Slim 全世界株式"),
-            ("任天堂", "任天堂"),
-            ("  KDDI  ", "KDDI"),
-            ("", ""),
-        ] {
-            assert_eq!(normalize_security_name(input), expected);
-        }
-    }
-
     /// CSV パース処理の所要時間を計測するタイミングテスト。
     /// 通常の `cargo test` では実行されない。以下で明示的に実行する:
     /// ```


### PR DESCRIPTION
## 概要
- backend/src/services/auth.rs の sync テスト 3 件を `test_auth_helpers` に統合
- backend/src/middleware/security.rs の DELETE オリジン検証テストを `test_validate_origin` に統合
- backend/src/services/csv_util.rs の銘柄名正規化テストを `test_parse_utilities` に統合
- `autoresearch-results.tsv` に iter 51 の結果を追記

## メトリクス
- backend/src 総行数: 7792 -> 7773
- 削減行数: 19
- 記録対象 commit: `975070f`

## テスト
- `cd backend && cargo fmt --check`
- `cd backend && cargo clippy --all-targets -- -D warnings`
- `cd backend && cargo test --lib -q`