### PR TITLE
refactor: #[rustfmt::skip] を全削除してテストを可読スタイルに展開

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -67,12 +67,185 @@ impl Config {
         config
     }
 }
-#[cfg(test)] #[rustfmt::skip] mod tests {
-    use {super::*, crate::{routes::app_router, state::AppState, test_env::{EnvGuard, ENV_MUTEX}}, axum::{body::Body, http::{header::ACCESS_CONTROL_ALLOW_ORIGIN, Method, Request, StatusCode}, Router}, reqwest::Client, std::sync::Arc, tower::ServiceExt};
-    fn build_test_app(config: &Config) -> Router { let database_url = "postgresql://user:password@localhost/test_db"; let pool = crate::db::connect_pool_lazy(database_url, 1).expect("Failed to create connection pool"); let secrets = Arc::new(crate::state::Secrets { database_url: database_url.to_string(), jquants_api_key: None, google_client_id: None, google_client_secret: None, frontend_url: "http://localhost:8080".to_string() }); app_router(AppState { pool, secrets, client: Client::new(), dividend_cache: crate::state::DividendCacheState::default() }, config) }
-    async fn preflight(app: Router, origin: &str) -> axum::response::Response { app.oneshot(Request::builder().method(Method::OPTIONS).uri("/health").header("origin", origin).header("access-control-request-method", "GET").body(Body::empty()).unwrap()).await.unwrap() }
-    async fn post_with_origin(app: Router, origin: &str) -> axum::response::Response { app.oneshot(Request::builder().method(Method::POST).uri("/health").header("origin", origin).body(Body::empty()).unwrap()).await.unwrap() }
-    fn allowed_origin(response: &axum::response::Response) -> Option<&str> { response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN).and_then(|value| value.to_str().ok()) }
-    #[test] fn test_config_creation() { let config = Config::default(); assert_eq!((config.database_max_connections, config.csv_rate_limit_rps, config.cors_origins.contains(&"https://shoken-webapp.vercel.app".to_string()), config.cors_origins.contains(&"http://localhost:8080".to_string())), (5, 2, true, true)); let _cors_layer = build_cors_layer(&config.cors_origins); let config = Config { cors_origins: vec!["http://example.com".to_string()], database_max_connections: 10, auth_rate_limit_rps: 10, jquants_rate_limit_rps: 5, csv_rate_limit_rps: 2 }; assert_eq!((config.database_max_connections, config.cors_origins.len(), config.cors_origins[0].as_str(), config.csv_rate_limit_rps), (10, 1, "http://example.com", 2)); let url = backend_url(); let expected_url = env::var("BACKEND_URL").unwrap_or_else(|_| env::var("PORT").map(|port| format!("http://localhost:{port}")).unwrap_or_else(|_| "http://localhost:3001".to_string())); assert_eq!(url, expected_url); assert!(server_addr().starts_with("0.0.0.0:")); let _ = is_secure_cookie(); }
-    #[tokio::test] async fn test_config_from_env() { let _lock = ENV_MUTEX.lock().await; { let _csv_rate_limit_rps = EnvGuard::set("CSV_RATE_LIMIT_RPS", Some("7")); assert_eq!(Config::from_env().csv_rate_limit_rps, 7); } { let _app_env = EnvGuard::set("APP_ENV", Some("production")); let _cors_origins = EnvGuard::set("CORS_ORIGINS", Some("https://shoken-webapp.vercel.app,http://localhost:8080")); let app = build_test_app(&Config::from_env()); assert_eq!(allowed_origin(&preflight(app.clone(), "https://shoken-webapp.vercel.app").await), Some("https://shoken-webapp.vercel.app")); assert_eq!(allowed_origin(&preflight(app, "http://localhost:8080").await), None); } { let _app_env = EnvGuard::set("APP_ENV", None); let _cors_origins = EnvGuard::set("CORS_ORIGINS", Some("http://custom-origin.example.com:8080")); let app = build_test_app(&Config::from_env()); assert_ne!(post_with_origin(app.clone(), "http://custom-origin.example.com:8080").await.status(), StatusCode::FORBIDDEN, "許可されたカスタムオリジンは通過すべき"); assert_eq!(post_with_origin(app, "http://disallowed-origin.example.com").await.status(), StatusCode::FORBIDDEN, "許可されていないオリジンは拒否すべき"); } { let _app_env = EnvGuard::set("APP_ENV", None); let _cors_origins = EnvGuard::set("CORS_ORIGINS", Some("http://localhost:8080")); let app = build_test_app(&Config::from_env()); assert_eq!(allowed_origin(&preflight(app.clone(), "http://localhost:8080").await), Some("http://localhost:8080")); let resp = post_with_origin(app, "http://evil.example.com").await; assert_eq!((resp.status(), resp.headers().get("X-Content-Type-Options").and_then(|v| v.to_str().ok()), resp.headers().get("X-Frame-Options").and_then(|v| v.to_str().ok())), (StatusCode::FORBIDDEN, Some("nosniff"), Some("DENY"))); } }
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::{
+            routes::app_router,
+            state::AppState,
+            test_env::{EnvGuard, ENV_MUTEX},
+        },
+        axum::{
+            body::Body,
+            http::{header::ACCESS_CONTROL_ALLOW_ORIGIN, Method, Request, StatusCode},
+            Router,
+        },
+        reqwest::Client,
+        std::sync::Arc,
+        tower::ServiceExt,
+    };
+    fn build_test_app(config: &Config) -> Router {
+        let database_url = "postgresql://user:password@localhost/test_db";
+        let pool = crate::db::connect_pool_lazy(database_url, 1)
+            .expect("Failed to create connection pool");
+        let secrets = Arc::new(crate::state::Secrets {
+            database_url: database_url.to_string(),
+            jquants_api_key: None,
+            google_client_id: None,
+            google_client_secret: None,
+            frontend_url: "http://localhost:8080".to_string(),
+        });
+        app_router(
+            AppState {
+                pool,
+                secrets,
+                client: Client::new(),
+                dividend_cache: crate::state::DividendCacheState::default(),
+            },
+            config,
+        )
+    }
+    async fn preflight(app: Router, origin: &str) -> axum::response::Response {
+        app.oneshot(
+            Request::builder()
+                .method(Method::OPTIONS)
+                .uri("/health")
+                .header("origin", origin)
+                .header("access-control-request-method", "GET")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+    }
+    async fn post_with_origin(app: Router, origin: &str) -> axum::response::Response {
+        app.oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/health")
+                .header("origin", origin)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+    }
+    fn allowed_origin(response: &axum::response::Response) -> Option<&str> {
+        response
+            .headers()
+            .get(ACCESS_CONTROL_ALLOW_ORIGIN)
+            .and_then(|value| value.to_str().ok())
+    }
+    #[test]
+    fn test_config_creation() {
+        let config = Config::default();
+        assert_eq!(
+            (
+                config.database_max_connections,
+                config.csv_rate_limit_rps,
+                config
+                    .cors_origins
+                    .contains(&"https://shoken-webapp.vercel.app".to_string()),
+                config
+                    .cors_origins
+                    .contains(&"http://localhost:8080".to_string())
+            ),
+            (5, 2, true, true)
+        );
+        let _cors_layer = build_cors_layer(&config.cors_origins);
+        let config = Config {
+            cors_origins: vec!["http://example.com".to_string()],
+            database_max_connections: 10,
+            auth_rate_limit_rps: 10,
+            jquants_rate_limit_rps: 5,
+            csv_rate_limit_rps: 2,
+        };
+        assert_eq!(
+            (
+                config.database_max_connections,
+                config.cors_origins.len(),
+                config.cors_origins[0].as_str(),
+                config.csv_rate_limit_rps
+            ),
+            (10, 1, "http://example.com", 2)
+        );
+        let url = backend_url();
+        let expected_url = env::var("BACKEND_URL").unwrap_or_else(|_| {
+            env::var("PORT")
+                .map(|port| format!("http://localhost:{port}"))
+                .unwrap_or_else(|_| "http://localhost:3001".to_string())
+        });
+        assert_eq!(url, expected_url);
+        assert!(server_addr().starts_with("0.0.0.0:"));
+        let _ = is_secure_cookie();
+    }
+    #[tokio::test]
+    async fn test_config_from_env() {
+        let _lock = ENV_MUTEX.lock().await;
+        {
+            let _csv_rate_limit_rps = EnvGuard::set("CSV_RATE_LIMIT_RPS", Some("7"));
+            assert_eq!(Config::from_env().csv_rate_limit_rps, 7);
+        }
+        {
+            let _app_env = EnvGuard::set("APP_ENV", Some("production"));
+            let _cors_origins = EnvGuard::set(
+                "CORS_ORIGINS",
+                Some("https://shoken-webapp.vercel.app,http://localhost:8080"),
+            );
+            let app = build_test_app(&Config::from_env());
+            assert_eq!(
+                allowed_origin(&preflight(app.clone(), "https://shoken-webapp.vercel.app").await),
+                Some("https://shoken-webapp.vercel.app")
+            );
+            assert_eq!(
+                allowed_origin(&preflight(app, "http://localhost:8080").await),
+                None
+            );
+        }
+        {
+            let _app_env = EnvGuard::set("APP_ENV", None);
+            let _cors_origins = EnvGuard::set(
+                "CORS_ORIGINS",
+                Some("http://custom-origin.example.com:8080"),
+            );
+            let app = build_test_app(&Config::from_env());
+            assert_ne!(
+                post_with_origin(app.clone(), "http://custom-origin.example.com:8080")
+                    .await
+                    .status(),
+                StatusCode::FORBIDDEN,
+                "許可されたカスタムオリジンは通過すべき"
+            );
+            assert_eq!(
+                post_with_origin(app, "http://disallowed-origin.example.com")
+                    .await
+                    .status(),
+                StatusCode::FORBIDDEN,
+                "許可されていないオリジンは拒否すべき"
+            );
+        }
+        {
+            let _app_env = EnvGuard::set("APP_ENV", None);
+            let _cors_origins = EnvGuard::set("CORS_ORIGINS", Some("http://localhost:8080"));
+            let app = build_test_app(&Config::from_env());
+            assert_eq!(
+                allowed_origin(&preflight(app.clone(), "http://localhost:8080").await),
+                Some("http://localhost:8080")
+            );
+            let resp = post_with_origin(app, "http://evil.example.com").await;
+            assert_eq!(
+                (
+                    resp.status(),
+                    resp.headers()
+                        .get("X-Content-Type-Options")
+                        .and_then(|v| v.to_str().ok()),
+                    resp.headers()
+                        .get("X-Frame-Options")
+                        .and_then(|v| v.to_str().ok())
+                ),
+                (StatusCode::FORBIDDEN, Some("nosniff"), Some("DENY"))
+            );
+        }
+    }
 }

--- a/backend/src/config/cors.rs
+++ b/backend/src/config/cors.rs
@@ -63,11 +63,47 @@ pub fn is_localhost_origin(origin: &str) -> bool {
     let host = origin.split(':').next().unwrap_or(origin);
     matches!(host, "localhost" | "localhost." | "127.0.0.1")
 }
-#[cfg(test)] #[rustfmt::skip] mod tests {
+#[cfg(test)]
+mod tests {
     use super::{is_localhost_origin, parse_cors_origins};
-    fn strings(origins: &[&str]) -> Vec<String> { origins.iter().map(|origin| (*origin).to_string()).collect() }
-    #[test] fn test_is_localhost_origin() {
-        for (origin, expected) in [("http://localhost", true), ("https://localhost:3000", true), ("http://localhost.:5173", true), ("http://127.0.0.1:8080", true), ("https://[::1]:3000", true), ("http://[0:0:0:0:0:0:0:1]:5173/path", true), ("https://localhost.example.com", false), ("https://127.0.0.1.example.com:3000", false), ("https://frontend.example.com", false)] { assert_eq!(is_localhost_origin(origin), expected, "unexpected localhost classification: {origin}"); }
-        for (input, expected) in [("https://app.example.com,http://localhost:3000", &["https://app.example.com", "http://localhost:3000"][..]), (" https://app.example.com , http://localhost:3000 ", &["https://app.example.com", "http://localhost:3000"][..]), ("", &[][..]), ("https://app.example.com,http://localhost:3000,", &["https://app.example.com", "http://localhost:3000"][..])] { assert_eq!(parse_cors_origins(input), strings(expected)); }
+    fn strings(origins: &[&str]) -> Vec<String> {
+        origins.iter().map(|origin| (*origin).to_string()).collect()
+    }
+    #[test]
+    fn test_is_localhost_origin() {
+        for (origin, expected) in [
+            ("http://localhost", true),
+            ("https://localhost:3000", true),
+            ("http://localhost.:5173", true),
+            ("http://127.0.0.1:8080", true),
+            ("https://[::1]:3000", true),
+            ("http://[0:0:0:0:0:0:0:1]:5173/path", true),
+            ("https://localhost.example.com", false),
+            ("https://127.0.0.1.example.com:3000", false),
+            ("https://frontend.example.com", false),
+        ] {
+            assert_eq!(
+                is_localhost_origin(origin),
+                expected,
+                "unexpected localhost classification: {origin}"
+            );
+        }
+        for (input, expected) in [
+            (
+                "https://app.example.com,http://localhost:3000",
+                &["https://app.example.com", "http://localhost:3000"][..],
+            ),
+            (
+                " https://app.example.com , http://localhost:3000 ",
+                &["https://app.example.com", "http://localhost:3000"][..],
+            ),
+            ("", &[][..]),
+            (
+                "https://app.example.com,http://localhost:3000,",
+                &["https://app.example.com", "http://localhost:3000"][..],
+            ),
+        ] {
+            assert_eq!(parse_cors_origins(input), strings(expected));
+        }
     }
 }

--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -19,7 +19,13 @@ pub fn connect_pool_lazy(database_url: &str, max_connections: u32) -> Result<PgP
 pub async fn run_migrations(pool: &PgPool) -> Result<(), sqlx::migrate::MigrateError> {
     sqlx::migrate!().run(pool).await
 }
-#[cfg(test)] #[rustfmt::skip] mod tests {
+#[cfg(test)]
+mod tests {
     use super::*;
-    #[tokio::test] async fn test_connect_pool_lazy() { let database_url = "postgresql://user:password@localhost/test_db"; assert!(connect_pool_lazy(database_url, 5).is_ok()); assert!(connect_pool_lazy(database_url, 10).is_ok()); }
+    #[tokio::test]
+    async fn test_connect_pool_lazy() {
+        let database_url = "postgresql://user:password@localhost/test_db";
+        assert!(connect_pool_lazy(database_url, 5).is_ok());
+        assert!(connect_pool_lazy(database_url, 10).is_ok());
+    }
 }

