### PR TITLE
refactor: CSVパイプラインを共通化

### DIFF
--- a/backend/src/services.rs
+++ b/backend/src/services.rs
@@ -2,6 +2,7 @@ pub mod asset_balance;
 pub mod auth;
 pub mod csv_domain;
 pub mod csv_import;
+pub mod csv_pipeline;
 pub mod csv_util;
 pub mod dividend;
 pub mod dividend_cache;

--- a/backend/src/services/asset_balance.rs
+++ b/backend/src/services/asset_balance.rs
@@ -2,17 +2,33 @@ use crate::errors::ApiError;
 use crate::models::asset_balance::{AssetBalance, CreateAssetBalanceRequest};
 use crate::models::common::BulkCreateResponse;
 use crate::models::csv_import::{CsvPreviewResponse, CsvRowError, CsvUploadResponse};
-use crate::services::csv_import::{finish_csv_upload, parse_csv};
+use crate::services::csv_import::{build_preview_response, finish_csv_upload, validate_csv_rows};
+use crate::services::csv_pipeline::{parse_csv_with_config, CsvParserConfig, CsvRow};
 use crate::services::csv_util::{
-    decode_bytes, normalize_security_name, parse_number, parse_optional_string,
+    get_row_cell, normalize_security_name, parse_number, parse_optional_string_row,
 };
 use crate::services::shared::BulkTimer;
-use csv::StringRecord;
 use rust_decimal::Decimal;
 use sqlx::PgPool;
-use std::collections::HashMap;
 use tracing::info;
 use uuid::Uuid;
