### PR TITLE
fix: csv_import.rs の圧縮テストを展開し #[rustfmt::skip] を除去

### DIFF
--- a/backend/src/handlers/csv_import.rs
+++ b/backend/src/handlers/csv_import.rs
@@ -55,14 +55,202 @@ pub async fn handle_upload_csv<D: CsvDomain>(
     let response = D::upload_csv(pool, user_id, &bytes).await?;
     Ok((StatusCode::CREATED, Json(response)))
 }
-#[cfg(test)] #[rustfmt::skip] mod tests {
-    use {super::*, crate::errors::ErrorResponse, async_trait::async_trait, axum::{body::{to_bytes, Body}, extract::{Multipart, State}, http::{Request, StatusCode}, routing::post, Router}, serde::de::DeserializeOwned, sqlx::postgres::PgPoolOptions, tower::ServiceExt, uuid::Uuid};
-    const BODY_LIMIT: usize = 1024 * 1024; fn test_app() -> Router { Router::new().route("/csv", post(csv_bytes_endpoint)) }
-    async fn csv_bytes_endpoint(multipart: Multipart) -> Result<Vec<u8>, ApiError> { read_csv_file_bytes(multipart).await } struct PreviewDomain; #[async_trait] impl CsvDomain for PreviewDomain { fn preview_csv(bytes: &[u8]) -> Result<crate::models::csv_import::CsvPreviewResponse, ApiError> { Ok(crate::models::csv_import::CsvPreviewResponse { total_rows: bytes.len(), valid_rows: 1, errors: vec![], rows: vec![serde_json::json!({"ok": true})] }) } async fn upload_csv(_pool: &sqlx::PgPool, _user_id: Uuid, _bytes: &[u8]) -> Result<crate::models::csv_import::CsvUploadResponse, ApiError> { unreachable!("preview test does not call upload") } }
-    struct UploadDomain; #[async_trait] impl CsvDomain for UploadDomain { fn preview_csv(_bytes: &[u8]) -> Result<crate::models::csv_import::CsvPreviewResponse, ApiError> { unreachable!("upload test does not call preview") } async fn upload_csv(_pool: &sqlx::PgPool, _user_id: Uuid, bytes: &[u8]) -> Result<crate::models::csv_import::CsvUploadResponse, ApiError> { Ok(crate::models::csv_import::CsvUploadResponse { inserted: usize::from(!bytes.is_empty()), skipped: 0, errors: vec![] }) } }
-    fn multipart_request(field_name: &str, filename: Option<&str>, content: &str) -> Request<Body> { let boundary = "boundary123"; let content_disposition = filename.map_or_else(|| format!("Content-Disposition: form-data; name=\"{field_name}\"\r\n"), |filename| format!("Content-Disposition: form-data; name=\"{field_name}\"; filename=\"{filename}\"\r\n")); let body = format!("--{boundary}\r\n{content_disposition}Content-Type: text/csv\r\n\r\n{content}\r\n--{boundary}--\r\n"); Request::builder().method("POST").uri("/csv").header("content-type", format!("multipart/form-data; boundary={boundary}")).body(Body::from(body)).unwrap() }
-    async fn read_json_response<T: DeserializeOwned>(response: axum::response::Response) -> T { let body = to_bytes(response.into_body(), BODY_LIMIT).await.unwrap(); serde_json::from_slice(&body).unwrap() }
-    fn preview_app() -> Router { Router::new().route("/csv", post(preview_endpoint)) } async fn preview_endpoint(multipart: Multipart) -> Result<impl IntoResponse, ApiError> { handle_preview_csv::<PreviewDomain>(multipart).await }
-    fn upload_app() -> Router { let pool = PgPoolOptions::new().max_connections(1).connect_lazy("postgresql://user:password@localhost/test_db").unwrap(); Router::new().route("/csv", post(upload_endpoint)).with_state(pool) } async fn upload_endpoint(State(pool): State<sqlx::PgPool>, multipart: Multipart) -> Result<impl IntoResponse, ApiError> { handle_upload_csv::<UploadDomain>(&pool, Uuid::nil(), multipart).await }
-    #[tokio::test] async fn test_csv_handler() { let content = "symbol,amount\n7203,100\n"; let response = test_app().oneshot(multipart_request("file", Some("positions.csv"), content)).await.unwrap(); assert_eq!(response.status(), StatusCode::OK); assert_eq!(to_bytes(response.into_body(), BODY_LIMIT).await.unwrap().as_ref(), content.as_bytes()); for (field, filename, msg_fragment) in [("other", Some("positions.csv"), Some("fileフィールド")), ("file", Some("positions.txt"), Some(".csv")), ("file", Some(""), None)] { let response = test_app().oneshot(multipart_request(field, filename, "dummy")).await.unwrap(); let status = response.status(); let error: ErrorResponse = read_json_response(response).await; assert_eq!((status, error.error.code.as_str(), msg_fragment.map_or(true, |fragment| error.error.message.contains(fragment))), (StatusCode::BAD_REQUEST, "VALIDATION_ERROR", true)); } let response = preview_app().oneshot(multipart_request("file", Some("preview.csv"), "a,b\n1,2\n")).await.unwrap(); let status = response.status(); let preview: serde_json::Value = read_json_response(response).await; assert_eq!((status, preview["valid_rows"].as_i64(), preview["rows"].as_array().map(Vec::len)), (StatusCode::OK, Some(1), Some(1))); let response = upload_app().oneshot(multipart_request("file", Some("upload.csv"), "a,b\n1,2\n")).await.unwrap(); let status = response.status(); let upload: serde_json::Value = read_json_response(response).await; assert_eq!((status, upload["inserted"].as_i64(), upload["skipped"].as_i64()), (StatusCode::CREATED, Some(1), Some(0))); }
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::errors::ErrorResponse;
+    use async_trait::async_trait;
+    use axum::{
+        body::{to_bytes, Body},
+        extract::{Multipart, State},
+        http::{Request, StatusCode},
+        routing::post,
+        Router,
+    };
+    use serde::de::DeserializeOwned;
+    use sqlx::postgres::PgPoolOptions;
+    use tower::ServiceExt;
+    use uuid::Uuid;
+
+    const BODY_LIMIT: usize = 1024 * 1024;
+
+    fn test_app() -> Router {
+        Router::new().route("/csv", post(csv_bytes_endpoint))
+    }
+
+    async fn csv_bytes_endpoint(multipart: Multipart) -> Result<Vec<u8>, ApiError> {
+        read_csv_file_bytes(multipart).await
+    }
+
+    struct PreviewDomain;
+
+    #[async_trait]
+    impl CsvDomain for PreviewDomain {
+        fn preview_csv(
+            bytes: &[u8],
+        ) -> Result<crate::models::csv_import::CsvPreviewResponse, ApiError> {
+            Ok(crate::models::csv_import::CsvPreviewResponse {
+                total_rows: bytes.len(),
+                valid_rows: 1,
+                errors: vec![],
+                rows: vec![serde_json::json!({ "ok": true })],
+            })
+        }
+
+        async fn upload_csv(
+            _pool: &sqlx::PgPool,
+            _user_id: Uuid,
+            _bytes: &[u8],
+        ) -> Result<crate::models::csv_import::CsvUploadResponse, ApiError> {
+            unreachable!("preview test does not call upload")
+        }
+    }
+
+    struct UploadDomain;
+
+    #[async_trait]
+    impl CsvDomain for UploadDomain {
+        fn preview_csv(
+            _bytes: &[u8],
+        ) -> Result<crate::models::csv_import::CsvPreviewResponse, ApiError> {
+            unreachable!("upload test does not call preview")
+        }
+
+        async fn upload_csv(
+            _pool: &sqlx::PgPool,
+            _user_id: Uuid,
+            bytes: &[u8],
+        ) -> Result<crate::models::csv_import::CsvUploadResponse, ApiError> {
+            Ok(crate::models::csv_import::CsvUploadResponse {
+                inserted: usize::from(!bytes.is_empty()),
+                skipped: 0,
+                errors: vec![],
+            })
+        }
+    }
+
+    fn multipart_request(field_name: &str, filename: Option<&str>, content: &str) -> Request<Body> {
+        let boundary = "boundary123";
+        let content_disposition = filename.map_or_else(
+            || format!("Content-Disposition: form-data; name=\"{field_name}\"\r\n"),
+            |filename| {
+                format!(
+                    "Content-Disposition: form-data; name=\"{field_name}\"; filename=\"{filename}\"\r\n"
+                )
+            },
+        );
+        let body = format!(
+            "--{boundary}\r\n{content_disposition}Content-Type: text/csv\r\n\r\n{content}\r\n--{boundary}--\r\n"
+        );
+
+        Request::builder()
+            .method("POST")
+            .uri("/csv")
+            .header(
+                "content-type",
+                format!("multipart/form-data; boundary={boundary}"),
+            )
+            .body(Body::from(body))
+            .unwrap()
+    }
+
+    async fn read_json_response<T: DeserializeOwned>(response: axum::response::Response) -> T {
+        let body = to_bytes(response.into_body(), BODY_LIMIT).await.unwrap();
+        serde_json::from_slice(&body).unwrap()
+    }
+
+    fn preview_app() -> Router {
+        Router::new().route("/csv", post(preview_endpoint))
+    }
+
+    async fn preview_endpoint(multipart: Multipart) -> Result<impl IntoResponse, ApiError> {
+        handle_preview_csv::<PreviewDomain>(multipart).await
+    }
+
+    fn upload_app() -> Router {
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .connect_lazy("postgresql://user:password@localhost/test_db")
+            .unwrap();
+
+        Router::new()
+            .route("/csv", post(upload_endpoint))
+            .with_state(pool)
+    }
+
+    async fn upload_endpoint(
+        State(pool): State<sqlx::PgPool>,
+        multipart: Multipart,
+    ) -> Result<impl IntoResponse, ApiError> {
+        handle_upload_csv::<UploadDomain>(&pool, Uuid::nil(), multipart).await
+    }
+
+    #[tokio::test]
+    async fn test_csv_handler() {
+        let content = "symbol,amount\n7203,100\n";
+        let response = test_app()
+            .oneshot(multipart_request("file", Some("positions.csv"), content))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            to_bytes(response.into_body(), BODY_LIMIT)
+                .await
+                .unwrap()
+                .as_ref(),
+            content.as_bytes()
+        );
+
+        for (field, filename, msg_fragment) in [
+            ("other", Some("positions.csv"), Some("fileフィールド")),
+            ("file", Some("positions.txt"), Some(".csv")),
+            ("file", Some(""), None),
+        ] {
+            let response = test_app()
+                .oneshot(multipart_request(field, filename, "dummy"))
+                .await
+                .unwrap();
+            let status = response.status();
+            let error: ErrorResponse = read_json_response(response).await;
+
+            assert_eq!(
+                (
+                    status,
+                    error.error.code.as_str(),
+                    msg_fragment.is_none_or(|fragment| { error.error.message.contains(fragment) }),
+                ),
+                (StatusCode::BAD_REQUEST, "VALIDATION_ERROR", true)
+            );
+        }
+
+        let response = preview_app()
+            .oneshot(multipart_request("file", Some("preview.csv"), "a,b\n1,2\n"))
+            .await
+            .unwrap();
+        let status = response.status();
+        let preview: serde_json::Value = read_json_response(response).await;
+        assert_eq!(
+            (
+                status,
+                preview["valid_rows"].as_i64(),
+                preview["rows"].as_array().map(Vec::len),
+            ),
+            (StatusCode::OK, Some(1), Some(1))
+        );
+
+        let response = upload_app()
+            .oneshot(multipart_request("file", Some("upload.csv"), "a,b\n1,2\n"))
+            .await
+            .unwrap();
+        let status = response.status();
+        let upload: serde_json::Value = read_json_response(response).await;
+        assert_eq!(
+            (
+                status,
+                upload["inserted"].as_i64(),
+                upload["skipped"].as_i64(),
+            ),
+            (StatusCode::CREATED, Some(1), Some(0))
+        );
+    }
 }


### PR DESCRIPTION
## 変更内容

`backend/src/handlers/csv_import.rs` のテストモジュールを展開し、`#[rustfmt::skip]` を除去。

- `#[rustfmt::skip]` を削除
- 1行に詰め込まれた `mod tests` を cargo fmt 準拠スタイルに展開

## 背景

`backend/.claude/rules/00-backend.md` に「`#[rustfmt::skip]` 使用禁止」ルールを追加。本 PR はそのルールへの対応。

## テスト

- `cargo fmt --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test --lib` ✅
- `cargo build` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * テスト モジュールの内部構造を改善しました。テスト ロジックと動作に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->