### PR TITLE
refactor: J-Quants サービスにモック HTTP テストを追加

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -219,6 +219,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "astral-tokio-tar"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +422,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "validator",
+ "wiremock",
 ]
 
 [[package]]
@@ -881,6 +892,24 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
 ]
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "debugid"
@@ -1429,6 +1458,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2194,6 +2229,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -5171,6 +5216,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -44,3 +44,4 @@ sentry-tower = "0.47"
 tokio-test = "0.4.5"
 testcontainers = "0.27.2"
 testcontainers-modules = { version = "0.15.0", features = ["postgres"] }
+wiremock = "0.6"

--- a/backend/src/handlers/jquants.rs
+++ b/backend/src/handlers/jquants.rs
@@ -1,7 +1,7 @@
 use crate::errors::{ApiError, ErrorResponse};
 use crate::extractors::auth::AuthenticatedUser;
 use crate::models::jquants::{FinSummaryQuery, FinSummaryResponse};
-use crate::services::jquants::JQuantsService;
+use crate::services::jquants::{JQuantsService, FIN_SUMMARY_URL};
 use crate::state::AppState;
 use axum::{
     extract::{Query, State},
@@ -45,6 +45,7 @@ pub async fn get_fin_summary(
             ApiError::ApiError("JQUANTS_API_KEY が設定されていません".to_string())
         })?;
 
-    let response = JQuantsService::get_fin_summary(&state.client, params, api_key).await?;
+    let response =
+        JQuantsService::get_fin_summary(&state.client, params, api_key, FIN_SUMMARY_URL).await?;
     Ok(Json(response))
 }

--- a/backend/src/services/dividend_cache/persistence.rs
+++ b/backend/src/services/dividend_cache/persistence.rs
@@ -1,6 +1,6 @@
 use crate::errors::ApiError;
 use crate::models::jquants::FinSummaryQuery;
-use crate::services::jquants::JQuantsService;
+use crate::services::jquants::{JQuantsService, FIN_SUMMARY_URL};
 use reqwest::Client;
 use sqlx::PgPool;
 
@@ -19,7 +19,8 @@ pub async fn fetch_and_cache(
         to: None,
     };
 
-    let response = JQuantsService::get_fin_summary(client, params, api_key).await?;
+    let response =
+        JQuantsService::get_fin_summary(client, params, api_key, FIN_SUMMARY_URL).await?;
 
     let (dividend_per_share, status) = extract_dividend(&response.data);
 

--- a/backend/src/services/jquants.rs
+++ b/backend/src/services/jquants.rs
@@ -2,6 +2,8 @@ use crate::errors::ApiError;
 use crate::models::jquants::{FinSummaryQuery, FinSummaryResponse};
 use reqwest::Client;
 