+
+const ASSET_BALANCE_CSV_CONFIG: CsvParserConfig = CsvParserConfig {
+    skip_header_rows: 6,
+    exclude_row_fn: Some(is_account_summary_row),
+    required_columns: &[
+        "銘柄コード",
+        "銘柄名",
+        "保有数量［株］",
+        "執行中［株］",
+        "平均取得価額［円］",
+        "取得総額［円］",
+        "現在値［円］",
+        "現在値（前日比）［円］",
+        "時価評価額［円］",
+        "評価損益［％］",
+    ],
+};
 
 /// 認証ユーザーの保有銘柄一覧を取得
 pub async fn list(pool: &PgPool, user_id: Uuid) -> Result<Vec<AssetBalance>, ApiError> {
@@ -107,20 +123,9 @@ pub async fn bulk_create(
 /// CSV bytes をパースしてプレビュー情報を返す（DB 書き込みなし）
 /// 現在の取込対象形式では、先頭6行はメタデータのためスキップ
 pub fn preview_csv(bytes: &[u8]) -> Result<CsvPreviewResponse, ApiError> {
-    if bytes.is_empty() {
-        return Err(ApiError::ValidationError("CSVが空です".to_string()));
-    }
-    let (items, errors) = parse_asset_balance_csv(bytes)?;
-    let rows = items
-        .iter()
-        .map(|item| serde_json::to_value(item).unwrap_or(serde_json::Value::Null))
-        .collect();
-    Ok(CsvPreviewResponse {
-        total_rows: items.len() + errors.len(),
-        valid_rows: items.len(),
-        errors,
-        rows,
-    })
+    let rows = parse_asset_balance_csv(bytes)?;
+    let (items, errors) = transform_asset_balance_rows(&rows);
+    Ok(build_preview_response(&items, errors))
 }
 
 /// CSV bytes をパースして保有銘柄を一括登録
@@ -129,7 +134,8 @@ pub async fn upload_csv(
     user_id: Uuid,
     bytes: &[u8],
 ) -> Result<CsvUploadResponse, ApiError> {
-    let (items, errors) = parse_asset_balance_csv(bytes)?;
+    let rows = parse_asset_balance_csv(bytes)?;
+    let (items, errors) = transform_asset_balance_rows(&rows);
     let result = bulk_create(pool, user_id, &items).await?;
     Ok(finish_csv_upload(result, errors))
 }
@@ -140,42 +146,29 @@ pub async fn delete_all(pool: &PgPool, user_id: Uuid) -> Result<u64, ApiError> {
         .await
 }
 
-/// 保有銘柄 CSV bytes をデコード・ヘッダースキップ・パース・フィルタして返す
-/// preview / upload の共通前処理経路
-pub(crate) fn parse_asset_balance_csv(
-    bytes: &[u8],
-) -> Result<(Vec<CreateAssetBalanceRequest>, Vec<CsvRowError>), ApiError> {
-    let content = decode_bytes(bytes);
-    let stripped = strip_asset_balance_csv_metadata(&content);
-    let filtered = strip_account_summary_rows(&stripped);
-    let (items, errors) = parse_csv(filtered.as_bytes(), parse_asset_balance_row)?;
+/// 保有銘柄 CSV bytes をパース段階まで共通化して返す
+fn parse_asset_balance_csv(bytes: &[u8]) -> Result<Vec<CsvRow>, ApiError> {
+    parse_csv_with_config(bytes, &ASSET_BALANCE_CSV_CONFIG)
+}
+
+fn transform_asset_balance_rows(
+    rows: &[CsvRow],
+) -> (Vec<CreateAssetBalanceRequest>, Vec<CsvRowError>) {
+    let (items, errors) = validate_csv_rows(rows, transform_asset_balance_row);
     let items = items
         .into_iter()
         .filter(|i| !i.security_code.is_empty())
         .collect();
-    Ok((items, errors))
-}
-
-/// 保有銘柄 CSV の先頭6行（メタデータ）をスキップした文字列を返す
-fn strip_asset_balance_csv_metadata(content: &str) -> String {
-    let lines: Vec<&str> = content.lines().collect();
-    if lines.len() > 6 {
-        lines[6..].join("\n")
-    } else {
-        String::new()
-    }
+    (items, errors)
 }
 
 /// 保有銘柄 CSV に混ざる「特定口座合計」などの口座集計行を除外する
 ///
 /// 先頭フィールド（銘柄コード）が空の行かつ「口座合計」を含む行のみ除外する。
 /// 銘柄名に「口座合計」を含む銘柄を誤除外しないよう、先頭が空であることを条件とする。
-fn strip_account_summary_rows(content: &str) -> String {
-    content
-        .lines()
-        .filter(|line| !(line.starts_with(',') && line.contains("口座合計")))
-        .collect::<Vec<_>>()
-        .join("\n")
+fn is_account_summary_row(row: &CsvRow) -> bool {
+    get_row_cell(row, "銘柄コード").trim().is_empty()
+        && row.values().any(|value| value.contains("口座合計"))
 }
 
 /// 保有銘柄 CSV の1行をパースして CreateAssetBalanceRequest に変換
@@ -185,13 +178,12 @@ fn strip_account_summary_rows(content: &str) -> String {
 ///   - 執行中: 執行中の注文がなければ "-" または空欄
 ///   - 現在値（前日比）: 変動なし時は 0 または "-"
 ///   - 評価損益（%）: NISA 等で表示されない場合に "-"
-pub(crate) fn parse_asset_balance_row(
-    record: &StringRecord,
-    header_map: &HashMap<String, usize>,
+fn transform_asset_balance_row(
+    row: &CsvRow,
     row_num: usize,
 ) -> Result<CreateAssetBalanceRequest, CsvRowError> {
     let num = |col: &str| {
-        let raw = parse_optional_string(record, header_map, col);
+        let raw = parse_optional_string_row(row, col);
         let trimmed = raw.trim();
         if trimmed.is_empty() || trimmed == "-" {
             return Err(CsvRowError {
@@ -205,36 +197,24 @@ pub(crate) fn parse_asset_balance_row(
         })
     };
 
-    let security_code = parse_optional_string(record, header_map, "銘柄コード").replace('"', "");
+    let security_code = parse_optional_string_row(row, "銘柄コード").replace('"', "");
     Ok(CreateAssetBalanceRequest {
         security_code,
-        security_name: normalize_security_name(&parse_optional_string(
-            record,
-            header_map,
-            "銘柄名",
-        )),
+        security_name: normalize_security_name(&parse_optional_string_row(row, "銘柄名")),
         shares: num("保有数量［株］")?,
         // 執行中は "-" / 空欄が仕様上ありうるため 0.0 フォールバック
-        executing_shares: parse_number(&parse_optional_string(record, header_map, "執行中［株］"))
+        executing_shares: parse_number(&parse_optional_string_row(row, "執行中［株］"))
             .unwrap_or(Decimal::ZERO),
         average_purchase_price: num("平均取得価額［円］")?,
         total_purchase_amount: num("取得総額［円］")?,
         current_price: num("現在値［円］")?,
         // 前日比は変動なし時に 0 または "-" が仕様上ありうるため 0.0 フォールバック
-        daily_change: parse_number(&parse_optional_string(
-            record,
-            header_map,
-            "現在値（前日比）［円］",
-        ))
-        .unwrap_or(Decimal::ZERO),
+        daily_change: parse_number(&parse_optional_string_row(row, "現在値（前日比）［円］"))
+            .unwrap_or(Decimal::ZERO),
         market_value: num("時価評価額［円］")?,
         // 評価損益は NISA 等で表示されない場合に "-" が仕様上ありうるため 0.0 フォールバック
-        profit_loss_rate: parse_number(&parse_optional_string(
-            record,
-            header_map,
-            "評価損益［％］",
-        ))
-        .unwrap_or(Decimal::ZERO),
+        profit_loss_rate: parse_number(&parse_optional_string_row(row, "評価損益［％］"))
+            .unwrap_or(Decimal::ZERO),
     })
 }
 #[cfg(test)]
@@ -267,11 +247,17 @@ mod tests {
         ",,,,,,特定口座合計,\"11,245,249\",,,\"14,517,240\",\"29.09\"";
 
     fn parse_row_csv(row: &str) -> (Vec<CreateAssetBalanceRequest>, Vec<CsvRowError>) {
-        parse_csv(
+        let rows = parse_csv_with_config(
             format!("{HEADER}\n{row}\n").as_bytes(),
-            parse_asset_balance_row,
+            &CsvParserConfig {
+                skip_header_rows: 0,
+                exclude_row_fn: None,
+                required_columns: ASSET_BALANCE_CSV_CONFIG.required_columns,
+            },
         )
-        .unwrap()
+        .unwrap();
+
+        transform_asset_balance_rows(&rows)
     }
 
     fn make_asset_balance_csv(rows: &[&str]) -> String {
@@ -385,8 +371,8 @@ mod tests {
                 &["1605", "7974"][..],
             ),
         ] {
-            let (items, errors) =
-                parse_asset_balance_csv(make_asset_balance_csv(rows).as_bytes()).unwrap();
+            let rows = parse_asset_balance_csv(make_asset_balance_csv(rows).as_bytes()).unwrap();
+            let (items, errors) = transform_asset_balance_rows(&rows);
 
             assert!(errors.is_empty(), "unexpected errors: {errors:?}");
             assert_eq!(

--- a/backend/src/services/csv_import.rs
+++ b/backend/src/services/csv_import.rs
@@ -1,11 +1,16 @@
-use crate::errors::ApiError;
 use crate::models::common::BulkCreateResponse;
 use crate::models::csv_import::{CsvPreviewResponse, CsvRowError, CsvUploadResponse};
+use crate::services::csv_pipeline::CsvRow;
+#[cfg(test)]
+use crate::errors::ApiError;
+#[cfg(test)]
 use crate::services::csv_util::decode_bytes;
+#[cfg(test)]
 use std::collections::HashMap;
 
 /// CSV bytes をデコードして行ごとにパース
 /// parse_row が Err を返した行はエラーとして収集し、items には含めない
+#[cfg(test)]
 pub fn parse_csv<T, F>(bytes: &[u8], parse_row: F) -> Result<(Vec<T>, Vec<CsvRowError>), ApiError>
 where
     F: Fn(&csv::StringRecord, &HashMap<String, usize>, usize) -> Result<T, CsvRowError>,
@@ -50,27 +55,44 @@ where
     Ok((items, errors))
 }
 
+#[cfg(test)]
 fn is_all_empty_record(record: &csv::StringRecord) -> bool {
     record.iter().all(|value| value.trim().is_empty())
 }
 
-/// CSV bytes をパースしてプレビュー情報を返す（DB 書き込みなし）
-pub fn build_preview<T, F>(bytes: &[u8], parse_row: F) -> Result<CsvPreviewResponse, ApiError>
+pub fn validate_csv_rows<T, F>(rows: &[CsvRow], transform_row: F) -> (Vec<T>, Vec<CsvRowError>)
+where
+    F: Fn(&CsvRow, usize) -> Result<T, CsvRowError>,
+{
+    let mut items = Vec::new();
+    let mut errors = Vec::new();
+
+    for (index, row) in rows.iter().enumerate() {
+        let row_num = index + 1;
+        match transform_row(row, row_num) {
+            Ok(item) => items.push(item),
+            Err(error) => errors.push(error),
+        }
+    }
+
+    (items, errors)
+}
+
+pub fn build_preview_response<T>(items: &[T], errors: Vec<CsvRowError>) -> CsvPreviewResponse
 where
     T: serde::Serialize,
-    F: Fn(&csv::StringRecord, &HashMap<String, usize>, usize) -> Result<T, CsvRowError>,
 {
-    let (items, errors) = parse_csv(bytes, parse_row)?;
     let rows = items
         .iter()
         .map(|item| serde_json::to_value(item).unwrap_or(serde_json::Value::Null))
         .collect();
-    Ok(CsvPreviewResponse {
+
+    CsvPreviewResponse {
         total_rows: items.len() + errors.len(),
         valid_rows: items.len(),
         errors,
         rows,
-    })
+    }
 }
 
 /// bulk_create 結果と行エラーから CsvUploadResponse を構築

--- a/backend/src/services/csv_import.rs
+++ b/backend/src/services/csv_import.rs
@@ -1,8 +1,8 @@
+#[cfg(test)]
+use crate::errors::ApiError;
 use crate::models::common::BulkCreateResponse;
 use crate::models::csv_import::{CsvPreviewResponse, CsvRowError, CsvUploadResponse};
 use crate::services::csv_pipeline::CsvRow;
-#[cfg(test)]
-use crate::errors::ApiError;
 #[cfg(test)]
 use crate::services::csv_util::decode_bytes;
 #[cfg(test)]

--- a/backend/src/services/csv_pipeline.rs
+++ b/backend/src/services/csv_pipeline.rs
@@ -1,0 +1,136 @@
+use crate::errors::ApiError;
+use crate::services::csv_util::decode_bytes;
+use std::collections::HashMap;
+
+pub type CsvRow = HashMap<String, String>;
+
+#[derive(Clone, Copy)]
+pub struct CsvParserConfig {
+    pub skip_header_rows: usize,
+    pub exclude_row_fn: Option<fn(&CsvRow) -> bool>,
+    pub required_columns: &'static [&'static str],
+}
+
+pub fn parse_csv_with_config(
+    bytes: &[u8],
+    config: &CsvParserConfig,
+) -> Result<Vec<CsvRow>, ApiError> {
+    if bytes.is_empty() {
+        return Err(ApiError::ValidationError("CSVが空です".to_string()));
+    }
+
+    let content = strip_header_rows(&decode_bytes(bytes), config.skip_header_rows);
+    let mut reader = csv::ReaderBuilder::new()
+        .flexible(true)
+        .from_reader(content.as_bytes());
+
+    let headers = reader
+        .headers()
+        .map_err(|error| {
+            ApiError::ValidationError(format!("CSVヘッダーの読み込みに失敗しました: {}", error))
+        })?
+        .iter()
+        .map(|header| header.trim().to_string())
+        .collect::<Vec<_>>();
+
+    let mut rows = Vec::new();
+    for record in reader.records() {
+        let record = record.map_err(|error| {
+            ApiError::ValidationError(format!("CSV行の読み込みに失敗しました: {}", error))
+        })?;
+
+        if is_all_empty_record(&record) {
+            continue;
+        }
+
+        let row = build_row_map(&headers, &record, config.required_columns);
+        if config
+            .exclude_row_fn
+            .is_some_and(|exclude_row| exclude_row(&row))
+        {
+            continue;
+        }
+        rows.push(row);
+    }
+
+    Ok(rows)
+}
+
+fn strip_header_rows(content: &str, skip_header_rows: usize) -> String {
+    content
+        .lines()
+        .skip(skip_header_rows)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn is_all_empty_record(record: &csv::StringRecord) -> bool {
+    record.iter().all(|value| value.trim().is_empty())
+}
+
+fn build_row_map(
+    headers: &[String],
+    record: &csv::StringRecord,
+    required_columns: &[&str],
+) -> CsvRow {
+    let mut row = headers
+        .iter()
+        .enumerate()
+        .map(|(index, header)| {
+            (
+                header.clone(),
+                record.get(index).unwrap_or("").trim().to_string(),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+
+    for column in required_columns {
+        row.entry((*column).to_string()).or_default();
+    }
+
+    row
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BASIC_CONFIG: CsvParserConfig = CsvParserConfig {
+        skip_header_rows: 0,
+        exclude_row_fn: None,
+        required_columns: &["name", "amount", "missing"],
+    };
+
+    fn exclude_total_row(row: &CsvRow) -> bool {
+        row.get("name").is_some_and(|name| name.contains("合計"))
+    }
+
+    #[test]
+    fn test_parse_csv_with_config() {
+        let rows = parse_csv_with_config(
+            "meta\nname,amount\nfoo,100\nbar\n,\n".as_bytes(),
+            &CsvParserConfig {
+                skip_header_rows: 1,
+                ..BASIC_CONFIG
+            },
+        )
+        .unwrap();
+
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].get("name"), Some(&"foo".to_string()));
+        assert_eq!(rows[1].get("amount"), Some(&"".to_string()));
+        assert_eq!(rows[1].get("missing"), Some(&"".to_string()));
+
+        let rows = parse_csv_with_config(
+            "name,amount\nfoo,100\n特定口座合計,200\n".as_bytes(),
+            &CsvParserConfig {
+                exclude_row_fn: Some(exclude_total_row),
+                ..BASIC_CONFIG
+            },
+        )
+        .unwrap();
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].get("name"), Some(&"foo".to_string()));
+    }
+}

--- a/backend/src/services/csv_util.rs
+++ b/backend/src/services/csv_util.rs
@@ -61,6 +61,7 @@ pub fn compute_taxes(account: &str, realized_pnl: Decimal) -> (Decimal, Decimal)
 }
 
 /// レコードから指定列の値を取得（列が存在しない場合は空文字）
+#[cfg(test)]
 pub fn get_cell<'a>(
     record: &'a csv::StringRecord,
     header_map: &HashMap<String, usize>,
@@ -72,7 +73,13 @@ pub fn get_cell<'a>(
         .unwrap_or("")
 }
 
+/// 行マップから指定列の値を取得（列が存在しない場合は空文字）
+pub fn get_row_cell<'a>(row: &'a HashMap<String, String>, name: &str) -> &'a str {
+    row.get(name).map(String::as_str).unwrap_or("")
+}
+
 /// オプション文字列フィールドを取得（空の場合は空文字列）
+#[cfg(test)]
 pub fn parse_optional_string(
     record: &csv::StringRecord,
     header_map: &HashMap<String, usize>,
@@ -81,7 +88,13 @@ pub fn parse_optional_string(
     get_cell(record, header_map, col).to_string()
 }
 
+/// 行マップからオプション文字列フィールドを取得（空の場合は空文字列）
+pub fn parse_optional_string_row(row: &HashMap<String, String>, col: &str) -> String {
+    get_row_cell(row, col).to_string()
+}
+
 /// 必須文字列フィールドを取得（空の場合はエラー）
+#[cfg(test)]
 pub fn parse_required_string(
     record: &csv::StringRecord,
     header_map: &HashMap<String, usize>,
@@ -89,6 +102,22 @@ pub fn parse_required_string(
     row_num: usize,
 ) -> Result<String, CsvRowError> {
     let val = get_cell(record, header_map, col);
+    if val.trim().is_empty() {
+        return Err(CsvRowError {
+            row: row_num,
+            message: format!("必須列 '{}' が空または存在しません", col),
+        });
+    }
+    Ok(val.to_string())
+}
+
+/// 行マップから必須文字列フィールドを取得（空の場合はエラー）
+pub fn parse_required_string_row(
+    row: &HashMap<String, String>,
+    col: &str,
+    row_num: usize,
+) -> Result<String, CsvRowError> {
+    let val = get_row_cell(row, col);
     if val.trim().is_empty() {
         return Err(CsvRowError {
             row: row_num,
@@ -113,6 +142,7 @@ pub fn normalize_security_name(name: &str) -> String {
 }
 
 /// 必須数値フィールドを取得（空またはパース失敗でエラー）
+#[cfg(test)]
 pub fn parse_required_number(
     record: &csv::StringRecord,
     header_map: &HashMap<String, usize>,
@@ -132,7 +162,27 @@ pub fn parse_required_number(
     })
 }
 
+/// 行マップから必須数値フィールドを取得（空またはパース失敗でエラー）
+pub fn parse_required_number_row(
+    row: &HashMap<String, String>,
+    col: &str,
+    row_num: usize,
+) -> Result<Decimal, CsvRowError> {
+    let raw = get_row_cell(row, col);
+    if raw.trim().is_empty() {
+        return Err(CsvRowError {
+            row: row_num,
+            message: format!("必須列 '{}' が空または存在しません", col),
+        });
+    }
+    parse_number(raw).map_err(|e| CsvRowError {
+        row: row_num,
+        message: format!("{}: {}", col, e),
+    })
+}
+
 /// 必須日付フィールドを取得（パース失敗でエラー）
+#[cfg(test)]
 pub fn parse_required_date(
     record: &csv::StringRecord,
     header_map: &HashMap<String, usize>,
@@ -140,6 +190,19 @@ pub fn parse_required_date(
     row_num: usize,
 ) -> Result<NaiveDate, CsvRowError> {
     let raw = get_cell(record, header_map, col);
+    parse_date(raw).map_err(|e| CsvRowError {
+        row: row_num,
+        message: format!("{}: {}", col, e),
+    })
+}
+
+/// 行マップから必須日付フィールドを取得（パース失敗でエラー）
+pub fn parse_required_date_row(
+    row: &HashMap<String, String>,
+    col: &str,
+    row_num: usize,
+) -> Result<NaiveDate, CsvRowError> {
+    let raw = get_row_cell(row, col);
     parse_date(raw).map_err(|e| CsvRowError {
         row: row_num,
         message: format!("{}: {}", col, e),

--- a/backend/src/services/dividend.rs
+++ b/backend/src/services/dividend.rs
@@ -2,17 +2,34 @@ use crate::errors::ApiError;
 use crate::models::common::BulkCreateResponse;
 use crate::models::csv_import::{CsvPreviewResponse, CsvRowError, CsvUploadResponse};
 use crate::models::dividend::{CreateDividendRequest, Dividend};
-use crate::services::csv_import::{build_preview, finish_csv_upload, parse_csv};
+use crate::services::csv_import::{build_preview_response, finish_csv_upload, validate_csv_rows};
+use crate::services::csv_pipeline::{parse_csv_with_config, CsvParserConfig, CsvRow};
 use crate::services::csv_util::{
-    normalize_security_name, parse_optional_string, parse_required_date, parse_required_number,
-    parse_required_string,
+    normalize_security_name, parse_optional_string_row, parse_required_date_row,
+    parse_required_number_row, parse_required_string_row,
 };
 use crate::services::shared::BulkTimer;
 use rust_decimal::Decimal;
 use sqlx::PgPool;
-use std::collections::HashMap;
 use tracing::info;
 use uuid::Uuid;
+
+const DIVIDEND_CSV_CONFIG: CsvParserConfig = CsvParserConfig {
+    skip_header_rows: 0,
+    exclude_row_fn: None,
+    required_columns: &[
+        "入金日",
+        "商品",
+        "口座",
+        "銘柄コード",
+        "銘柄",
+        "単価[円/現地通貨]",
+        "数量[株/口]",
+        "配当・分配金合計（税引前）[円/現地通貨]",
+        "税額合計[円/現地通貨]",
+        "受取金額[円/現地通貨]",
+    ],
+};
 
 /// 認証ユーザーの配当金一覧を取得
 pub async fn list(pool: &PgPool, user_id: Uuid) -> Result<Vec<Dividend>, ApiError> {
@@ -97,10 +114,9 @@ pub async fn bulk_create(
 
 /// CSV バイト列から配当金をパースしてプレビュー情報を返す（DB 書き込みなし）
 pub fn preview_csv(bytes: &[u8]) -> Result<CsvPreviewResponse, ApiError> {
-    if bytes.is_empty() {
-        return Err(ApiError::ValidationError("CSVが空です".to_string()));
-    }
-    build_preview(bytes, parse_dividend_row)
+    let rows = parse_dividend_csv(bytes)?;
+    let (items, errors) = transform_dividend_rows(&rows);
+    Ok(build_preview_response(&items, errors))
 }
 
 /// CSV バイト列から配当金をパースして一括挿入
@@ -109,39 +125,39 @@ pub async fn upload_csv(
     user_id: Uuid,
     bytes: &[u8],
 ) -> Result<CsvUploadResponse, ApiError> {
-    let (items, errors) = parse_csv(bytes, parse_dividend_row)?;
+    let rows = parse_dividend_csv(bytes)?;
+    let (items, errors) = transform_dividend_rows(&rows);
     let result = bulk_create(pool, user_id, &items).await?;
     Ok(finish_csv_upload(result, errors))
 }
 
-fn parse_dividend_row(
-    record: &csv::StringRecord,
-    header_map: &HashMap<String, usize>,
+fn parse_dividend_csv(bytes: &[u8]) -> Result<Vec<CsvRow>, ApiError> {
+    parse_csv_with_config(bytes, &DIVIDEND_CSV_CONFIG)
+}
+
+fn transform_dividend_rows(rows: &[CsvRow]) -> (Vec<CreateDividendRequest>, Vec<CsvRowError>) {
+    validate_csv_rows(rows, transform_dividend_row)
+}
+
+fn transform_dividend_row(
+    row: &CsvRow,
     row_num: usize,
 ) -> Result<CreateDividendRequest, CsvRowError> {
     Ok(CreateDividendRequest {
-        settlement_date: parse_required_date(record, header_map, "入金日", row_num)?,
-        product: parse_required_string(record, header_map, "商品", row_num)?,
-        account: parse_required_string(record, header_map, "口座", row_num)?,
-        security_code: parse_optional_string(record, header_map, "銘柄コード"),
-        security_name: normalize_security_name(&parse_required_string(
-            record, header_map, "銘柄", row_num,
-        )?),
-        unit_price: parse_required_number(record, header_map, "単価[円/現地通貨]", row_num)?,
-        shares: parse_required_number(record, header_map, "数量[株/口]", row_num)?,
-        dividends_before_tax: parse_required_number(
-            record,
-            header_map,
+        settlement_date: parse_required_date_row(row, "入金日", row_num)?,
+        product: parse_required_string_row(row, "商品", row_num)?,
+        account: parse_required_string_row(row, "口座", row_num)?,
+        security_code: parse_optional_string_row(row, "銘柄コード"),
+        security_name: normalize_security_name(&parse_required_string_row(row, "銘柄", row_num)?),
+        unit_price: parse_required_number_row(row, "単価[円/現地通貨]", row_num)?,
+        shares: parse_required_number_row(row, "数量[株/口]", row_num)?,
+        dividends_before_tax: parse_required_number_row(
+            row,
             "配当・分配金合計（税引前）[円/現地通貨]",
             row_num,
         )?,
-        taxes: parse_required_number(record, header_map, "税額合計[円/現地通貨]", row_num)?,
-        net_amount_received: parse_required_number(
-            record,
-            header_map,
-            "受取金額[円/現地通貨]",
-            row_num,
-        )?,
+        taxes: parse_required_number_row(row, "税額合計[円/現地通貨]", row_num)?,
+        net_amount_received: parse_required_number_row(row, "受取金額[円/現地通貨]", row_num)?,
     })
 }
 

--- a/backend/src/services/domestic_stock.rs
+++ b/backend/src/services/domestic_stock.rs
@@ -2,17 +2,34 @@ use crate::errors::ApiError;
 use crate::models::common::BulkCreateResponse;
 use crate::models::csv_import::{CsvPreviewResponse, CsvRowError, CsvUploadResponse};
 use crate::models::domestic_stock::{CreateDomesticStockRequest, DomesticStock};
-use crate::services::csv_import::{build_preview, finish_csv_upload, parse_csv};
+use crate::services::csv_import::{build_preview_response, finish_csv_upload, validate_csv_rows};
+use crate::services::csv_pipeline::{parse_csv_with_config, CsvParserConfig, CsvRow};
 use crate::services::csv_util::{
-    compute_taxes, normalize_security_name, parse_required_date, parse_required_number,
-    parse_required_string,
+    compute_taxes, normalize_security_name, parse_required_date_row, parse_required_number_row,
+    parse_required_string_row,
 };
 use crate::services::shared::BulkTimer;
 use rust_decimal::Decimal;
 use sqlx::PgPool;
-use std::collections::HashMap;
 use tracing::info;
 use uuid::Uuid;
+
+const DOMESTIC_STOCK_CSV_CONFIG: CsvParserConfig = CsvParserConfig {
+    skip_header_rows: 0,
+    exclude_row_fn: None,
+    required_columns: &[
+        "約定日",
+        "受渡日",
+        "銘柄コード",
+        "銘柄名",
+        "口座",
+        "数量[株]",
+        "売却/決済単価[円]",
+        "売却/決済額[円]",
+        "平均取得価額[円]",
+        "実現損益[円]",
+    ],
+};
 
 /// 認証ユーザーの国内株式取引一覧を取得
 pub async fn list(pool: &PgPool, user_id: Uuid) -> Result<Vec<DomesticStock>, ApiError> {
@@ -161,10 +178,9 @@ pub async fn bulk_create(
 
 /// CSV バイト列から国内株式取引をパースしてプレビュー情報を返す（DB 書き込みなし）
 pub fn preview_csv(bytes: &[u8]) -> Result<CsvPreviewResponse, ApiError> {
-    if bytes.is_empty() {
-        return Err(ApiError::ValidationError("CSVが空です".to_string()));
-    }
-    build_preview(bytes, parse_domestic_stock_row)
+    let rows = parse_domestic_stock_csv(bytes)?;
+    let (items, errors) = transform_domestic_stock_rows(&rows);
+    Ok(build_preview_response(&items, errors))
 }
 
 /// CSV バイト列から国内株式取引をパースして一括挿入
@@ -173,36 +189,41 @@ pub async fn upload_csv(
     user_id: Uuid,
     bytes: &[u8],
 ) -> Result<CsvUploadResponse, ApiError> {
-    let (items, errors) = parse_csv(bytes, parse_domestic_stock_row)?;
+    let rows = parse_domestic_stock_csv(bytes)?;
+    let (items, errors) = transform_domestic_stock_rows(&rows);
     let result = bulk_create(pool, user_id, &items).await?;
     Ok(finish_csv_upload(result, errors))
 }
 
-fn parse_domestic_stock_row(
-    record: &csv::StringRecord,
-    header_map: &HashMap<String, usize>,
+fn parse_domestic_stock_csv(bytes: &[u8]) -> Result<Vec<CsvRow>, ApiError> {
+    parse_csv_with_config(bytes, &DOMESTIC_STOCK_CSV_CONFIG)
+}
+
+fn transform_domestic_stock_rows(
+    rows: &[CsvRow],
+) -> (Vec<CreateDomesticStockRequest>, Vec<CsvRowError>) {
+    validate_csv_rows(rows, transform_domestic_stock_row)
+}
+
+fn transform_domestic_stock_row(
+    row: &CsvRow,
     row_num: usize,
 ) -> Result<CreateDomesticStockRequest, CsvRowError> {
-    let trade_date = parse_required_date(record, header_map, "約定日", row_num)?;
-    let settlement_date = parse_required_date(record, header_map, "受渡日", row_num)?;
-    let account = parse_required_string(record, header_map, "口座", row_num)?;
-    let realized_pnl = parse_required_number(record, header_map, "実現損益[円]", row_num)?;
+    let trade_date = parse_required_date_row(row, "約定日", row_num)?;
+    let settlement_date = parse_required_date_row(row, "受渡日", row_num)?;
+    let account = parse_required_string_row(row, "口座", row_num)?;
+    let realized_pnl = parse_required_number_row(row, "実現損益[円]", row_num)?;
     let (taxes, realized_pnl_after_tax) = compute_taxes(&account, realized_pnl);
     Ok(CreateDomesticStockRequest {
         trade_date,
         settlement_date,
-        security_code: parse_required_string(record, header_map, "銘柄コード", row_num)?,
-        security_name: normalize_security_name(&parse_required_string(
-            record,
-            header_map,
-            "銘柄名",
-            row_num,
-        )?),
+        security_code: parse_required_string_row(row, "銘柄コード", row_num)?,
+        security_name: normalize_security_name(&parse_required_string_row(row, "銘柄名", row_num)?),
         account,
-        shares: parse_required_number(record, header_map, "数量[株]", row_num)?,
-        asked_price: parse_required_number(record, header_map, "売却/決済単価[円]", row_num)?,
-        proceeds: parse_required_number(record, header_map, "売却/決済額[円]", row_num)?,
-        purchase_price: parse_required_number(record, header_map, "平均取得価額[円]", row_num)?,
+        shares: parse_required_number_row(row, "数量[株]", row_num)?,
+        asked_price: parse_required_number_row(row, "売却/決済単価[円]", row_num)?,
+        proceeds: parse_required_number_row(row, "売却/決済額[円]", row_num)?,
+        purchase_price: parse_required_number_row(row, "平均取得価額[円]", row_num)?,
         realized_profit_and_loss: realized_pnl,
         taxes,
         realized_profit_and_loss_after_tax: realized_pnl_after_tax,

--- a/backend/src/services/mutualfund.rs
+++ b/backend/src/services/mutualfund.rs
@@ -2,16 +2,35 @@ use crate::errors::ApiError;
 use crate::models::common::BulkCreateResponse;
 use crate::models::csv_import::{CsvPreviewResponse, CsvRowError, CsvUploadResponse};
 use crate::models::mutualfund::{CreateMutualfundRequest, Mutualfund};
-use crate::services::csv_import::{build_preview, finish_csv_upload, parse_csv};
+use crate::services::csv_import::{build_preview_response, finish_csv_upload, validate_csv_rows};
+use crate::services::csv_pipeline::{parse_csv_with_config, CsvParserConfig, CsvRow};
 use crate::services::csv_util::{
-    compute_taxes, get_cell, parse_required_date, parse_required_number, parse_required_string,
+    compute_taxes, get_row_cell, parse_required_date_row, parse_required_number_row,
+    parse_required_string_row,
 };
 use crate::services::shared::BulkTimer;
 use rust_decimal::Decimal;
 use sqlx::PgPool;
-use std::collections::HashMap;
 use tracing::info;
 use uuid::Uuid;
+
+const MUTUALFUND_CSV_CONFIG: CsvParserConfig = CsvParserConfig {
+    skip_header_rows: 0,
+    exclude_row_fn: None,
+    required_columns: &[
+        "約定日",
+        "受渡日",
+        "ファンド名",
+        "分配金",
+        "口座",
+        "数量[口]",
+        "為替レート［円］",
+        "解約単価［円］",
+        "解約額［円］",
+        "平均取得価額［円］",
+        "実現損益［円］",
+    ],
+};
 
 /// 認証ユーザーの投資信託一覧を取得
 pub async fn list(pool: &PgPool, user_id: Uuid) -> Result<Vec<Mutualfund>, ApiError> {
@@ -113,10 +132,9 @@ pub async fn bulk_create(
 
 /// CSV バイト列から投資信託をパースしてプレビュー情報を返す（DB 書き込みなし）
 pub fn preview_csv(bytes: &[u8]) -> Result<CsvPreviewResponse, ApiError> {
-    if bytes.is_empty() {
-        return Err(ApiError::ValidationError("CSVが空です".to_string()));
-    }
-    build_preview(bytes, parse_mutualfund_row)
+    let rows = parse_mutualfund_csv(bytes)?;
+    let (items, errors) = transform_mutualfund_rows(&rows);
+    Ok(build_preview_response(&items, errors))
 }
 
 /// CSV バイト列から投資信託をパースして一括挿入
@@ -125,23 +143,31 @@ pub async fn upload_csv(
     user_id: Uuid,
     bytes: &[u8],
 ) -> Result<CsvUploadResponse, ApiError> {
-    let (items, errors) = parse_csv(bytes, parse_mutualfund_row)?;
+    let rows = parse_mutualfund_csv(bytes)?;
+    let (items, errors) = transform_mutualfund_rows(&rows);
     let result = bulk_create(pool, user_id, &items).await?;
     Ok(finish_csv_upload(result, errors))
 }
 
-fn parse_mutualfund_row(
-    record: &csv::StringRecord,
-    header_map: &HashMap<String, usize>,
+fn parse_mutualfund_csv(bytes: &[u8]) -> Result<Vec<CsvRow>, ApiError> {
+    parse_csv_with_config(bytes, &MUTUALFUND_CSV_CONFIG)
+}
+
+fn transform_mutualfund_rows(rows: &[CsvRow]) -> (Vec<CreateMutualfundRequest>, Vec<CsvRowError>) {
+    validate_csv_rows(rows, transform_mutualfund_row)
+}
+
+fn transform_mutualfund_row(
+    row: &CsvRow,
     row_num: usize,
 ) -> Result<CreateMutualfundRequest, CsvRowError> {
-    let trade_date = parse_required_date(record, header_map, "約定日", row_num)?;
-    let settlement_date = parse_required_date(record, header_map, "受渡日", row_num)?;
-    let account = parse_required_string(record, header_map, "口座", row_num)?;
-    let realized_pnl = parse_required_number(record, header_map, "実現損益［円］", row_num)?;
+    let trade_date = parse_required_date_row(row, "約定日", row_num)?;
+    let settlement_date = parse_required_date_row(row, "受渡日", row_num)?;
+    let account = parse_required_string_row(row, "口座", row_num)?;
+    let realized_pnl = parse_required_number_row(row, "実現損益［円］", row_num)?;
     let (taxes, realized_pnl_after_tax) = compute_taxes(&account, realized_pnl);
     // 分配金フィールドは空文字を None に変換
-    let dividends_raw = get_cell(record, header_map, "分配金");
+    let dividends_raw = get_row_cell(row, "分配金");
     let dividends = if dividends_raw.trim().is_empty() {
         None
     } else {
@@ -150,26 +176,15 @@ fn parse_mutualfund_row(
     Ok(CreateMutualfundRequest {
         trade_date,
         settlement_date,
-        fund_name: parse_required_string(record, header_map, "ファンド名", row_num)?,
+        fund_name: parse_required_string_row(row, "ファンド名", row_num)?,
         dividends,
         account,
-        shares: parse_required_number(record, header_map, "数量[口]", row_num)?,
-        exchange_rate: parse_required_number(record, header_map, "為替レート［円］", row_num)?,
-        cancellation_unit_price_yen: parse_required_number(
-            record,
-            header_map,
-            "解約単価［円］",
-            row_num,
-        )?,
-        cancellation_amount_yen: parse_required_number(
-            record,
-            header_map,
-            "解約額［円］",
-            row_num,
-        )?,
-        average_acquisition_price_yen: parse_required_number(
-            record,
-            header_map,
+        shares: parse_required_number_row(row, "数量[口]", row_num)?,
+        exchange_rate: parse_required_number_row(row, "為替レート［円］", row_num)?,
+        cancellation_unit_price_yen: parse_required_number_row(row, "解約単価［円］", row_num)?,
+        cancellation_amount_yen: parse_required_number_row(row, "解約額［円］", row_num)?,
+        average_acquisition_price_yen: parse_required_number_row(
+            row,
             "平均取得価額［円］",
             row_num,
         )?,


### PR DESCRIPTION
## 概要

各CSV サービスに散在していたパース・スキップ・除外ロジックを `CsvParserConfig` として宣言的に定義し、共通パイプラインに集約する。

## 変更内容

- `backend/src/services/csv_pipeline.rs` を新規作成
  - `CsvParserConfig` 構造体（`skip_header_rows`, `exclude_row_fn`, `required_columns`）
  - `parse_csv_with_config()` 共通関数
- 各サービスを `parse → validate → transform → import` の4段階に統一
  - `asset_balance.rs`: skip_header_rows=6、口座合計行 exclude_row_fn を config 化
  - `dividend.rs`, `domestic_stock.rs`, `mutualfund.rs`: 同様

## テスト結果

- `cargo fmt --check`: 通過
- `cargo clippy -- -D warnings`: 通過
- `cargo test --lib`: 41 passed / 0 failed

## 非対象

- DB スキーマ変更なし
- API エンドポイント変更なし
- フロントエンド変更なし

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * CSV処理パイプラインを再設計し、複数のCSVタイプ（資産残高、配当、国内株式、投資信託）の解析・変換フローを統一
  * エラーハンドリングを改善し、行単位での検証と詳細なエラー情報を提供するよう改善

* **Tests**
  * 更新されたCSV処理パイプラインに対応するテストを更新

<!-- end of auto-generated comment: release notes by coderabbit.ai -->