### PR TITLE
test: useResize フックと receiptQueryKeys のユニットテストを追加

### DIFF
--- a/frontend/src/features/receipt/__tests__/queryKeys.test.ts
+++ b/frontend/src/features/receipt/__tests__/queryKeys.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { QueryClient } from '@tanstack/react-query';
+import { receiptQueryKeys, clearReceiptsCache } from '../queryKeys';
+
+describe('receiptQueryKeys', () => {
+  it('prefix が ["receipts"] である', () => {
+    expect(receiptQueryKeys.prefix).toEqual(['receipts']);
+  });
+
+  it('dividend("user-1") が ["receipts", "user-1", "dividend"] を返す', () => {
+    expect(receiptQueryKeys.dividend('user-1')).toEqual(['receipts', 'user-1', 'dividend']);
+  });
+
+  it('domesticstock("user-1") が ["receipts", "user-1", "domesticstock"] を返す', () => {
+    expect(receiptQueryKeys.domesticstock('user-1')).toEqual([
+      'receipts',
+      'user-1',
+      'domesticstock',
+    ]);
+  });
+
+  it('mutualfund("user-1") が ["receipts", "user-1", "mutualfund"] を返す', () => {
+    expect(receiptQueryKeys.mutualfund('user-1')).toEqual(['receipts', 'user-1', 'mutualfund']);
+  });
+});
+
+describe('clearReceiptsCache', () => {
+  it('cancelQueries と removeQueries がプレフィックスキーで呼ばれる', () => {
+    const mockQueryClient = {
+      cancelQueries: vi.fn(),
+      removeQueries: vi.fn(),
+    } as unknown as QueryClient;
+
+    clearReceiptsCache(mockQueryClient);
+
+    expect(mockQueryClient.cancelQueries).toHaveBeenCalledWith({
+      queryKey: receiptQueryKeys.prefix,
+    });
+    expect(mockQueryClient.removeQueries).toHaveBeenCalledWith({
+      queryKey: receiptQueryKeys.prefix,
+    });
+  });
+});

--- a/frontend/src/hooks/common/__tests__/useResize.test.tsx
+++ b/frontend/src/hooks/common/__tests__/useResize.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import React from 'react';
+import { ResizeContext } from '@/contexts/ResizeContextDefinition';
+import { useForceResize, useTriggerResize } from '../useResize';
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ResizeContext.Provider value={{ forceResize: 1, triggerResize: vi.fn() }}>
+    {children}
+  </ResizeContext.Provider>
+);
+
+describe('useForceResize', () => {
+  it('Provider外ではundefinedを返す', () => {
+    const { result } = renderHook(() => useForceResize());
+    expect(result.current).toBeUndefined();
+  });
+
+  it('Provider内ではcontextのforceResize値を返す', () => {
+    const { result } = renderHook(() => useForceResize(), { wrapper });
+    expect(result.current).toBe(1);
+  });
+});
+
+describe('useTriggerResize', () => {
+  it('Provider外ではundefinedを返す', () => {
+    const { result } = renderHook(() => useTriggerResize());
+    expect(result.current).toBeUndefined();
+  });
+
+  it('Provider内ではcontextのtriggerResize関数を返す', () => {
+    const { result } = renderHook(() => useTriggerResize(), { wrapper });
+    expect(typeof result.current).toBe('function');
+  });
+});


### PR DESCRIPTION
## 概要

未テストだった2ファイルにユニットテストを追加。

- `useForceResize` / `useTriggerResize`: Provider外（undefined）とProvider内（値返却）の動作検証
- `receiptQueryKeys`: prefix・各キー生成関数の返却値、`clearReceiptsCache` の QueryClient 呼び出し検証

## テスト結果

- `vp lint`: 0 errors
- `npx tsc --noEmit`: pass
- `npm test`: 802 passed (93 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * レシート機能のクエリキー関連テストスイートを追加
  * リサイズフック機能のテストスイートを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->