--- a/backend/src/errors.rs
+++ b/backend/src/errors.rs
@@ -171,12 +171,81 @@ where
         ApiError::OAuthError(err.to_string())
     }
 }
-#[cfg(test)] #[rustfmt::skip] mod tests {
-    use {super::*, axum::http::StatusCode, oauth2::url::ParseError, sqlx::Error as SqlxError, std::env::VarError};
-    fn check_status(error: ApiError, expected: StatusCode) { assert_eq!(error.into_response().status(), expected); }
-    #[test] fn test_all_error_status_codes() {
+#[cfg(test)]
+mod tests {
+    use {
+        super::*, axum::http::StatusCode, oauth2::url::ParseError, sqlx::Error as SqlxError,
+        std::env::VarError,
+    };
+    fn check_status(error: ApiError, expected: StatusCode) {
+        assert_eq!(error.into_response().status(), expected);
+    }
+    #[test]
+    fn test_all_error_status_codes() {
         let serde_err = serde_json::from_str::<serde_json::Value>("invalid json").unwrap_err();
-        for (error, expected) in [(ApiError::ValidationError("必須フィールドが不足しています".to_string()), StatusCode::BAD_REQUEST), (ApiError::JsonParseError, StatusCode::BAD_REQUEST), (ApiError::DatabaseError(SqlxError::RowNotFound), StatusCode::NOT_FOUND), (ApiError::DatabaseError(SqlxError::ColumnNotFound("test_column".to_string())), StatusCode::INTERNAL_SERVER_ERROR), (ApiError::NotFound, StatusCode::NOT_FOUND), (ApiError::EnvVarError(VarError::NotPresent), StatusCode::INTERNAL_SERVER_ERROR), (ApiError::RateLimitError("Rate limit exceeded".to_string()), StatusCode::TOO_MANY_REQUESTS), (ApiError::UrlParseError(ParseError::EmptyHost), StatusCode::INTERNAL_SERVER_ERROR), (ApiError::OAuthError("認証エラー".to_string()), StatusCode::INTERNAL_SERVER_ERROR), (ApiError::Unauthorized("認証が必要です".to_string()), StatusCode::UNAUTHORIZED), (ApiError::NetworkError("接続エラー".to_string()), StatusCode::BAD_GATEWAY), (ApiError::ApiError("API エラー".to_string()), StatusCode::BAD_REQUEST), (ApiError::SerdeJsonError(serde_err), StatusCode::INTERNAL_SERVER_ERROR)] { check_status(error, expected); }
-        let (status, details) = simple_error(StatusCode::BAD_REQUEST, "TEST_CODE", "test message".to_string()); assert_eq!((status, details.code, details.message, details.details), (StatusCode::BAD_REQUEST, "TEST_CODE".to_string(), "test message".to_string(), None));
+        for (error, expected) in [
+            (
+                ApiError::ValidationError("必須フィールドが不足しています".to_string()),
+                StatusCode::BAD_REQUEST,
+            ),
+            (ApiError::JsonParseError, StatusCode::BAD_REQUEST),
+            (
+                ApiError::DatabaseError(SqlxError::RowNotFound),
+                StatusCode::NOT_FOUND,
+            ),
+            (
+                ApiError::DatabaseError(SqlxError::ColumnNotFound("test_column".to_string())),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+            (ApiError::NotFound, StatusCode::NOT_FOUND),
+            (
+                ApiError::EnvVarError(VarError::NotPresent),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+            (
+                ApiError::RateLimitError("Rate limit exceeded".to_string()),
+                StatusCode::TOO_MANY_REQUESTS,
+            ),
+            (
+                ApiError::UrlParseError(ParseError::EmptyHost),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+            (
+                ApiError::OAuthError("認証エラー".to_string()),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+            (
+                ApiError::Unauthorized("認証が必要です".to_string()),
+                StatusCode::UNAUTHORIZED,
+            ),
+            (
+                ApiError::NetworkError("接続エラー".to_string()),
+                StatusCode::BAD_GATEWAY,
+            ),
+            (
+                ApiError::ApiError("API エラー".to_string()),
+                StatusCode::BAD_REQUEST,
+            ),
+            (
+                ApiError::SerdeJsonError(serde_err),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+        ] {
+            check_status(error, expected);
+        }
+        let (status, details) = simple_error(
+            StatusCode::BAD_REQUEST,
+            "TEST_CODE",
+            "test message".to_string(),
+        );
+        assert_eq!(
+            (status, details.code, details.message, details.details),
+            (
+                StatusCode::BAD_REQUEST,
+                "TEST_CODE".to_string(),
+                "test message".to_string(),
+                None
+            )
+        );
     }
 }

--- a/backend/src/extractors/auth.rs
+++ b/backend/src/extractors/auth.rs
@@ -49,7 +49,20 @@ where
         Ok(AuthenticatedUser(user))
     }
 }
-#[cfg(test)] #[rustfmt::skip] mod tests {
+#[cfg(test)]
+mod tests {
     use {super::AuthenticatedUser, crate::models::user::User, chrono::Utc, uuid::Uuid};
-    #[test] fn id_returns_wrapped_user_id() { let user = User { id: Uuid::new_v4(), google_id: "google-123".to_string(), email: "test@example.com".to_string(), name: Some("Test User".to_string()), picture_url: None, created_at: Utc::now(), updated_at: Utc::now() }; assert_eq!(AuthenticatedUser(user.clone()).id(), user.id); }
+    #[test]
+    fn id_returns_wrapped_user_id() {
+        let user = User {
+            id: Uuid::new_v4(),
+            google_id: "google-123".to_string(),
+            email: "test@example.com".to_string(),
+            name: Some("Test User".to_string()),
+            picture_url: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        assert_eq!(AuthenticatedUser(user.clone()).id(), user.id);
+    }
 }

--- a/backend/src/extractors/char_width_converter.rs
+++ b/backend/src/extractors/char_width_converter.rs
@@ -9,7 +9,24 @@ pub fn halfwidth_to_fullwidth(c: char) -> char {
 pub fn char_from_u32_with_default(i: u32, def: char) -> char {
     char::from_u32(i).unwrap_or(def)
 }
-#[cfg(test)] #[rustfmt::skip] mod tests {
+#[cfg(test)]
+mod tests {
     use super::*;
-    #[test] fn test_halfwidth_to_fullwidth() { for (input, expected) in [('a', 'ａ'), ('z', 'ｚ'), ('A', 'Ａ'), ('Z', 'Ｚ'), ('1', '1'), ('!', '!'), ('あ', 'あ')] { assert_eq!(halfwidth_to_fullwidth(input), expected); } for (input, default, expected) in [(0x41, 'X', 'A'), (0x110000, 'X', 'X')] { assert_eq!(char_from_u32_with_default(input, default), expected); } }
+    #[test]
+    fn test_halfwidth_to_fullwidth() {
+        for (input, expected) in [
+            ('a', 'ａ'),
+            ('z', 'ｚ'),
+            ('A', 'Ａ'),
+            ('Z', 'Ｚ'),
+            ('1', '1'),
+            ('!', '!'),
+            ('あ', 'あ'),
+        ] {
+            assert_eq!(halfwidth_to_fullwidth(input), expected);
+        }
+        for (input, default, expected) in [(0x41, 'X', 'A'), (0x110000, 'X', 'X')] {
+            assert_eq!(char_from_u32_with_default(input, default), expected);
+        }
+    }
 }

--- a/backend/src/extractors/validated_json.rs
+++ b/backend/src/extractors/validated_json.rs
@@ -37,13 +37,77 @@ where
         Ok(ValidatedJson(value))
     }
 }
-#[cfg(test)] #[rustfmt::skip] mod tests {
-    use {super::*, axum::{body::Body, extract::FromRequest, http::{Request, StatusCode}}, serde::{Deserialize, Serialize}, tower::ServiceExt, validator::Validate};
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        axum::{
+            body::Body,
+            extract::FromRequest,
+            http::{Request, StatusCode},
+        },
+        serde::{Deserialize, Serialize},
+        tower::ServiceExt,
+        validator::Validate,
+    };
     #[derive(Clone, Debug, Serialize, Deserialize, Validate, PartialEq)]
-    struct TestData { #[validate(length(min = 1, max = 50))] name: String, #[validate(range(min = 1, max = 150))] age: u8 }
-    fn json_request(body: impl Into<Body>) -> Request<Body> { Request::builder().header("content-type", "application/json").method("POST").uri("/test").body(body.into()).unwrap() }
-    #[tokio::test] async fn test_valid_json() {
-        let json_data = TestData { name: "テストユーザー".to_string(), age: 30 }; let app = tower::service_fn(|req: Request<Body>| async { let ValidatedJson(data) = ValidatedJson::<TestData>::from_request(req, &()).await.unwrap(); assert_eq!(data, json_data); Ok::<_, hyper::Error>(axum::response::Response::new(Body::empty())) });
-        assert_eq!(app.oneshot(json_request(serde_json::to_string(&json_data).unwrap())).await.unwrap().status(), StatusCode::OK); assert!(matches!(ValidatedJson::<TestData>::from_request(json_request(r#"{"name": "テストユーザー", age: 30}"#), &()).await.unwrap_err(), ApiError::JsonParseError)); assert!(matches!(ValidatedJson::<TestData>::from_request(json_request(serde_json::to_string(&TestData { name: "".to_string(), age: 30 }).unwrap()), &()).await.unwrap_err(), ApiError::ValidationError(_)));
+    struct TestData {
+        #[validate(length(min = 1, max = 50))]
+        name: String,
+        #[validate(range(min = 1, max = 150))]
+        age: u8,
+    }
+    fn json_request(body: impl Into<Body>) -> Request<Body> {
+        Request::builder()
+            .header("content-type", "application/json")
+            .method("POST")
+            .uri("/test")
+            .body(body.into())
+            .unwrap()
+    }
+    #[tokio::test]
+    async fn test_valid_json() {
+        let json_data = TestData {
+            name: "テストユーザー".to_string(),
+            age: 30,
+        };
+        let app = tower::service_fn(|req: Request<Body>| async {
+            let ValidatedJson(data) = ValidatedJson::<TestData>::from_request(req, &())
+                .await
+                .unwrap();
+            assert_eq!(data, json_data);
+            Ok::<_, hyper::Error>(axum::response::Response::new(Body::empty()))
+        });
+        assert_eq!(
+            app.oneshot(json_request(serde_json::to_string(&json_data).unwrap()))
+                .await
+                .unwrap()
+                .status(),
+            StatusCode::OK
+        );
+        assert!(matches!(
+            ValidatedJson::<TestData>::from_request(
+                json_request(r#"{"name": "テストユーザー", age: 30}"#),
+                &()
+            )
+            .await
+            .unwrap_err(),
+            ApiError::JsonParseError
+        ));
+        assert!(matches!(
+            ValidatedJson::<TestData>::from_request(
+                json_request(
+                    serde_json::to_string(&TestData {
+                        name: "".to_string(),
+                        age: 30
+                    })
+                    .unwrap()
+                ),
+                &()
+            )
+            .await
+            .unwrap_err(),
+            ApiError::ValidationError(_)
+        ));
     }
 }

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -219,16 +219,81 @@ pub async fn delete_account(
         Json(serde_json::json!({"message": "アカウントを削除しました"})),
     ))
 }
-#[cfg(test)] #[rustfmt::skip] mod tests {
-    use crate::{config::Config, db::connect_pool_lazy, errors::ErrorResponse, models::common::MessageResponse, routes::app_router, state::{AppState, Secrets}};
-    use axum::{body::{to_bytes, Body}, http::{Request, StatusCode}, Router};
+#[cfg(test)]
+mod tests {
+    use crate::{
+        config::Config,
+        db::connect_pool_lazy,
+        errors::ErrorResponse,
+        models::common::MessageResponse,
+        routes::app_router,
+        state::{AppState, Secrets},
+    };
+    use axum::{
+        body::{to_bytes, Body},
+        http::{Request, StatusCode},
+        Router,
+    };
     use {reqwest::Client, serde::de::DeserializeOwned, std::sync::Arc, tower::ServiceExt};
     const BODY_LIMIT: usize = 1024 * 1024;
-    fn make_test_state() -> AppState { let database_url = "postgresql://user:password@localhost/test_db"; let pool = connect_pool_lazy(database_url, 1).expect("pool"); let secrets = Arc::new(Secrets { database_url: database_url.to_string(), jquants_api_key: None, google_client_id: None, google_client_secret: None, frontend_url: "http://localhost:8080".to_string() }); AppState { pool, secrets, client: Client::new(), dividend_cache: crate::state::DividendCacheState::default() } }
-    fn test_app() -> Router { let config = Config { auth_rate_limit_rps: 0, jquants_rate_limit_rps: 0, ..Config::default() }; app_router(make_test_state(), &config) }
-    async fn read_json_response<T: DeserializeOwned>(response: axum::response::Response) -> T { let body = to_bytes(response.into_body(), BODY_LIMIT).await.unwrap(); serde_json::from_slice(&body).unwrap() }
-    async fn request_json<T: DeserializeOwned>(method: &str, uri: &str) -> (StatusCode, T) { let response = test_app().oneshot(Request::builder().method(method).uri(uri).body(Body::empty()).unwrap()).await.unwrap(); let status = response.status(); (status, read_json_response(response).await) }
-    #[tokio::test] async fn test_auth_endpoints_without_cookie() {
-        let (status, error) = request_json::<ErrorResponse>("GET", "/auth/me").await; assert_eq!((status, error.error.code.as_str(), error.error.message.contains("ログインが必要")), (StatusCode::UNAUTHORIZED, "UNAUTHORIZED", true)); let (status, message) = request_json::<MessageResponse>("POST", "/auth/logout").await; assert_eq!((status, message.message.as_str()), (StatusCode::OK, "ログアウトしました"));
+    fn make_test_state() -> AppState {
+        let database_url = "postgresql://user:password@localhost/test_db";
+        let pool = connect_pool_lazy(database_url, 1).expect("pool");
+        let secrets = Arc::new(Secrets {
+            database_url: database_url.to_string(),
+            jquants_api_key: None,
+            google_client_id: None,
+            google_client_secret: None,
+            frontend_url: "http://localhost:8080".to_string(),
+        });
+        AppState {
+            pool,
+            secrets,
+            client: Client::new(),
+            dividend_cache: crate::state::DividendCacheState::default(),
+        }
+    }
+    fn test_app() -> Router {
+        let config = Config {
+            auth_rate_limit_rps: 0,
+            jquants_rate_limit_rps: 0,
+            ..Config::default()
+        };
+        app_router(make_test_state(), &config)
+    }
+    async fn read_json_response<T: DeserializeOwned>(response: axum::response::Response) -> T {
+        let body = to_bytes(response.into_body(), BODY_LIMIT).await.unwrap();
+        serde_json::from_slice(&body).unwrap()
+    }
+    async fn request_json<T: DeserializeOwned>(method: &str, uri: &str) -> (StatusCode, T) {
+        let response = test_app()
+            .oneshot(
+                Request::builder()
+                    .method(method)
+                    .uri(uri)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        (status, read_json_response(response).await)
+    }
+    #[tokio::test]
+    async fn test_auth_endpoints_without_cookie() {
+        let (status, error) = request_json::<ErrorResponse>("GET", "/auth/me").await;
+        assert_eq!(
+            (
+                status,
+                error.error.code.as_str(),
+                error.error.message.contains("ログインが必要")
+            ),
+            (StatusCode::UNAUTHORIZED, "UNAUTHORIZED", true)
+        );
+        let (status, message) = request_json::<MessageResponse>("POST", "/auth/logout").await;
+        assert_eq!(
+            (status, message.message.as_str()),
+            (StatusCode::OK, "ログアウトしました")
+        );
     }
 }

--- a/backend/src/handlers/stock.rs
+++ b/backend/src/handlers/stock.rs
@@ -61,4 +61,5 @@ pub async fn create_stock(
     let stock = stock_service::create(&state.pool, &data).await?;
     Ok((StatusCode::CREATED, Json(stock)))
 }
-#[cfg(test)] #[rustfmt::skip] mod tests;
+#[cfg(test)]
+mod tests;

--- a/backend/src/handlers/stock/tests.rs
+++ b/backend/src/handlers/stock/tests.rs
@@ -1,9 +1,210 @@
-#[rustfmt::skip] use {super::*, crate::state::Secrets, axum::{body::Body, http::{Request, StatusCode}, routing::{get, post}, Router}, chrono::NaiveDate, reqwest::Client, serde_json::{json, Value}, sqlx::{Pool, Postgres}, std::sync::Arc, testcontainers::runners::AsyncRunner, testcontainers_modules::postgres::Postgres as PgImage, tokio::time::{sleep, timeout, Duration}, tower::ServiceExt}; const BODY_LIMIT: usize = 100;
-#[rustfmt::skip] async fn setup_test_db() -> (Pool<Postgres>, impl Drop) { let node = PgImage::default().start().await.unwrap(); let port = node.get_host_port_ipv4(5432).await.unwrap(); let database_url = format!("postgres://postgres:postgres@127.0.0.1:{}/postgres", port); let pool = { let mut last_error = None; let mut pool_ok = None; for _ in 0..20 { match timeout(Duration::from_secs(2), sqlx::postgres::PgPoolOptions::new().connect(&database_url)).await { Ok(Ok(p)) => { pool_ok = Some(p); break; } Ok(Err(e)) => last_error = Some(e), Err(_) => {} } sleep(Duration::from_millis(500)).await; } pool_ok.unwrap_or_else(|| panic!("DB 接続失敗: {:?}", last_error)) }; crate::db::run_migrations(&pool).await.expect("マイグレーション失敗"); #[rustfmt::skip] sqlx::query(r#"INSERT INTO stock (date, code, name, market_category, industry_code_33, industry_category_33, industry_code_17, industry_category_17, size_code, size_category) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)"#).bind(NaiveDate::from_ymd_opt(2025, 3, 24).unwrap()).bind("1234").bind("テスト株式会社").bind("プライム").bind(Option::<String>::Some("123".to_string())).bind(Option::<String>::Some("情報・通信業".to_string())).bind(Option::<String>::Some("12".to_string())).bind(Option::<String>::Some("情報通信".to_string())).bind(Option::<String>::Some("10".to_string())).bind(Option::<String>::Some("大型株".to_string())).execute(&pool).await.expect("テストデータ投入失敗"); (pool, node) }
-#[rustfmt::skip] fn setup_test_app(pool: Pool<Postgres>) -> Router { Router::new().route("/stocks/{search_query}", get(search_stock)).route("/stocks", post(create_stock)).with_state(crate::AppState { pool: pool.clone(), secrets: Arc::new(Secrets { database_url: "postgresql://postgres:postgres@localhost/postgres".to_string(), jquants_api_key: None, google_client_id: None, google_client_secret: None, frontend_url: "http://localhost:8080".to_string() }), client: Client::new(), dividend_cache: crate::state::DividendCacheState::default() }) }
-#[rustfmt::skip] async fn call(app: Router, method: &str, uri: &str, body: Option<Value>) -> axum::response::Response { let mut request = Request::builder().method(method).uri(uri); let body = if let Some(payload) = body { request = request.header("content-type", "application/json"); Body::from(payload.to_string()) } else { Body::empty() }; app.oneshot(request.body(body).unwrap()).await.unwrap() }
-#[rustfmt::skip] async fn read_json(response: axum::response::Response) -> Value { serde_json::from_slice(&axum::body::to_bytes(response.into_body(), BODY_LIMIT).await.unwrap()).unwrap() }
-#[rustfmt::skip] fn stock_payload(code: &str, name: &str) -> Value { json!({ "date": "2025-03-25", "code": code, "name": name, "market_category": "スタンダード", "industry_code_33": "456", "industry_category_33": "製造業", "industry_code_17": "45", "industry_category_17": "製造", "size_code": "20", "size_category": "中型株" }) }
-#[tokio::test] #[ignore = "requires Docker to run Postgres container"] #[rustfmt::skip] async fn test_search_stock() { let (pool, _node) = setup_test_db().await; let app = setup_test_app(pool); let response = call(app.clone(), "GET", "/stocks/1234", None).await; assert_eq!(response.status(), StatusCode::OK); let stock = read_json(response).await; assert_eq!((stock["code"].as_str(), stock["name"].as_str()), (Some("1234"), Some("テスト株式会社"))); for (uri, expected_status) in [("/stocks/テスト", StatusCode::OK), ("/stocks/9999", StatusCode::NOT_FOUND)] { assert_eq!(call(app.clone(), "GET", uri, None).await.status(), expected_status); } }
-#[tokio::test] #[ignore = "requires Docker to run Postgres container"] #[rustfmt::skip] async fn test_create_stock() { let (pool, _node) = setup_test_db().await; let app = setup_test_app(pool); let response = call(app.clone(), "POST", "/stocks", Some(stock_payload("5678", "新規テスト株式会社"))).await; assert_eq!(response.status(), StatusCode::CREATED); let stock = read_json(response).await; assert_eq!((stock["code"].as_str(), stock["name"].as_str()), (Some("5678"), Some("新規テスト株式会社"))); let mut invalid_data = stock_payload("5678", "新規テスト株式会社"); invalid_data["code"] = json!(""); assert_eq!(call(app, "POST", "/stocks", Some(invalid_data)).await.status(), StatusCode::BAD_REQUEST); }
-#[tokio::test] #[rustfmt::skip] async fn test_create_stock_unauthorized() { let pool = crate::db::connect_pool_lazy("postgresql://postgres:postgres@localhost/postgres", 1).unwrap(); let app = setup_test_app(pool); assert_eq!(call(app, "POST", "/stocks", Some(stock_payload("9999", "未認証テスト"))).await.status(), StatusCode::UNAUTHORIZED); }
+use {
+    super::*,
+    crate::state::Secrets,
+    axum::{
+        body::Body,
+        http::{Request, StatusCode},
+        routing::{get, post},
+        Router,
+    },
+    chrono::NaiveDate,
+    reqwest::Client,
+    serde_json::{json, Value},
+    sqlx::{Pool, Postgres},
+    std::sync::Arc,
+    testcontainers::runners::AsyncRunner,
+    testcontainers_modules::postgres::Postgres as PgImage,
+    tokio::time::{sleep, timeout, Duration},
+    tower::ServiceExt,
+};
+
+const BODY_LIMIT: usize = 100;
+
+async fn setup_test_db() -> (Pool<Postgres>, impl Drop) {
+    let node = PgImage::default().start().await.unwrap();
+    let port = node.get_host_port_ipv4(5432).await.unwrap();
+    let database_url = format!("postgres://postgres:postgres@127.0.0.1:{}/postgres", port);
+
+    let pool = {
+        let mut last_error = None;
+        let mut pool_ok = None;
+
+        for _ in 0..20 {
+            match timeout(
+                Duration::from_secs(2),
+                sqlx::postgres::PgPoolOptions::new().connect(&database_url),
+            )
+            .await
+            {
+                Ok(Ok(pool)) => {
+                    pool_ok = Some(pool);
+                    break;
+                }
+                Ok(Err(error)) => last_error = Some(error),
+                Err(_) => {}
+            }
+
+            sleep(Duration::from_millis(500)).await;
+        }
+
+        pool_ok.unwrap_or_else(|| panic!("DB 接続失敗: {:?}", last_error))
+    };
+
+    crate::db::run_migrations(&pool)
+        .await
+        .expect("マイグレーション失敗");
+
+    sqlx::query(
+        r#"INSERT INTO stock (date, code, name, market_category, industry_code_33, industry_category_33, industry_code_17, industry_category_17, size_code, size_category) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)"#,
+    )
+    .bind(NaiveDate::from_ymd_opt(2025, 3, 24).unwrap())
+    .bind("1234")
+    .bind("テスト株式会社")
+    .bind("プライム")
+    .bind(Option::<String>::Some("123".to_string()))
+    .bind(Option::<String>::Some("情報・通信業".to_string()))
+    .bind(Option::<String>::Some("12".to_string()))
+    .bind(Option::<String>::Some("情報通信".to_string()))
+    .bind(Option::<String>::Some("10".to_string()))
+    .bind(Option::<String>::Some("大型株".to_string()))
+    .execute(&pool)
+    .await
+    .expect("テストデータ投入失敗");
+
+    (pool, node)
+}
+
+fn setup_test_app(pool: Pool<Postgres>) -> Router {
+    Router::new()
+        .route("/stocks/{search_query}", get(search_stock))
+        .route("/stocks", post(create_stock))
+        .with_state(crate::AppState {
+            pool: pool.clone(),
+            secrets: Arc::new(Secrets {
+                database_url: "postgresql://postgres:postgres@localhost/postgres".to_string(),
+                jquants_api_key: None,
+                google_client_id: None,
+                google_client_secret: None,
+                frontend_url: "http://localhost:8080".to_string(),
+            }),
+            client: Client::new(),
+            dividend_cache: crate::state::DividendCacheState::default(),
+        })
+}
+
+async fn call(
+    app: Router,
+    method: &str,
+    uri: &str,
+    body: Option<Value>,
+) -> axum::response::Response {
+    let mut request = Request::builder().method(method).uri(uri);
+    let body = if let Some(payload) = body {
+        request = request.header("content-type", "application/json");
+        Body::from(payload.to_string())
+    } else {
+        Body::empty()
+    };
+
+    app.oneshot(request.body(body).unwrap()).await.unwrap()
+}
+
+async fn read_json(response: axum::response::Response) -> Value {
+    serde_json::from_slice(
+        &axum::body::to_bytes(response.into_body(), BODY_LIMIT)
+            .await
+            .unwrap(),
+    )
+    .unwrap()
+}
+
+fn stock_payload(code: &str, name: &str) -> Value {
+    json!({
+        "date": "2025-03-25",
+        "code": code,
+        "name": name,
+        "market_category": "スタンダード",
+        "industry_code_33": "456",
+        "industry_category_33": "製造業",
+        "industry_code_17": "45",
+        "industry_category_17": "製造",
+        "size_code": "20",
+        "size_category": "中型株"
+    })
+}
+
+#[tokio::test]
+#[ignore = "requires Docker to run Postgres container"]
+async fn test_search_stock() {
+    let (pool, _node) = setup_test_db().await;
+    let app = setup_test_app(pool);
+
+    let response = call(app.clone(), "GET", "/stocks/1234", None).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let stock = read_json(response).await;
+    assert_eq!(
+        (stock["code"].as_str(), stock["name"].as_str()),
+        (Some("1234"), Some("テスト株式会社"))
+    );
+
+    for (uri, expected_status) in [
+        ("/stocks/テスト", StatusCode::OK),
+        ("/stocks/9999", StatusCode::NOT_FOUND),
+    ] {
+        assert_eq!(
+            call(app.clone(), "GET", uri, None).await.status(),
+            expected_status
+        );
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires Docker to run Postgres container"]
+async fn test_create_stock() {
+    let (pool, _node) = setup_test_db().await;
+    let app = setup_test_app(pool);
+
+    let response = call(
+        app.clone(),
+        "POST",
+        "/stocks",
+        Some(stock_payload("5678", "新規テスト株式会社")),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let stock = read_json(response).await;
+    assert_eq!(
+        (stock["code"].as_str(), stock["name"].as_str()),
+        (Some("5678"), Some("新規テスト株式会社"))
+    );
+
+    let mut invalid_data = stock_payload("5678", "新規テスト株式会社");
+    invalid_data["code"] = json!("");
+    assert_eq!(
+        call(app, "POST", "/stocks", Some(invalid_data))
+            .await
+            .status(),
+        StatusCode::BAD_REQUEST
+    );
+}
+
+#[tokio::test]
+async fn test_create_stock_unauthorized() {
+    let pool = crate::db::connect_pool_lazy("postgresql://postgres:postgres@localhost/postgres", 1)
+        .unwrap();
+    let app = setup_test_app(pool);
+
+    assert_eq!(
+        call(
+            app,
+            "POST",
+            "/stocks",
+            Some(stock_payload("9999", "未認証テスト"))
+        )
+        .await
+        .status(),
+        StatusCode::UNAUTHORIZED
+    );
+}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -10,7 +10,8 @@ pub mod openapi;
 pub mod routes;
 pub mod services;
 pub mod state;
-#[cfg(test)] #[rustfmt::skip] pub mod test_env;
+#[cfg(test)]
+pub mod test_env;
 
 pub use config::Config;
 pub use errors::ApiError;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -10,7 +10,8 @@ mod openapi;
 mod routes;
 mod services;
 mod state;
-#[cfg(test)] #[rustfmt::skip] mod test_env;
+#[cfg(test)]
+mod test_env;
 
 use config::Config;
 use db::{connect_pool, run_migrations};

--- a/backend/src/middleware/rate_limit.rs
+++ b/backend/src/middleware/rate_limit.rs
@@ -78,16 +78,62 @@ pub async fn keyed_rate_limit(
     }
     next.run(req).await
 }
-#[cfg(test)] #[rustfmt::skip] mod tests {
-    use {super::*, axum::{middleware, routing::post, Router}, tower::ServiceExt};
-    fn test_route() -> Router { Router::new().route("/test", post(|| async { "ok" })) }
-    fn direct_app(limiter: Arc<DefaultDirectRateLimiter>) -> Router { test_route().layer(middleware::from_fn(move |req, next| { let limiter = limiter.clone(); async move { rate_limit(limiter, req, next).await } })) }
-    fn keyed_app(limiter: Arc<DefaultKeyedRateLimiter<std::net::IpAddr>>) -> Router { test_route().layer(middleware::from_fn(move |req, next| { let limiter = limiter.clone(); async move { keyed_rate_limit(limiter, req, next).await } })) }
-    fn test_request(ip: Option<&str>) -> Request<Body> { let req = Request::builder().method(axum::http::Method::POST).uri("/test"); match ip { Some(ip) => req.header("fly-client-ip", ip), None => req }.body(Body::empty()).unwrap() }
-    async fn assert_status(router: Router, ip: Option<&str>, expected: StatusCode) { assert_eq!(router.oneshot(test_request(ip)).await.unwrap().status(), expected); }
-    #[tokio::test] async fn test_rate_limiters() {
-        assert_eq!((build_rate_limiter(0).is_none(), build_rate_limiter(10).is_some(), build_keyed_rate_limiter(0).is_none(), build_keyed_rate_limiter(10).is_some()), (true, true, true, true));
-        let router = direct_app(build_rate_limiter(1).unwrap()); assert_status(router.clone(), None, StatusCode::OK).await; assert_status(router, None, StatusCode::TOO_MANY_REQUESTS).await;
-        let router = keyed_app(build_keyed_rate_limiter(1).unwrap()); assert_status(router.clone(), Some("1.2.3.4"), StatusCode::OK).await; assert_status(router.clone(), Some("5.6.7.8"), StatusCode::OK).await; assert_status(router, Some("1.2.3.4"), StatusCode::TOO_MANY_REQUESTS).await;
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        axum::{middleware, routing::post, Router},
+        tower::ServiceExt,
+    };
+    fn test_route() -> Router {
+        Router::new().route("/test", post(|| async { "ok" }))
+    }
+    fn direct_app(limiter: Arc<DefaultDirectRateLimiter>) -> Router {
+        test_route().layer(middleware::from_fn(move |req, next| {
+            let limiter = limiter.clone();
+            async move { rate_limit(limiter, req, next).await }
+        }))
+    }
+    fn keyed_app(limiter: Arc<DefaultKeyedRateLimiter<std::net::IpAddr>>) -> Router {
+        test_route().layer(middleware::from_fn(move |req, next| {
+            let limiter = limiter.clone();
+            async move { keyed_rate_limit(limiter, req, next).await }
+        }))
+    }
+    fn test_request(ip: Option<&str>) -> Request<Body> {
+        let req = Request::builder()
+            .method(axum::http::Method::POST)
+            .uri("/test");
+        match ip {
+            Some(ip) => req.header("fly-client-ip", ip),
+            None => req,
+        }
+        .body(Body::empty())
+        .unwrap()
+    }
+    async fn assert_status(router: Router, ip: Option<&str>, expected: StatusCode) {
+        assert_eq!(
+            router.oneshot(test_request(ip)).await.unwrap().status(),
+            expected
+        );
+    }
+    #[tokio::test]
+    async fn test_rate_limiters() {
+        assert_eq!(
+            (
+                build_rate_limiter(0).is_none(),
+                build_rate_limiter(10).is_some(),
+                build_keyed_rate_limiter(0).is_none(),
+                build_keyed_rate_limiter(10).is_some()
+            ),
+            (true, true, true, true)
+        );
+        let router = direct_app(build_rate_limiter(1).unwrap());
+        assert_status(router.clone(), None, StatusCode::OK).await;
+        assert_status(router, None, StatusCode::TOO_MANY_REQUESTS).await;
+        let router = keyed_app(build_keyed_rate_limiter(1).unwrap());
+        assert_status(router.clone(), Some("1.2.3.4"), StatusCode::OK).await;
+        assert_status(router.clone(), Some("5.6.7.8"), StatusCode::OK).await;
+        assert_status(router, Some("1.2.3.4"), StatusCode::TOO_MANY_REQUESTS).await;
     }
 }

--- a/backend/src/models/asset_balance.rs
+++ b/backend/src/models/asset_balance.rs
@@ -66,7 +66,24 @@ pub struct BulkCreateAssetBalanceRequest {
     #[validate(length(min = 1))]
     pub items: Vec<CreateAssetBalanceRequest>,
 }
-#[cfg(test)] #[rustfmt::skip] mod tests {
+#[cfg(test)]
+mod tests {
     use {super::*, rust_decimal_macros::dec};
-    #[test] fn test_create_asset_balance_request_validation() { assert!(CreateAssetBalanceRequest { security_code: "1234".to_string(), security_name: "テスト株式会社".to_string(), shares: dec!(100), executing_shares: dec!(0), average_purchase_price: dec!(1500), total_purchase_amount: dec!(150000), current_price: dec!(1600), daily_change: dec!(10), market_value: dec!(160000), profit_loss_rate: dec!(6.67) }.validate().is_ok()); }
+    #[test]
+    fn test_create_asset_balance_request_validation() {
+        assert!(CreateAssetBalanceRequest {
+            security_code: "1234".to_string(),
+            security_name: "テスト株式会社".to_string(),
+            shares: dec!(100),
+            executing_shares: dec!(0),
+            average_purchase_price: dec!(1500),
+            total_purchase_amount: dec!(150000),
+            current_price: dec!(1600),
+            daily_change: dec!(10),
+            market_value: dec!(160000),
+            profit_loss_rate: dec!(6.67)
+        }
+        .validate()
+        .is_ok());
+    }
 }

--- a/backend/src/models/common.rs
+++ b/backend/src/models/common.rs
@@ -13,10 +13,25 @@ pub struct BulkCreateResponse {
 pub struct MessageResponse {
     pub message: String,
 }
-#[cfg(test)] #[rustfmt::skip] mod tests {
+#[cfg(test)]
+mod tests {
     use super::{BulkCreateResponse, MessageResponse};
-    #[test] fn test_serde_round_trips() {
-        let r = BulkCreateResponse { inserted: 3, skipped: 2 }; let json = serde_json::to_string(&r).expect("BulkCreateResponse should serialize"); let d: BulkCreateResponse = serde_json::from_str(&json).expect("BulkCreateResponse should deserialize"); assert_eq!((d.inserted, d.skipped), (r.inserted, r.skipped));
-        let r = MessageResponse { message: "ok".to_string() }; let json = serde_json::to_string(&r).expect("MessageResponse should serialize"); let d: MessageResponse = serde_json::from_str(&json).expect("MessageResponse should deserialize"); assert_eq!(d.message, r.message);
+    #[test]
+    fn test_serde_round_trips() {
+        let r = BulkCreateResponse {
+            inserted: 3,
+            skipped: 2,
+        };
+        let json = serde_json::to_string(&r).expect("BulkCreateResponse should serialize");
+        let d: BulkCreateResponse =
+            serde_json::from_str(&json).expect("BulkCreateResponse should deserialize");
+        assert_eq!((d.inserted, d.skipped), (r.inserted, r.skipped));
+        let r = MessageResponse {
+            message: "ok".to_string(),
+        };
+        let json = serde_json::to_string(&r).expect("MessageResponse should serialize");
+        let d: MessageResponse =
+            serde_json::from_str(&json).expect("MessageResponse should deserialize");
+        assert_eq!(d.message, r.message);
     }
 }

--- a/backend/src/models/dividend.rs
+++ b/backend/src/models/dividend.rs
@@ -55,7 +55,24 @@ pub struct CreateDividendRequest {
     #[schema(value_type = f64)]
     pub net_amount_received: Decimal,
 }
-#[cfg(test)] #[rustfmt::skip] mod tests {
+#[cfg(test)]
+mod tests {
     use {super::*, rust_decimal_macros::dec};
-    #[test] fn test_create_dividend_request_validation() { assert!(CreateDividendRequest { settlement_date: NaiveDate::from_ymd_opt(2024, 1, 15).expect("有効な日付 2024-01-15"), product: "国内株式".to_string(), account: "特定".to_string(), security_code: "1234".to_string(), security_name: "テスト株式会社".to_string(), unit_price: dec!(100), shares: dec!(100), dividends_before_tax: dec!(1000), taxes: dec!(200), net_amount_received: dec!(800) }.validate().is_ok()); }
+    #[test]
+    fn test_create_dividend_request_validation() {
+        assert!(CreateDividendRequest {
+            settlement_date: NaiveDate::from_ymd_opt(2024, 1, 15).expect("有効な日付 2024-01-15"),
+            product: "国内株式".to_string(),
+            account: "特定".to_string(),
+            security_code: "1234".to_string(),
+            security_name: "テスト株式会社".to_string(),
+            unit_price: dec!(100),
+            shares: dec!(100),
+            dividends_before_tax: dec!(1000),
+            taxes: dec!(200),
+            net_amount_received: dec!(800)
+        }
+        .validate()
+        .is_ok());
+    }
 }

--- a/backend/src/models/domestic_stock.rs
+++ b/backend/src/models/domestic_stock.rs
@@ -62,7 +62,26 @@ pub struct CreateDomesticStockRequest {
     #[schema(value_type = f64)]
     pub realized_profit_and_loss_after_tax: Decimal,
 }
-#[cfg(test)] #[rustfmt::skip] mod tests {
+#[cfg(test)]
+mod tests {
     use {super::*, rust_decimal_macros::dec};
-    #[test] fn test_create_domestic_stock_request_validation() { assert!(CreateDomesticStockRequest { trade_date: NaiveDate::from_ymd_opt(2024, 1, 15).expect("有効な日付 2024-01-15"), settlement_date: NaiveDate::from_ymd_opt(2024, 1, 17).expect("有効な日付 2024-01-17"), security_code: "1234".to_string(), security_name: "テスト株式会社".to_string(), account: "特定".to_string(), shares: dec!(100), asked_price: dec!(1500), proceeds: dec!(150000), purchase_price: dec!(1400), realized_profit_and_loss: dec!(10000), taxes: dec!(2000), realized_profit_and_loss_after_tax: dec!(8000) }.validate().is_ok()); }
+    #[test]
+    fn test_create_domestic_stock_request_validation() {
+        assert!(CreateDomesticStockRequest {
+            trade_date: NaiveDate::from_ymd_opt(2024, 1, 15).expect("有効な日付 2024-01-15"),
+            settlement_date: NaiveDate::from_ymd_opt(2024, 1, 17).expect("有効な日付 2024-01-17"),
+            security_code: "1234".to_string(),
+            security_name: "テスト株式会社".to_string(),
+            account: "特定".to_string(),
+            shares: dec!(100),
+            asked_price: dec!(1500),
+            proceeds: dec!(150000),
+            purchase_price: dec!(1400),
+            realized_profit_and_loss: dec!(10000),
+            taxes: dec!(2000),
+            realized_profit_and_loss_after_tax: dec!(8000)
+        }
+        .validate()
+        .is_ok());
+    }
 }

--- a/backend/src/models/jquants/query.rs
+++ b/backend/src/models/jquants/query.rs
@@ -8,12 +8,36 @@ pub struct FinSummaryQuery {
     pub from: Option<String>,
     pub to: Option<String>,
 }
-#[cfg(test)] #[rustfmt::skip] mod tests {
+#[cfg(test)]
+mod tests {
     use super::*;
-    #[test] fn test_fin_summary_query() {
-        let query = FinSummaryQuery { code: "7203".to_string(), from: Some("2023-01-01".to_string()), to: Some("2023-12-31".to_string()) };
-        assert_eq!((query.code.as_str(), query.from.as_deref(), query.to.as_deref()), ("7203", Some("2023-01-01"), Some("2023-12-31")));
-        let query = FinSummaryQuery { code: "7203".to_string(), from: None, to: None };
-        assert_eq!((query.code.as_str(), query.from.as_deref(), query.to.as_deref()), ("7203", None, None));
+    #[test]
+    fn test_fin_summary_query() {
+        let query = FinSummaryQuery {
+            code: "7203".to_string(),
+            from: Some("2023-01-01".to_string()),
+            to: Some("2023-12-31".to_string()),
+        };
+        assert_eq!(
+            (
+                query.code.as_str(),
+                query.from.as_deref(),
+                query.to.as_deref()
+            ),
+            ("7203", Some("2023-01-01"), Some("2023-12-31"))
+        );
+        let query = FinSummaryQuery {
+            code: "7203".to_string(),
+            from: None,
+            to: None,
+        };
+        assert_eq!(
+            (
+                query.code.as_str(),
+                query.from.as_deref(),
+                query.to.as_deref()
+            ),
+            ("7203", None, None)
+        );
     }
 }

--- a/backend/src/models/jquants/response.rs
+++ b/backend/src/models/jquants/response.rs
@@ -458,13 +458,48 @@ pub struct FinSummaryData {
     #[serde(rename = "NxFNCEPS", default)]
     pub next_year_forecast_non_consolidated_earnings_per_share: Option<String>,
 }
-#[cfg(test)] #[rustfmt::skip] mod tests {
+#[cfg(test)]
+mod tests {
     use {super::*, serde_json::json};
-    #[test] fn test_fin_summary_data_deserialize_v2_format() {
+    #[test]
+    fn test_fin_summary_data_deserialize_v2_format() {
         let fin_summary_data: FinSummaryData = serde_json::from_value(json!({"DiscDate":"2023-11-14","DiscTime":"15:00:00","Code":"72030","DiscNo":"20231114502171","DocType":"決算短信","CurPerType":"2Q","CurPerSt":"2023-04-01","CurPerEn":"2023-09-30","CurFYSt":"2023-04-01","CurFYEn":"2024-03-31","NxtFYSt":"2024-04-01","NxtFYEn":"2025-03-31","Sales":"18733067000000","OP":"1686297000000","NxFDivAnn":"50.00","FDivAnn":"45.00","DivAnn":"40.00"})).expect("有効なテスト用 JSON");
-        assert_eq!((fin_summary_data.disclosed_date.as_str(), fin_summary_data.local_code.as_str(), fin_summary_data.net_sales.as_deref(), fin_summary_data.next_year_forecast_dividend_per_share_annual.as_deref(), fin_summary_data.forecast_dividend_per_share_annual.as_deref(), fin_summary_data.result_dividend_per_share_annual.as_deref()), ("2023-11-14", "72030", Some("18733067000000"), Some("50.00"), Some("45.00"), Some("40.00")));
+        assert_eq!(
+            (
+                fin_summary_data.disclosed_date.as_str(),
+                fin_summary_data.local_code.as_str(),
+                fin_summary_data.net_sales.as_deref(),
+                fin_summary_data
+                    .next_year_forecast_dividend_per_share_annual
+                    .as_deref(),
+                fin_summary_data
+                    .forecast_dividend_per_share_annual
+                    .as_deref(),
+                fin_summary_data.result_dividend_per_share_annual.as_deref()
+            ),
+            (
+                "2023-11-14",
+                "72030",
+                Some("18733067000000"),
+                Some("50.00"),
+                Some("45.00"),
+                Some("40.00")
+            )
+        );
         let response: FinSummaryResponse = serde_json::from_value(json!({"data":[{"DiscDate":"2023-11-14","Code":"72030","DocType":"決算短信","CurPerType":"2Q","CurPerSt":"2023-04-01","CurPerEn":"2023-09-30","CurFYSt":"2023-04-01","CurFYEn":"2024-03-31"}]})).expect("有効なテスト用 JSON");
-        assert_eq!((response.data.len(), response.data[0].disclosed_date.as_str(), response.data[0].local_code.as_str()), (1, "2023-11-14", "72030"));
-        assert!(serde_json::from_value::<FinSummaryResponse>(json!({"data":[]})).expect("有効なテスト用 JSON").data.is_empty());
+        assert_eq!(
+            (
+                response.data.len(),
+                response.data[0].disclosed_date.as_str(),
+                response.data[0].local_code.as_str()
+            ),
+            (1, "2023-11-14", "72030")
+        );
+        assert!(
+            serde_json::from_value::<FinSummaryResponse>(json!({"data":[]}))
+                .expect("有効なテスト用 JSON")
+                .data
+                .is_empty()
+        );
     }
 }

--- a/backend/src/models/mutualfund.rs
+++ b/backend/src/models/mutualfund.rs
@@ -66,7 +66,27 @@ pub struct CreateMutualfundRequest {
     #[schema(value_type = f64)]
     pub realized_profit_and_loss_after_tax: Decimal,
 }
-#[cfg(test)] #[rustfmt::skip] mod tests {
+#[cfg(test)]
+mod tests {
     use {super::*, rust_decimal_macros::dec};
-    #[test] fn test_create_mutualfund_request_validation() { assert!(CreateMutualfundRequest { trade_date: NaiveDate::from_ymd_opt(2024, 1, 15).expect("有効な日付 2024-01-15"), settlement_date: NaiveDate::from_ymd_opt(2024, 1, 19).expect("有効な日付 2024-01-19"), fund_name: "テストファンド".to_string(), dividends: Some("再投資型".to_string()), account: "特定".to_string(), shares: dec!(10000), exchange_rate: dec!(1), cancellation_unit_price_yen: dec!(15000), cancellation_amount_yen: dec!(150000), average_acquisition_price_yen: dec!(14000), realized_profit_and_loss: dec!(10000), taxes: dec!(2000), realized_profit_and_loss_after_tax: dec!(8000) }.validate().is_ok()); }
+    #[test]
+    fn test_create_mutualfund_request_validation() {
+        assert!(CreateMutualfundRequest {
+            trade_date: NaiveDate::from_ymd_opt(2024, 1, 15).expect("有効な日付 2024-01-15"),
+            settlement_date: NaiveDate::from_ymd_opt(2024, 1, 19).expect("有効な日付 2024-01-19"),
+            fund_name: "テストファンド".to_string(),
+            dividends: Some("再投資型".to_string()),
+            account: "特定".to_string(),
+            shares: dec!(10000),
+            exchange_rate: dec!(1),
+            cancellation_unit_price_yen: dec!(15000),
+            cancellation_amount_yen: dec!(150000),
+            average_acquisition_price_yen: dec!(14000),
+            realized_profit_and_loss: dec!(10000),
+            taxes: dec!(2000),
+            realized_profit_and_loss_after_tax: dec!(8000)
+        }
+        .validate()
+        .is_ok());
+    }
 }

--- a/backend/src/models/stock.rs
+++ b/backend/src/models/stock.rs
@@ -26,8 +26,32 @@ pub struct Stock {
     #[validate(length(max = 50))]
     pub size_category: Option<String>,
 }
-#[cfg(test)] #[rustfmt::skip] mod tests {
+#[cfg(test)]
+mod tests {
     use {super::*, chrono::NaiveDate};
-    fn make_stock(code: &str, name: &str, market_category: &str) -> Stock { Stock { date: NaiveDate::from_ymd_opt(2025, 3, 24).expect("有効な日付 2025-03-24"), code: code.to_string(), name: name.to_string(), market_category: market_category.to_string(), industry_code_33: Some("123".to_string()), industry_category_33: Some("情報・通信業".to_string()), industry_code_17: Some("12".to_string()), industry_category_17: Some("情報通信".to_string()), size_code: Some("10".to_string()), size_category: Some("大型株".to_string()) } }
-    #[test] fn test_stock_validation() { assert!(make_stock("1234", "テスト株式会社", "プライム").validate().is_ok()); assert!(make_stock("", "テスト株式会社", "プライム").validate().is_err()); assert!(make_stock("1234", "", "プライム").validate().is_err()); assert!(make_stock("1234", "テスト株式会社", "").validate().is_err()); }
+    fn make_stock(code: &str, name: &str, market_category: &str) -> Stock {
+        Stock {
+            date: NaiveDate::from_ymd_opt(2025, 3, 24).expect("有効な日付 2025-03-24"),
+            code: code.to_string(),
+            name: name.to_string(),
+            market_category: market_category.to_string(),
+            industry_code_33: Some("123".to_string()),
+            industry_category_33: Some("情報・通信業".to_string()),
+            industry_code_17: Some("12".to_string()),
+            industry_category_17: Some("情報通信".to_string()),
+            size_code: Some("10".to_string()),
+            size_category: Some("大型株".to_string()),
+        }
+    }
+    #[test]
+    fn test_stock_validation() {
+        assert!(make_stock("1234", "テスト株式会社", "プライム")
+            .validate()
+            .is_ok());
+        assert!(make_stock("", "テスト株式会社", "プライム")
+            .validate()
+            .is_err());
+        assert!(make_stock("1234", "", "プライム").validate().is_err());
+        assert!(make_stock("1234", "テスト株式会社", "").validate().is_err());
+    }
 }

--- a/backend/src/models/user.rs
+++ b/backend/src/models/user.rs
@@ -44,7 +44,29 @@ pub struct GoogleUserInfo {
     pub name: Option<String>,
     pub picture: Option<String>,
 }
-#[cfg(test)] #[rustfmt::skip] mod tests {
+#[cfg(test)]
+mod tests {
     use super::*;
-    #[test] fn test_user_response_from_user() { let user = User { id: Uuid::new_v4(), google_id: "google123".to_string(), email: "test@example.com".to_string(), name: Some("テストユーザー".to_string()), picture_url: Some("https://example.com/photo.jpg".to_string()), created_at: Utc::now(), updated_at: Utc::now() }; let response: UserResponse = user.clone().into(); assert_eq!((response.id, response.email, response.name, response.picture_url), (user.id.to_string(), user.email, user.name, user.picture_url)); }
+    #[test]
+    fn test_user_response_from_user() {
+        let user = User {
+            id: Uuid::new_v4(),
+            google_id: "google123".to_string(),
+            email: "test@example.com".to_string(),
+            name: Some("テストユーザー".to_string()),
+            picture_url: Some("https://example.com/photo.jpg".to_string()),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        let response: UserResponse = user.clone().into();
+        assert_eq!(
+            (
+                response.id,
+                response.email,
+                response.name,
+                response.picture_url
+            ),
+            (user.id.to_string(), user.email, user.name, user.picture_url)
+        );
+    }
 }

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -123,14 +123,250 @@ fn csv_upload_routes() -> Router<AppState> {
         .merge(handlers::mutualfund::mutualfund_csv_upload_routes())
         .merge(handlers::asset_balance::asset_balance_csv_upload_routes())
 }
-#[cfg(test)] #[rustfmt::skip] mod tests {
-    use {super::*, crate::test_env::{EnvGuard, ENV_MUTEX}, axum::{body::Body, http::{Method, Request}}, std::sync::Arc, tower::ServiceExt};
-    fn make_test_state() -> AppState { let database_url = "postgresql://user:password@localhost/test_db"; let pool = crate::db::connect_pool_lazy(database_url, 1).expect("pool"); let secrets = Arc::new(crate::state::Secrets { database_url: database_url.to_string(), jquants_api_key: None, google_client_id: None, google_client_secret: None, frontend_url: "http://localhost:8080".to_string() }); AppState { pool, secrets, client: reqwest::Client::new(), dividend_cache: crate::state::DividendCacheState::default() } }
-    #[test] fn test_all_routes_creation() { let _ = handlers::stock::stock_routes(); let _ = handlers::jquants::jquants_routes(); let _ = handlers::auth::auth_routes(); let _ = handlers::dividend::dividend_routes(); let _ = handlers::domestic_stock::domestic_stock_routes(); let _ = handlers::mutualfund::mutualfund_routes(); let _ = handlers::asset_balance::asset_balance_routes(); }
-    #[tokio::test] async fn test_routes_rate_limit_returns_429() { let router = if let Some(l) = crate::middleware::build_keyed_rate_limiter(1) { handlers::auth::auth_routes().layer(middleware::from_fn(move |req, next| { let l = l.clone(); async move { keyed_rate_limit(l, req, next).await } })) } else { handlers::auth::auth_routes() }.with_state(make_test_state()); assert_rate_limited(router, Method::GET, "/auth/me", Some("1.2.3.4")).await; let router = if let Some(l) = crate::middleware::build_rate_limiter(1) { handlers::jquants::jquants_routes().layer(middleware::from_fn(move |req, next| { let l = l.clone(); async move { rate_limit(l, req, next).await } })) } else { handlers::jquants::jquants_routes() }.with_state(make_test_state()); assert_rate_limited(router, Method::GET, "/jquants/fins/summary", None).await; }
-    async fn assert_rate_limited(router: axum::Router, method: Method, uri: &str, ip: Option<&str>) { let make_req = || { let mut b = Request::builder().method(method.clone()).uri(uri); if let Some(ip) = ip { b = b.header("fly-client-ip", ip); } b.body(Body::empty()).unwrap() }; let resp = router.clone().oneshot(make_req()).await.unwrap(); assert_ne!(resp.status(), axum::http::StatusCode::TOO_MANY_REQUESTS); assert_eq!(router.oneshot(make_req()).await.unwrap().status(), axum::http::StatusCode::TOO_MANY_REQUESTS); }
-    async fn check_unauthorized(router: axum::Router, method: Method, uri: &str) { assert_eq!(router.oneshot(Request::builder().method(method).uri(uri).body(Body::empty()).unwrap()).await.unwrap().status(), axum::http::StatusCode::UNAUTHORIZED); }
-    #[tokio::test] async fn test_all_endpoints_require_auth() { for (router, method, uri) in [(handlers::jquants::jquants_routes(), Method::GET, "/jquants/fins/summary?code=7203"), (handlers::dividend::dividend_routes(), Method::DELETE, "/dividends"), (handlers::dividend::dividend_routes(), Method::GET, "/dividends"), (handlers::dividend::dividend_routes(), Method::POST, "/dividends/csv/preview"), (handlers::domestic_stock::domestic_stock_routes(), Method::DELETE, "/domestic-stocks"), (handlers::domestic_stock::domestic_stock_routes(), Method::GET, "/domestic-stocks"), (handlers::domestic_stock::domestic_stock_routes(), Method::POST, "/domestic-stocks/csv/preview"), (handlers::mutualfund::mutualfund_routes(), Method::DELETE, "/mutualfunds"), (handlers::mutualfund::mutualfund_routes(), Method::GET, "/mutualfunds"), (handlers::mutualfund::mutualfund_routes(), Method::POST, "/mutualfunds/csv/preview"), (handlers::asset_balance::asset_balance_routes(), Method::DELETE, "/asset-balances"), (handlers::asset_balance::asset_balance_routes(), Method::POST, "/asset-balances/bulk"), (handlers::asset_balance::asset_balance_routes(), Method::POST, "/asset-balances/csv/preview"), (csv_upload_routes(), Method::POST, "/dividends/csv"), (handlers::dividend_per_share::dividend_per_share_routes(), Method::POST, "/dividends/per-share/batch")] { check_unauthorized(router.with_state(make_test_state()), method, uri).await; } }
-    #[tokio::test] async fn test_csv_upload_routes_rate_limit_returns_429() { let _lock = ENV_MUTEX.lock().await; let _csv_rate_limit_rps = EnvGuard::set("CSV_RATE_LIMIT_RPS", Some("1")); for (path, ip) in [("/domestic-stocks/csv", "1.2.3.4"), ("/dividends/csv", "1.2.3.5"), ("/mutualfunds/csv", "1.2.3.6"), ("/asset-balances/csv", "1.2.3.7")] { assert_rate_limited(app_router(make_test_state(), &Config::from_env()), Method::POST, path, Some(ip)).await; } let resp = app_router(make_test_state(), &Config::from_env()).oneshot(Request::builder().method(Method::POST).uri("/domestic-stocks/csv/preview").header("fly-client-ip", "1.2.3.4").body(Body::empty()).unwrap()).await.unwrap(); assert_ne!(resp.status(), axum::http::StatusCode::TOO_MANY_REQUESTS); }
-    #[tokio::test] async fn test_request_id_propagated_to_response() { use {axum::{routing::get, Router}, tower_http::request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer}}; let router: Router = Router::new().route("/health", get(|| async { "OK" })).layer(PropagateRequestIdLayer::x_request_id()).layer(SetRequestIdLayer::x_request_id(MakeRequestUuid)); let health_req = |id: Option<&str>| { let mut b = Request::builder().method(Method::GET).uri("/health"); if let Some(id) = id { b = b.header("x-request-id", id); } b.body(Body::empty()).unwrap() }; assert!(router.clone().oneshot(health_req(None)).await.unwrap().headers().contains_key("x-request-id"), "x-request-id should be auto-generated"); assert_eq!(router.oneshot(health_req(Some("my-custom-id"))).await.unwrap().headers().get("x-request-id").and_then(|v| v.to_str().ok()), Some("my-custom-id"), "existing x-request-id should be propagated unchanged"); }
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::test_env::{EnvGuard, ENV_MUTEX},
+        axum::{
+            body::Body,
+            http::{Method, Request},
+        },
+        std::sync::Arc,
+        tower::ServiceExt,
+    };
+    fn make_test_state() -> AppState {
+        let database_url = "postgresql://user:password@localhost/test_db";
+        let pool = crate::db::connect_pool_lazy(database_url, 1).expect("pool");
+        let secrets = Arc::new(crate::state::Secrets {
+            database_url: database_url.to_string(),
+            jquants_api_key: None,
+            google_client_id: None,
+            google_client_secret: None,
+            frontend_url: "http://localhost:8080".to_string(),
+        });
+        AppState {
+            pool,
+            secrets,
+            client: reqwest::Client::new(),
+            dividend_cache: crate::state::DividendCacheState::default(),
+        }
+    }
+    #[test]
+    fn test_all_routes_creation() {
+        let _ = handlers::stock::stock_routes();
+        let _ = handlers::jquants::jquants_routes();
+        let _ = handlers::auth::auth_routes();
+        let _ = handlers::dividend::dividend_routes();
+        let _ = handlers::domestic_stock::domestic_stock_routes();
+        let _ = handlers::mutualfund::mutualfund_routes();
+        let _ = handlers::asset_balance::asset_balance_routes();
+    }
+    #[tokio::test]
+    async fn test_routes_rate_limit_returns_429() {
+        let router = if let Some(l) = crate::middleware::build_keyed_rate_limiter(1) {
+            handlers::auth::auth_routes().layer(middleware::from_fn(move |req, next| {
+                let l = l.clone();
+                async move { keyed_rate_limit(l, req, next).await }
+            }))
+        } else {
+            handlers::auth::auth_routes()
+        }
+        .with_state(make_test_state());
+        assert_rate_limited(router, Method::GET, "/auth/me", Some("1.2.3.4")).await;
+        let router = if let Some(l) = crate::middleware::build_rate_limiter(1) {
+            handlers::jquants::jquants_routes().layer(middleware::from_fn(move |req, next| {
+                let l = l.clone();
+                async move { rate_limit(l, req, next).await }
+            }))
+        } else {
+            handlers::jquants::jquants_routes()
+        }
+        .with_state(make_test_state());
+        assert_rate_limited(router, Method::GET, "/jquants/fins/summary", None).await;
+    }
+    async fn assert_rate_limited(
+        router: axum::Router,
+        method: Method,
+        uri: &str,
+        ip: Option<&str>,
+    ) {
+        let make_req = || {
+            let mut b = Request::builder().method(method.clone()).uri(uri);
+            if let Some(ip) = ip {
+                b = b.header("fly-client-ip", ip);
+            }
+            b.body(Body::empty()).unwrap()
+        };
+        let resp = router.clone().oneshot(make_req()).await.unwrap();
+        assert_ne!(resp.status(), axum::http::StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(
+            router.oneshot(make_req()).await.unwrap().status(),
+            axum::http::StatusCode::TOO_MANY_REQUESTS
+        );
+    }
+    async fn check_unauthorized(router: axum::Router, method: Method, uri: &str) {
+        assert_eq!(
+            router
+                .oneshot(
+                    Request::builder()
+                        .method(method)
+                        .uri(uri)
+                        .body(Body::empty())
+                        .unwrap()
+                )
+                .await
+                .unwrap()
+                .status(),
+            axum::http::StatusCode::UNAUTHORIZED
+        );
+    }
+    #[tokio::test]
+    async fn test_all_endpoints_require_auth() {
+        for (router, method, uri) in [
+            (
+                handlers::jquants::jquants_routes(),
+                Method::GET,
+                "/jquants/fins/summary?code=7203",
+            ),
+            (
+                handlers::dividend::dividend_routes(),
+                Method::DELETE,
+                "/dividends",
+            ),
+            (
+                handlers::dividend::dividend_routes(),
+                Method::GET,
+                "/dividends",
+            ),
+            (
+                handlers::dividend::dividend_routes(),
+                Method::POST,
+                "/dividends/csv/preview",
+            ),
+            (
+                handlers::domestic_stock::domestic_stock_routes(),
+                Method::DELETE,
+                "/domestic-stocks",
+            ),
+            (
+                handlers::domestic_stock::domestic_stock_routes(),
+                Method::GET,
+                "/domestic-stocks",
+            ),
+            (
+                handlers::domestic_stock::domestic_stock_routes(),
+                Method::POST,
+                "/domestic-stocks/csv/preview",
+            ),
+            (
+                handlers::mutualfund::mutualfund_routes(),
+                Method::DELETE,
+                "/mutualfunds",
+            ),
+            (
+                handlers::mutualfund::mutualfund_routes(),
+                Method::GET,
+                "/mutualfunds",
+            ),
+            (
+                handlers::mutualfund::mutualfund_routes(),
+                Method::POST,
+                "/mutualfunds/csv/preview",
+            ),
+            (
+                handlers::asset_balance::asset_balance_routes(),
+                Method::DELETE,
+                "/asset-balances",
+            ),
+            (
+                handlers::asset_balance::asset_balance_routes(),
+                Method::POST,
+                "/asset-balances/bulk",
+            ),
+            (
+                handlers::asset_balance::asset_balance_routes(),
+                Method::POST,
+                "/asset-balances/csv/preview",
+            ),
+            (csv_upload_routes(), Method::POST, "/dividends/csv"),
+            (
+                handlers::dividend_per_share::dividend_per_share_routes(),
+                Method::POST,
+                "/dividends/per-share/batch",
+            ),
+        ] {
+            check_unauthorized(router.with_state(make_test_state()), method, uri).await;
+        }
+    }
+    #[tokio::test]
+    async fn test_csv_upload_routes_rate_limit_returns_429() {
+        let _lock = ENV_MUTEX.lock().await;
+        let _csv_rate_limit_rps = EnvGuard::set("CSV_RATE_LIMIT_RPS", Some("1"));
+        for (path, ip) in [
+            ("/domestic-stocks/csv", "1.2.3.4"),
+            ("/dividends/csv", "1.2.3.5"),
+            ("/mutualfunds/csv", "1.2.3.6"),
+            ("/asset-balances/csv", "1.2.3.7"),
+        ] {
+            assert_rate_limited(
+                app_router(make_test_state(), &Config::from_env()),
+                Method::POST,
+                path,
+                Some(ip),
+            )
+            .await;
+        }
+        let resp = app_router(make_test_state(), &Config::from_env())
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/domestic-stocks/csv/preview")
+                    .header("fly-client-ip", "1.2.3.4")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_ne!(resp.status(), axum::http::StatusCode::TOO_MANY_REQUESTS);
+    }
+    #[tokio::test]
+    async fn test_request_id_propagated_to_response() {
+        use {
+            axum::{routing::get, Router},
+            tower_http::request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer},
+        };
+        let router: Router = Router::new()
+            .route("/health", get(|| async { "OK" }))
+            .layer(PropagateRequestIdLayer::x_request_id())
+            .layer(SetRequestIdLayer::x_request_id(MakeRequestUuid));
+        let health_req = |id: Option<&str>| {
+            let mut b = Request::builder().method(Method::GET).uri("/health");
+            if let Some(id) = id {
+                b = b.header("x-request-id", id);
+            }
+            b.body(Body::empty()).unwrap()
+        };
+        assert!(
+            router
+                .clone()
+                .oneshot(health_req(None))
+                .await
+                .unwrap()
+                .headers()
+                .contains_key("x-request-id"),
+            "x-request-id should be auto-generated"
+        );
+        assert_eq!(
+            router
+                .oneshot(health_req(Some("my-custom-id")))
+                .await
+                .unwrap()
+                .headers()
+                .get("x-request-id")
+                .and_then(|v| v.to_str().ok()),
+            Some("my-custom-id"),
+            "existing x-request-id should be propagated unchanged"
+        );
+    }
 }

--- a/backend/src/services/auth.rs
+++ b/backend/src/services/auth.rs
@@ -211,13 +211,91 @@ pub async fn delete_account(pool: &PgPool, user_id: uuid::Uuid) -> Result<(), sq
 
     Ok(())
 }
-#[cfg(test)] #[rustfmt::skip] mod tests {
+#[cfg(test)]
+mod tests {
     use {super::*, crate::state::Secrets, std::sync::Arc};
-    fn test_state() -> AppState { AppState { pool: crate::db::connect_pool_lazy("postgresql://user:password@localhost/test_db", 1).expect("pool"), secrets: Arc::new(Secrets { database_url: "postgresql://user:password@localhost/test_db".to_string(), jquants_api_key: None, google_client_id: Some("client-id".to_string()), google_client_secret: Some("client-secret".to_string()), frontend_url: "http://localhost:8080".to_string() }), client: reqwest::Client::new(), dividend_cache: crate::state::DividendCacheState::default() } }
-    #[test] fn test_auth_helpers() {
-        for (secure, expected_secure) in [(true, true), (false, false)] { for (cookie, expected_name, expected_value) in [(build_state_cookie("test_state", secure), OAUTH_STATE_COOKIE_NAME, "test_state"), (build_session_cookie("test_token", secure), SESSION_COOKIE_NAME, "test_token")] { assert_eq!((cookie.name(), cookie.value(), cookie.secure(), cookie.http_only()), (expected_name, expected_value, Some(expected_secure), Some(true))); } }
-        assert!(get_session_id_from_jar(&CookieJar::new()).is_err()); assert!(get_session_id_from_jar(&CookieJar::new().add(Cookie::new(SESSION_COOKIE_NAME, "invalid-uuid"))).is_err()); let uuid = uuid::Uuid::new_v4(); assert_eq!(get_session_id_from_jar(&CookieJar::new().add(Cookie::new(SESSION_COOKIE_NAME, uuid.to_string()))).unwrap(), uuid);
-        for (cookie, expected_name) in [(clear_state_cookie(true), OAUTH_STATE_COOKIE_NAME), (clear_session_cookie(true), SESSION_COOKIE_NAME)] { assert_eq!((cookie.name(), cookie.value()), (expected_name, "")); } assert_eq!((same_site(true), same_site(false), SESSION_COOKIE_NAME, OAUTH_STATE_COOKIE_NAME), (SameSite::None, SameSite::Lax, "session_token", "oauth_state"));
+    fn test_state() -> AppState {
+        AppState {
+            pool: crate::db::connect_pool_lazy("postgresql://user:password@localhost/test_db", 1)
+                .expect("pool"),
+            secrets: Arc::new(Secrets {
+                database_url: "postgresql://user:password@localhost/test_db".to_string(),
+                jquants_api_key: None,
+                google_client_id: Some("client-id".to_string()),
+                google_client_secret: Some("client-secret".to_string()),
+                frontend_url: "http://localhost:8080".to_string(),
+            }),
+            client: reqwest::Client::new(),
+            dividend_cache: crate::state::DividendCacheState::default(),
+        }
     }
-    #[tokio::test] async fn test_create_oauth_client() { assert!(create_oauth_client(&test_state()).is_ok()); }
+    #[test]
+    fn test_auth_helpers() {
+        for (secure, expected_secure) in [(true, true), (false, false)] {
+            for (cookie, expected_name, expected_value) in [
+                (
+                    build_state_cookie("test_state", secure),
+                    OAUTH_STATE_COOKIE_NAME,
+                    "test_state",
+                ),
+                (
+                    build_session_cookie("test_token", secure),
+                    SESSION_COOKIE_NAME,
+                    "test_token",
+                ),
+            ] {
+                assert_eq!(
+                    (
+                        cookie.name(),
+                        cookie.value(),
+                        cookie.secure(),
+                        cookie.http_only()
+                    ),
+                    (
+                        expected_name,
+                        expected_value,
+                        Some(expected_secure),
+                        Some(true)
+                    )
+                );
+            }
+        }
+        assert!(get_session_id_from_jar(&CookieJar::new()).is_err());
+        assert!(get_session_id_from_jar(
+            &CookieJar::new().add(Cookie::new(SESSION_COOKIE_NAME, "invalid-uuid"))
+        )
+        .is_err());
+        let uuid = uuid::Uuid::new_v4();
+        assert_eq!(
+            get_session_id_from_jar(
+                &CookieJar::new().add(Cookie::new(SESSION_COOKIE_NAME, uuid.to_string()))
+            )
+            .unwrap(),
+            uuid
+        );
+        for (cookie, expected_name) in [
+            (clear_state_cookie(true), OAUTH_STATE_COOKIE_NAME),
+            (clear_session_cookie(true), SESSION_COOKIE_NAME),
+        ] {
+            assert_eq!((cookie.name(), cookie.value()), (expected_name, ""));
+        }
+        assert_eq!(
+            (
+                same_site(true),
+                same_site(false),
+                SESSION_COOKIE_NAME,
+                OAUTH_STATE_COOKIE_NAME
+            ),
+            (
+                SameSite::None,
+                SameSite::Lax,
+                "session_token",
+                "oauth_state"
+            )
+        );
+    }
+    #[tokio::test]
+    async fn test_create_oauth_client() {
+        assert!(create_oauth_client(&test_state()).is_ok());
+    }
 }

--- a/backend/src/services/csv_domain.rs
+++ b/backend/src/services/csv_domain.rs
@@ -95,12 +95,23 @@ impl CsvDomain for AssetBalanceDomain {
         crate::services::asset_balance::upload_csv(pool, user_id, bytes).await
     }
 }
-#[cfg(test)] #[rustfmt::skip] mod tests {
-    use super::{AssetBalanceDomain, CsvDomain, DividendDomain, DomesticStockDomain, MutualfundDomain};
-    fn assert_valid_rows<D: CsvDomain>(lines: &[&str], expected_valid_rows: usize) { let csv = lines.join("\n"); assert_eq!(D::preview_csv(csv.as_bytes()).unwrap().valid_rows, expected_valid_rows); }
-    #[test] fn test_domain_preview_csv_delegates() {
+#[cfg(test)]
+mod tests {
+    use super::{
+        AssetBalanceDomain, CsvDomain, DividendDomain, DomesticStockDomain, MutualfundDomain,
+    };
+    fn assert_valid_rows<D: CsvDomain>(lines: &[&str], expected_valid_rows: usize) {
+        let csv = lines.join("\n");
+        assert_eq!(
+            D::preview_csv(csv.as_bytes()).unwrap().valid_rows,
+            expected_valid_rows
+        );
+    }
+    #[test]
+    fn test_domain_preview_csv_delegates() {
         assert_valid_rows::<DividendDomain>(&["入金日,商品,口座,銘柄コード,銘柄,受取通貨,単価[円/現地通貨],数量[株/口],配当・分配金合計（税引前）[円/現地通貨],税額合計[円/現地通貨],受取金額[円/現地通貨]", "\"2025/12/09\",\"国内株式\",\"特定・一般\",\"8591\",\"オリックス\",\"円\",\"93.76\",\"200\",\"18,752\",\"3,808\",\"14,944\""], 1);
-        assert_valid_rows::<DomesticStockDomain>(&["約定日,受渡日,銘柄コード,銘柄名,口座,信用区分,取引,数量[株],売却/決済単価[円],売却/決済額[円],平均取得価額[円],実現損益[円]", "\"2026/02/09\",\"2026/02/12\",\"5020\",\"ＥＮＥＯＳホールディングス\",\"特定\",\"-\",\"売付\",\"100\",\"1,441.0\",\"144,100\",\"1,350.00\",\"9,100\""], 1); assert_valid_rows::<MutualfundDomain>(&["約定日,受渡日,ファンド名,分配金,口座,取引,数量[口],為替レート［円］,解約単価［円］,解約額［円］,平均取得価額［円］,実現損益［円］", "\"2022/10/28\",\"2022/11/2\",\"eMAXIS Slim 米国株式(S&P500)\",\"再投資型\",\"特定\",\"解約\",\"3,721,147\",\"-\",\"19,661\",\"7,316,147\",\"18,005.20\",\"615,849\""], 1);
+        assert_valid_rows::<DomesticStockDomain>(&["約定日,受渡日,銘柄コード,銘柄名,口座,信用区分,取引,数量[株],売却/決済単価[円],売却/決済額[円],平均取得価額[円],実現損益[円]", "\"2026/02/09\",\"2026/02/12\",\"5020\",\"ＥＮＥＯＳホールディングス\",\"特定\",\"-\",\"売付\",\"100\",\"1,441.0\",\"144,100\",\"1,350.00\",\"9,100\""], 1);
+        assert_valid_rows::<MutualfundDomain>(&["約定日,受渡日,ファンド名,分配金,口座,取引,数量[口],為替レート［円］,解約単価［円］,解約額［円］,平均取得価額［円］,実現損益［円］", "\"2022/10/28\",\"2022/11/2\",\"eMAXIS Slim 米国株式(S&P500)\",\"再投資型\",\"特定\",\"解約\",\"3,721,147\",\"-\",\"19,661\",\"7,316,147\",\"18,005.20\",\"615,849\""], 1);
         assert_valid_rows::<AssetBalanceDomain>(&["■現在の評価額合計［円］,,\"9,474,000\"", "■評価損益合計,前日比［円］,\"288,000\"", ",前月比［円］,\"-120,000\"", ",評価損益［円］,\"2,005,900\"", "■特定口座", "", "銘柄コード,銘柄名,保有数量［株］,執行中［株］,(内訳　通常数量[株]),(内訳　積立数量[株]),平均取得価額［円］,取得総額［円］,現在値［円］,現在値（前日比）［円］,時価評価額［円］,評価損益［％］", "\"1605\",\"ＩＮＰＥＸ\",\"200\",\"0\",\"200\",\"0\",\"2,355.00\",\"471,000\",\"3,685.0\",\"65.0\",\"737,000\",\"56.47\"", "\"7974\",\"任天堂\",\"1,000\",\"0\",\"1,000\",\"0\",\"5,997.60\",\"5,997,600\",\"8,737.0\",\"223.0\",\"8,737,000\",\"45.67\"", ",,,,,,特定口座合計,\"11,245,249\",,,\"14,517,240\",\"29.09\""], 2);
     }
 }

--- a/backend/src/services/csv_import.rs
+++ b/backend/src/services/csv_import.rs
@@ -106,13 +106,76 @@ pub fn finish_csv_upload(
         errors,
     }
 }
-#[cfg(test)] #[rustfmt::skip] mod tests {
-    use {super::*, crate::services::csv_util::{get_cell, parse_required_string}};
-    fn parse_pair_csv(csv: &str) -> (Vec<String>, Vec<CsvRowError>) { parse_csv::<String, _>(csv.as_bytes(), |record, header_map, _row| { let a = get_cell(record, header_map, "col_a").to_string(); let b = get_cell(record, header_map, "col_b").to_string(); Ok(format!("{a}/{b}")) }).unwrap() }
-    fn strings(values: &[&str]) -> Vec<String> { values.iter().map(|value| (*value).to_string()).collect() }
-    #[test] fn test_parse_csv() {
-        let (items, errors) = parse_pair_csv("col_a,col_b\nfoo,123\nbar,456\n"); assert_eq!((items, errors.is_empty()), (strings(&["foo/123", "bar/456"]), true));
-        let (items, errors) = parse_csv::<String, _>("name,id\ngood,1\n,2\nbad,3\n".as_bytes(), |record, header_map, row_num| parse_required_string(record, header_map, "name", row_num)).unwrap(); assert_eq!((items, errors.len(), errors.first().map(|error| error.row)), (strings(&["good", "bad"]), 1, Some(2))); let (items, errors) = parse_pair_csv("col_a,col_b\nfoo,123\n,\nbar,456\n"); assert_eq!((items, errors.is_empty()), (strings(&["foo/123", "bar/456"]), true));
-        let (items, errors) = parse_pair_csv("col_a,col_b\nfoo,123\nbar\nbaz,456\n"); assert_eq!((items, errors.len(), errors.first().map(|error| error.row), errors.first().is_some_and(|error| error.message.contains("CSV行の読み込み"))), (strings(&["foo/123", "baz/456"]), 1, Some(2), true)); let response = finish_csv_upload(crate::models::common::BulkCreateResponse { inserted: 3, skipped: 1 }, vec![CsvRowError { row: 5, message: "エラー".to_string() }]); assert_eq!((response.inserted, response.skipped, response.errors.len(), response.errors.first().map(|error| error.row)), (3, 1, 1, Some(5)));
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::services::csv_util::{get_cell, parse_required_string},
+    };
+    fn parse_pair_csv(csv: &str) -> (Vec<String>, Vec<CsvRowError>) {
+        parse_csv::<String, _>(csv.as_bytes(), |record, header_map, _row| {
+            let a = get_cell(record, header_map, "col_a").to_string();
+            let b = get_cell(record, header_map, "col_b").to_string();
+            Ok(format!("{a}/{b}"))
+        })
+        .unwrap()
+    }
+    fn strings(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| (*value).to_string()).collect()
+    }
+    #[test]
+    fn test_parse_csv() {
+        let (items, errors) = parse_pair_csv("col_a,col_b\nfoo,123\nbar,456\n");
+        assert_eq!(
+            (items, errors.is_empty()),
+            (strings(&["foo/123", "bar/456"]), true)
+        );
+        let (items, errors) = parse_csv::<String, _>(
+            "name,id\ngood,1\n,2\nbad,3\n".as_bytes(),
+            |record, header_map, row_num| {
+                parse_required_string(record, header_map, "name", row_num)
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            (items, errors.len(), errors.first().map(|error| error.row)),
+            (strings(&["good", "bad"]), 1, Some(2))
+        );
+        let (items, errors) = parse_pair_csv("col_a,col_b\nfoo,123\n,\nbar,456\n");
+        assert_eq!(
+            (items, errors.is_empty()),
+            (strings(&["foo/123", "bar/456"]), true)
+        );
+        let (items, errors) = parse_pair_csv("col_a,col_b\nfoo,123\nbar\nbaz,456\n");
+        assert_eq!(
+            (
+                items,
+                errors.len(),
+                errors.first().map(|error| error.row),
+                errors
+                    .first()
+                    .is_some_and(|error| error.message.contains("CSV行の読み込み"))
+            ),
+            (strings(&["foo/123", "baz/456"]), 1, Some(2), true)
+        );
+        let response = finish_csv_upload(
+            crate::models::common::BulkCreateResponse {
+                inserted: 3,
+                skipped: 1,
+            },
+            vec![CsvRowError {
+                row: 5,
+                message: "エラー".to_string(),
+            }],
+        );
+        assert_eq!(
+            (
+                response.inserted,
+                response.skipped,
+                response.errors.len(),
+                response.errors.first().map(|error| error.row)
+            ),
+            (3, 1, 1, Some(5))
+        );
     }
 }

--- a/backend/src/services/csv_util.rs
+++ b/backend/src/services/csv_util.rs
@@ -208,9 +208,167 @@ pub fn parse_required_date_row(
         message: format!("{}: {}", col, e),
     })
 }
