### PR TITLE
test: assetBalance の queryKeys ユニットテストを追加

### DIFF
--- a/frontend/src/features/assetBalance/__tests__/queryKeys.test.ts
+++ b/frontend/src/features/assetBalance/__tests__/queryKeys.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { QueryClient } from '@tanstack/react-query';
+import { assetBalanceQueryKeys, clearAssetBalanceCache } from '../queryKeys';
+
+describe('assetBalanceQueryKeys', () => {
+  it('prefix が ["assetBalance"] である', () => {
+    expect(assetBalanceQueryKeys.prefix).toEqual(['assetBalance']);
+  });
+
+  it('all("user-1") が ["assetBalance", "user-1"] を返す', () => {
+    expect(assetBalanceQueryKeys.all('user-1')).toEqual(['assetBalance', 'user-1']);
+  });
+
+  it('all("user-2") が ["assetBalance", "user-2"] を返す', () => {
+    expect(assetBalanceQueryKeys.all('user-2')).toEqual(['assetBalance', 'user-2']);
+  });
+});
+
+describe('clearAssetBalanceCache', () => {
+  it('cancelQueries と removeQueries がプレフィックスキーで呼ばれる', () => {
+    const mockQueryClient = {
+      cancelQueries: vi.fn(),
+      removeQueries: vi.fn(),
+    } as unknown as QueryClient;
+
+    clearAssetBalanceCache(mockQueryClient);
+
+    expect(mockQueryClient.cancelQueries).toHaveBeenCalledWith({
+      queryKey: assetBalanceQueryKeys.prefix,
+    });
+    expect(mockQueryClient.removeQueries).toHaveBeenCalledWith({
+      queryKey: assetBalanceQueryKeys.prefix,
+    });
+  });
+});


### PR DESCRIPTION
## 変更内容

`assetBalance/queryKeys.ts` のユニットテストを追加する。

同様の実装を持つ `receipt/queryKeys` のテスト（#412）と同じパターンで、
`assetBalanceQueryKeys` のキー形状と `clearAssetBalanceCache` の呼び出しを検証する。

## テスト結果

- テストファイル: `src/features/assetBalance/__tests__/queryKeys.test.ts`
- テスト数: 4件（すべてパス）

## チェックリスト

- [x] `npm test` パス

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * アセットバランスのクエリ機能に対するテストカバレッジを追加しました。キーの検証とキャッシュクリア機能の動作を確認するテストが実装されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->