### PR TITLE
test: モデルバリデーションの失敗ケースにユニットテストを追加

### DIFF
--- a/backend/src/models/asset_balance.rs
+++ b/backend/src/models/asset_balance.rs
@@ -69,9 +69,9 @@ pub struct BulkCreateAssetBalanceRequest {
 #[cfg(test)]
 mod tests {
     use {super::*, rust_decimal_macros::dec};
-    #[test]
-    fn test_create_asset_balance_request_validation() {
-        assert!(CreateAssetBalanceRequest {
+
+    fn base() -> CreateAssetBalanceRequest {
+        CreateAssetBalanceRequest {
             security_code: "1234".to_string(),
             security_name: "テスト株式会社".to_string(),
             shares: dec!(100),
@@ -81,7 +81,49 @@ mod tests {
             current_price: dec!(1600),
             daily_change: dec!(10),
             market_value: dec!(160000),
-            profit_loss_rate: dec!(6.67)
+            profit_loss_rate: dec!(6.67),
+        }
+    }
+
+    #[test]
+    fn test_create_asset_balance_request_validation() {
+        assert!(base().validate().is_ok());
+
+        // security_code は max=10 のため 11 文字は NG
+        assert!(CreateAssetBalanceRequest {
+            security_code: "12345678901".to_string(),
+            ..base()
+        }
+        .validate()
+        .is_err());
+
+        // security_code は min=1 のため空文字は NG
+        assert!(CreateAssetBalanceRequest {
+            security_code: String::new(),
+            ..base()
+        }
+        .validate()
+        .is_err());
+
+        // security_name は min=1 のため空文字は NG
+        assert!(CreateAssetBalanceRequest {
+            security_name: String::new(),
+            ..base()
+        }
+        .validate()
+        .is_err());
+    }
+
+    #[test]
+    fn test_bulk_create_asset_balance_request_validation() {
+        // items が空の場合は NG（min=1）
+        assert!(BulkCreateAssetBalanceRequest { items: vec![] }
+            .validate()
+            .is_err());
+
+        // items が 1 件以上なら OK
+        assert!(BulkCreateAssetBalanceRequest {
+            items: vec![base()]
         }
         .validate()
         .is_ok());

--- a/backend/src/models/dividend.rs
+++ b/backend/src/models/dividend.rs
@@ -58,9 +58,8 @@ pub struct CreateDividendRequest {
 #[cfg(test)]
 mod tests {
     use {super::*, rust_decimal_macros::dec};
-    #[test]
-    fn test_create_dividend_request_validation() {
-        assert!(CreateDividendRequest {
+    fn base() -> CreateDividendRequest {
+        CreateDividendRequest {
             settlement_date: NaiveDate::from_ymd_opt(2024, 1, 15).expect("有効な日付 2024-01-15"),
             product: "国内株式".to_string(),
             account: "特定".to_string(),
@@ -70,7 +69,50 @@ mod tests {
             shares: dec!(100),
             dividends_before_tax: dec!(1000),
             taxes: dec!(200),
-            net_amount_received: dec!(800)
+            net_amount_received: dec!(800),
+        }
+    }
+
+    #[test]
+    fn test_create_dividend_request_validation() {
+        assert!(base().validate().is_ok());
+
+        // security_code は max=10 のため 11 文字は NG
+        assert!(CreateDividendRequest {
+            security_code: "12345678901".to_string(),
+            ..base()
+        }
+        .validate()
+        .is_err());
+
+        // product は min=1 のため空文字は NG
+        assert!(CreateDividendRequest {
+            product: String::new(),
+            ..base()
+        }
+        .validate()
+        .is_err());
+
+        // account は min=1 のため空文字は NG
+        assert!(CreateDividendRequest {
+            account: String::new(),
+            ..base()
+        }
+        .validate()
+        .is_err());
+
+        // security_name は min=1 のため空文字は NG
+        assert!(CreateDividendRequest {
+            security_name: String::new(),
+            ..base()
+        }
+        .validate()
+        .is_err());
+
+        // security_code は空文字でも OK（max=10 のみ）
+        assert!(CreateDividendRequest {
+            security_code: String::new(),
+            ..base()
         }
         .validate()
         .is_ok());

--- a/backend/src/models/domestic_stock.rs
+++ b/backend/src/models/domestic_stock.rs
@@ -65,9 +65,9 @@ pub struct CreateDomesticStockRequest {
 #[cfg(test)]
 mod tests {
     use {super::*, rust_decimal_macros::dec};
-    #[test]
-    fn test_create_domestic_stock_request_validation() {
-        assert!(CreateDomesticStockRequest {
+
+    fn base() -> CreateDomesticStockRequest {
+        CreateDomesticStockRequest {
             trade_date: NaiveDate::from_ymd_opt(2024, 1, 15).expect("有効な日付 2024-01-15"),
             settlement_date: NaiveDate::from_ymd_opt(2024, 1, 17).expect("有効な日付 2024-01-17"),
             security_code: "1234".to_string(),
@@ -79,9 +79,36 @@ mod tests {
             purchase_price: dec!(1400),
             realized_profit_and_loss: dec!(10000),
             taxes: dec!(2000),
-            realized_profit_and_loss_after_tax: dec!(8000)
+            realized_profit_and_loss_after_tax: dec!(8000),
+        }
+    }
+
+    #[test]
+    fn test_create_domestic_stock_request_validation() {
+        assert!(base().validate().is_ok());
+
+        // security_code は max=10 のため 11 文字は NG
+        assert!(CreateDomesticStockRequest {
+            security_code: "12345678901".to_string(),
+            ..base()
         }
         .validate()
-        .is_ok());
+        .is_err());
+
+        // security_name は min=1 のため空文字は NG
+        assert!(CreateDomesticStockRequest {
+            security_name: String::new(),
+            ..base()
+        }
+        .validate()
+        .is_err());
+
+        // account は min=1 のため空文字は NG
+        assert!(CreateDomesticStockRequest {
+            account: String::new(),
+            ..base()
+        }
+        .validate()
+        .is_err());
     }
 }

--- a/backend/src/models/mutualfund.rs
+++ b/backend/src/models/mutualfund.rs
@@ -69,9 +69,9 @@ pub struct CreateMutualfundRequest {
 #[cfg(test)]
 mod tests {
     use {super::*, rust_decimal_macros::dec};
-    #[test]
-    fn test_create_mutualfund_request_validation() {
-        assert!(CreateMutualfundRequest {
+
+    fn base() -> CreateMutualfundRequest {
+        CreateMutualfundRequest {
             trade_date: NaiveDate::from_ymd_opt(2024, 1, 15).expect("有効な日付 2024-01-15"),
             settlement_date: NaiveDate::from_ymd_opt(2024, 1, 19).expect("有効な日付 2024-01-19"),
             fund_name: "テストファンド".to_string(),
@@ -84,7 +84,42 @@ mod tests {
             average_acquisition_price_yen: dec!(14000),
             realized_profit_and_loss: dec!(10000),
             taxes: dec!(2000),
-            realized_profit_and_loss_after_tax: dec!(8000)
+            realized_profit_and_loss_after_tax: dec!(8000),
+        }
+    }
+
+    #[test]
+    fn test_create_mutualfund_request_validation() {
+        assert!(base().validate().is_ok());
+
+        // fund_name は min=1 のため空文字は NG
+        assert!(CreateMutualfundRequest {
+            fund_name: String::new(),
+            ..base()
+        }
+        .validate()
+        .is_err());
+
+        // account は min=1 のため空文字は NG
+        assert!(CreateMutualfundRequest {
+            account: String::new(),
+            ..base()
+        }
+        .validate()
+        .is_err());
+
+        // dividends は max=100 のため 101 文字は NG
+        assert!(CreateMutualfundRequest {
+            dividends: Some("あ".repeat(101)),
+            ..base()
+        }
+        .validate()
+        .is_err());
+
+        // dividends は None でも OK
+        assert!(CreateMutualfundRequest {
+            dividends: None,
+            ..base()
         }
         .validate()
         .is_ok());


### PR DESCRIPTION
## 変更内容

4つのバックエンドモデルに対して、バリデーション失敗ケースのテストを追加する。

| モデル | 追加ケース |
|--------|-----------|
| `CreateDividendRequest` | 空 product/account/security_name、security_code 超過・空 |
| `CreateDomesticStockRequest` | security_code 超過、空 security_name/account |
| `CreateMutualfundRequest` | 空 fund_name/account、dividends 超過・None |
| `CreateAssetBalanceRequest` | security_code 超過・空、空 security_name |
| `BulkCreateAssetBalanceRequest` | items 空リスト |

各モデルで `base()` ヘルパーを導入し、フィールドを一つずつ変えるパターンで網羅的に検証する。

## テスト結果

- `cargo test`: 70 passed（69 → 70）
- `cargo fmt --check`: pass
- `cargo clippy`: pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * バリデーション機能の包括的なテスト範囲を拡張し、エッジケースをカバーする追加のアサーションを実装しました。複数のモデルにおいて、テストの信頼性と保守性を向上させるための内部改善を実施しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->