### PR TITLE
test: HomePage のフィーチャーカードとはじめかたセクションのテストを追加

### DIFF
--- a/frontend/src/features/receipt/hooks/__tests__/useReceiptsState.test.ts
+++ b/frontend/src/features/receipt/hooks/__tests__/useReceiptsState.test.ts
@@ -17,7 +17,7 @@ vi.mock('../useReceiptsData');
 // useReceiptsState が useEffect 内で onLogout を呼ぶため、
 // クリーンアップ関数を返すモックを用意する
 function makeOnLogoutMock() {
-  return vi.fn((_cb: () => void) => () => {});
+  return vi.fn((_cb: () => void) => () => {}); // eslint-disable-line @typescript-eslint/no-unused-vars
 }
 
 const mockUploadCsv = vi.fn();

--- a/frontend/src/pages/__tests__/Home.test.tsx
+++ b/frontend/src/pages/__tests__/Home.test.tsx
@@ -58,4 +58,61 @@ describe('HomePage', () => {
     expect(scoped.getByRole('link', { name: '資産管理' })).toHaveAttribute('href', '/assetbalance');
     expect(scoped.getByRole('link', { name: '取引明細' })).toHaveAttribute('href', '/receipts');
   });
+
+  it('フィーチャーカードを3件表示する', () => {
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('heading', { name: '銘柄検索' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: '資産管理' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: '取引明細' })).toBeInTheDocument();
+  });
+
+  it('フィーチャーカードの説明文を表示する', () => {
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('日本の株式銘柄情報を検索できます。')).toBeInTheDocument();
+    expect(screen.getByText('保有している銘柄の一覧と評価額を確認できます。')).toBeInTheDocument();
+    expect(screen.getByText('配当金や分配金の記録を管理できます。')).toBeInTheDocument();
+  });
+
+  it('フィーチャーカードのリンク先が正しい', () => {
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>
+    );
+
+    // フィーチャーカードはクイックアクションと同名リンクがあるため、すべてのリンクを取得して確認する
+    const links = screen.getAllByRole('link', { name: /銘柄検索/ });
+    expect(links.some((l) => l.getAttribute('href') === '/search')).toBe(true);
+
+    const assetLinks = screen.getAllByRole('link', { name: /資産管理/ });
+    expect(assetLinks.some((l) => l.getAttribute('href') === '/assetbalance')).toBe(true);
+
+    const receiptLinks = screen.getAllByRole('link', { name: /取引明細/ });
+    expect(receiptLinks.some((l) => l.getAttribute('href') === '/receipts')).toBe(true);
+  });
+
+  it('はじめかたセクションのSTEPを表示する', () => {
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('STEP 1')).toBeInTheDocument();
+    expect(screen.getByText('証券会社からCSVをダウンロード')).toBeInTheDocument();
+    expect(screen.getByText('STEP 2')).toBeInTheDocument();
+    expect(screen.getByText('各ページでCSVファイルを取り込み')).toBeInTheDocument();
+    expect(screen.getByText('STEP 3')).toBeInTheDocument();
+    expect(screen.getByText('配当金や資産管理の情報を確認')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## 概要

`Home.test.tsx` に未テストだった UI セクションのテストを追加。

- フィーチャーカード3件の表示確認
- フィーチャーカードの説明文確認
- フィーチャーカードのリンク先確認
- はじめかた（STEP 1〜3）の表示確認

## テスト結果

```
Test Files  1 passed (1)
      Tests  7 passed (7)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)