### PR TITLE
refactor: AssetBalance ページの状態管理と utility rail を分離

### DIFF
--- a/frontend/src/features/assetBalance/components/AssetBalanceUtilityRail.tsx
+++ b/frontend/src/features/assetBalance/components/AssetBalanceUtilityRail.tsx
@@ -1,0 +1,47 @@
+import { Alert } from '@/components/atoms/Alert';
+import {
+  DataActionRail,
+  type DataActionRailProps,
+} from '@/components/organisms/DataActionRail/DataActionRail';
+import { SearchCard } from '@/components/organisms/SearchCard/SearchCard';
+import type { SearchCategories } from '@/types/common';
+
+export interface AssetBalanceUtilityRailProps {
+  actionRailProps: DataActionRailProps;
+  error: string | null;
+  searchCardProps: {
+    visible: boolean;
+    categories: SearchCategories;
+    value: string;
+    onSearch: (query: string) => void;
+  };
+}
+
+export function AssetBalanceUtilityRail({
+  actionRailProps,
+  error,
+  searchCardProps,
+}: AssetBalanceUtilityRailProps) {
+  return (
+    <>
+      <DataActionRail {...actionRailProps} />
+
+      {error && (
+        <div className="px-5 py-4">
+          <Alert variant="danger" role="alert" aria-live="assertive">
+            <strong>エラー:</strong> {error}
+          </Alert>
+        </div>
+      )}
+
+      {searchCardProps.visible && (
+        <SearchCard
+          onSearch={searchCardProps.onSearch}
+          categories={searchCardProps.categories}
+          value={searchCardProps.value}
+          compact
+        />
+      )}
+    </>
+  );
+}

