### PR TITLE
refactor: autoresearch ループ継続（iter 56〜）

### DIFF
--- a/autoresearch-results.tsv
+++ b/autoresearch-results.tsv
@@ -55,3 +55,4 @@ iteration	commit	metric	status	description
 61	e77748e	7692	reverted	csv_import: 長い tuple 比較は rustfmt 展開で 3 行増えたためリバート
 62	acacae3	7685	kept	csv_import: テスト内容と重複するコメント削除で 4 行削減
 63	8b0fcb5	7680	kept	config: 環境別 CORS テストのコメント削除で 5 行削減
+64	919097e	7675	kept	stock/tests: 重複コメント削除で 5 行削減

--- a/autoresearch-results.tsv
+++ b/autoresearch-results.tsv
@@ -54,3 +54,4 @@ iteration	commit	metric	status	description
 60	e77748e	7689	reverted	dividend: プレビュー件数の集約は rustfmt 後に行数改善が出ずリバート
 61	e77748e	7692	reverted	csv_import: 長い tuple 比較は rustfmt 展開で 3 行増えたためリバート
 62	acacae3	7685	kept	csv_import: テスト内容と重複するコメント削除で 4 行削減
+63	8b0fcb5	7680	kept	config: 環境別 CORS テストのコメント削除で 5 行削減

--- a/autoresearch-results.tsv
+++ b/autoresearch-results.tsv
@@ -49,3 +49,7 @@ iteration	commit	metric	status	description
 53	8cf63c3	7733	kept	db/dividend/dividend_cache/jquants_response: テスト統合で 16 行削減
 56	01ae56c	7706	reverted	routes: 関数ポインタ化と一時変数削減は rustfmt 後に 9 行増で悪化したためリバート
 57	b14d0fc	7696	kept	config: rustfmt 再整形で CORS テストの改行を 1 行削減
+58	e77748e	7689	kept	shared: BulkTimer テストを tuple 比較に寄せて 7 行削減
+59	ab86da7	7690	reverted	mutualfund: tuple 比較化は rustfmt 後に 1 行増えたためコミットを巻き戻し
+60	e77748e	7689	reverted	dividend: プレビュー件数の集約は rustfmt 後に行数改善が出ずリバート
+61	e77748e	7692	reverted	csv_import: 長い tuple 比較は rustfmt 展開で 3 行増えたためリバート

--- a/autoresearch-results.tsv
+++ b/autoresearch-results.tsv
@@ -47,3 +47,4 @@ iteration	commit	metric	status	description
 51	975070f	7773	kept	auth/security/csv_util: テスト統合で 19 行削減
 52	7cd899a	7749	kept	char_width/cors/rate_limit/csv_import/validated_json: テスト統合で 24 行削減
 53	8cf63c3	7733	kept	db/dividend/dividend_cache/jquants_response: テスト統合で 16 行削減
+56	01ae56c	7706	reverted	routes: 関数ポインタ化と一時変数削減は rustfmt 後に 9 行増で悪化したためリバート

--- a/autoresearch-results.tsv
+++ b/autoresearch-results.tsv
@@ -53,3 +53,4 @@ iteration	commit	metric	status	description
 59	ab86da7	7690	reverted	mutualfund: tuple 比較化は rustfmt 後に 1 行増えたためコミットを巻き戻し
 60	e77748e	7689	reverted	dividend: プレビュー件数の集約は rustfmt 後に行数改善が出ずリバート
 61	e77748e	7692	reverted	csv_import: 長い tuple 比較は rustfmt 展開で 3 行増えたためリバート
+62	acacae3	7685	kept	csv_import: テスト内容と重複するコメント削除で 4 行削減

--- a/autoresearch-results.tsv
+++ b/autoresearch-results.tsv
@@ -48,3 +48,4 @@ iteration	commit	metric	status	description
 52	7cd899a	7749	kept	char_width/cors/rate_limit/csv_import/validated_json: テスト統合で 24 行削減
 53	8cf63c3	7733	kept	db/dividend/dividend_cache/jquants_response: テスト統合で 16 行削減
 56	01ae56c	7706	reverted	routes: 関数ポインタ化と一時変数削減は rustfmt 後に 9 行増で悪化したためリバート
