### PR TITLE
refactor: autoresearch ループ継続（iter 54）

### DIFF
--- a/backend/src/handlers/csv_import.rs
+++ b/backend/src/handlers/csv_import.rs
@@ -185,7 +185,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_read_csv_file_bytes_valid() {
+    async fn test_read_csv_file_bytes() {
         let content = "symbol,amount\n7203,100\n";
         let response = test_app()
             .oneshot(multipart_request("file", Some("positions.csv"), content))
@@ -195,10 +195,6 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         let body = to_bytes(response.into_body(), BODY_LIMIT).await.unwrap();
         assert_eq!(body.as_ref(), content.as_bytes());
-    }
-
-    #[tokio::test]
-    async fn test_read_csv_file_bytes_validation_errors() {
         for (field, filename, msg_fragment) in [
             ("other", Some("positions.csv"), Some("fileフィールド")),
             ("file", Some("positions.txt"), Some(".csv")),

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -164,9 +164,10 @@ mod tests {
         let _ = handlers::asset_balance::asset_balance_routes();
     }
 
-    /// auth ルートが rps=1 制限を超えると 429 を返すことを確認
+    /// auth/jquants ルートが rps=1 制限を超えると 429 を返すことを確認
     #[tokio::test]
-    async fn test_auth_routes_rate_limit_returns_429() {
+    async fn test_routes_rate_limit_returns_429() {
+        // auth: キー付きレート制限（IP ごと）
         let limiter = crate::middleware::build_keyed_rate_limiter(1);
         let state = make_test_state();
         let router = if let Some(l) = limiter {
@@ -180,11 +181,8 @@ mod tests {
         .with_state(state);
 
         assert_rate_limited(router, Method::GET, "/auth/me", Some("1.2.3.4")).await;
-    }
 
-    /// jquants ルートが rps=1 制限を超えると 429 を返すことを確認
-    #[tokio::test]
-    async fn test_jquants_routes_rate_limit_returns_429() {
+        // jquants: グローバルレート制限
         let limiter = crate::middleware::build_rate_limiter(1);
         let state = make_test_state();
         let router = if let Some(l) = limiter {

--- a/backend/src/services/csv_util.rs
+++ b/backend/src/services/csv_util.rs
@@ -230,10 +230,7 @@ mod tests {
         ] {
             assert_eq!(normalize_security_name(input), expected);
         }
-    }
 
-    #[test]
-    fn test_parse_required() {
         let record = csv::StringRecord::from(vec!["", "value"]);
         let header_map = make_header_map(&["col_a", "col_b"]);
         let err = parse_required_string(&record, &header_map, "col_a", 3).unwrap_err();

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -48,49 +48,39 @@ mod tests {
     use crate::test_env::{EnvGuard, ENV_MUTEX};
 
     #[tokio::test]
-    async fn test_secrets_from_env_error_without_database_url() {
+    async fn test_secrets_from_env() {
         let _lock = ENV_MUTEX.lock().await;
-        let _db = EnvGuard::set("DATABASE_URL", None);
-
-        let result = Secrets::from_env();
-
-        assert!(result.is_err());
-        let err_msg = result.unwrap_err();
-        assert!(
-            err_msg.contains("DATABASE_URL"),
-            "エラーメッセージに DATABASE_URL が含まれること: {err_msg}"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_secrets_from_env_frontend_url_default() {
-        // FRONTEND_URL 未設定時はデフォルト値 "http://localhost:8080" を使用する
-        let _lock = ENV_MUTEX.lock().await;
-        let _db = EnvGuard::set(
-            "DATABASE_URL",
-            Some("postgresql://user:password@localhost/test"),
-        );
-        let _fe = EnvGuard::set("FRONTEND_URL", None);
-
-        let result = Secrets::from_env();
-
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().frontend_url, "http://localhost:8080");
-    }
-
-    #[tokio::test]
-    async fn test_secrets_from_env_jquants_key_is_optional() {
-        // JQUANTS_API_KEY は省略可能で None になる
-        let _lock = ENV_MUTEX.lock().await;
-        let _db = EnvGuard::set(
-            "DATABASE_URL",
-            Some("postgresql://user:password@localhost/test"),
-        );
-        let _jq = EnvGuard::set("JQUANTS_API_KEY", None);
-
-        let result = Secrets::from_env();
-
-        assert!(result.is_ok());
-        assert!(result.unwrap().jquants_api_key.is_none());
+        {
+            let _db = EnvGuard::set("DATABASE_URL", None);
+            let result = Secrets::from_env();
+            assert!(result.is_err());
+            let err_msg = result.unwrap_err();
+            assert!(
+                err_msg.contains("DATABASE_URL"),
+                "エラーメッセージに DATABASE_URL が含まれること: {err_msg}"
+            );
+        }
+        {
+            // FRONTEND_URL 未設定時はデフォルト値 "http://localhost:8080" を使用する
+            let _db = EnvGuard::set(
+                "DATABASE_URL",
+                Some("postgresql://user:password@localhost/test"),
+            );
+            let _fe = EnvGuard::set("FRONTEND_URL", None);
+            let result = Secrets::from_env();
+            assert!(result.is_ok());
+            assert_eq!(result.unwrap().frontend_url, "http://localhost:8080");
+        }
+        {
+            // JQUANTS_API_KEY は省略可能で None になる
+            let _db = EnvGuard::set(
+                "DATABASE_URL",
+                Some("postgresql://user:password@localhost/test"),
+            );
+            let _jq = EnvGuard::set("JQUANTS_API_KEY", None);
+            let result = Secrets::from_env();
+            assert!(result.is_ok());
+            assert!(result.unwrap().jquants_api_key.is_none());
+        }
     }
 }


### PR DESCRIPTION
state/csv_import/routes/csv_util: テスト統合で行数削減