### PR TITLE
test: receipt コンポーネントの単体テストを追加

### DIFF
--- a/frontend/src/features/receipt/components/__tests__/ReceiptsAlerts.test.tsx
+++ b/frontend/src/features/receipt/components/__tests__/ReceiptsAlerts.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ReceiptsAlerts } from '../ReceiptsAlerts';
+
+const csvPreview = {
+  totalRows: 4,
+  validRows: 3,
+  errors: [{ row: 2, message: '金額が不正です' }],
+  rows: [],
+};
+
+describe('ReceiptsAlerts', () => {
+  it('dbError があればエラーアラートが表示される', () => {
+    render(
+      <ReceiptsAlerts
+        dbError="DB からの取得に失敗しました"
+        hasCsvFile={false}
+        previewing={false}
+        csvPreview={null}
+      />
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent('エラー:');
+    expect(screen.getByRole('alert')).toHaveTextContent('DB からの取得に失敗しました');
+  });
+
+  it('CSV プレビュー条件を満たせばプレビュー情報が表示される', () => {
+    render(
+      <ReceiptsAlerts
+        dbError={null}
+        hasCsvFile
+        previewing={false}
+        csvPreview={{ ...csvPreview, errors: [] }}
+      />
+    );
+
+    expect(screen.getByRole('status')).toHaveTextContent('3件 追加で保存されます');
+    expect(screen.getByRole('status')).toHaveTextContent('（保存モード: 追加）');
+  });
+
+  it('エラー行がある場合はエラーリストが表示される', () => {
+    render(
+      <ReceiptsAlerts
+        dbError={null}
+        hasCsvFile
+        previewing={false}
+        csvPreview={csvPreview}
+      />
+    );
+
+    expect(screen.getByText('2行目: 金額が不正です')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveTextContent('1件エラー');
+  });
+
+  it('条件が満たされない場合は何も表示しない', () => {
+    const { container } = render(
+      <ReceiptsAlerts
+        dbError={null}
+        hasCsvFile={false}
+        previewing={false}
+        csvPreview={null}
+      />
+    );
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/src/features/receipt/components/__tests__/ReceiptsTabNav.test.tsx
+++ b/frontend/src/features/receipt/components/__tests__/ReceiptsTabNav.test.tsx
@@ -1,0 +1,68 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { createRef } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { ReceiptsTabNav } from '../ReceiptsTabNav';
+
+describe('ReceiptsTabNav', () => {
+  const counts = {
+    dividend: 3,
+    domesticstock: 5,
+    mutualfund: 2,
+  };
+
+  it('タブが3つ表示され、アクティブタブに aria-selected=true が設定される', () => {
+    render(
+      <ReceiptsTabNav
+        receiptsType="domesticstock"
+        tablistRef={createRef<HTMLDivElement>()}
+        onTabChange={vi.fn()}
+        onKeyDown={vi.fn()}
+        counts={counts}
+      />
+    );
+
+    const tabs = screen.getAllByRole('tab');
+
+    expect(tabs).toHaveLength(3);
+    expect(screen.getByRole('tab', { name: /配当金/ })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /国内株式/ })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tab', { name: /投資信託/ })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /配当金/ })).toHaveAttribute('aria-selected', 'false');
+    expect(screen.getByRole('tab', { name: /投資信託/ })).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('各タブに件数バッジが表示される', () => {
+    render(
+      <ReceiptsTabNav
+        receiptsType="dividend"
+        tablistRef={createRef<HTMLDivElement>()}
+        onTabChange={vi.fn()}
+        onKeyDown={vi.fn()}
+        counts={counts}
+      />
+    );
+
+    expect(screen.getByTestId('tab-count-dividend')).toHaveTextContent('3');
+    expect(screen.getByTestId('tab-count-domesticstock')).toHaveTextContent('5');
+    expect(screen.getByTestId('tab-count-mutualfund')).toHaveTextContent('2');
+  });
+
+  it('タブクリックで onTabChange コールバックが呼ばれる', () => {
+    const onTabChange = vi.fn();
+
+    render(
+      <ReceiptsTabNav
+        receiptsType="dividend"
+        tablistRef={createRef<HTMLDivElement>()}
+        onTabChange={onTabChange}
+        onKeyDown={vi.fn()}
+        counts={counts}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: /投資信託/ }));
+
+    expect(onTabChange).toHaveBeenCalledWith('mutualfund');
+    expect(onTabChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/features/receipt/components/__tests__/ReceiptsUtilityRail.test.tsx
+++ b/frontend/src/features/receipt/components/__tests__/ReceiptsUtilityRail.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ReceiptsUtilityRail } from '../ReceiptsUtilityRail';
+
+vi.mock('@/components/organisms/DataActionRail/DataActionRail', () => ({
+  DataActionRail: ({ saveLabel }: { saveLabel: string }) => (
+    <div data-testid="data-action-rail">{saveLabel}</div>
+  ),
+}));
+
+const actionRailProps = {
+  onFileSelect: vi.fn(),
+  selectedFileName: 'receipts.csv',
+  fileInputDisabled: false,
+  hasCsvFile: true,
+  saveLabel: '3件 追加で保存',
+  onSave: vi.fn(),
+  saveDisabled: false,
+  hasDbData: true,
+  deleteLabel: '全件削除 (3件)',
+  onDeleteRequest: vi.fn(),
+  deleteDisabled: false,
+  saveResult: null,
+  saveModeLabel: '追加',
+};
+
+const alertsProps = {
+  dbError: null,
+  hasCsvFile: false,
+  previewing: false,
+  csvPreview: null,
+};
+
+describe('ReceiptsUtilityRail', () => {
+  it('DataActionRail が描画される', () => {
+    render(
+      <ReceiptsUtilityRail
+        actionRailProps={actionRailProps}
+        alertsProps={alertsProps}
+        authLoading={false}
+        dbLoading={false}
+      />
+    );
+
+    expect(screen.getByTestId('data-action-rail')).toHaveTextContent('3件 追加で保存');
+  });
+
+  it('authLoading=true のとき Spinner と認証確認メッセージが表示される', () => {
+    render(
+      <ReceiptsUtilityRail
+        actionRailProps={actionRailProps}
+        alertsProps={alertsProps}
+        authLoading
+        dbLoading={false}
+      />
+    );
+
+    expect(screen.getByLabelText('読み込み中...')).toBeInTheDocument();
+    expect(screen.getByText('認証状態を確認しています...')).toBeInTheDocument();
+  });
+
+  it('dbLoading=true のときデータ読み込みメッセージが表示される', () => {
+    render(
+      <ReceiptsUtilityRail
+        actionRailProps={actionRailProps}
+        alertsProps={alertsProps}
+        authLoading={false}
+        dbLoading
+      />
+    );
+
+    expect(screen.getByText('データを読み込んでいます...')).toBeInTheDocument();
+    expect(screen.getByLabelText('読み込み中...')).toBeInTheDocument();
+  });
+
+  it('authLoading=false かつ dbLoading=false のとき Spinner は表示されない', () => {
+    render(
+      <ReceiptsUtilityRail
+        actionRailProps={actionRailProps}
+        alertsProps={alertsProps}
+        authLoading={false}
+        dbLoading={false}
+      />
+    );
+
+    expect(screen.queryByLabelText('読み込み中...')).not.toBeInTheDocument();
+    expect(screen.queryByText('認証状態を確認しています...')).not.toBeInTheDocument();
+    expect(screen.queryByText('データを読み込んでいます...')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
receipt 関連コンポーネント 3 件の単体テストを追加しました。

- `ReceiptsTabNav` のタブ表示、`aria-selected`、件数バッジ、`onTabChange` を検証
- `ReceiptsAlerts` のエラー表示、CSV プレビュー表示、エラー行リスト、非表示条件を検証
- `ReceiptsUtilityRail` の `DataActionRail` モック描画、ローディング文言、Spinner 非表示条件を検証

## テスト
- `cd frontend && vp lint`
- `cd frontend && npx tsc --noEmit`
- `cd frontend && npm test -- --run`
- `cd frontend && vp build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * 領収書機能のUIコンポーネントに対する包括的なテストスイートを追加しました。アラート表示、タブナビゲーション、ローディング状態の条件付き描画動作を検証します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->