### PR TITLE
test: config/environment.rs のユニットテストを追加

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -408,6 +408,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
+ "temp-env",
  "testcontainers",
  "testcontainers-modules",
  "thiserror 2.0.18",
@@ -4063,6 +4064,15 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "parking_lot",
+]
 
 [[package]]
 name = "tempfile"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -45,3 +45,4 @@ tokio-test = "0.4.5"
 testcontainers = "0.27.2"
 testcontainers-modules = { version = "0.15.0", features = ["postgres"] }
 wiremock = "0.6"
+temp-env = "0.3"

--- a/backend/src/config/environment.rs
+++ b/backend/src/config/environment.rs
@@ -48,3 +48,212 @@ pub fn csv_rate_limit_rps() -> u32 {
         .and_then(|v| v.parse().ok())
         .unwrap_or(2)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use temp_env::with_vars;
+
+    // --- is_production_env ---
+
+    #[test]
+    fn test_is_production_env_rust_env() {
+        with_vars(
+            [
+                ("RUST_ENV", Some("production")),
+                ("APP_ENV", None::<&str>),
+                ("BACKEND_URL", None::<&str>),
+            ],
+            || {
+                assert!(is_production_env());
+            },
+        );
+    }
+
+    #[test]
+    fn test_is_production_env_app_env() {
+        with_vars(
+            [
+                ("RUST_ENV", None::<&str>),
+                ("APP_ENV", Some("production")),
+                ("BACKEND_URL", None::<&str>),
+            ],
+            || {
+                assert!(is_production_env());
+            },
+        );
+    }
+
+    #[test]
+    fn test_is_production_env_backend_url_https() {
+        with_vars(
+            [
+                ("RUST_ENV", None::<&str>),
+                ("APP_ENV", None::<&str>),
+                ("BACKEND_URL", Some("https://api.example.com")),
+            ],
+            || {
+                assert!(is_production_env());
+            },
+        );
+    }
+
+    #[test]
+    fn test_is_production_env_backend_url_http() {
+        with_vars(
+            [
+                ("RUST_ENV", None::<&str>),
+                ("APP_ENV", None::<&str>),
+                ("BACKEND_URL", Some("http://api.example.com")),
+            ],
+            || {
+                assert!(!is_production_env());
+            },
+        );
+    }
+
+    #[test]
+    fn test_is_production_env_none() {
+        with_vars(
+            [
+                ("RUST_ENV", None::<&str>),
+                ("APP_ENV", None::<&str>),
+                ("BACKEND_URL", None::<&str>),
+            ],
+            || {
+                assert!(!is_production_env());
+            },
+        );
+    }
+
+    // --- backend_url ---
+
+    #[test]
+    fn test_backend_url_explicit() {
+        with_vars(
+            [
+                ("BACKEND_URL", Some("https://api.example.com")),
+                ("PORT", None::<&str>),
+            ],
+            || {
+                assert_eq!(backend_url(), "https://api.example.com");
+            },
+        );
+    }
+
+    #[test]
+    fn test_backend_url_port() {
+        with_vars(
+            [("BACKEND_URL", None::<&str>), ("PORT", Some("8080"))],
+            || {
+                assert_eq!(backend_url(), "http://localhost:8080");
+            },
+        );
+    }
+
+    #[test]
+    fn test_backend_url_default() {
+        with_vars(
+            [("BACKEND_URL", None::<&str>), ("PORT", None::<&str>)],
+            || {
+                assert_eq!(backend_url(), "http://localhost:3001");
+            },
+        );
+    }
+
+    // --- server_addr ---
+
+    #[test]
+    fn test_server_addr_port() {
+        with_vars([("PORT", Some("9000"))], || {
+            assert_eq!(server_addr(), "0.0.0.0:9000");
+        });
+    }
+
+    #[test]
+    fn test_server_addr_default() {
+        with_vars([("PORT", None::<&str>)], || {
+            assert_eq!(server_addr(), "0.0.0.0:3001");
+        });
+    }
+
+    // --- is_secure_cookie ---
+
+    #[test]
+    fn test_is_secure_cookie_true() {
+        with_vars(
+            [
+                ("SECURE_COOKIE", Some("true")),
+                ("BACKEND_URL", None::<&str>),
+            ],
+            || {
+                assert!(is_secure_cookie());
+            },
+        );
+    }
+
+    #[test]
+    fn test_is_secure_cookie_one() {
+        with_vars(
+            [("SECURE_COOKIE", Some("1")), ("BACKEND_URL", None::<&str>)],
+            || {
+                assert!(is_secure_cookie());
+            },
+        );
+    }
+
+    #[test]
+    fn test_is_secure_cookie_false() {
+        with_vars(
+            [
+                ("SECURE_COOKIE", Some("false")),
+                ("BACKEND_URL", None::<&str>),
+            ],
+            || {
+                assert!(!is_secure_cookie());
+            },
+        );
+    }
+
+    #[test]
+    fn test_is_secure_cookie_backend_url_https() {
+        with_vars(
+            [
+                ("SECURE_COOKIE", None::<&str>),
+                ("BACKEND_URL", Some("https://api.example.com")),
+            ],
+            || {
+                assert!(is_secure_cookie());
+            },
+        );
+    }
+
+    #[test]
+    fn test_is_secure_cookie_none() {
+        with_vars(
+            [
+                ("SECURE_COOKIE", None::<&str>),
+                ("BACKEND_URL", None::<&str>),
+            ],
+            || {
+                assert!(!is_secure_cookie());
+            },
+        );
+    }
+
+    // --- csv_rate_limit_rps ---
+
+    #[test]
+    fn test_csv_rate_limit_rps_explicit() {
+        with_vars([("CSV_RATE_LIMIT_RPS", Some("5"))], || {
+            assert_eq!(csv_rate_limit_rps(), 5);
+        });
+    }
+
+    #[test]
+    fn test_csv_rate_limit_rps_default() {
+        with_vars([("CSV_RATE_LIMIT_RPS", None::<&str>)], || {
+            assert_eq!(csv_rate_limit_rps(), 2);
+        });
+    }
+}


### PR DESCRIPTION
## 概要

`backend/src/config/environment.rs` の5つの環境変数読み取り関数にユニットテストを追加。

`temp-env` クレートを dev-dependency に追加し、各テストで安全に環境変数を設定・クリアする。

## テスト対象

- `is_production_env`: RUST_ENV / APP_ENV / BACKEND_URL の各ケース（5テスト）
- `backend_url`: 明示指定 / PORT指定 / デフォルト（3テスト）
- `server_addr`: PORT指定 / デフォルト（2テスト）
- `is_secure_cookie`: SECURE_COOKIE / BACKEND_URL の各ケース（5テスト）
- `csv_rate_limit_rps`: 明示指定 / デフォルト（2テスト）

## テスト結果

- `cargo fmt --check`: pass
- `cargo clippy --all-targets -- -D warnings`: pass
- `cargo test`: 69 passed (17 新規)

🤖 Generated with [Claude Code](https://claude.com/claude-code)