### PR TITLE
refactor: Receipts.tsx の責務を features/receipt/ に分散

### DIFF
--- a/frontend/src/components/organisms/DataActionRail/DataActionRail.tsx
+++ b/frontend/src/components/organisms/DataActionRail/DataActionRail.tsx
@@ -3,7 +3,7 @@ import { CsvSaveResultNotice } from '@/components/molecules/CsvSaveResultNotice'
 import { Button } from '@/components/atoms/Button';
 import type { CsvUploadResult } from '@/lib/csvImport';
 
-interface DataActionRailProps {
+export interface DataActionRailProps {
   // ファイル入力
   onFileSelect: (file: File) => void;
   selectedFileName?: string;

--- a/frontend/src/features/receipt/components/ReceiptsAlerts.tsx
+++ b/frontend/src/features/receipt/components/ReceiptsAlerts.tsx
@@ -1,5 +1,5 @@
 import { Alert } from '@/components/atoms/Alert';
-import { type CsvPreview } from './receiptsReducer';
+import type { CsvPreview } from '../reducer';
 
 interface ReceiptsAlertsProps {
   dbError: string | null | undefined;
@@ -34,8 +34,10 @@ export function ReceiptsAlerts({
             </p>
             {csvPreview.errors.length > 0 && (
               <ul className="mt-2 list-disc list-inside text-sm space-y-1">
-                {csvPreview.errors.map((e) => (
-                  <li key={e.row}>{e.row}行目: {e.message}</li>
+                {csvPreview.errors.map((error) => (
+                  <li key={error.row}>
+                    {error.row}行目: {error.message}
+                  </li>
                 ))}
               </ul>
             )}

--- a/frontend/src/features/receipt/components/ReceiptsTabNav.tsx
+++ b/frontend/src/features/receipt/components/ReceiptsTabNav.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { type ReceiptsType } from './receiptsReducer';
+import type { ReceiptsType } from '../reducer';
 
 const TAB_LABEL: Record<ReceiptsType, string> = {
   dividend: '配当金',
@@ -13,7 +13,7 @@ interface ReceiptsTabNavProps {
   receiptsType: ReceiptsType;
   tablistRef: React.RefObject<HTMLDivElement | null>;
   onTabChange: (tab: ReceiptsType) => void;
-  onKeyDown: (e: React.KeyboardEvent<HTMLButtonElement>) => void;
+  onKeyDown: (event: React.KeyboardEvent<HTMLButtonElement>) => void;
   counts: Record<ReceiptsType, number>;
 }
 
@@ -54,7 +54,9 @@ export function ReceiptsTabNav({
               <span
                 data-testid={`tab-count-${tab}`}
                 className={`inline-flex min-w-6 items-center justify-center rounded-full px-2 py-0.5 text-xs font-semibold ${
-                  isActive ? 'border border-slate-200 bg-slate-100 text-slate-700' : 'bg-slate-100 text-slate-500'
+                  isActive
+                    ? 'border border-slate-200 bg-slate-100 text-slate-700'
+                    : 'bg-slate-100 text-slate-500'
                 }`}
               >
                 {counts[tab]}

--- a/frontend/src/features/receipt/components/ReceiptsUtilityRail.tsx
+++ b/frontend/src/features/receipt/components/ReceiptsUtilityRail.tsx
@@ -1,0 +1,46 @@
+import { Spinner } from '@/components/atoms/Spinner';
+import {
+  DataActionRail,
+  type DataActionRailProps,
+} from '@/components/organisms/DataActionRail/DataActionRail';
+import type { CsvPreview } from '../reducer';
+import { ReceiptsAlerts } from './ReceiptsAlerts';
+
+export interface ReceiptsUtilityRailProps {
+  actionRailProps: DataActionRailProps;
+  alertsProps: {
+    dbError: string | null | undefined;
+    hasCsvFile: boolean;
+    previewing: boolean;
+    csvPreview: CsvPreview | null | undefined;
+  };
+  authLoading: boolean;
+  dbLoading: boolean;
+}
+
+export function ReceiptsUtilityRail({
+  actionRailProps,
+  alertsProps,
+  authLoading,
+  dbLoading,
+}: ReceiptsUtilityRailProps) {
+  return (
+    <>
+      <DataActionRail {...actionRailProps} />
+      <ReceiptsAlerts {...alertsProps} />
+      <div aria-live="polite" aria-atomic="true">
+        {(authLoading || dbLoading) && (
+          <section className="px-5 py-4" role="status">
+            <div className="status-message">
+              <Spinner size="md" className="text-primary" />
+              <p className="text-sm text-secondary">
+                {authLoading && '認証状態を確認しています...'}
+                {dbLoading && 'データを読み込んでいます...'}
+              </p>
+            </div>
+          </section>
+        )}
+      </div>
+    </>
+  );
+}

--- a/frontend/src/features/receipt/hooks/useReceiptsData.ts
+++ b/frontend/src/features/receipt/hooks/useReceiptsData.ts
@@ -7,7 +7,7 @@ import {
   transformDBMutualfund,
 } from '../parsers';
 import { receiptQueryKeys, clearReceiptsCache } from '../queryKeys';
-import { type ReceiptsType } from '@/pages/receiptsReducer';
+import { type ReceiptsType } from '../reducer';
 import { getDisplayErrorMessage } from '@/lib/utils/errorHandler';
 import { useAuth } from '@/features/auth/hooks/useAuth';
 import type { CsvImportError, CsvUploadResult } from '@/lib/csvImport';

--- a/frontend/src/features/receipt/hooks/useReceiptsState.ts
+++ b/frontend/src/features/receipt/hooks/useReceiptsState.ts
@@ -1,0 +1,188 @@
+import { useEffect, useReducer, useRef, type KeyboardEvent } from 'react';
+import type { DataActionRailProps } from '@/components/organisms/DataActionRail/DataActionRail';
+import { useAuth } from '@/features/auth/hooks/useAuth';
+import type { ReceiptsUtilityRailProps } from '../components/ReceiptsUtilityRail';
+import { TAB_LABEL, TABS } from '../components/ReceiptsTabNav';
+import {
+  transformDBDividend,
+  transformDBDomesticStock,
+  transformDBMutualfund,
+} from '../parsers';
+import { initialState, receiptsReducer, type ReceiptsType } from '../reducer';
+import { useReceiptsData } from './useReceiptsData';
+
+export function useReceiptsState() {
+  const { isAuthenticated, isLoading: authLoading, onLogout } = useAuth();
+  const [state, dispatch] = useReducer(receiptsReducer, initialState);
+  const {
+    dividendData,
+    domesticstockData,
+    mutualfundData,
+    dbLoading,
+    dbError,
+    saving,
+    deleting,
+    previewing,
+    uploadCsv,
+    previewCsv,
+    deleteAll,
+  } = useReceiptsData();
+
+  useEffect(() => {
+    return onLogout(() => {
+      dispatch({ type: 'LOGOUT' });
+    });
+  }, [onLogout]);
+
+  const { receiptsType, rawFiles, csvPreviews, lastImportResults, showDeleteConfirm } = state;
+  const tablistRef = useRef<HTMLDivElement>(null);
+  const currentData = {
+    dividend: dividendData,
+    domesticstock: domesticstockData,
+    mutualfund: mutualfundData,
+  }[receiptsType];
+  const rawFile = rawFiles[receiptsType];
+  const csvPreview = csvPreviews[receiptsType];
+  const importResult = lastImportResults[receiptsType];
+  const dbDataCount = currentData.length;
+  const hasCsvFile = rawFile !== null;
+  const tabName = TAB_LABEL[receiptsType];
+  const saveLabel = csvPreview ? `${csvPreview.validRows}件 追加で保存` : '追加で保存';
+
+  const counts = {
+    dividend: dividendData.length,
+    domesticstock: domesticstockData.length,
+    mutualfund: mutualfundData.length,
+  };
+
+  const previewData = {
+    dividend: csvPreviews.dividend?.rows.map((row) => transformDBDividend(row)),
+    domesticstock: csvPreviews.domesticstock?.rows.map((row) => transformDBDomesticStock(row)),
+    mutualfund: csvPreviews.mutualfund?.rows.map((row) => transformDBMutualfund(row)),
+  };
+
+  const setReceiptsType = (tab: ReceiptsType) => {
+    dispatch({ type: 'SET_RECEIPTS_TYPE', payload: tab });
+  };
+
+  const handleTabKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    const currentIndex = TABS.indexOf(receiptsType);
+    let nextIndex: number | null = null;
+
+    if (event.key === 'ArrowRight') {
+      nextIndex = (currentIndex + 1) % TABS.length;
+    } else if (event.key === 'ArrowLeft') {
+      nextIndex = (currentIndex - 1 + TABS.length) % TABS.length;
+    } else if (event.key === 'Home') {
+      nextIndex = 0;
+    } else if (event.key === 'End') {
+      nextIndex = TABS.length - 1;
+    }
+
+    if (nextIndex === null) {
+      return;
+    }
+
+    event.preventDefault();
+    const nextTab = TABS[nextIndex];
+    dispatch({ type: 'SET_RECEIPTS_TYPE', payload: nextTab });
+    const buttons = tablistRef.current?.querySelectorAll<HTMLButtonElement>('[role="tab"]');
+    buttons?.[nextIndex]?.focus();
+  };
+
+  const handleFileSelect = (file: File) => {
+    dispatch({ type: 'SET_RAW_FILE', receiptsType, payload: file });
+    previewCsv({
+      type: receiptsType,
+      file,
+      onSuccess: (result) => {
+        dispatch({ type: 'SET_CSV_PREVIEW', receiptsType, payload: result });
+      },
+    });
+  };
+
+  const handleSaveToDB = () => {
+    if (!isAuthenticated || rawFile === null) {
+      return;
+    }
+
+    uploadCsv({
+      type: receiptsType,
+      file: rawFile,
+      onSuccess: (result) => {
+        dispatch({ type: 'SET_RAW_FILE', receiptsType, payload: null });
+        dispatch({ type: 'SET_IMPORT_RESULT', receiptsType, payload: result });
+      },
+    });
+  };
+
+  const openDeleteConfirm = () => {
+    dispatch({ type: 'SET_SHOW_DELETE_CONFIRM', payload: true });
+  };
+
+  const closeDeleteConfirm = () => {
+    dispatch({ type: 'SET_SHOW_DELETE_CONFIRM', payload: false });
+  };
+
+  const confirmDeleteAll = () => {
+    if (!isAuthenticated) {
+      return;
+    }
+
+    closeDeleteConfirm();
+    deleteAll(receiptsType, {
+      onSuccess: () => {
+        dispatch({ type: 'CLEAR_IMPORT_RESULT', receiptsType });
+      },
+    });
+  };
+
+  const actionRailProps: DataActionRailProps = {
+    onFileSelect: handleFileSelect,
+    selectedFileName: rawFile?.name ?? undefined,
+    fileInputDisabled: dbLoading || saving || deleting || previewing || authLoading,
+    hasCsvFile: isAuthenticated && hasCsvFile,
+    saveLabel: saving ? '保存中...' : previewing ? '解析中...' : saveLabel,
+    onSave: handleSaveToDB,
+    saveDisabled: saving || deleting || previewing,
+    hasDbData: isAuthenticated && dbDataCount > 0,
+    deleteLabel: deleting ? '削除中...' : `全件削除 (${dbDataCount}件)`,
+    onDeleteRequest: openDeleteConfirm,
+    deleteDisabled: saving || deleting || dbLoading,
+    saveResult: importResult,
+    saveModeLabel: '追加保存',
+  };
+
+  const utilityRailProps: ReceiptsUtilityRailProps = {
+    actionRailProps,
+    alertsProps: {
+      dbError,
+      hasCsvFile,
+      previewing,
+      csvPreview,
+    },
+    authLoading,
+    dbLoading,
+  };
+
+  return {
+    receiptsType,
+    counts,
+    tablistRef,
+    setReceiptsType,
+    handleTabKeyDown,
+    showDeleteConfirm,
+    closeDeleteConfirm,
+    confirmDeleteAll,
+    tabName,
+    dbDataCount,
+    dividendData,
+    domesticstockData,
+    mutualfundData,
+    previewData,
+    utilityRailProps,
+    deleteModalLoading: deleting,
+    initialLoading: authLoading || dbLoading,
+    workspaceBusy: authLoading || dbLoading || saving || deleting,
+  };
+}

--- a/frontend/src/features/receipt/reducer.ts
+++ b/frontend/src/features/receipt/reducer.ts
@@ -31,7 +31,7 @@ export interface ReceiptsState {
   showDeleteConfirm: boolean;
 }
 
-type ReceiptsAction =
+export type ReceiptsAction =
   | { type: 'SET_RECEIPTS_TYPE'; payload: ReceiptsType }
   | { type: 'SET_RAW_FILE'; receiptsType: ReceiptsType; payload: File | null }
   | { type: 'SET_CSV_PREVIEW'; receiptsType: ReceiptsType; payload: CsvPreview | null }
@@ -48,7 +48,10 @@ export const initialState: ReceiptsState = {
   showDeleteConfirm: false,
 };
 
-export function receiptsReducer(state: ReceiptsState, action: ReceiptsAction): ReceiptsState {
+export function receiptsReducer(
+  state: ReceiptsState,
+  action: ReceiptsAction,
+): ReceiptsState {
   switch (action.type) {
     case 'SET_RECEIPTS_TYPE':
       return { ...state, receiptsType: action.payload };
@@ -56,7 +59,6 @@ export function receiptsReducer(state: ReceiptsState, action: ReceiptsAction): R
       return {
         ...state,
         rawFiles: { ...state.rawFiles, [action.receiptsType]: action.payload },
-        // 新しいファイルを選択したら前回の結果とプレビューをクリア
         csvPreviews: { ...state.csvPreviews, [action.receiptsType]: null },
         lastImportResults: { ...state.lastImportResults, [action.receiptsType]: null },
       };

--- a/frontend/src/pages/Receipts.tsx
+++ b/frontend/src/pages/Receipts.tsx
@@ -1,23 +1,13 @@
-import { useReducer, useEffect, useCallback, useRef } from 'react';
 import { Layout } from '../components/templates/Layout';
 import { PageHeader } from '../components/atoms/PageHeader';
 import { usePageTitle } from '../hooks/usePageTitle';
-import { Spinner } from '@/components/atoms/Spinner';
-import { useAuth } from '@/features/auth/hooks/useAuth';
 import { Dividend } from './Receipt/Dividend';
 import { DomesticStock } from './Receipt/DomesticStock';
 import { Mutualfund } from './Receipt/Mutualfund';
 import { ConfirmDeleteModal } from '@/components/molecules/ConfirmDeleteModal/ConfirmDeleteModal';
-import { initialState, receiptsReducer } from './receiptsReducer';
-import { useReceiptsData } from '@/features/receipt/hooks/useReceiptsData';
-import {
-  transformDBDividend,
-  transformDBDomesticStock,
-  transformDBMutualfund,
-} from '@/features/receipt/parsers';
-import { ReceiptsTabNav, TABS, TAB_LABEL } from './ReceiptsTabNav';
-import { DataActionRail } from '@/components/organisms/DataActionRail/DataActionRail';
-import { ReceiptsAlerts } from './ReceiptsAlerts';
+import { ReceiptsTabNav } from '@/features/receipt/components/ReceiptsTabNav';
+import { ReceiptsUtilityRail } from '@/features/receipt/components/ReceiptsUtilityRail';
+import { useReceiptsState } from '@/features/receipt/hooks/useReceiptsState';
 
 /**
  * 明細種類ごとにCSVデータを管理するページコンポーネント
@@ -25,132 +15,48 @@ import { ReceiptsAlerts } from './ReceiptsAlerts';
 export function ReceiptsPage() {
   usePageTitle('取引明細');
 
-  const { isAuthenticated, isLoading: authLoading, onLogout } = useAuth();
-  const [state, dispatch] = useReducer(receiptsReducer, initialState);
-  const { receiptsType, rawFiles, lastImportResults, showDeleteConfirm } = state;
-
-  // TanStack Query ベースのデータ管理
   const {
+    receiptsType,
+    counts,
+    tablistRef,
+    setReceiptsType,
+    handleTabKeyDown,
+    showDeleteConfirm,
+    closeDeleteConfirm,
+    confirmDeleteAll,
+    tabName,
+    dbDataCount,
     dividendData,
     domesticstockData,
     mutualfundData,
-    dbLoading,
-    dbError,
-    saving,
-    deleting,
-    previewing,
-    uploadCsv,
-    previewCsv,
-    deleteAll,
-  } = useReceiptsData();
+    previewData,
+    utilityRailProps,
+    deleteModalLoading,
+    initialLoading,
+    workspaceBusy,
+  } = useReceiptsState();
 
-  // ログアウト時に状態をクリア（Query キャッシュは useReceiptsData が内部処理）
-  useEffect(() => {
-    return onLogout(() => {
-      dispatch({ type: 'LOGOUT' });
-    });
-  }, [onLogout]);
-
-  const rawFile = rawFiles[receiptsType];
-  const selectedFileName = rawFile?.name ?? undefined;
-  const csvPreview = state.csvPreviews[receiptsType];
-
-  const handleFileSelect = useCallback((file: File) => {
-    dispatch({ type: 'SET_RAW_FILE', receiptsType, payload: file });
-    previewCsv({
-      type: receiptsType,
-      file,
-      onSuccess: (result) => {
-        dispatch({ type: 'SET_CSV_PREVIEW', receiptsType, payload: result });
-      },
-    });
-  }, [receiptsType, previewCsv]);
-
-  const handleSaveToDB = useCallback(() => {
-    if (!isAuthenticated || rawFile === null) return;
-    uploadCsv({
-      type: receiptsType,
-      file: rawFile,
-      onSuccess: (result) => {
-        dispatch({ type: 'SET_RAW_FILE', receiptsType, payload: null });
-        dispatch({ type: 'SET_IMPORT_RESULT', receiptsType, payload: result });
-      },
-    });
-  }, [uploadCsv, isAuthenticated, receiptsType, rawFile]);
-
-  const handleDeleteAll = useCallback(() => {
-    if (!isAuthenticated) return;
-    dispatch({ type: 'SET_SHOW_DELETE_CONFIRM', payload: false });
-    deleteAll(receiptsType, {
-      onSuccess: () => dispatch({ type: 'CLEAR_IMPORT_RESULT', receiptsType }),
-    });
-  }, [deleteAll, isAuthenticated, receiptsType]);
-
-  const hasCsvFile = rawFile !== null;
-  const dbDataCount = { dividend: dividendData, domesticstock: domesticstockData, mutualfund: mutualfundData }[receiptsType].length;
-  const hasDbData = dbDataCount > 0;
-  const tabName = TAB_LABEL[receiptsType];
-  const importResult = lastImportResults[receiptsType];
-  const saveLabel = csvPreview ? `${csvPreview.validRows}件 追加で保存` : '追加で保存';
-
-  const tablistRef = useRef<HTMLDivElement>(null);
-
-  // 矢印キーでのタブ切り替え（roving tabIndex パターン）
-  const handleTabKeyDown = useCallback((e: React.KeyboardEvent<HTMLButtonElement>) => {
-    const currentIndex = TABS.indexOf(receiptsType);
-    let nextIndex: number | null = null;
-    if (e.key === 'ArrowRight') nextIndex = (currentIndex + 1) % TABS.length;
-    else if (e.key === 'ArrowLeft') nextIndex = (currentIndex - 1 + TABS.length) % TABS.length;
-    else if (e.key === 'Home') nextIndex = 0;
-    else if (e.key === 'End') nextIndex = TABS.length - 1;
-    if (nextIndex !== null) {
-      e.preventDefault();
-      dispatch({ type: 'SET_RECEIPTS_TYPE', payload: TABS[nextIndex] });
-      const buttons = tablistRef.current?.querySelectorAll<HTMLButtonElement>('[role="tab"]');
-      buttons?.[nextIndex]?.focus();
-    }
-  }, [receiptsType]);
-
-  const utilityRail = (
-    <>
-      <DataActionRail
-        onFileSelect={handleFileSelect}
-        selectedFileName={selectedFileName}
-        fileInputDisabled={dbLoading || saving || deleting || previewing || authLoading}
-        hasCsvFile={isAuthenticated && hasCsvFile}
-        saveLabel={saving ? '保存中...' : previewing ? '解析中...' : saveLabel}
-        onSave={handleSaveToDB}
-        saveDisabled={saving || deleting || previewing}
-        hasDbData={isAuthenticated && hasDbData}
-        deleteLabel={deleting ? '削除中...' : `全件削除 (${dbDataCount}件)`}
-        onDeleteRequest={() => dispatch({ type: 'SET_SHOW_DELETE_CONFIRM', payload: true })}
-        deleteDisabled={saving || deleting || dbLoading}
-        saveResult={importResult}
-        saveModeLabel="追加保存"
-      />
-
-      <ReceiptsAlerts
-        dbError={dbError}
-        hasCsvFile={hasCsvFile}
-        previewing={previewing}
-        csvPreview={csvPreview}
-      />
-
-      <div aria-live="polite" aria-atomic="true">
-        {(dbLoading || authLoading) && (
-          <section className="px-5 py-4" role="status">
-            <div className="status-message">
-              <Spinner size="md" className="text-primary" />
-              <p className="text-sm text-secondary">
-                {authLoading && '認証状態を確認しています...'}
-                {dbLoading && 'データを読み込んでいます...'}
-              </p>
-            </div>
-          </section>
-        )}
-      </div>
-    </>
-  );
+  const utilityRail = <ReceiptsUtilityRail {...utilityRailProps} />;
+  const panels = [
+    {
+      type: 'dividend',
+      content: <Dividend data={dividendData} previewData={previewData.dividend} utilityRail={utilityRail} />,
+    },
+    {
+      type: 'domesticstock',
+      content: (
+        <DomesticStock
+          data={domesticstockData}
+          previewData={previewData.domesticstock}
+          utilityRail={utilityRail}
+        />
+      ),
+    },
+    {
+      type: 'mutualfund',
+      content: <Mutualfund data={mutualfundData} previewData={previewData.mutualfund} utilityRail={utilityRail} />,
+    },
+  ] as const;
 
   return (
     <Layout>
@@ -161,57 +67,34 @@ export function ReceiptsPage() {
       <ReceiptsTabNav
         receiptsType={receiptsType}
         tablistRef={tablistRef}
-        onTabChange={(tab) => dispatch({ type: 'SET_RECEIPTS_TYPE', payload: tab })}
+        onTabChange={setReceiptsType}
         onKeyDown={handleTabKeyDown}
-        counts={{
-          dividend: dividendData.length,
-          domesticstock: domesticstockData.length,
-          mutualfund: mutualfundData.length,
-        }}
+        counts={counts}
       />
-      <div className="mt-2" aria-busy={dbLoading || authLoading || saving || deleting}>
+      <div className="mt-2" aria-busy={workspaceBusy}>
         <div data-testid="receipts-workspace">
-          {!authLoading && !dbLoading && (
-            <>
-              <div id="tabpanel-dividend" role="tabpanel" aria-labelledby="tab-dividend" hidden={receiptsType !== 'dividend'}>
-                {receiptsType === 'dividend' && (
-                  <Dividend
-                    data={dividendData}
-                    previewData={csvPreview?.rows?.map(r => transformDBDividend(r))}
-                    utilityRail={utilityRail}
-                  />
-                )}
+          {!initialLoading &&
+            panels.map((panel) => (
+              <div
+                key={panel.type}
+                id={`tabpanel-${panel.type}`}
+                role="tabpanel"
+                aria-labelledby={`tab-${panel.type}`}
+                hidden={receiptsType !== panel.type}
+              >
+                {receiptsType === panel.type && panel.content}
               </div>
-              <div id="tabpanel-domesticstock" role="tabpanel" aria-labelledby="tab-domesticstock" hidden={receiptsType !== 'domesticstock'}>
-                {receiptsType === 'domesticstock' && (
-                  <DomesticStock
-                    data={domesticstockData}
-                    previewData={csvPreview?.rows?.map(r => transformDBDomesticStock(r))}
-                    utilityRail={utilityRail}
-                  />
-                )}
-              </div>
-              <div id="tabpanel-mutualfund" role="tabpanel" aria-labelledby="tab-mutualfund" hidden={receiptsType !== 'mutualfund'}>
-                {receiptsType === 'mutualfund' && (
-                  <Mutualfund
-                    data={mutualfundData}
-                    previewData={csvPreview?.rows?.map(r => transformDBMutualfund(r))}
-                    utilityRail={utilityRail}
-                  />
-                )}
-              </div>
-            </>
-          )}
+            ))}
         </div>
 
         <ConfirmDeleteModal
           isOpen={showDeleteConfirm}
-          onConfirm={handleDeleteAll}
-          onCancel={() => dispatch({ type: 'SET_SHOW_DELETE_CONFIRM', payload: false })}
+          onConfirm={confirmDeleteAll}
+          onCancel={closeDeleteConfirm}
           title={`${tabName}データの全件削除`}
           description={`【${tabName}】のデータをすべて削除します。`}
           itemCount={dbDataCount}
-          loading={deleting}
+          loading={deleteModalLoading}
         />
       </div>
     </Layout>

--- a/frontend/src/pages/__tests__/Receipts.test.tsx
+++ b/frontend/src/pages/__tests__/Receipts.test.tsx
@@ -11,8 +11,8 @@ import userEvent from '@testing-library/user-event';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { makeQueryClient, renderWithQuery, waitOpts } from '@/test/utils';
 
-import { receiptsReducer, initialState } from '../receiptsReducer';
-import type { ReceiptsState } from '../receiptsReducer';
+import { initialState, receiptsReducer } from '@/features/receipt/reducer';
+import type { ReceiptsState } from '@/features/receipt/reducer';
 import { ReceiptsPage } from '../Receipts';
 import { receiptQueryKeys } from '@/features/receipt/queryKeys';
 import * as receiptParsers from '@/features/receipt/parsers';

--- a/frontend/src/pages/__tests__/ReceiptsAlerts.test.tsx
+++ b/frontend/src/pages/__tests__/ReceiptsAlerts.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
-import { ReceiptsAlerts } from '../ReceiptsAlerts';
-import type { CsvPreview } from '../receiptsReducer';
+import { ReceiptsAlerts } from '@/features/receipt/components/ReceiptsAlerts';
+import type { CsvPreview } from '@/features/receipt/reducer';
 
 function makeCsvPreview(overrides: Partial<CsvPreview> = {}): CsvPreview {
   return {


### PR DESCRIPTION
## 概要
Receipts.tsx が認証・状態管理・CSV 操作・削除導線・タブ制御まで抱えており、ページ責務が肥大化していました。変更時に page 直下と feature 配下の境界が曖昧で、関連ロジックの追跡コストが高い状態でした。

## 原因
receiptsReducer と補助 UI が pages 配下に残っており、useReceiptsData とページ状態の責務分担が不十分だったためです。その結果、Receipts.tsx 自身が useReducer と各種ハンドラを保持し、配線コードが大半を占めていました。

## 対応
- receiptsReducer を `frontend/src/features/receipt/reducer.ts` に移動
- `ReceiptsAlerts` と `ReceiptsTabNav` を `features/receipt/components` に移動
- `useReceiptsState` を追加し、タブ操作・CSV preview/save・削除確認状態を集約
- `ReceiptsUtilityRail` を追加し、DataActionRail / alert / loading を feature 側へ分離
- `Receipts.tsx` はレイアウト、タブ表示、削除モーダル配線に限定
- 既存テストの import 先を更新
- `Receipts.tsx` を 102 行まで縮小

## 影響
ユーザー向けの画面挙動は維持しつつ、Receipts ページの変更点が feature 配下に集約されます。今後の receipt 関連改修でも、ページコンポーネントへの責務逆流を避けやすくなります。

## 検証
- `cd frontend && vp lint`
- `cd frontend && npx tsc --noEmit`
- `cd frontend && npm test -- --run`
- `cd frontend && vp build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * 受領書管理ページの内部構造を改善し、状態管理ロジックを最適化しました。
  * UI コンポーネントの依存関係を整理し、コード保守性を向上させました。

* **Chores**
  * 内部モジュールのパス定義と型エクスポートを更新しました。
  * テストのインポートパスを統一しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->