### PR TITLE
refactor: autoresearch ループ継続（iter 53）

### DIFF
--- a/autoresearch-results.tsv
+++ b/autoresearch-results.tsv
@@ -46,3 +46,4 @@ iteration	commit	metric	status	description
 50	3028ee6	7792	kept	security/domestic_stock/asset_balance: テスト統合で 10 行削減
 51	975070f	7773	kept	auth/security/csv_util: テスト統合で 19 行削減
 52	7cd899a	7749	kept	char_width/cors/rate_limit/csv_import/validated_json: テスト統合で 24 行削減
+53	8cf63c3	7733	kept	db/dividend/dividend_cache/jquants_response: テスト統合で 16 行削減

--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -25,16 +25,9 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn test_connect_pool_lazy_creates_pool() {
+    async fn test_connect_pool_lazy() {
         let database_url = "postgresql://user:password@localhost/test_db";
-        let result = connect_pool_lazy(database_url, 5);
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_connect_pool_lazy_with_max_connections() {
-        let database_url = "postgresql://user:password@localhost/test_db";
-        let result = connect_pool_lazy(database_url, 10);
-        assert!(result.is_ok());
+        assert!(connect_pool_lazy(database_url, 5).is_ok());
+        assert!(connect_pool_lazy(database_url, 10).is_ok());
     }
 }

--- a/backend/src/models/jquants/response.rs
+++ b/backend/src/models/jquants/response.rs
@@ -508,10 +508,7 @@ mod tests {
             fin_summary_data.result_dividend_per_share_annual,
             Some("40.00".to_string())
         );
-    }
 
-    #[test]
-    fn test_fin_summary_response() {
         // V2 API では "data" フィールド名を使用
         let json_data = json!({
             "data": [

--- a/backend/src/services/dividend.rs
+++ b/backend/src/services/dividend.rs
@@ -189,10 +189,7 @@ mod tests {
         assert_eq!(preview.valid_rows, 1);
         assert_eq!(preview.rows[0]["security_code"], "");
         assert_eq!(preview.rows[0]["security_name"], "KDDI");
-    }
 
-    #[test]
-    fn test_preview_csv_row_errors() {
         let cases = [
             (
                 "入金日,商品,口座,銘柄コード,受取通貨,単価[円/現地通貨],数量[株/口],配当・分配金合計（税引前）[円/現地通貨],税額合計[円/現地通貨],受取金額[円/現地通貨]",

--- a/backend/src/services/dividend_cache/logic.rs
+++ b/backend/src/services/dividend_cache/logic.rs
@@ -122,10 +122,7 @@ mod tests {
         ];
         let (val, _) = extract_dividend(&data);
         assert_eq!(val, Some(60.0));
-    }
 
-    #[test]
-    fn test_compute_is_stale() {
         let now = Utc::now();
         let past = Some(now - chrono::Duration::hours(1));
         let future = Some(now + chrono::Duration::days(7));


### PR DESCRIPTION
## 概要
- backend/src 配下の 4 ファイルで重複テストを統合し、行数を削減
- autoresearch-results.tsv に iter 53 の結果を追記
- backend/src の総行数を 7749 から 7733 に削減

## 変更内容
- `backend/src/db.rs` の lazy pool テスト 2 件を 1 件に統合
- `backend/src/services/dividend.rs` の CSV row error テストを basic テストへ統合
- `backend/src/services/dividend_cache/logic.rs` の stale 判定テストを配当抽出テストへ統合
- `backend/src/models/jquants/response.rs` の FinSummaryResponse テストを V2 deserialize テストへ統合

## テスト
- [x] `cd backend && cargo fmt --check`
- [x] `cd backend && cargo clippy --all-targets -- -D warnings`
- [x] `cd backend && cargo test --lib -q`