--- a/frontend/src/features/assetBalance/components/__tests__/AssetBalanceUtilityRail.test.tsx
+++ b/frontend/src/features/assetBalance/components/__tests__/AssetBalanceUtilityRail.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { AssetBalanceUtilityRail } from '../AssetBalanceUtilityRail';
+
+vi.mock('@/components/organisms/DataActionRail/DataActionRail', () => ({
+  DataActionRail: ({ saveLabel }: { saveLabel: string }) => (
+    <div data-testid="data-action-rail">{saveLabel}</div>
+  ),
+}));
+
+vi.mock('@/components/organisms/SearchCard/SearchCard', () => ({
+  SearchCard: ({ value }: { value: string }) => <div data-testid="search-card">{value}</div>,
+}));
+
+const actionRailProps = {
+  onFileSelect: vi.fn(),
+  selectedFileName: 'assetbalance.csv',
+  fileInputDisabled: false,
+  hasCsvFile: true,
+  saveLabel: '2件 全件置換で保存',
+  onSave: vi.fn(),
+  saveDisabled: false,
+  hasDbData: true,
+  deleteLabel: '全件削除 (2件)',
+  onDeleteRequest: vi.fn(),
+  deleteDisabled: false,
+  saveResult: null,
+  saveModeLabel: '全件置換',
+};
+
+describe('AssetBalanceUtilityRail', () => {
+  it('データ操作、エラー、検索カードを表示する', () => {
+    render(
+      <AssetBalanceUtilityRail
+        actionRailProps={actionRailProps}
+        error="取得失敗"
+        searchCardProps={{
+          visible: true,
+          categories: {
+            securities: [{ value: '7203', label: '7203: トヨタ自動車' }],
+          },
+          value: '7203',
+          onSearch: vi.fn(),
+        }}
+      />
+    );
+
+    expect(screen.getByTestId('data-action-rail')).toHaveTextContent('2件 全件置換で保存');
+    expect(screen.getByRole('alert')).toHaveTextContent('取得失敗');
+    expect(screen.getByTestId('search-card')).toHaveTextContent('7203');
+  });
+
+  it('検索対象がないときは SearchCard を表示しない', () => {
+    render(
+      <AssetBalanceUtilityRail
+        actionRailProps={actionRailProps}
+        error={null}
+        searchCardProps={{
+          visible: false,
+          categories: {},
+          value: '',
+          onSearch: vi.fn(),
+        }}
+      />
+    );
+
+    expect(screen.queryByTestId('search-card')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/assetBalance/hooks/__tests__/useAssetBalanceState.test.ts
+++ b/frontend/src/features/assetBalance/hooks/__tests__/useAssetBalanceState.test.ts
@@ -1,0 +1,189 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { AssetBalanceData } from '@/types/api';
+import { useAssetBalanceState } from '../useAssetBalanceState';
+import * as authHook from '@/features/auth/hooks/useAuth';
+import * as dataSourceHook from '../useAssetBalanceDataSource';
+
+vi.mock('@/features/auth/hooks/useAuth');
+vi.mock('../useAssetBalanceDataSource');
+vi.mock('@/features/jquants/hooks/useDividendBatch', () => ({
+  useDividendBatch: vi.fn(() => ({
+    dividendPerShareMap: new Map(),
+    dividendStatusMap: new Map(),
+  })),
+}));
+
+type LogoutCallback = () => void;
+type UseAuthReturn = ReturnType<typeof authHook.useAuth>;
+type UseAssetBalanceDataSourceReturn = ReturnType<typeof dataSourceHook.useAssetBalanceDataSourceCore>;
+
+function makeAuthMock(opts: {
+  isAuthenticated?: boolean;
+  authLoading?: boolean;
+  onLogoutCapture?: (cb: LogoutCallback) => void;
+}): UseAuthReturn {
+  const { isAuthenticated = true, authLoading = false, onLogoutCapture } = opts;
+
+  return {
+    user: isAuthenticated ? { id: 'user-1', email: 'test@example.com' } : null,
+    setUser: vi.fn(),
+    login: vi.fn(),
+    logout: vi.fn().mockResolvedValue(undefined),
+    deleteAccount: vi.fn().mockResolvedValue(undefined),
+    isAuthenticated,
+    isLoading: authLoading,
+    onLogout: (cb: LogoutCallback) => {
+      onLogoutCapture?.(cb);
+      return () => {};
+    },
+  };
+}
+
+function makeRow(overrides: Partial<AssetBalanceData> = {}): AssetBalanceData {
+  return {
+    id: 'asset-balance-1',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    security_code: '7203',
+    security_name: 'トヨタ自動車',
+    shares: 100,
+    executing_shares: 0,
+    average_purchase_price: 2500,
+    total_purchase_amount: 250000,
+    current_price: 2600,
+    daily_change: 50,
+    market_value: 260000,
+    profit_loss_rate: 4.0,
+    ...overrides,
+  };
+}
+
+function makeDataSourceMock(
+  overrides: Partial<UseAssetBalanceDataSourceReturn> = {}
+): UseAssetBalanceDataSourceReturn {
+  return {
+    dbData: [],
+    previewRows: [],
+    loading: false,
+    error: null,
+    saving: false,
+    deleting: false,
+    previewing: false,
+    lastSavedResult: null,
+    hasCsvFile: false,
+    hasDbData: false,
+    csvFileName: null,
+    handleFileSelect: vi.fn(),
+    handleSaveToDB: vi.fn(),
+    handleDeleteAll: vi.fn().mockResolvedValue(undefined),
+    resetState: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('useAssetBalanceState', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({}));
+    vi.mocked(dataSourceHook.useAssetBalanceDataSourceCore).mockReturnValue(makeDataSourceMock());
+  });
+
+  it('プレビュー行を優先し、rail props と検索結果を組み立てる', () => {
+    const previewRows = [
+      makeRow(),
+      makeRow({
+        id: 'asset-balance-2',
+        security_code: '6758',
+        security_name: 'ソニーグループ',
+      }),
+    ];
+
+    vi.mocked(dataSourceHook.useAssetBalanceDataSourceCore).mockReturnValue(
+      makeDataSourceMock({
+        dbData: [makeRow({ security_code: '9984', security_name: 'ソフトバンクグループ' })],
+        previewRows,
+        hasCsvFile: true,
+        hasDbData: true,
+        csvFileName: 'assetbalance.csv',
+      })
+    );
+
+    const { result } = renderHook(() => useAssetBalanceState());
+
+    expect(result.current.assetBalanceData).toEqual(previewRows);
+    expect(result.current.filteredData).toEqual(previewRows);
+    expect(result.current.utilityRailProps.actionRailProps.selectedFileName).toBe('assetbalance.csv');
+    expect(result.current.utilityRailProps.actionRailProps.saveLabel).toBe('2件 全件置換で保存');
+    expect(result.current.utilityRailProps.actionRailProps.deleteLabel).toBe('全件削除 (1件)');
+    expect(result.current.utilityRailProps.searchCardProps.visible).toBe(true);
+
+    act(() => {
+      result.current.utilityRailProps.searchCardProps.onSearch('6758');
+    });
+
+    expect(result.current.utilityRailProps.searchCardProps.value).toBe('6758');
+    expect(result.current.filteredData).toEqual([previewRows[1]]);
+  });
+
+  it('削除確認を開き、confirmDeleteAll で閉じて削除処理を実行する', async () => {
+    const handleDeleteAll = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(dataSourceHook.useAssetBalanceDataSourceCore).mockReturnValue(
+      makeDataSourceMock({
+        dbData: [makeRow()],
+        hasDbData: true,
+        handleDeleteAll,
+      })
+    );
+
+    const { result } = renderHook(() => useAssetBalanceState());
+
+    act(() => {
+      result.current.utilityRailProps.actionRailProps.onDeleteRequest();
+    });
+
+    expect(result.current.showDeleteConfirm).toBe(true);
+
+    await act(async () => {
+      await result.current.confirmDeleteAll();
+    });
+
+    expect(handleDeleteAll).toHaveBeenCalledTimes(1);
+    expect(result.current.showDeleteConfirm).toBe(false);
+  });
+
+  it('ログアウト時に検索条件と削除確認状態をリセットする', () => {
+    let logoutCallback: LogoutCallback | null = null;
+
+    vi.mocked(authHook.useAuth).mockReturnValue(
+      makeAuthMock({
+        onLogoutCapture: (cb) => {
+          logoutCallback = cb;
+        },
+      })
+    );
+    vi.mocked(dataSourceHook.useAssetBalanceDataSourceCore).mockReturnValue(
+      makeDataSourceMock({
+        dbData: [makeRow()],
+        hasDbData: true,
+      })
+    );
+
+    const { result } = renderHook(() => useAssetBalanceState());
+
+    act(() => {
+      result.current.utilityRailProps.searchCardProps.onSearch('7203');
+      result.current.utilityRailProps.actionRailProps.onDeleteRequest();
+    });
+
+    expect(result.current.utilityRailProps.searchCardProps.value).toBe('7203');
+    expect(result.current.showDeleteConfirm).toBe(true);
+
+    act(() => {
+      logoutCallback?.();
+    });
+
+    expect(result.current.utilityRailProps.searchCardProps.value).toBe('');
+    expect(result.current.showDeleteConfirm).toBe(false);
+  });
+});

--- a/frontend/src/features/assetBalance/hooks/useAssetBalanceDataSource.ts
+++ b/frontend/src/features/assetBalance/hooks/useAssetBalanceDataSource.ts
@@ -7,7 +7,15 @@ import { getDisplayErrorMessage } from '@/lib/utils/errorHandler';
 import { assetBalanceQueryKeys, clearAssetBalanceCache } from '../queryKeys';
 import type { CsvUploadResult } from '@/lib/csvImport';
 
-interface UseAssetBalanceDataSourceResult {
+interface AssetBalanceDataSourceAuthContext {
+  isAuthenticated: boolean;
+  authLoading: boolean;
+  onLogout: ReturnType<typeof useAuth>['onLogout'];
+  userId: string;
+  registerLogoutReset?: boolean;
+}
+
+export interface UseAssetBalanceDataSourceResult {
   // データ
   dbData: AssetBalanceData[];
   previewRows: AssetBalanceData[];
@@ -26,16 +34,21 @@ interface UseAssetBalanceDataSourceResult {
   handleFileSelect: (file: File) => void;
   handleSaveToDB: () => void;
   handleDeleteAll: () => Promise<void>;
+  resetState: () => void;
 }
 
 /**
  * 保有銘柄データソースを TanStack Query で管理するフック
  * ファイル選択時にバックエンドプレビューAPIを呼び出し、行データを取得する
  */
-export function useAssetBalanceDataSource(): UseAssetBalanceDataSourceResult {
-  const { isAuthenticated, isLoading: authLoading, onLogout, user } = useAuth();
+export function useAssetBalanceDataSourceCore({
+  isAuthenticated,
+  authLoading,
+  onLogout,
+  userId,
+  registerLogoutReset = true,
+}: AssetBalanceDataSourceAuthContext): UseAssetBalanceDataSourceResult {
   const queryClient = useQueryClient();
-  const userId = user?.id ?? '';
 
   const [rawFile, setRawFile] = useState<File | null>(null);
   const [previewRows, setPreviewRows] = useState<AssetBalanceData[]>([]);
@@ -77,14 +90,22 @@ export function useAssetBalanceDataSource(): UseAssetBalanceDataSourceResult {
     },
   });
 
+  const resetState = useCallback(() => {
+    clearAssetBalanceCache(queryClient);
+    setRawFile(null);
+    setPreviewRows([]);
+    setLastSavedResult(null);
+  }, [queryClient]);
+
   useEffect(() => {
+    if (!registerLogoutReset) {
+      return;
+    }
+
     return onLogout(() => {
-      clearAssetBalanceCache(queryClient);
-      setRawFile(null);
-      setPreviewRows([]);
-      setLastSavedResult(null);
+      resetState();
     });
-  }, [onLogout, queryClient]);
+  }, [onLogout, registerLogoutReset, resetState]);
 
   const handleFileSelect = useCallback((file: File) => {
     setRawFile(file);
@@ -127,5 +148,17 @@ export function useAssetBalanceDataSource(): UseAssetBalanceDataSourceResult {
     handleFileSelect,
     handleSaveToDB,
     handleDeleteAll,
+    resetState,
   };
+}
+
+export function useAssetBalanceDataSource(): UseAssetBalanceDataSourceResult {
+  const { isAuthenticated, isLoading: authLoading, onLogout, user } = useAuth();
+
+  return useAssetBalanceDataSourceCore({
+    isAuthenticated,
+    authLoading,
+    onLogout,
+    userId: user?.id ?? '',
+  });
 }

--- a/frontend/src/features/assetBalance/hooks/useAssetBalanceDataSource.ts
+++ b/frontend/src/features/assetBalance/hooks/useAssetBalanceDataSource.ts
@@ -92,10 +92,13 @@ export function useAssetBalanceDataSourceCore({
 
   const resetState = useCallback(() => {
     clearAssetBalanceCache(queryClient);
+    previewMutation.reset();
+    uploadCsvMutation.reset();
+    deleteAllMutation.reset();
     setRawFile(null);
     setPreviewRows([]);
     setLastSavedResult(null);
-  }, [queryClient]);
+  }, [deleteAllMutation, previewMutation, queryClient, uploadCsvMutation]);
 
   useEffect(() => {
     if (!registerLogoutReset) {

--- a/frontend/src/features/assetBalance/hooks/useAssetBalanceState.ts
+++ b/frontend/src/features/assetBalance/hooks/useAssetBalanceState.ts
@@ -125,14 +125,8 @@ export function useAssetBalanceState() {
   }, [closeDeleteConfirm, deleteAll]);
 
   const assetBalanceData = useMemo(() => {
-    if (previewRows.length > 0) {
-      return previewRows;
-    }
-    if (dbData.length > 0) {
-      return dbData;
-    }
-    return [];
-  }, [previewRows, dbData]);
+    return hasCsvFile ? previewRows : dbData;
+  }, [hasCsvFile, previewRows, dbData]);
 
   const securityCodes = useMemo(
     () => (saving || loading ? [] : assetBalanceData.map((item) => item.security_code)),

--- a/frontend/src/features/assetBalance/hooks/useAssetBalanceState.ts
+++ b/frontend/src/features/assetBalance/hooks/useAssetBalanceState.ts
@@ -1,0 +1,229 @@
+import { useCallback, useEffect, useMemo, useReducer } from 'react';
+import type { DataActionRailProps } from '@/components/organisms/DataActionRail/DataActionRail';
+import type { DividendStatus } from '@/features/jquants/api/dividendPerShareApi';
+import { useDividendBatch } from '@/features/jquants/hooks/useDividendBatch';
+import { useAuth } from '@/features/auth/hooks/useAuth';
+import { createSearchOptions } from '@/lib/utils/dataTransformer';
+import { filterByConfig, type FilterConfig } from '@/lib/utils/searchUtils';
+import type { AssetBalanceData } from '@/types/api';
+import type { SearchCategories } from '@/types/common';
+import type { AssetBalanceUtilityRailProps } from '../components/AssetBalanceUtilityRail';
+import { useAssetBalanceDataSourceCore } from './useAssetBalanceDataSource';
+
+interface AssetBalanceState {
+  searchQuery: string;
+  showDeleteConfirm: boolean;
+}
+
+type AssetBalanceAction =
+  | { type: 'SET_SEARCH_QUERY'; payload: string }
+  | { type: 'SET_SHOW_DELETE_CONFIRM'; payload: boolean }
+  | { type: 'LOGOUT' };
+
+const initialState: AssetBalanceState = {
+  searchQuery: '',
+  showDeleteConfirm: false,
+};
+
+const filterConfig: FilterConfig<AssetBalanceData> = {
+  partialStringFields: [
+    (item) => item.security_code,
+    (item) => item.security_name,
+  ],
+};
+
+function assetBalanceReducer(
+  state: AssetBalanceState,
+  action: AssetBalanceAction
+): AssetBalanceState {
+  switch (action.type) {
+    case 'SET_SEARCH_QUERY':
+      return { ...state, searchQuery: action.payload };
+    case 'SET_SHOW_DELETE_CONFIRM':
+      return { ...state, showDeleteConfirm: action.payload };
+    case 'LOGOUT':
+      return initialState;
+    default:
+      return state;
+  }
+}
+
+function getMainStatusMessage(flags: {
+  loading: boolean;
+  saving: boolean;
+  deleting: boolean;
+  previewing: boolean;
+}) {
+  if (flags.loading) {
+    return 'データを読み込んでいます...';
+  }
+  if (flags.saving) {
+    return 'データを保存しています...';
+  }
+  if (flags.deleting) {
+    return 'データを削除しています...';
+  }
+  if (flags.previewing) {
+    return 'CSVファイルを解析しています...';
+  }
+  return null;
+}
+
+export function useAssetBalanceState() {
+  const { isAuthenticated, isLoading: authLoading, login, onLogout, user } = useAuth();
+  const [state, dispatch] = useReducer(assetBalanceReducer, initialState);
+  const {
+    dbData,
+    previewRows,
+    loading,
+    error,
+    saving,
+    deleting,
+    previewing,
+    lastSavedResult,
+    hasCsvFile,
+    hasDbData,
+    csvFileName,
+    handleFileSelect: selectFile,
+    handleSaveToDB: saveToDB,
+    handleDeleteAll: deleteAll,
+    resetState,
+  } = useAssetBalanceDataSourceCore({
+    isAuthenticated,
+    authLoading,
+    onLogout,
+    userId: user?.id ?? '',
+    registerLogoutReset: false,
+  });
+
+  useEffect(() => {
+    return onLogout(() => {
+      resetState();
+      dispatch({ type: 'LOGOUT' });
+    });
+  }, [onLogout, resetState]);
+
+  const handleSearch = useCallback((query: string) => {
+    dispatch({ type: 'SET_SEARCH_QUERY', payload: query });
+  }, []);
+
+  const clearSearch = useCallback(() => {
+    dispatch({ type: 'SET_SEARCH_QUERY', payload: '' });
+  }, []);
+
+  const openDeleteConfirm = useCallback(() => {
+    dispatch({ type: 'SET_SHOW_DELETE_CONFIRM', payload: true });
+  }, []);
+
+  const closeDeleteConfirm = useCallback(() => {
+    dispatch({ type: 'SET_SHOW_DELETE_CONFIRM', payload: false });
+  }, []);
+
+  const confirmDeleteAll = useCallback(async () => {
+    closeDeleteConfirm();
+    await deleteAll();
+  }, [closeDeleteConfirm, deleteAll]);
+
+  const assetBalanceData = useMemo(() => {
+    if (previewRows.length > 0) {
+      return previewRows;
+    }
+    if (dbData.length > 0) {
+      return dbData;
+    }
+    return [];
+  }, [previewRows, dbData]);
+
+  const securityCodes = useMemo(
+    () => (saving || loading ? [] : assetBalanceData.map((item) => item.security_code)),
+    [saving, loading, assetBalanceData]
+  );
+
+  const { dividendPerShareMap, dividendStatusMap } = useDividendBatch(securityCodes, isAuthenticated);
+
+  const filteredData = useMemo(
+    () => filterByConfig(assetBalanceData, state.searchQuery, filterConfig),
+    [assetBalanceData, state.searchQuery]
+  );
+
+  const searchCategories = useMemo<SearchCategories>(
+    () => ({
+      securities: createSearchOptions(assetBalanceData, 'security_code', 'security_name', true),
+    }),
+    [assetBalanceData]
+  );
+
+  const saveLabel = previewRows.length > 0
+    ? `${previewRows.length}件 全件置換で保存`
+    : '全件置換で保存';
+
+  const actionRailProps = useMemo<DataActionRailProps>(
+    () => ({
+      onFileSelect: selectFile,
+      selectedFileName: csvFileName ?? undefined,
+      fileInputDisabled: loading || saving || deleting || previewing,
+      hasCsvFile,
+      saveLabel: saving ? '保存中...' : previewing ? '解析中...' : saveLabel,
+      onSave: saveToDB,
+      saveDisabled: saving || deleting || previewing || previewRows.length === 0,
+      hasDbData,
+      deleteLabel: deleting ? '削除中...' : `全件削除 (${dbData.length}件)`,
+      onDeleteRequest: openDeleteConfirm,
+      deleteDisabled: saving || deleting || loading,
+      saveResult: lastSavedResult,
+      saveModeLabel: '全件置換',
+    }),
+    [
+      selectFile,
+      csvFileName,
+      loading,
+      saving,
+      deleting,
+      previewing,
+      hasCsvFile,
+      saveLabel,
+      saveToDB,
+      previewRows.length,
+      hasDbData,
+      dbData.length,
+      openDeleteConfirm,
+      lastSavedResult,
+    ]
+  );
+
+  const utilityRailProps = useMemo<AssetBalanceUtilityRailProps>(
+    () => ({
+      actionRailProps,
+      error,
+      searchCardProps: {
+        visible: assetBalanceData.length > 0,
+        categories: searchCategories,
+        value: state.searchQuery,
+        onSearch: handleSearch,
+      },
+    }),
+    [actionRailProps, error, assetBalanceData.length, searchCategories, state.searchQuery, handleSearch]
+  );
+
+  const mainStatusMessage = getMainStatusMessage({ loading, saving, deleting, previewing });
+
+  return {
+    isAuthenticated,
+    authLoading,
+    login,
+    assetBalanceData,
+    filteredData,
+    clearSearch,
+    utilityRailProps,
+    showDeleteConfirm: state.showDeleteConfirm,
+    closeDeleteConfirm,
+    confirmDeleteAll,
+    dbDataCount: dbData.length,
+    deleteModalLoading: deleting,
+    showPortfolioSummary: !loading && !previewing,
+    mainStatusMessage,
+    workspaceBusy: authLoading || loading || saving || deleting || previewing,
+    dividendPerShareMap: dividendPerShareMap as Map<string, number>,
+    dividendStatusMap: dividendStatusMap as Map<string, DividendStatus> | undefined,
+  };
+}

--- a/frontend/src/pages/AssetBalance.tsx
+++ b/frontend/src/pages/AssetBalance.tsx
@@ -1,20 +1,15 @@
-import React, { useState, useMemo, useCallback, Suspense, lazy } from 'react';
+import { Suspense, lazy } from 'react';
 import { Layout } from '../components/templates/Layout';
 import { WorkspaceShell } from '@/components/templates/WorkspaceShell';
-import { DataActionRail } from '@/components/organisms/DataActionRail/DataActionRail';
 import { PageHeader } from '../components/atoms/PageHeader';
 import { Alert } from '@/components/atoms/Alert';
 import { Button } from '@/components/atoms/Button';
 import { Spinner } from '@/components/atoms/Spinner';
-import { SearchCard } from '@/components/organisms/SearchCard/SearchCard';
-import { useAuth } from '@/features/auth/hooks/useAuth';
 import type { AssetBalanceData } from '@/types/api';
-import { useDividendBatch } from '@/features/jquants/hooks/useDividendBatch';
 import { DividendStatus } from '@/features/jquants/api/dividendPerShareApi';
-import { useAssetBalanceDataSource } from '@/features/assetBalance/hooks/useAssetBalanceDataSource';
-import { createSearchOptions } from '@/lib/utils/dataTransformer';
+import { AssetBalanceUtilityRail } from '@/features/assetBalance/components/AssetBalanceUtilityRail';
+import { useAssetBalanceState } from '@/features/assetBalance/hooks/useAssetBalanceState';
 import { usePageTitle } from '../hooks/usePageTitle';
-import { filterByConfig, FilterConfig } from '@/lib/utils/searchUtils';
 import { ConfirmDeleteModal } from '@/components/molecules/ConfirmDeleteModal/ConfirmDeleteModal';
 
 // PortfolioPieChartコンポーネントを遅延読み込み（バンドルサイズ最適化）
@@ -37,14 +32,14 @@ interface AssetBalanceInfoProps {
 /**
  * 保有銘柄データを表示するコンポーネント（概要重視）
  */
-export const AssetBalanceInfo: React.FC<AssetBalanceInfoProps> = ({
+export function AssetBalanceInfo({
   assetBalanceData,
   filteredData,
   searchQuery,
   onClearFilter,
   dividendPerShareMap,
   dividendStatusMap,
-}) => {
+}: AssetBalanceInfoProps) {
   const isFiltered = searchQuery !== '';
 
   return (
@@ -59,7 +54,7 @@ export const AssetBalanceInfo: React.FC<AssetBalanceInfoProps> = ({
       />
     </Suspense>
   );
-};
+}
 
 /**
  * 保有銘柄管理ページコンポーネント
@@ -67,68 +62,25 @@ export const AssetBalanceInfo: React.FC<AssetBalanceInfoProps> = ({
 export function AssetBalancePage() {
   usePageTitle('資産管理');
 
-  const { isAuthenticated, isLoading: authLoading, login } = useAuth();
-
   const {
-    dbData,
-    previewRows,
-    loading,
-    error,
-    saving,
-    deleting,
-    previewing,
-    lastSavedResult,
-    hasCsvFile,
-    hasDbData,
-    csvFileName,
-    handleFileSelect,
-    handleSaveToDB,
-    handleDeleteAll,
-  } = useAssetBalanceDataSource();
-
-  const [searchQuery, setSearchQuery] = useState('');
-  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
-
-  const handleConfirmDelete = useCallback(async () => {
-    setShowDeleteConfirm(false);
-    await handleDeleteAll();
-  }, [handleDeleteAll]);
-
-  // CSVプレビュー行 > DBデータ の優先順位でテーブルデータを決定
-  const assetBalanceData = useMemo(() => {
-    if (previewRows.length > 0) return previewRows;
-    if (dbData.length > 0) return dbData;
-    return [];
-  }, [previewRows, dbData]);
-
-  // J-Quants APIから1株配当を一括取得
-  const securityCodes = useMemo(
-    () => (saving || loading) ? [] : assetBalanceData.map(item => item.security_code),
-    [saving, loading, assetBalanceData]
-  );
-  const { dividendPerShareMap, dividendStatusMap } = useDividendBatch(securityCodes, isAuthenticated);
-
-  const searchCategories = useMemo(() => ({
-    securities: createSearchOptions(assetBalanceData, 'security_code', 'security_name', true)
-  }), [assetBalanceData]);
-
-  const filterConfig: FilterConfig<AssetBalanceData> = useMemo(() => ({
-    partialStringFields: [
-      item => item.security_code,
-      item => item.security_name,
-    ],
-  }), []);
-
-  const filteredData = useMemo(
-    () => filterByConfig(assetBalanceData, searchQuery, filterConfig),
-    [assetBalanceData, searchQuery, filterConfig]
-  );
-
-  const isProcessing = loading || saving || deleting || previewing || authLoading;
-
-  const saveLabel = previewRows.length > 0
-    ? `${previewRows.length}件 全件置換で保存`
-    : '全件置換で保存';
+    isAuthenticated,
+    authLoading,
+    login,
+    assetBalanceData,
+    filteredData,
+    clearSearch,
+    utilityRailProps,
+    showDeleteConfirm,
+    closeDeleteConfirm,
+    confirmDeleteAll,
+    dbDataCount,
+    deleteModalLoading,
+    showPortfolioSummary,
+    mainStatusMessage,
+    workspaceBusy,
+    dividendPerShareMap,
+    dividendStatusMap,
+  } = useAssetBalanceState();
 
   return (
     <Layout>
@@ -136,7 +88,7 @@ export function AssetBalancePage() {
         title="資産管理"
         description="保有している銘柄の一覧と評価額を確認できます。"
       />
-      <div className="mt-2" aria-busy={isProcessing}>
+      <div className="mt-2" aria-busy={workspaceBusy}>
         {/* 認証確認中 */}
         {authLoading && (
           <div className="status-message" role="status" aria-live="polite">
@@ -168,79 +120,38 @@ export function AssetBalancePage() {
               main={
                 <>
                   <div aria-live="polite" aria-atomic="true">
-                    {(loading || saving || deleting || previewing) && (
+                    {mainStatusMessage && (
                       <div className="status-message" role="status">
                         <Spinner size="md" className="text-primary" />
-                        <p className="text-sm text-secondary">
-                          {loading && 'データを読み込んでいます...'}
-                          {saving && 'データを保存しています...'}
-                          {deleting && 'データを削除しています...'}
-                          {previewing && 'CSVファイルを解析しています...'}
-                        </p>
+                        <p className="text-sm text-secondary">{mainStatusMessage}</p>
                       </div>
                     )}
                   </div>
 
                   {/* ローディング完了後に表示（空データでもEmptyStateを表示） */}
-                  {!loading && !previewing && (
+                  {showPortfolioSummary && (
                     <AssetBalanceInfo
                       assetBalanceData={assetBalanceData}
                       filteredData={filteredData}
-                      searchQuery={searchQuery}
-                      onClearFilter={() => setSearchQuery('')}
+                      searchQuery={utilityRailProps.searchCardProps.value}
+                      onClearFilter={clearSearch}
                       dividendPerShareMap={dividendPerShareMap}
                       dividendStatusMap={dividendStatusMap}
                     />
                   )}
                 </>
               }
-              rail={
-                <>
-                  <DataActionRail
-                    onFileSelect={handleFileSelect}
-                    selectedFileName={csvFileName ?? ''}
-                    fileInputDisabled={loading || saving || deleting || previewing}
-                    hasCsvFile={hasCsvFile}
-                    saveLabel={saving ? '保存中...' : previewing ? '解析中...' : saveLabel}
-                    onSave={handleSaveToDB}
-                    saveDisabled={saving || deleting || previewing || previewRows.length === 0}
-                    hasDbData={hasDbData}
-                    deleteLabel={deleting ? '削除中...' : `全件削除 (${dbData.length}件)`}
-                    onDeleteRequest={() => setShowDeleteConfirm(true)}
-                    deleteDisabled={saving || deleting || loading}
-                    saveResult={lastSavedResult}
-                    saveModeLabel="全件置換"
-                  />
-
-                  {error && (
-                    <div className="px-5 py-4">
-                      <Alert variant="danger" role="alert" aria-live="assertive">
-                        <strong>エラー:</strong> {error}
-                      </Alert>
-                    </div>
-                  )}
-
-                  {/* 検索カード（データがある場合のみ表示） */}
-                  {assetBalanceData.length > 0 && (
-                    <SearchCard
-                      onSearch={query => setSearchQuery(query)}
-                      categories={searchCategories}
-                      value={searchQuery}
-                      compact
-                    />
-                  )}
-                </>
-              }
+              rail={<AssetBalanceUtilityRail {...utilityRailProps} />}
             />
 
             <ConfirmDeleteModal
               isOpen={showDeleteConfirm}
-              onConfirm={handleConfirmDelete}
-              onCancel={() => setShowDeleteConfirm(false)}
+              onConfirm={confirmDeleteAll}
+              onCancel={closeDeleteConfirm}
               title="資産管理データの全件削除"
               description="保存された資産管理データをすべて削除します。"
-              itemCount={dbData.length}
-              loading={deleting}
+              itemCount={dbDataCount}
+              loading={deleteModalLoading}
             />
           </>
         )}


### PR DESCRIPTION
## 概要
- AssetBalance ページの状態管理と utility rail の責務を features/assetBalance 配下へ分離
- AssetBalance.tsx をレイアウト組み立て中心に整理し、200 行以下に削減
- ログアウト時の UI 状態とキャッシュ初期化を一か所で扱えるように調整

## 主な変更
- useAssetBalanceState を追加し、検索条件・削除確認・rail props の組み立てを集約
- AssetBalanceUtilityRail を追加し、CSV 操作・エラー表示・検索カードを切り出し
- useAssetBalanceDataSourceCore を追加し、ログアウト時の reset を state hook から統合可能に変更
- AssetBalance 向けの hook / component テストを追加

## テスト
- npm run lint
- npx tsc --noEmit
- npm test -- --run
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 資産残高管理画面に検索機能を追加しました
  * 削除操作時の確認ダイアログを改善しました

* **Refactor**
  * 内部状態管理とデータ処理ロジックを整理しました

* **Tests**
  * コンポーネントとフック機能のテストカバレッジを拡充しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->