### PR TITLE
test: useIdleTimer の単体テストを追加

### DIFF
--- a/frontend/src/features/auth/hooks/__tests__/useIdleTimer.test.ts
+++ b/frontend/src/features/auth/hooks/__tests__/useIdleTimer.test.ts
@@ -1,0 +1,105 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useIdleTimer } from '../useIdleTimer';
+
+describe('useIdleTimer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('enabled=true のとき timeout 経過後に onIdle を呼ぶ', () => {
+    const onIdle = vi.fn();
+
+    renderHook(() => useIdleTimer({ timeout: 1000, onIdle, enabled: true }));
+
+    act(() => {
+      vi.advanceTimersByTime(999);
+    });
+    expect(onIdle).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(onIdle).toHaveBeenCalledTimes(1);
+  });
+
+  it('enabled=false のとき onIdle を呼ばない', () => {
+    const onIdle = vi.fn();
+
+    renderHook(() => useIdleTimer({ timeout: 1000, onIdle, enabled: false }));
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(onIdle).not.toHaveBeenCalled();
+  });
+
+  it('mousedown でタイマーがリセットされ、その後に再度 timeout 経過で onIdle を呼ぶ', () => {
+    const onIdle = vi.fn();
+
+    renderHook(() => useIdleTimer({ timeout: 1000, onIdle }));
+
+    act(() => {
+      vi.advanceTimersByTime(800);
+    });
+    expect(onIdle).not.toHaveBeenCalled();
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mousedown'));
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(800);
+    });
+    expect(onIdle).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(onIdle).toHaveBeenCalledTimes(1);
+  });
+
+  it('アンマウント時にイベントリスナーを解除する', () => {
+    const addEventListenerSpy = vi.spyOn(document, 'addEventListener');
+    const removeEventListenerSpy = vi.spyOn(document, 'removeEventListener');
+    const onIdle = vi.fn();
+    const expectedEvents = [
+      'mousedown',
+      'mousemove',
+      'keydown',
+      'scroll',
+      'touchstart',
+      'click',
+    ] as const;
+
+    const { unmount } = renderHook(() => useIdleTimer({ timeout: 1000, onIdle }));
+
+    expectedEvents.forEach((eventName) => {
+      expect(addEventListenerSpy).toHaveBeenCalledWith(
+        eventName,
+        expect.any(Function),
+        { passive: true }
+      );
+    });
+
+    const handlers = new Map(
+      addEventListenerSpy.mock.calls
+        .filter(([eventName]) => expectedEvents.includes(eventName as (typeof expectedEvents)[number]))
+        .map(([eventName, handler]) => [eventName, handler])
+    );
+
+    unmount();
+
+    expectedEvents.forEach((eventName) => {
+      expect(removeEventListenerSpy).toHaveBeenCalledWith(eventName, handlers.get(eventName));
+    });
+  });
+});


### PR DESCRIPTION
## 概要
`frontend/src/features/auth/hooks/useIdleTimer.ts` の単体テストを追加しました。

## 変更内容
- `enabled=true` かつ `timeout` 経過後に `onIdle` が呼ばれることを確認
- `enabled=false` のとき `onIdle` が呼ばれないことを確認
- `mousedown` イベントでタイマーがリセットされ、再度 `timeout` 経過後に `onIdle` が呼ばれることを確認
- `document.addEventListener` / `document.removeEventListener` をスパイし、アンマウント時のイベントリスナー解除を確認

## テスト
- `cd frontend && vp lint`
- `cd frontend && npx tsc --noEmit`
- `cd frontend && npm test -- --run`
- `cd frontend && vp build`