-#[cfg(test)] #[rustfmt::skip] mod tests {
+#[cfg(test)]
+mod tests {
     use {super::*, rust_decimal_macros::dec};
-    fn time_n(label: &str, n: usize, mut f: impl FnMut()) { let start = std::time::Instant::now(); for _ in 0..n { f(); } println!("[timing] {} × {}回: {:.2}ms", label, n, start.elapsed().as_secs_f64() * 1000.0); } fn make_header_map(cols: &[&str]) -> HashMap<String, usize> { cols.iter().enumerate().map(|(i, col)| ((*col).to_string(), i)).collect() }
-    #[test] fn test_parse_utilities() { for (input, expected) in [("1,234", dec!(1234)), ("500", dec!(500)), ("(500)", dec!(-500)), ("", Decimal::ZERO), ("-", Decimal::ZERO)] { assert_eq!(parse_number(input).unwrap(), expected); } let (record, header_map) = (csv::StringRecord::from(vec!["", "value"]), make_header_map(&["empty", "filled"])); for (col, expected) in [("empty", ""), ("filled", "value"), ("missing", "")] { assert_eq!(parse_optional_string(&record, &header_map, col), expected); } let expected_date = NaiveDate::from_ymd_opt(2024, 1, 15).unwrap(); for input in ["2024/01/15", "2024-01-15"] { assert_eq!(parse_date(input).unwrap(), expected_date); } for (account, realized_pnl, expected_taxes, expected_after) in [("特定", dec!(10000), dec!(2031), dec!(7969)), ("特定", dec!(-5000), Decimal::ZERO, dec!(-5000)), ("NISA", dec!(10000), Decimal::ZERO, dec!(10000))] { assert_eq!(compute_taxes(account, realized_pnl), (expected_taxes, expected_after)); } use encoding_rs::SHIFT_JIS; assert_eq!(decode_bytes("テスト".as_bytes()), "テスト"); assert_eq!(decode_bytes(b"\xEF\xBB\xBF\xE3\x83\x86\xE3\x82\xB9\xE3\x83\x88"), "テスト"); let (bytes, _, _) = SHIFT_JIS.encode("テスト"); assert_eq!(decode_bytes(&bytes), "テスト"); let (record, header_map) = (csv::StringRecord::from(vec!["value"]), make_header_map(&["present"])); assert_eq!(get_cell(&record, &header_map, "present"), "value"); assert_eq!(get_cell(&record, &header_map, "missing"), ""); for (input, expected) in [("K D D I", "KDDI"), ("I N P E X", "INPEX"), ("eMAXIS Slim 全世界株式", "eMAXIS Slim 全世界株式"), ("任天堂", "任天堂"), ("  KDDI  ", "KDDI"), ("", "")] { assert_eq!(normalize_security_name(input), expected); } let (record, header_map) = (csv::StringRecord::from(vec!["", "value"]), make_header_map(&["col_a", "col_b"])); let err = parse_required_string(&record, &header_map, "col_a", 3).unwrap_err(); assert_eq!((err.row, err.message.contains("col_a")), (3, true)); assert_eq!(parse_required_string(&record, &header_map, "col_b", 1).unwrap(), "value"); let (record, hm) = (csv::StringRecord::from(vec!["abc", "1,234", ""]), make_header_map(&["invalid", "valid", "empty"])); assert_eq!(parse_required_number(&record, &hm, "invalid", 5).unwrap_err().row, 5); assert_eq!(parse_required_number(&record, &hm, "valid", 1).unwrap(), dec!(1234)); let err = parse_required_number(&record, &hm, "empty", 7).unwrap_err(); assert_eq!((err.row, err.message.contains("empty")), (7, true)); let (record, hm) = (csv::StringRecord::from(vec!["not-a-date", "2024/03/01", "2024/13/40"]), make_header_map(&["invalid", "valid", "out_of_range"])); assert_eq!(parse_required_date(&record, &hm, "invalid", 2).unwrap_err().row, 2); assert_eq!(parse_required_date(&record, &hm, "valid", 1).unwrap(), NaiveDate::from_ymd_opt(2024, 3, 1).unwrap()); let err = parse_required_date(&record, &hm, "out_of_range", 9).unwrap_err(); assert_eq!((err.row, err.message.contains("out_of_range")), (9, true)); }
-    #[test] #[ignore = "タイミング計測専用。cargo test --lib -- timing_csv_util --ignored --nocapture で実行"] fn timing_csv_util() { use encoding_rs::SHIFT_JIS; const ROWS: usize = 1_000; let csv_utf8: String = { let mut s = String::from("日付,銘柄コード,金額\n"); for i in 0..ROWS { s.push_str(&format!("2024/{:02}/{:02},1234,{}\n", (i % 12) + 1, (i % 28) + 1, i * 100)); } s }; let bytes_utf8 = csv_utf8.as_bytes(); let (bytes_sjis_cow, _, _) = SHIFT_JIS.encode(&csv_utf8); let bytes_sjis = bytes_sjis_cow.into_owned(); time_n(&format!("decode_bytes (UTF-8, {}行)", ROWS), 10, || { std::hint::black_box(decode_bytes(std::hint::black_box(bytes_utf8))); }); time_n(&format!("decode_bytes (Shift-JIS フォールバック, {}行)", ROWS), 10, || { std::hint::black_box(decode_bytes(std::hint::black_box(bytes_sjis.as_slice()))); }); let samples = ["1,234,567", "0", "(1,000)", "3.14159", "-"]; time_n("parse_number", 10_000, || { for s in &samples { let _ = std::hint::black_box(parse_number(std::hint::black_box(s))); } }); let date_samples = ["2024/03/01", "2024-12-31", "2023/01/01"]; time_n("parse_date", 10_000, || { for s in &date_samples { let _ = std::hint::black_box(parse_date(std::hint::black_box(s))); } }); }
+    fn time_n(label: &str, n: usize, mut f: impl FnMut()) {
+        let start = std::time::Instant::now();
+        for _ in 0..n {
+            f();
+        }
+        println!(
+            "[timing] {} × {}回: {:.2}ms",
+            label,
+            n,
+            start.elapsed().as_secs_f64() * 1000.0
+        );
+    }
+    fn make_header_map(cols: &[&str]) -> HashMap<String, usize> {
+        cols.iter()
+            .enumerate()
+            .map(|(i, col)| ((*col).to_string(), i))
+            .collect()
+    }
+    #[test]
+    fn test_parse_utilities() {
+        for (input, expected) in [
+            ("1,234", dec!(1234)),
+            ("500", dec!(500)),
+            ("(500)", dec!(-500)),
+            ("", Decimal::ZERO),
+            ("-", Decimal::ZERO),
+        ] {
+            assert_eq!(parse_number(input).unwrap(), expected);
+        }
+        let (record, header_map) = (
+            csv::StringRecord::from(vec!["", "value"]),
+            make_header_map(&["empty", "filled"]),
+        );
+        for (col, expected) in [("empty", ""), ("filled", "value"), ("missing", "")] {
+            assert_eq!(parse_optional_string(&record, &header_map, col), expected);
+        }
+        let expected_date = NaiveDate::from_ymd_opt(2024, 1, 15).unwrap();
+        for input in ["2024/01/15", "2024-01-15"] {
+            assert_eq!(parse_date(input).unwrap(), expected_date);
+        }
+        for (account, realized_pnl, expected_taxes, expected_after) in [
+            ("特定", dec!(10000), dec!(2031), dec!(7969)),
+            ("特定", dec!(-5000), Decimal::ZERO, dec!(-5000)),
+            ("NISA", dec!(10000), Decimal::ZERO, dec!(10000)),
+        ] {
+            assert_eq!(
+                compute_taxes(account, realized_pnl),
+                (expected_taxes, expected_after)
+            );
+        }
+        use encoding_rs::SHIFT_JIS;
+        assert_eq!(decode_bytes("テスト".as_bytes()), "テスト");
+        assert_eq!(
+            decode_bytes(b"\xEF\xBB\xBF\xE3\x83\x86\xE3\x82\xB9\xE3\x83\x88"),
+            "テスト"
+        );
+        let (bytes, _, _) = SHIFT_JIS.encode("テスト");
+        assert_eq!(decode_bytes(&bytes), "テスト");
+        let (record, header_map) = (
+            csv::StringRecord::from(vec!["value"]),
+            make_header_map(&["present"]),
+        );
+        assert_eq!(get_cell(&record, &header_map, "present"), "value");
+        assert_eq!(get_cell(&record, &header_map, "missing"), "");
+        for (input, expected) in [
+            ("K D D I", "KDDI"),
+            ("I N P E X", "INPEX"),
+            ("eMAXIS Slim 全世界株式", "eMAXIS Slim 全世界株式"),
+            ("任天堂", "任天堂"),
+            ("  KDDI  ", "KDDI"),
+            ("", ""),
+        ] {
+            assert_eq!(normalize_security_name(input), expected);
+        }
+        let (record, header_map) = (
+            csv::StringRecord::from(vec!["", "value"]),
+            make_header_map(&["col_a", "col_b"]),
+        );
+        let err = parse_required_string(&record, &header_map, "col_a", 3).unwrap_err();
+        assert_eq!((err.row, err.message.contains("col_a")), (3, true));
+        assert_eq!(
+            parse_required_string(&record, &header_map, "col_b", 1).unwrap(),
+            "value"
+        );
+        let (record, hm) = (
+            csv::StringRecord::from(vec!["abc", "1,234", ""]),
+            make_header_map(&["invalid", "valid", "empty"]),
+        );
+        assert_eq!(
+            parse_required_number(&record, &hm, "invalid", 5)
+                .unwrap_err()
+                .row,
+            5
+        );
+        assert_eq!(
+            parse_required_number(&record, &hm, "valid", 1).unwrap(),
+            dec!(1234)
+        );
+        let err = parse_required_number(&record, &hm, "empty", 7).unwrap_err();
+        assert_eq!((err.row, err.message.contains("empty")), (7, true));
+        let (record, hm) = (
+            csv::StringRecord::from(vec!["not-a-date", "2024/03/01", "2024/13/40"]),
+            make_header_map(&["invalid", "valid", "out_of_range"]),
+        );
+        assert_eq!(
+            parse_required_date(&record, &hm, "invalid", 2)
+                .unwrap_err()
+                .row,
+            2
+        );
+        assert_eq!(
+            parse_required_date(&record, &hm, "valid", 1).unwrap(),
+            NaiveDate::from_ymd_opt(2024, 3, 1).unwrap()
+        );
+        let err = parse_required_date(&record, &hm, "out_of_range", 9).unwrap_err();
+        assert_eq!((err.row, err.message.contains("out_of_range")), (9, true));
+    }
+    #[test]
+    #[ignore = "タイミング計測専用。cargo test --lib -- timing_csv_util --ignored --nocapture で実行"]
+    fn timing_csv_util() {
+        use encoding_rs::SHIFT_JIS;
+        const ROWS: usize = 1_000;
+        let csv_utf8: String = {
+            let mut s = String::from("日付,銘柄コード,金額\n");
+            for i in 0..ROWS {
+                s.push_str(&format!(
+                    "2024/{:02}/{:02},1234,{}\n",
+                    (i % 12) + 1,
+                    (i % 28) + 1,
+                    i * 100
+                ));
+            }
+            s
+        };
+        let bytes_utf8 = csv_utf8.as_bytes();
+        let (bytes_sjis_cow, _, _) = SHIFT_JIS.encode(&csv_utf8);
+        let bytes_sjis = bytes_sjis_cow.into_owned();
+        time_n(&format!("decode_bytes (UTF-8, {}行)", ROWS), 10, || {
+            std::hint::black_box(decode_bytes(std::hint::black_box(bytes_utf8)));
+        });
+        time_n(
+            &format!("decode_bytes (Shift-JIS フォールバック, {}行)", ROWS),
+            10,
+            || {
+                std::hint::black_box(decode_bytes(std::hint::black_box(bytes_sjis.as_slice())));
+            },
+        );
+        let samples = ["1,234,567", "0", "(1,000)", "3.14159", "-"];
+        time_n("parse_number", 10_000, || {
+            for s in &samples {
+                let _ = std::hint::black_box(parse_number(std::hint::black_box(s)));
+            }
+        });
+        let date_samples = ["2024/03/01", "2024-12-31", "2023/01/01"];
+        time_n("parse_date", 10_000, || {
+            for s in &date_samples {
+                let _ = std::hint::black_box(parse_date(std::hint::black_box(s)));
+            }
+        });
+    }
 }

