### PR TITLE
refactor: 手書きinterfacesをgenerated型に移行

### DIFF
--- a/frontend/src/components/organisms/AssetPortfolioSummary/__tests__/AssetPortfolioSummary.test.tsx
+++ b/frontend/src/components/organisms/AssetPortfolioSummary/__tests__/AssetPortfolioSummary.test.tsx
@@ -11,6 +11,9 @@ vi.mock('@/components/atoms/SecurityCodeLink', () => ({
 const createMockData = (overrides: Partial<AssetBalanceData>[] = []): AssetBalanceData[] => {
   const defaults: AssetBalanceData[] = [
     {
+      id: 'asset-balance-1',
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
       security_code: '7203',
       security_name: 'トヨタ自動車',
       shares: 100,
@@ -23,6 +26,9 @@ const createMockData = (overrides: Partial<AssetBalanceData>[] = []): AssetBalan
       profit_loss_rate: 4.0,
     },
     {
+      id: 'asset-balance-2',
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
       security_code: '6758',
       security_name: 'ソニーグループ',
       shares: 50,
@@ -98,6 +104,9 @@ describe('AssetPortfolioSummary', () => {
   it('取得総額がnull/undefinedの場合は0として扱う', () => {
     const mockData: AssetBalanceData[] = [
       {
+        id: 'asset-balance-1',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
         security_code: '7203',
         security_name: 'トヨタ自動車',
         shares: 100,
@@ -110,6 +119,9 @@ describe('AssetPortfolioSummary', () => {
         profit_loss_rate: 4.0,
       },
       {
+        id: 'asset-balance-2',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
         security_code: '6758',
         security_name: 'ソニーグループ',
         shares: 50,
@@ -133,6 +145,9 @@ describe('AssetPortfolioSummary', () => {
   it('security_nameが空の場合security_codeをグラフ名に使用する', () => {
     const mockData: AssetBalanceData[] = [
       {
+        id: 'asset-balance-1',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
         security_code: '7203',
         security_name: '',
         shares: 100,
@@ -154,6 +169,9 @@ describe('AssetPortfolioSummary', () => {
   it('合計取得総額がマイナスの場合data-negative属性が付く', () => {
     const mockData: AssetBalanceData[] = [
       {
+        id: 'asset-balance-1',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
         security_code: '7203',
         security_name: 'テスト銘柄',
         shares: 100,

--- a/frontend/src/features/assetBalance/api/assetBalanceApi.ts
+++ b/frontend/src/features/assetBalance/api/assetBalanceApi.ts
@@ -1,10 +1,10 @@
 import { apiClient } from '@/lib/api/client';
 import { uploadCsvFile, previewCsvFile } from '@/lib/api/csvHelpers';
-import { AssetBalanceData } from '@/lib/interfaces/assetBalance';
+import type { AssetBalanceApiData } from '@/lib/interfaces/assetBalance';
 
 export const assetBalanceApi = {
   list: () =>
-    apiClient.get<AssetBalanceData[]>('/asset-balances', { withCredentials: true }),
+    apiClient.get<AssetBalanceApiData[]>('/asset-balances', { withCredentials: true }),
 
   previewCsv: (file: File) => previewCsvFile('/asset-balances/csv/preview', file),
 

--- a/frontend/src/features/assetBalance/hooks/__tests__/useAssetBalance.test.ts
+++ b/frontend/src/features/assetBalance/hooks/__tests__/useAssetBalance.test.ts
@@ -12,7 +12,7 @@ import { useAssetBalance } from '../useAssetBalance';
 import { assetBalanceQueryKeys } from '../../queryKeys';
 import * as assetBalanceApiModule from '@/features/assetBalance/api/assetBalanceApi';
 import * as authHook from '@/features/auth/hooks/useAuth';
-import type { AssetBalanceData } from '@/lib/interfaces/assetBalance';
+import type { AssetBalanceApiData } from '@/lib/interfaces/assetBalance';
 
 // ────────────────────────────────────────────────────────
 // モック
@@ -55,8 +55,11 @@ function makeWrapper(qc: QueryClient) {
   return Wrapper;
 }
 
-function makeAssetBalanceData(overrides: Partial<AssetBalanceData> = {}): AssetBalanceData {
+function makeAssetBalanceData(overrides: Partial<AssetBalanceApiData> = {}): AssetBalanceApiData {
   return {
+    id: 'asset-balance-1',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
     security_code: '7203',
     security_name: 'トヨタ自動車',
     shares: 100,
@@ -131,6 +134,7 @@ describe('useAssetBalance', () => {
     vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue([
       makeAssetBalanceData({ security_code: '7203' }),
       makeAssetBalanceData({
+        id: 'asset-balance-2',
         security_code: '6758',
         security_name: 'ソニーグループ',
       }),
@@ -156,6 +160,7 @@ describe('useAssetBalance', () => {
     vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue([
       makeAssetBalanceData({ security_code: '7203', market_value: 210000 }),
       makeAssetBalanceData({
+        id: 'asset-balance-2',
         security_code: '6758',
         security_name: 'ソニーグループ',
         market_value: 180000,
@@ -189,7 +194,7 @@ describe('useAssetBalance', () => {
 
     vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue([
       makeAssetBalanceData({ security_code: '7203', market_value: 100000 }),
-      makeAssetBalanceData({ security_code: '6758', market_value: 0 }),
+      makeAssetBalanceData({ id: 'asset-balance-2', security_code: '6758', market_value: 0 }),
     ]);
 
     const { result } = renderHook(() => useAssetBalance(), { wrapper: makeWrapper(qc) });

--- a/frontend/src/features/receipt/api/receiptApi.ts
+++ b/frontend/src/features/receipt/api/receiptApi.ts
@@ -1,13 +1,13 @@
 import { apiClient } from '@/lib/api/client';
 import { uploadCsvFile, previewCsvFile } from '@/lib/api/csvHelpers';
-import { DividendData } from '@/lib/interfaces/dividend';
-import { DomesticStockData } from '@/lib/interfaces/domesticStock';
-import { MutualfundData } from '@/lib/interfaces/mutualfund';
+import type { DividendApiData } from '@/lib/interfaces/dividend';
+import type { DomesticStockApiData } from '@/lib/interfaces/domesticStock';
+import type { MutualfundApiData } from '@/lib/interfaces/mutualfund';
 
 // 配当金API
 export const dividendApi = {
   list: () =>
-    apiClient.get<DividendData[]>('/dividends', { withCredentials: true }),
+    apiClient.get<DividendApiData[]>('/dividends', { withCredentials: true }),
 
   previewCsv: (file: File) => previewCsvFile('/dividends/csv/preview', file),
 
@@ -20,7 +20,7 @@ export const dividendApi = {
 // 国内株式API
 export const domesticStockApi = {
   list: () =>
-    apiClient.get<DomesticStockData[]>('/domestic-stocks', { withCredentials: true }),
+    apiClient.get<DomesticStockApiData[]>('/domestic-stocks', { withCredentials: true }),
 
   previewCsv: (file: File) => previewCsvFile('/domestic-stocks/csv/preview', file),
 
@@ -33,7 +33,7 @@ export const domesticStockApi = {
 // 投資信託API
 export const mutualfundApi = {
   list: () =>
-    apiClient.get<MutualfundData[]>('/mutualfunds', { withCredentials: true }),
+    apiClient.get<MutualfundApiData[]>('/mutualfunds', { withCredentials: true }),
 
   previewCsv: (file: File) => previewCsvFile('/mutualfunds/csv/preview', file),
 

--- a/frontend/src/features/receipt/hooks/useReceiptsData.ts
+++ b/frontend/src/features/receipt/hooks/useReceiptsData.ts
@@ -64,27 +64,21 @@ export function useReceiptsData(): UseReceiptsDataResult {
   const dividendQuery = useQuery({
     queryKey: receiptQueryKeys.dividend(userId),
     queryFn: () =>
-      dividendApi.list().then(items =>
-        items.map(d => transformDBDividend(d as unknown as Record<string, unknown>))
-      ),
+      dividendApi.list().then(items => items.map(transformDBDividend)),
     enabled: isAuthenticated && !authLoading && !!userId,
   });
 
   const domesticstockQuery = useQuery({
     queryKey: receiptQueryKeys.domesticstock(userId),
     queryFn: () =>
-      domesticStockApi.list().then(items =>
-        items.map(d => transformDBDomesticStock(d as unknown as Record<string, unknown>))
-      ),
+      domesticStockApi.list().then(items => items.map(transformDBDomesticStock)),
     enabled: isAuthenticated && !authLoading && !!userId,
   });
 
   const mutualfundQuery = useQuery({
     queryKey: receiptQueryKeys.mutualfund(userId),
     queryFn: () =>
-      mutualfundApi.list().then(items =>
-        items.map(d => transformDBMutualfund(d as unknown as Record<string, unknown>))
-      ),
+      mutualfundApi.list().then(items => items.map(transformDBMutualfund)),
     enabled: isAuthenticated && !authLoading && !!userId,
   });
 

--- a/frontend/src/features/receipt/parsers/dividendParser.ts
+++ b/frontend/src/features/receipt/parsers/dividendParser.ts
@@ -1,4 +1,6 @@
-import { DividendData } from '@/lib/interfaces/dividend';
+import type { DividendApiData, DividendData } from '@/lib/interfaces/dividend';
+
+type DividendSource = Partial<DividendApiData> | Record<string, unknown>;
 
 /**
  * 決済日でソート
@@ -12,20 +14,21 @@ export const sortDividendBySettlementDate = (data: DividendData[]): DividendData
 /**
  * DBレスポンスをDividendDataに変換
  */
-export const transformDBDividend = (item: Record<string, unknown>): DividendData => {
-    const securityCode = String(item.security_code || '');
-    const securityName = String(item.security_name || '');
+export const transformDBDividend = (item: DividendSource): DividendData => {
+    const record = item as Record<string, unknown>;
+    const securityCode = String(record.security_code || '');
+    const securityName = String(record.security_name || '');
 
     return {
-        settlement_date: new Date(item.settlement_date as string),
-        product: String(item.product || ''),
-        account: String(item.account || ''),
+        settlement_date: new Date(record.settlement_date as string),
+        product: String(record.product || ''),
+        account: String(record.account || ''),
         security_code: securityCode,
         security_name: securityName,
-        unit_price: Number(item.unit_price) || 0,
-        shares: Number(item.shares) || 0,
-        dividends_before_tax: Number(item.dividends_before_tax) || 0,
-        taxes: Number(item.taxes) || 0,
-        net_amount_received: Number(item.net_amount_received) || 0,
+        unit_price: Number(record.unit_price) || 0,
+        shares: Number(record.shares) || 0,
+        dividends_before_tax: Number(record.dividends_before_tax) || 0,
+        taxes: Number(record.taxes) || 0,
+        net_amount_received: Number(record.net_amount_received) || 0,
     };
 };

--- a/frontend/src/features/receipt/parsers/domesticStockParser.ts
+++ b/frontend/src/features/receipt/parsers/domesticStockParser.ts
@@ -1,4 +1,6 @@
-import { DomesticStockData } from '@/lib/interfaces/domesticStock';
+import type { DomesticStockApiData, DomesticStockData } from '@/lib/interfaces/domesticStock';
+
+type DomesticStockSource = Partial<DomesticStockApiData> | Record<string, unknown>;
 
 /**
  * 取引日でソート
@@ -12,22 +14,23 @@ export const sortDomesticStockByTradeDate = (data: DomesticStockData[]): Domesti
 /**
  * DBレスポンスをDomesticStockDataに変換
  */
-export const transformDBDomesticStock = (item: Record<string, unknown>): DomesticStockData => {
-    const securityCode = String(item.security_code || '');
-    const securityName = String(item.security_name || '');
+export const transformDBDomesticStock = (item: DomesticStockSource): DomesticStockData => {
+    const record = item as Record<string, unknown>;
+    const securityCode = String(record.security_code || '');
+    const securityName = String(record.security_name || '');
 
     return {
-        trade_date: new Date(item.trade_date as string),
-        settlement_date: new Date(item.settlement_date as string),
+        trade_date: new Date(record.trade_date as string),
+        settlement_date: new Date(record.settlement_date as string),
         security_code: securityCode,
         security_name: securityName,
-        account: String(item.account || ''),
-        shares: Number(item.shares) || 0,
-        asked_price: Number(item.asked_price) || 0,
-        proceeds: Number(item.proceeds) || 0,
-        purchase_price: Number(item.purchase_price) || 0,
-        realized_profit_and_loss: Number(item.realized_profit_and_loss) || 0,
-        taxes: Number(item.taxes) || 0,
-        realized_profit_and_loss_after_tax: Number(item.realized_profit_and_loss_after_tax) || 0,
+        account: String(record.account || ''),
+        shares: Number(record.shares) || 0,
+        asked_price: Number(record.asked_price) || 0,
+        proceeds: Number(record.proceeds) || 0,
+        purchase_price: Number(record.purchase_price) || 0,
+        realized_profit_and_loss: Number(record.realized_profit_and_loss) || 0,
+        taxes: Number(record.taxes) || 0,
+        realized_profit_and_loss_after_tax: Number(record.realized_profit_and_loss_after_tax) || 0,
     };
 };

--- a/frontend/src/features/receipt/parsers/mutualfundParser.ts
+++ b/frontend/src/features/receipt/parsers/mutualfundParser.ts
@@ -1,4 +1,6 @@
-import { MutualfundData } from '@/lib/interfaces/mutualfund';
+import type { MutualfundApiData, MutualfundData } from '@/lib/interfaces/mutualfund';
+
+type MutualfundSource = Partial<MutualfundApiData> | Record<string, unknown>;
 
 /**
  * 取引日でソート
@@ -12,20 +14,22 @@ export const sortMutualfundByTradeDate = (data: MutualfundData[]): MutualfundDat
 /**
  * DBレスポンスをMutualfundDataに変換
  */
-export const transformDBMutualfund = (item: Record<string, unknown>): MutualfundData => {
+export const transformDBMutualfund = (item: MutualfundSource): MutualfundData => {
+    const record = item as Record<string, unknown>;
+
     return {
-        trade_date: new Date(item.trade_date as string),
-        settlement_date: new Date(item.settlement_date as string),
-        fund_name: String(item.fund_name || ''),
-        dividends: String(item.dividends || ''),
-        account: String(item.account || ''),
-        shares: Number(item.shares) || 0,
-        exchange_rate: Number(item.exchange_rate) || 0,
-        cancellation_unit_price_yen: Number(item.cancellation_unit_price_yen) || 0,
-        cancellation_amount_yen: Number(item.cancellation_amount_yen) || 0,
-        average_acquisition_price_yen: Number(item.average_acquisition_price_yen) || 0,
-        realized_profit_and_loss: Number(item.realized_profit_and_loss) || 0,
-        taxes: Number(item.taxes) || 0,
-        realized_profit_and_loss_after_tax: Number(item.realized_profit_and_loss_after_tax) || 0,
+        trade_date: new Date(record.trade_date as string),
+        settlement_date: new Date(record.settlement_date as string),
+        fund_name: String(record.fund_name || ''),
+        dividends: String(record.dividends || ''),
+        account: String(record.account || ''),
+        shares: Number(record.shares) || 0,
+        exchange_rate: Number(record.exchange_rate) || 0,
+        cancellation_unit_price_yen: Number(record.cancellation_unit_price_yen) || 0,
+        cancellation_amount_yen: Number(record.cancellation_amount_yen) || 0,
+        average_acquisition_price_yen: Number(record.average_acquisition_price_yen) || 0,
+        realized_profit_and_loss: Number(record.realized_profit_and_loss) || 0,
+        taxes: Number(record.taxes) || 0,
+        realized_profit_and_loss_after_tax: Number(record.realized_profit_and_loss_after_tax) || 0,
     };
 };

--- a/frontend/src/lib/interfaces/__tests__/generatedTypes.test.ts
+++ b/frontend/src/lib/interfaces/__tests__/generatedTypes.test.ts
@@ -1,0 +1,38 @@
+import { describe, expectTypeOf, it } from 'vitest';
+
+import type { components } from '@/generated/api';
+import type {
+  AssetBalanceApiData,
+  AssetBalanceData,
+} from '@/lib/interfaces/assetBalance';
+import type { DividendApiData, DividendData } from '@/lib/interfaces/dividend';
+import type {
+  DomesticStockApiData,
+  DomesticStockData,
+} from '@/lib/interfaces/domesticStock';
+import type { MutualfundApiData, MutualfundData } from '@/lib/interfaces/mutualfund';
+
+describe('generated interface bindings', () => {
+  it('asset balance API and view data types are derived from generated schemas', () => {
+    expectTypeOf<AssetBalanceApiData>().toEqualTypeOf<components['schemas']['AssetBalance']>();
+    expectTypeOf<AssetBalanceData>().toEqualTypeOf<components['schemas']['AssetBalance']>();
+  });
+
+  it('receipt API data types are identical to generated schemas', () => {
+    expectTypeOf<DividendApiData>().toEqualTypeOf<components['schemas']['Dividend']>();
+    expectTypeOf<DomesticStockApiData>().toEqualTypeOf<components['schemas']['DomesticStock']>();
+    expectTypeOf<MutualfundApiData>().toEqualTypeOf<components['schemas']['Mutualfund']>();
+  });
+
+  it('receipt view data keeps Date based fields for UI logic', () => {
+    expectTypeOf<DividendData['settlement_date']>().toEqualTypeOf<Date>();
+    expectTypeOf<DomesticStockData['trade_date']>().toEqualTypeOf<Date>();
+    expectTypeOf<DomesticStockData['settlement_date']>().toEqualTypeOf<Date>();
+    expectTypeOf<MutualfundData['trade_date']>().toEqualTypeOf<Date>();
+    expectTypeOf<MutualfundData['settlement_date']>().toEqualTypeOf<Date>();
+  });
+
+  it('MutualfundData keeps dividends as a normalized string for the UI', () => {
+    expectTypeOf<MutualfundData['dividends']>().toEqualTypeOf<string>();
+  });
+});

--- a/frontend/src/lib/interfaces/assetBalance.ts
+++ b/frontend/src/lib/interfaces/assetBalance.ts
@@ -1,27 +1,5 @@
-/**
- * 保有銘柄の情報を表すインターフェース
- */
-export interface AssetBalanceData {
-  /** 銘柄コード */
-  security_code: string;
-  /** 銘柄名 */
-  security_name: string;
-  /** 保有数量 */
-  shares: number;
-  /** 執行中数量 */
-  executing_shares: number;
-  /** 平均取得価額 */
-  average_purchase_price: number;
-  /** 取得総額 */
-  total_purchase_amount: number;
-  /** 現在値 */
-  current_price: number;
-  /** 前日比 */
-  daily_change: number;
-  /** 時価評価額 */
-  market_value: number;
-  /** 評価損益率（%） */
-  profit_loss_rate: number;
-  // インデックスシグネチャを追加して汎用的なアクセスを許可
-  [key: string]: unknown;
-}
+import type { components } from '@/generated/api';
+
+export type AssetBalanceApiData = components['schemas']['AssetBalance'];
+
+export type AssetBalanceData = components['schemas']['AssetBalance'];

--- a/frontend/src/lib/interfaces/dividend.ts
+++ b/frontend/src/lib/interfaces/dividend.ts
@@ -1,20 +1,16 @@
-import { ReceiptBase, TaxCalculations } from './receipt';
+import type { components } from '@/generated/api';
 
-export interface DividendData extends ReceiptBase {
-    product: string;
-    account: string;
-    security_code: string;
-    security_name: string;
-    unit_price: number;
-    shares: number;
-    dividends_before_tax: number;
-    taxes: number;
-    net_amount_received: number;
-    // インデックスシグネチャを追加して汎用的なアクセスを許可
-    [key: string]: unknown;
+import type { ReceiptBase, TaxCalculations } from './receipt';
+
+export type DividendApiData = components['schemas']['Dividend'];
+
+export interface DividendData
+  extends Omit<DividendApiData, 'settlement_date' | 'id' | 'created_at' | 'updated_at'>,
+    ReceiptBase {
+  [key: string]: unknown;
 }
 
 export interface DividendCalculations extends TaxCalculations {
-    total_dividends_before_tax: number;
-    total_net_amount_received: number;
+  total_dividends_before_tax: number;
+  total_net_amount_received: number;
 }

--- a/frontend/src/lib/interfaces/domesticStock.ts
+++ b/frontend/src/lib/interfaces/domesticStock.ts
@@ -1,28 +1,25 @@
-import { ReceiptBase, TaxCalculations } from './receipt';
+import type { components } from '@/generated/api';
 
-export interface DomesticStockData extends ReceiptBase {
-    trade_date: Date;
-    security_code: string;
-    security_name: string;
-    account: string;
-    shares: number;
-    asked_price: number;
-    proceeds: number;
-    purchase_price: number;
-    realized_profit_and_loss: number;
-    taxes: number;
-    realized_profit_and_loss_after_tax: number;
-    // インデックスシグネチャを追加して汎用的なアクセスを許可
-    [key: string]: unknown;
+import type { ReceiptBase, TaxCalculations } from './receipt';
+
+export type DomesticStockApiData = components['schemas']['DomesticStock'];
+
+export interface DomesticStockData
+  extends Omit<
+      DomesticStockApiData,
+      'trade_date' | 'settlement_date' | 'id' | 'created_at' | 'updated_at'
+    >,
+    ReceiptBase {
+  trade_date: Date;
+  [key: string]: unknown;
 }
 
 export interface DomesticStockCalculations extends TaxCalculations {
-    total_realized_profit_and_loss: number;
-    total_realized_profit_and_loss_after_tax: number;
+  total_realized_profit_and_loss: number;
+  total_realized_profit_and_loss_after_tax: number;
 }
 
 export interface DomesticStockSummary extends DomesticStockCalculations {
-    filter: string;
-    // インデックスシグネチャを追加して汎用的なアクセスを許可
-    [key: string]: unknown;
+  filter: string;
+  [key: string]: unknown;
 }

--- a/frontend/src/lib/interfaces/mutualfund.ts
+++ b/frontend/src/lib/interfaces/mutualfund.ts
@@ -1,31 +1,21 @@
-import { ReceiptBase, TaxCalculations } from './receipt';
+import type { components } from '@/generated/api';
 
-/**
- * 投資信託データの基本構造
- */
-export interface MutualfundData extends ReceiptBase {
-    trade_date: Date;                       // 約定日
-    settlement_date: Date;                  // 受渡日
-    fund_name: string;                      // ファンド名
-    dividends: string;                      // 分配金
-    account: string;                        // 口座
-    shares: number;                         // 数量[口]
-    exchange_rate: number;                  // 為替レート[円]
-    cancellation_unit_price_yen: number;    // 解約単価[円]
-    cancellation_amount_yen: number;        // 解約額[円]
-    average_acquisition_price_yen: number;  // 平均取得価額[円]
-    realized_profit_and_loss: number;       // 実現損益[円]
-    taxes: number;                          // 税額
-    realized_profit_and_loss_after_tax: number; // 実現損益(税引)[円]
-    // インデックスシグネチャを追加して汎用的なアクセスを許可
-    [key: string]: unknown;
+import type { ReceiptBase, TaxCalculations } from './receipt';
+
+export type MutualfundApiData = components['schemas']['Mutualfund'];
+
+export interface MutualfundData
+  extends Omit<
+      MutualfundApiData,
+      'trade_date' | 'settlement_date' | 'dividends' | 'id' | 'created_at' | 'updated_at'
+    >,
+    ReceiptBase {
+  trade_date: Date;
+  dividends: string;
+  [key: string]: unknown;
 }
 
-/**
- * 投資信託の集計計算結果
- */
 export interface MutualfundCalculations extends TaxCalculations {
-    total_realized_profit_and_loss: number;           // 合計実現損益
-    total_realized_profit_and_loss_after_tax: number; // 合計実現損益(税引)
+  total_realized_profit_and_loss: number;
+  total_realized_profit_and_loss_after_tax: number;
 }
-

--- a/frontend/src/pages/__tests__/AssetBalance.test.tsx
+++ b/frontend/src/pages/__tests__/AssetBalance.test.tsx
@@ -21,8 +21,11 @@ vi.mock('@/lib/utils/formatters', async (importOriginal) => {
   };
 });
 
-const mockAssetBalanceData: AssetBalanceData[] = [
-  {
+function makeAssetBalanceData(overrides: Partial<AssetBalanceData> = {}): AssetBalanceData {
+  return {
+    id: 'asset-balance-1',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
     security_code: '7203',
     security_name: 'トヨタ自動車',
     shares: 100,
@@ -33,19 +36,24 @@ const mockAssetBalanceData: AssetBalanceData[] = [
     daily_change: 50,
     market_value: 260000,
     profit_loss_rate: 4.0,
-  },
-  {
+    ...overrides,
+  };
+}
+
+const mockAssetBalanceData: AssetBalanceData[] = [
+  makeAssetBalanceData(),
+  makeAssetBalanceData({
+    id: 'asset-balance-2',
     security_code: '6758',
     security_name: 'ソニーグループ',
     shares: 50,
-    executing_shares: 0,
     average_purchase_price: 12000,
     total_purchase_amount: 600000,
     current_price: 11500,
     daily_change: -100,
     market_value: 575000,
     profit_loss_rate: -4.17,
-  },
+  }),
 ];
 
 

--- a/frontend/src/pages/__tests__/AssetBalancePage.test.tsx
+++ b/frontend/src/pages/__tests__/AssetBalancePage.test.tsx
@@ -14,7 +14,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import { AssetBalancePage } from '../AssetBalance';
 import { assetBalanceQueryKeys } from '@/features/assetBalance/queryKeys';
-import { AssetBalanceData } from '@/lib/interfaces/assetBalance';
+import type { AssetBalanceApiData, AssetBalanceData } from '@/lib/interfaces/assetBalance';
 
 // ────────────────────────────────────────────────────────
 // モック定義
@@ -166,7 +166,10 @@ function renderWithQuery(ui: React.ReactElement, qc?: QueryClient) {
 }
 
 // DBデータの型に合わせたモック行
-const mockDbRow: AssetBalanceData = {
+const mockPreviewRow: AssetBalanceData = {
+  id: 'asset-balance-preview-1',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
   security_code: '7203',
   security_name: 'トヨタ自動車',
   shares: 100,
@@ -179,7 +182,14 @@ const mockDbRow: AssetBalanceData = {
   profit_loss_rate: 4.0,
 };
 
-const secondMockDbRow: AssetBalanceData = {
+const mockDbRow: AssetBalanceApiData = {
+  ...mockPreviewRow,
+  id: 'asset-balance-1',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
+const secondMockDbRow: AssetBalanceApiData = {
   ...mockDbRow,
   security_code: '6758',
   security_name: 'ソニーグループ',
@@ -265,7 +275,7 @@ describe('AssetBalancePage 認証境界・キャッシュ境界', () => {
       total_rows: 2,
       valid_rows: 2,
       errors: [],
-      rows: [mockDbRow, { ...mockDbRow, security_code: '6758' }],
+      rows: [mockPreviewRow, { ...mockPreviewRow, security_code: '6758' }],
     } as never);
     vi.mocked(assetBalanceApiModule.assetBalanceApi.uploadCsv).mockResolvedValue({
       inserted: 2,
@@ -409,7 +419,7 @@ describe('AssetBalancePage 認証境界・キャッシュ境界', () => {
       total_rows: 1,
       valid_rows: 1,
       errors: [],
-      rows: [mockDbRow],
+      rows: [mockPreviewRow],
     } as never);
     vi.mocked(assetBalanceApiModule.assetBalanceApi.uploadCsv).mockReturnValue(
       new Promise((resolve) => {


### PR DESCRIPTION
## 概要
`lib/interfaces/` の手書き型を削除し、OpenAPI generated 型を唯一の正本にする。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 資産残高、配当金、国内株式、投信データにタイムスタンプとID フィールドを追加

* **Tests**
  * API スキーマ型との整合性を検証する型レベルテストを追加
  * テストデータ構造を更新し、新しいデータフィールドに対応

<!-- end of auto-generated comment: release notes by coderabbit.ai -->