+pub const FIN_SUMMARY_URL: &str = "https://api.jquants.com/v2/fins/summary";
+
 pub struct JQuantsService;
 
 impl JQuantsService {
@@ -11,9 +13,8 @@ impl JQuantsService {
         client: &Client,
         params: FinSummaryQuery,
         api_key: &str,
+        base_url: &str,
     ) -> Result<FinSummaryResponse, ApiError> {
-        let base_url = "https://api.jquants.com/v2/fins/summary";
-
         // クエリパラメータを構築（reqwest が自動でエンコード）
         let mut query_params: Vec<(&str, &str)> = vec![("code", &params.code)];
         let from_str;
@@ -85,11 +86,177 @@ impl JQuantsService {
         Ok(fin_summary_response)
     }
 }
-#[cfg(test)] #[rustfmt::skip] mod tests {
+#[cfg(test)]
+mod tests {
     use super::*;
-    async fn fetch_fin_summary(code: &str) -> FinSummaryResponse { let api_key = std::env::var("JQUANTS_API_KEY").expect("JQUANTS_API_KEY 環境変数が設定されていません"); let params = FinSummaryQuery { code: code.to_string(), from: None, to: None }; JQuantsService::get_fin_summary(&Client::new(), params, &api_key).await.unwrap_or_else(|e| panic!("API呼び出しエラー: {:?}", e)) }
-    fn log_summary_overview(response: &FinSummaryResponse) { println!("取得件数: {}", response.data.len()); if let Some(first) = response.data.first() { println!("銘柄コード: {}", first.local_code); println!("開示日: {}", first.disclosed_date); println!("書類種別: {}", first.type_of_document); println!("当期種別: {:?}", first.type_of_current_period); println!("当期開始日: {:?}", first.current_period_start_date); println!("当期終了日: {:?}", first.current_period_end_date); } }
-    fn log_dividend_summaries(response: &FinSummaryResponse) { println!("取得件数: {}", response.data.len()); for summary in &response.data { println!("---"); println!("開示日: {}", summary.disclosed_date); println!("書類種別: {}", summary.type_of_document); println!("年間配当実績(DivAnn): {:?}", summary.result_dividend_per_share_annual); println!("年間配当予想(FDivAnn): {:?}", summary.forecast_dividend_per_share_annual); println!("年間配当来期予想(NxFDivAnn): {:?}", summary.next_year_forecast_dividend_per_share_annual); } }
-    #[tokio::test] #[ignore = "requires JQUANTS_API_KEY env var (real external API call)"] async fn test_get_fin_summary_real_api() { let response = fetch_fin_summary("7203").await; log_summary_overview(&response); assert!(!response.data.is_empty(), "データが取得できること"); }
-    #[tokio::test] #[ignore = "requires JQUANTS_API_KEY env var (real external API call)"] async fn test_get_nintendo_dividend() { let response = fetch_fin_summary("7974").await; log_dividend_summaries(&response); assert!(!response.data.is_empty(), "データが取得できること"); }
+    use serde_json::json;
+    use wiremock::{
+        matchers::{header, method, path, query_param},
+        Mock, MockServer, ResponseTemplate,
+    };
+
+    async fn fetch_fin_summary(base_url: &str, code: &str) -> FinSummaryResponse {
+        let api_key =
+            std::env::var("JQUANTS_API_KEY").expect("JQUANTS_API_KEY 環境変数が設定されていません");
+        let params = FinSummaryQuery {
+            code: code.to_string(),
+            from: None,
+            to: None,
+        };
+
+        JQuantsService::get_fin_summary(&Client::new(), params, &api_key, base_url)
+            .await
+            .unwrap_or_else(|e| panic!("API呼び出しエラー: {:?}", e))
+    }
+
+    async fn fetch_mock_fin_summary(server: &MockServer) -> Result<FinSummaryResponse, ApiError> {
+        let params = FinSummaryQuery {
+            code: "7203".to_string(),
+            from: None,
+            to: None,
+        };
+        let base_url = format!("{}/v2/fins/summary", server.uri());
+
+        JQuantsService::get_fin_summary(&Client::new(), params, "test-api-key", &base_url).await
+    }
+
+    fn log_summary_overview(response: &FinSummaryResponse) {
+        println!("取得件数: {}", response.data.len());
+        if let Some(first) = response.data.first() {
+            println!("銘柄コード: {}", first.local_code);
+            println!("開示日: {}", first.disclosed_date);
+            println!("書類種別: {}", first.type_of_document);
+            println!("当期種別: {:?}", first.type_of_current_period);
+            println!("当期開始日: {:?}", first.current_period_start_date);
+            println!("当期終了日: {:?}", first.current_period_end_date);
+        }
+    }
+
+    fn log_dividend_summaries(response: &FinSummaryResponse) {
+        println!("取得件数: {}", response.data.len());
+        for summary in &response.data {
+            println!("---");
+            println!("開示日: {}", summary.disclosed_date);
+            println!("書類種別: {}", summary.type_of_document);
+            println!(
+                "年間配当実績(DivAnn): {:?}",
+                summary.result_dividend_per_share_annual
+            );
+            println!(
+                "年間配当予想(FDivAnn): {:?}",
+                summary.forecast_dividend_per_share_annual
+            );
+            println!(
+                "年間配当来期予想(NxFDivAnn): {:?}",
+                summary.next_year_forecast_dividend_per_share_annual
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_fin_summary_success() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/v2/fins/summary"))
+            .and(query_param("code", "7203"))
+            .and(header("x-api-key", "test-api-key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": [
+                    {
+                        "DiscDate": "2024-05-10",
+                        "Code": "7203",
+                        "DocType": "FY"
+                    }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let response = fetch_mock_fin_summary(&server)
+            .await
+            .expect("モック API から正常レスポンスを取得できること");
+
+        assert_eq!(response.data.len(), 1);
+        assert_eq!(response.data[0].local_code, "7203");
+    }
+
+    #[tokio::test]
+    async fn test_get_fin_summary_rate_limit() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/v2/fins/summary"))
+            .and(query_param("code", "7203"))
+            .respond_with(ResponseTemplate::new(429).set_body_string("rate limited"))
+            .mount(&server)
+            .await;
+
+        let error = fetch_mock_fin_summary(&server)
+            .await
+            .expect_err("429 では RateLimitError を返すこと");
+
+        assert!(matches!(
+            error,
+            ApiError::RateLimitError(message) if message.contains("rate limited")
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_get_fin_summary_api_error() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/v2/fins/summary"))
+            .and(query_param("code", "7203"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("upstream failed"))
+            .mount(&server)
+            .await;
+
+        let error = fetch_mock_fin_summary(&server)
+            .await
+            .expect_err("非 2xx では ApiError を返すこと");
+
+        assert!(matches!(
+            error,
+            ApiError::ApiError(message) if message.contains("upstream failed")
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_get_fin_summary_deserialize_error() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/v2/fins/summary"))
+            .and(query_param("code", "7203"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("{invalid"))
+            .mount(&server)
+            .await;
+
+        let error = fetch_mock_fin_summary(&server)
+            .await
+            .expect_err("不正 JSON では NetworkError を返すこと");
+
+        assert!(matches!(
+            error,
+            ApiError::NetworkError(message) if message.contains("解析エラー")
+        ));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires JQUANTS_API_KEY env var (real external API call)"]
+    async fn test_get_fin_summary_real_api() {
+        let response = fetch_fin_summary("https://api.jquants.com/v2/fins/summary", "7203").await;
+        log_summary_overview(&response);
+        assert!(!response.data.is_empty(), "データが取得できること");
+    }
+
+    #[tokio::test]
+    #[ignore = "requires JQUANTS_API_KEY env var (real external API call)"]
+    async fn test_get_nintendo_dividend() {
+        let response = fetch_fin_summary("https://api.jquants.com/v2/fins/summary", "7974").await;
+        log_dividend_summaries(&response);
+        assert!(!response.data.is_empty(), "データが取得できること");
+    }
 }


### PR DESCRIPTION
## 変更内容
- `backend` の `dev-dependencies` に `wiremock` を追加
- `JQuantsService::get_fin_summary` に `base_url` 引数を追加し、既存呼び出し元は既定 URL 定数を利用
- `wiremock` を使った成功・429・500・不正 JSON のユニットテストを追加
- 既存の実 API テスト 2 件は `#[ignore]` のまま維持し、`#[rustfmt::skip]` を削除

## 背景
- 実 API キーに依存しない形で J-Quants サービスのテストを CI で通せるようにするため
- 429、非 2xx、デシリアライズ失敗の分岐を自動テストでカバーするため

## テスト
- `cd backend && cargo fmt --check`
- `cd backend && cargo clippy --all-targets -- -D warnings`
- `cd backend && cargo test --lib`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * J-Quants API統合のテストをモックサーバーベースの包括的なテストに更新しました。成功シナリオからレート制限、APIエラー処理、データのデシリアライゼーション失敗など複数のケースをカバーするようになりました。

* **その他**
  * テスト環境用の依存関係を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->