--- a/backend/src/services/mutualfund.rs
+++ b/backend/src/services/mutualfund.rs
@@ -198,10 +198,28 @@ fn transform_mutualfund_row(
 pub async fn delete_all(pool: &PgPool, user_id: Uuid) -> Result<u64, ApiError> {
     crate::services::shared::delete_all_for_user(pool, user_id, "mutualfunds", "mutualfund").await
 }
-#[cfg(test)] #[rustfmt::skip] mod tests {
+#[cfg(test)]
+mod tests {
     use super::*;
-    #[test] fn test_preview_csv_basic() {
-        let csv = concat!("約定日,受渡日,ファンド名,分配金,口座,取引,数量[口],為替レート［円］,解約単価［円］,解約額［円］,平均取得価額［円］,実現損益［円］\n", "\"2022/10/28\",\"2022/11/2\",\"eMAXIS Slim 米国株式(S&P500)\",\"再投資型\",\"特定\",\"解約\",\"3,721,147\",\"-\",\"19,661\",\"7,316,147\",\"18,005.20\",\"615,849\""); let preview = preview_csv(csv.as_bytes()).unwrap(); assert_eq!((preview.total_rows, preview.valid_rows, preview.rows.len(), preview.errors.is_empty(), matches!(preview_csv(b""), Err(ApiError::ValidationError(_)))), (1, 1, 1, true, true));
-        let csv = concat!("約定日,受渡日,ファンド名,分配金,口座,取引,数量[口],為替レート［円］,解約単価［円］,解約額［円］,平均取得価額［円］,実現損益［円］\n", "\"2022/10/28\",\"2022/11/2\",\"eMAXIS Slim\",\"\",\"特定\",\"解約\",\"1000\",\"1\",\"12000\",\"12000000\",\"10000\",\"615849\""); let preview = preview_csv(csv.as_bytes()).unwrap(); assert_eq!((preview.valid_rows, preview.rows[0]["dividends"].is_null()), (1, true));
+    #[test]
+    fn test_preview_csv_basic() {
+        let csv = concat!("約定日,受渡日,ファンド名,分配金,口座,取引,数量[口],為替レート［円］,解約単価［円］,解約額［円］,平均取得価額［円］,実現損益［円］\n", "\"2022/10/28\",\"2022/11/2\",\"eMAXIS Slim 米国株式(S&P500)\",\"再投資型\",\"特定\",\"解約\",\"3,721,147\",\"-\",\"19,661\",\"7,316,147\",\"18,005.20\",\"615,849\"");
+        let preview = preview_csv(csv.as_bytes()).unwrap();
+        assert_eq!(
+            (
+                preview.total_rows,
+                preview.valid_rows,
+                preview.rows.len(),
+                preview.errors.is_empty(),
+                matches!(preview_csv(b""), Err(ApiError::ValidationError(_)))
+            ),
+            (1, 1, 1, true, true)
+        );
+        let csv = concat!("約定日,受渡日,ファンド名,分配金,口座,取引,数量[口],為替レート［円］,解約単価［円］,解約額［円］,平均取得価額［円］,実現損益［円］\n", "\"2022/10/28\",\"2022/11/2\",\"eMAXIS Slim\",\"\",\"特定\",\"解約\",\"1000\",\"1\",\"12000\",\"12000000\",\"10000\",\"615849\"");
+        let preview = preview_csv(csv.as_bytes()).unwrap();
+        assert_eq!(
+            (preview.valid_rows, preview.rows[0]["dividends"].is_null()),
+            (1, true)
+        );
     }
 }

--- a/backend/src/services/shared.rs
+++ b/backend/src/services/shared.rs
@@ -50,7 +50,14 @@ pub async fn delete_all_for_user(
     info!("[{}.delete_all] 完了: {}件削除", domain, deleted);
     Ok(deleted)
 }
-#[cfg(test)] #[rustfmt::skip] mod tests {
+#[cfg(test)]
+mod tests {
     use super::BulkTimer;
-    #[test] fn test_bulk_timer_finish() { for (inserted, expected) in [(0, (0, 5)), (5, (5, 0)), (3, (3, 2))] { let response = BulkTimer::new("test", 5).finish(inserted); assert_eq!((response.inserted, response.skipped), expected); } }
+    #[test]
+    fn test_bulk_timer_finish() {
+        for (inserted, expected) in [(0, (0, 5)), (5, (5, 0)), (3, (3, 2))] {
+            let response = BulkTimer::new("test", 5).finish(inserted);
+            assert_eq!((response.inserted, response.skipped), expected);
+        }
+    }
 }

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -41,7 +41,41 @@ pub struct AppState {
     /// 配当キャッシュのバックグラウンド更新状態（多重起動防止）
     pub dividend_cache: DividendCacheState,
 }
-#[cfg(test)] #[rustfmt::skip] mod tests {
-    use {super::*, crate::test_env::{EnvGuard, ENV_MUTEX}};
-    #[tokio::test] async fn test_secrets_from_env() { let _lock = ENV_MUTEX.lock().await; { let _db = EnvGuard::set("DATABASE_URL", None); let err_msg = Secrets::from_env().unwrap_err(); assert!(err_msg.contains("DATABASE_URL"), "エラーメッセージに DATABASE_URL が含まれること: {err_msg}"); } { let _db = EnvGuard::set("DATABASE_URL", Some("postgresql://user:password@localhost/test")); let _fe = EnvGuard::set("FRONTEND_URL", None); assert_eq!(Secrets::from_env().unwrap().frontend_url, "http://localhost:8080"); } { let _db = EnvGuard::set("DATABASE_URL", Some("postgresql://user:password@localhost/test")); let _jq = EnvGuard::set("JQUANTS_API_KEY", None); assert!(Secrets::from_env().unwrap().jquants_api_key.is_none()); } }
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::test_env::{EnvGuard, ENV_MUTEX},
+    };
+    #[tokio::test]
+    async fn test_secrets_from_env() {
+        let _lock = ENV_MUTEX.lock().await;
+        {
+            let _db = EnvGuard::set("DATABASE_URL", None);
+            let err_msg = Secrets::from_env().unwrap_err();
+            assert!(
+                err_msg.contains("DATABASE_URL"),
+                "エラーメッセージに DATABASE_URL が含まれること: {err_msg}"
+            );
+        }
+        {
+            let _db = EnvGuard::set(
+                "DATABASE_URL",
+                Some("postgresql://user:password@localhost/test"),
+            );
+            let _fe = EnvGuard::set("FRONTEND_URL", None);
+            assert_eq!(
+                Secrets::from_env().unwrap().frontend_url,
+                "http://localhost:8080"
+            );
+        }
+        {
+            let _db = EnvGuard::set(
+                "DATABASE_URL",
+                Some("postgresql://user:password@localhost/test"),
+            );
+            let _jq = EnvGuard::set("JQUANTS_API_KEY", None);
+            assert!(Secrets::from_env().unwrap().jquants_api_key.is_none());
+        }
+    }
 }

