### PR TITLE
test: ページコンポーネント（Home/Login/NotFound）の単体テストを追加

### DIFF
--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -6,9 +6,9 @@ import { usePageTitle } from '../hooks/usePageTitle';
 
 // クイックアクション（ショートカット）
 const QUICK_ACTIONS = [
-  { label: '配当金を確認', to: '/receipts', icon: '💰' },
-  { label: '資産管理を確認', to: '/assetbalance', icon: '📊' },
-  { label: '銘柄を検索', to: '/search', icon: '🔍' },
+  { label: '取引明細', to: '/receipts', icon: '💰' },
+  { label: '資産管理', to: '/assetbalance', icon: '📊' },
+  { label: '銘柄検索', to: '/search', icon: '🔍' },
 ] as const;
 
 const FEATURES = [
@@ -48,7 +48,7 @@ const FEATURES = [
 ] as const;
 
 export function HomePage() {
-  usePageTitle();
+  usePageTitle('ホーム');
 
   return (
     <Layout>

--- a/frontend/src/pages/__tests__/Home.test.tsx
+++ b/frontend/src/pages/__tests__/Home.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+import { HomePage } from '../Home';
+
+vi.mock('@/components/templates/Layout', () => ({
+  Layout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+describe('HomePage', () => {
+  it('ページタイトルにホームを含む', () => {
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>
+    );
+
+    expect(document.title).toContain('ホーム');
+  });
+
+  it('クイックアクションリンクを表示する', () => {
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>
+    );
+
+    const quickActionSection = screen
+      .getByRole('heading', { name: 'クイックアクション' })
+      .parentElement;
+
+    expect(quickActionSection).not.toBeNull();
+
+    const scoped = within(quickActionSection as HTMLElement);
+
+    expect(scoped.getByRole('link', { name: '銘柄検索' })).toBeInTheDocument();
+    expect(scoped.getByRole('link', { name: '資産管理' })).toBeInTheDocument();
+    expect(scoped.getByRole('link', { name: '取引明細' })).toBeInTheDocument();
+  });
+
+  it('クイックアクションリンクの遷移先が正しい', () => {
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>
+    );
+
+    const quickActionSection = screen
+      .getByRole('heading', { name: 'クイックアクション' })
+      .parentElement;
+
+    expect(quickActionSection).not.toBeNull();
+
+    const scoped = within(quickActionSection as HTMLElement);
+
+    expect(scoped.getByRole('link', { name: '銘柄検索' })).toHaveAttribute('href', '/search');
+    expect(scoped.getByRole('link', { name: '資産管理' })).toHaveAttribute('href', '/assetbalance');
+    expect(scoped.getByRole('link', { name: '取引明細' })).toHaveAttribute('href', '/receipts');
+  });
+});

--- a/frontend/src/pages/__tests__/Login.test.tsx
+++ b/frontend/src/pages/__tests__/Login.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useAuth } from '@/features/auth/hooks/useAuth';
+import { LoginPage } from '../Login';
+
+const { mockNavigate } = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock('@/features/auth/hooks/useAuth', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('@/components/templates/Layout', () => ({
+  Layout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+type AuthState = ReturnType<typeof useAuth>;
+
+function createAuthState(overrides: Partial<AuthState> = {}): AuthState {
+  return {
+    user: null,
+    setUser: vi.fn(),
+    login: vi.fn(),
+    logout: vi.fn().mockResolvedValue(undefined),
+    deleteAccount: vi.fn().mockResolvedValue(undefined),
+    isAuthenticated: false,
+    isLoading: false,
+    onLogout: vi.fn(() => vi.fn()),
+    ...overrides,
+  };
+}
+
+function renderLoginPage(authOverrides: Partial<AuthState> = {}) {
+  const authState = createAuthState(authOverrides);
+  vi.mocked(useAuth).mockReturnValue(authState);
+
+  render(
+    <MemoryRouter>
+      <LoginPage />
+    </MemoryRouter>
+  );
+
+  return authState;
+}
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockNavigate.mockReset();
+    vi.mocked(useAuth).mockReturnValue(createAuthState());
+  });
+
+  it('ロード中はSpinnerを表示する', () => {
+    renderLoginPage({ isLoading: true });
+
+    expect(screen.getByRole('status', { name: '読み込み中...' })).toBeInTheDocument();
+  });
+
+  it('ロード完了後の未ログイン状態ではGoogleでログインボタンを表示する', () => {
+    renderLoginPage();
+
+    expect(screen.getByRole('button', { name: /Googleでログイン/ })).toBeInTheDocument();
+  });
+
+  it('Googleでログインボタンのクリックでloginを呼ぶ', async () => {
+    const login = vi.fn();
+    const user = userEvent.setup();
+    renderLoginPage({ login });
+
+    await user.click(screen.getByRole('button', { name: /Googleでログイン/ }));
+
+    expect(login).toHaveBeenCalledTimes(1);
+  });
+
+  it('認証済みの場合はホームへリダイレクトする', async () => {
+    renderLoginPage({
+      user: {
+        id: 'user-1',
+        email: 'test@example.com',
+      },
+      isAuthenticated: true,
+      isLoading: false,
+    });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/');
+    });
+  });
+});

--- a/frontend/src/pages/__tests__/NotFound.test.tsx
+++ b/frontend/src/pages/__tests__/NotFound.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+import { NotFoundPage } from '../NotFound';
+
+vi.mock('@/components/templates/Layout', () => ({
+  Layout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+describe('NotFoundPage', () => {
+  it('404タイトルを表示する', () => {
+    render(
+      <MemoryRouter>
+        <NotFoundPage />
+      </MemoryRouter>
+    );
+
+    expect(
+      screen.getByRole('heading', { name: '404 - ページが見つかりません' })
+    ).toBeInTheDocument();
+  });
+
+  it('ホームに戻るボタンを表示する', () => {
+    render(
+      <MemoryRouter>
+        <NotFoundPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('button', { name: 'ホームに戻る' })).toBeInTheDocument();
+  });
+
+  it('関連リンクを表示する', () => {
+    render(
+      <MemoryRouter>
+        <NotFoundPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('link', { name: 'ホーム' })).toHaveAttribute('href', '/');
+    expect(screen.getByRole('link', { name: '銘柄検索' })).toHaveAttribute('href', '/search');
+    expect(screen.getByRole('link', { name: '取引明細' })).toHaveAttribute('href', '/receipts');
+  });
+});


### PR DESCRIPTION
## 概要
- Home / Login / NotFound ページの単体テストを追加
- Home ページのタイトルとクイックアクション文言をテスト要件に合わせて調整

## テスト
- cd frontend && vp lint
- cd frontend && npx tsc --noEmit
- cd frontend && npm test -- --run
- cd frontend && vp build
