### PR TITLE
refactor: autoresearch ループ継続（iter 52）

### DIFF
--- a/autoresearch-results.tsv
+++ b/autoresearch-results.tsv
@@ -45,3 +45,4 @@ iteration	commit	metric	status	description
 49	4dba61e	7802	kept	errors/csv_import/asset_balance/config: テスト統合で 13 行削減
 50	3028ee6	7792	kept	security/domestic_stock/asset_balance: テスト統合で 10 行削減
 51	975070f	7773	kept	auth/security/csv_util: テスト統合で 19 行削減
+52	7cd899a	7749	kept	char_width/cors/rate_limit/csv_import/validated_json: テスト統合で 24 行削減

--- a/backend/src/config/cors.rs
+++ b/backend/src/config/cors.rs
@@ -93,10 +93,6 @@ mod tests {
                 "expected {origin} to be rejected as non-localhost"
             );
         }
-    }
-
-    #[test]
-    fn test_parse_cors_origins() {
         assert_eq!(
             parse_cors_origins("https://app.example.com,http://localhost:3000"),
             vec![

--- a/backend/src/extractors/char_width_converter.rs
+++ b/backend/src/extractors/char_width_converter.rs
@@ -23,10 +23,6 @@ mod tests {
         assert_eq!(halfwidth_to_fullwidth('1'), '1');
         assert_eq!(halfwidth_to_fullwidth('!'), '!');
         assert_eq!(halfwidth_to_fullwidth('あ'), 'あ');
-    }
-
-    #[test]
-    fn test_char_from_u32_with_default() {
         assert_eq!(char_from_u32_with_default(0x41, 'X'), 'A');
         assert_eq!(char_from_u32_with_default(0x110000, 'X'), 'X');
     }

--- a/backend/src/extractors/validated_json.rs
+++ b/backend/src/extractors/validated_json.rs
@@ -82,10 +82,7 @@ mod tests {
 
         let response = app.oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
-    }
 
-    #[tokio::test]
-    async fn test_invalid_json_syntax() {
         let body = Body::from(r#"{"name": "テストユーザー", age: 30}"#);
         let request = Request::builder()
             .header("content-type", "application/json")
@@ -101,10 +98,7 @@ mod tests {
             Err(ApiError::JsonParseError) => (),
             _ => panic!("Expected JsonParseError"),
         }
-    }
 
-    #[tokio::test]
-    async fn test_invalid_validation() {
         let json_data = TestData {
             name: "".to_string(),
             age: 30,

--- a/backend/src/middleware/rate_limit.rs
+++ b/backend/src/middleware/rate_limit.rs
@@ -120,23 +120,17 @@ mod tests {
         assert_eq!(resp.status(), expected);
     }
 
-    #[test]
-    fn test_build_rate_limiters() {
+    #[tokio::test]
+    async fn test_rate_limiters() {
         assert!(build_rate_limiter(0).is_none());
         assert!(build_rate_limiter(10).is_some());
         assert!(build_keyed_rate_limiter(0).is_none());
         assert!(build_keyed_rate_limiter(10).is_some());
-    }
 
-    #[tokio::test]
-    async fn test_rate_limit() {
         let router = direct_app(build_rate_limiter(1).unwrap());
         assert_status(router.clone(), None, StatusCode::OK).await;
         assert_status(router, None, StatusCode::TOO_MANY_REQUESTS).await;
-    }
 
-    #[tokio::test]
-    async fn test_keyed_rate_limit() {
         let router = keyed_app(build_keyed_rate_limiter(1).unwrap());
         assert_status(router.clone(), Some("1.2.3.4"), StatusCode::OK).await;
         assert_status(router.clone(), Some("5.6.7.8"), StatusCode::OK).await;

--- a/backend/src/services/csv_import.rs
+++ b/backend/src/services/csv_import.rs
@@ -132,11 +132,7 @@ mod tests {
         assert_eq!(errors.len(), 1);
         assert_eq!(errors[0].row, 2);
         assert!(errors[0].message.contains("CSV行の読み込み"));
-    }
 
-    #[test]
-    fn test_finish_csv_upload() {
-        use crate::models::csv_import::CsvRowError;
         let result = crate::models::common::BulkCreateResponse {
             inserted: 3,
             skipped: 1,


### PR DESCRIPTION
## 概要
backend/src 配下の指定テストを統合し、重複したテスト関数を減らして行数を削減しました。あわせて autoresearch-results.tsv に iter 52 の実測値を追記しています。

## 変更内容
- char_width_converter の 2 テストを 1 つに統合
- cors の 2 テストを 1 つに統合
- rate_limit の sync/async 3 テストを 1 つの tokio テストに統合
- csv_import の 2 テストを 1 つに統合
- validated_json の 3 テストを 1 つに統合
- autoresearch-results.tsv に iter 52 を追加

## 結果
- backend/src の行数: 7773 -> 7749
- 削減行数: 24
- 実装 commit: `7cd899a`

## 確認
- `cd backend && cargo fmt --check`
- `cd backend && cargo clippy --all-targets -- -D warnings`
- `cd backend && cargo test --lib -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * 複数のユニットテスト関数を削除しました。本番機能には変更はなく、テストカバレッジの最適化に伴う修正です。CORS設定、文字幅変換、JSON検証、レート制限、およびCSVインポート機能に関連するテストコードを削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->