--- a/backend/src/test_env.rs
+++ b/backend/src/test_env.rs
@@ -1,5 +1,28 @@
-#[rustfmt::skip] use {std::env, tokio::sync::Mutex};
+use {std::env, tokio::sync::Mutex};
 pub static ENV_MUTEX: Mutex<()> = Mutex::const_new(());
-#[rustfmt::skip] pub struct EnvGuard { key: &'static str, previous: Option<String> }
-#[rustfmt::skip] impl EnvGuard { pub fn set(key: &'static str, value: Option<&str>) -> Self { let previous = env::var(key).ok(); match value { Some(v) => env::set_var(key, v), None => env::remove_var(key) }; Self { key, previous } } }
-#[rustfmt::skip] impl Drop for EnvGuard { fn drop(&mut self) { match &self.previous { Some(v) => env::set_var(self.key, v), None => env::remove_var(self.key) } } }
+pub struct EnvGuard {
+    key: &'static str,
+    previous: Option<String>,
+}
+
+impl EnvGuard {
+    pub fn set(key: &'static str, value: Option<&str>) -> Self {
+        let previous = env::var(key).ok();
+
+        match value {
+            Some(v) => unsafe { env::set_var(key, v) },
+            None => unsafe { env::remove_var(key) },
+        };
+
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        match &self.previous {
+            Some(v) => unsafe { env::set_var(self.key, v) },
+            None => unsafe { env::remove_var(self.key) },
+        }
+    }
+}


### PR DESCRIPTION
## 概要
- backend 配下の `#[rustfmt::skip]` を全削除し、圧縮されていたテストコードと test helper を `cargo fmt` 準拠の可読スタイルへ展開
- 指定対象に加えて `backend/src/main.rs` に残っていた `#[rustfmt::skip]` も除去
- `backend/src/handlers/stock/tests.rs` と `backend/src/test_env.rs` は手で読みやすい構造に整形

## 確認
- [x] `cd backend && cargo fmt --check`
- [x] `cd backend && cargo clippy --all-targets -- -D warnings`
- [x] `cd backend && cargo test --lib`

## 補足
- 既存の ignored test はそのまま維持
- push 時の openapi / api.ts 再生成チェックでも差分なしを確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

この週のリリースには、ユーザー向けの新機能やバグ修正はありません。このリリースは、内部コードの品質向上と保守性の改善に焦点を当てています。

* **Tests**
  * テストモジュールのコード形式とレイアウトを改善。テストの機能と動作に変更なし。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->