+57	b14d0fc	7696	kept	config: rustfmt 再整形で CORS テストの改行を 1 行削減

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -171,13 +171,11 @@ mod tests {
     async fn test_config_from_env() {
         let _lock = ENV_MUTEX.lock().await;
         {
-            // CSV_RATE_LIMIT_RPS が config に反映される
             let _csv_rate_limit_rps = EnvGuard::set("CSV_RATE_LIMIT_RPS", Some("7"));
             let config = Config::from_env();
             assert_eq!(config.csv_rate_limit_rps, 7);
         }
         {
-            // 本番環境では localhost が CORS から除外される
             let _app_env = EnvGuard::set("APP_ENV", Some("production"));
             let _cors_origins = EnvGuard::set(
                 "CORS_ORIGINS",
@@ -195,7 +193,6 @@ mod tests {
             );
         }
         {
-            // CORS_ORIGINS 環境変数が validate_origin に反映される
             let _app_env = EnvGuard::set("APP_ENV", None);
             let _cors_origins = EnvGuard::set(
                 "CORS_ORIGINS",
@@ -217,7 +214,6 @@ mod tests {
             );
         }
         {
-            // 非本番環境では localhost が許可される
             let _app_env = EnvGuard::set("APP_ENV", None);
             let _cors_origins = EnvGuard::set("CORS_ORIGINS", Some("http://localhost:8080"));
             let config = Config::from_env();
@@ -226,7 +222,6 @@ mod tests {
                 allowed_origin(&preflight(app.clone(), "http://localhost:8080").await),
                 Some("http://localhost:8080")
             );
-            // 許可されていないオリジンは 403 + セキュリティヘッダーが付与される
             let resp = post_with_origin(app, "http://evil.example.com").await;
             assert_eq!(resp.status(), StatusCode::FORBIDDEN);
             assert_eq!(

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -203,8 +203,7 @@ mod tests {
             );
             let config = Config::from_env();
             let app = build_test_app(&config);
-            let resp =
-                post_with_origin(app.clone(), "http://custom-origin.example.com:8080").await;
+            let resp = post_with_origin(app.clone(), "http://custom-origin.example.com:8080").await;
             assert_ne!(
                 resp.status(),
                 StatusCode::FORBIDDEN,

--- a/backend/src/handlers/stock/tests.rs
+++ b/backend/src/handlers/stock/tests.rs
@@ -145,14 +145,12 @@ async fn test_search_stock() {
     let (pool, _node) = setup_test_db().await;
     let app = setup_test_app(pool);
 
-    // コードによる検索テスト
     let response = call(app.clone(), "GET", "/stocks/1234", None).await;
     assert_eq!(response.status(), StatusCode::OK);
     let stock = read_json(response).await;
     assert_eq!(stock["code"], "1234");
     assert_eq!(stock["name"], "テスト株式会社");
 
-    // 銘柄名による検索テスト
     for (uri, expected_status) in [
         ("/stocks/テスト", StatusCode::OK),
         ("/stocks/9999", StatusCode::NOT_FOUND),
@@ -193,15 +191,12 @@ async fn test_create_stock() {
     );
 }
 
-/// 未認証時に POST /stocks が 401 を返すことを確認
-/// セッション検証はハンドラー入口で実行され DB クエリは発生しないため DB 不要
 #[tokio::test]
 async fn test_create_stock_unauthorized() {
     let pool = crate::db::connect_pool_lazy("postgresql://postgres:postgres@localhost/postgres", 1)
         .unwrap();
     let app = setup_test_app(pool);
 
-    // セッション Cookie なしでリクエスト
     assert_eq!(
         call(
             app,

--- a/backend/src/services/csv_import.rs
+++ b/backend/src/services/csv_import.rs
@@ -102,13 +102,11 @@ mod tests {
 
     #[test]
     fn test_parse_csv() {
-        // 正常行のパース
         let csv = "col_a,col_b\nfoo,123\nbar,456\n";
         let (items, errors) = parse_pair_csv(csv);
         assert_eq!(items, vec!["foo/123", "bar/456"]);
         assert!(errors.is_empty());
 
-        // name が空の行（2行目）はエラーとして収集され、items には含まれない
         let csv = "name,id\ngood,1\n,2\nbad,3\n";
         let (items, errors) =
             parse_csv::<String, _>(csv.as_bytes(), |record, header_map, row_num| {
@@ -119,13 +117,11 @@ mod tests {
         assert_eq!(errors.len(), 1);
         assert_eq!(errors[0].row, 2);
 
-        // 全列が空の行はスキップされる
         let csv = "col_a,col_b\nfoo,123\n,\nbar,456\n";
         let (items, errors) = parse_pair_csv(csv);
         assert_eq!(items, vec!["foo/123", "bar/456"]);
         assert!(errors.is_empty());
 
-        // フィールド数が不一致の行は CSV 読み込みエラーとして収集される
         let csv = "col_a,col_b\nfoo,123\nbar\nbaz,456\n";
         let (items, errors) = parse_pair_csv(csv);
         assert_eq!(items, vec!["foo/123", "baz/456"]);

--- a/backend/src/services/shared.rs
+++ b/backend/src/services/shared.rs
@@ -57,16 +57,9 @@ mod tests {
 
     #[test]
     fn test_bulk_timer_finish() {
-        let response = BulkTimer::new("test", 5).finish(0);
-        assert_eq!(response.inserted, 0);
-        assert_eq!(response.skipped, 5);
-
-        let response = BulkTimer::new("test", 5).finish(5);
-        assert_eq!(response.inserted, 5);
-        assert_eq!(response.skipped, 0);
-
-        let response = BulkTimer::new("test", 5).finish(3);
-        assert_eq!(response.inserted, 3);
-        assert_eq!(response.skipped, 2);
+        for (inserted, expected) in [(0, (0, 5)), (5, (5, 0)), (3, (3, 2))] {
+            let response = BulkTimer::new("test", 5).finish(inserted);
+            assert_eq!((response.inserted, response.skipped), expected);
+        }
     }
 }


### PR DESCRIPTION
autoresearch ループの継続。複数イテレーションの削減をまとめて PR にする。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **修正 (Chores)**
  * テストコードおよび設定の内部整理と最適化を行いました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->