### PR TITLE
test: DividendInfo コンポーネントのユニットテストを追加

### DIFF
--- a/frontend/src/components/molecules/DividendInfo/__tests__/DividendInfo.test.tsx
+++ b/frontend/src/components/molecules/DividendInfo/__tests__/DividendInfo.test.tsx
@@ -1,13 +1,30 @@
+import type { ComponentProps } from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { DividendInfo } from '../DividendInfo';
 
-vi.mock('@/features/jquants/hooks/useDividendBatch', () => ({
-  useDividendBatch: vi.fn(() => ({
+function createMockDividendBatchResult(
+  overrides: Partial<{
+    dividendPerShareMap: Map<string, number>;
+    dividendStatusMap: Map<string, 'ok' | 'zero' | 'pending' | 'error'>;
+    loading: boolean;
+    fetchedCount: number;
+    totalCount: number;
+  }> = {}
+) {
+  return {
     dividendPerShareMap: new Map<string, number>(),
+    dividendStatusMap: new Map<string, 'ok' | 'zero' | 'pending' | 'error'>(),
     loading: false,
-  })),
+    fetchedCount: 0,
+    totalCount: 0,
+    ...overrides,
+  };
+}
+
+vi.mock('@/features/jquants/hooks/useDividendBatch', () => ({
+  useDividendBatch: vi.fn(() => createMockDividendBatchResult()),
 }));
 
 vi.mock('@/features/assetBalance/hooks/useAssetBalance', () => ({
@@ -17,26 +34,26 @@ vi.mock('@/features/assetBalance/hooks/useAssetBalance', () => ({
   })),
 }));
 
-const emptySummary = [] as const;
+const emptySummary: ComponentProps<typeof DividendInfo>['summary'] = [];
 
 describe('DividendInfo', () => {
   it('searchQuery が空のとき何も描画しない', () => {
     const { container } = render(
-      <DividendInfo searchQuery="" summary={emptySummary as never} />
+      <DividendInfo searchQuery="" summary={emptySummary} />
     );
     expect(container.firstChild).toBeNull();
   });
 
   it('searchQuery があるとき standalone モードで配当シミュレーションを表示する', () => {
     render(
-      <DividendInfo searchQuery="1234" summary={emptySummary as never} />
+      <DividendInfo searchQuery="1234" summary={emptySummary} />
     );
     expect(screen.getByText('配当シミュレーション')).toBeInTheDocument();
   });
 
   it('standalone モードで入力フィールドを表示する', () => {
     render(
-      <DividendInfo searchQuery="1234" summary={emptySummary as never} />
+      <DividendInfo searchQuery="1234" summary={emptySummary} />
     );
     expect(screen.getByLabelText('平均取得価格')).toBeInTheDocument();
     expect(screen.getByLabelText('保有数量(株)')).toBeInTheDocument();
@@ -45,14 +62,14 @@ describe('DividendInfo', () => {
 
   it('embedded モードで配当シミュレーション見出しを表示しない', () => {
     render(
-      <DividendInfo searchQuery="1234" summary={emptySummary as never} embedded />
+      <DividendInfo searchQuery="1234" summary={emptySummary} embedded />
     );
     expect(screen.queryByText('配当シミュレーション')).not.toBeInTheDocument();
   });
 
   it('embedded モードで平均取得価格・保有数量・一株配当のラベルを表示する', () => {
     render(
-      <DividendInfo searchQuery="1234" summary={emptySummary as never} embedded />
+      <DividendInfo searchQuery="1234" summary={emptySummary} embedded />
     );
     expect(screen.getByText('平均取得価格')).toBeInTheDocument();
     expect(screen.getByText('保有数量(株)')).toBeInTheDocument();
@@ -61,7 +78,7 @@ describe('DividendInfo', () => {
 
   it('embedded モードでデータなし時に --- を表示する', () => {
     render(
-      <DividendInfo searchQuery="1234" summary={emptySummary as never} embedded />
+      <DividendInfo searchQuery="1234" summary={emptySummary} embedded />
     );
     const dashes = screen.getAllByText('---');
     expect(dashes.length).toBeGreaterThanOrEqual(2);
@@ -69,26 +86,30 @@ describe('DividendInfo', () => {
 
   it('embedded モードで一株配当取得中に取得中... を表示する', async () => {
     const { useDividendBatch } = await import('@/features/jquants/hooks/useDividendBatch');
-    vi.mocked(useDividendBatch).mockReturnValueOnce({
-      dividendPerShareMap: new Map(),
+    vi.mocked(useDividendBatch).mockReturnValueOnce(createMockDividendBatchResult({
       loading: true,
-    } as never);
+    }));
 
     render(
-      <DividendInfo searchQuery="1234" summary={emptySummary as never} embedded />
+      <DividendInfo searchQuery="1234" summary={emptySummary} embedded />
     );
     expect(screen.getByText('取得中...')).toBeInTheDocument();
   });
 
   it('summary データがある場合 embedded モードで集計金額を表示する', () => {
-    const summary = [
-      { dividends_before_tax: 10000, taxes: 2000, net_amount_received: 8000 },
+    const summary: ComponentProps<typeof DividendInfo>['summary'] = [
+      {
+        filter: '1234',
+        dividends_before_tax: 10000,
+        taxes: 2000,
+        net_amount_received: 8000,
+      },
     ];
 
     render(
       <DividendInfo
         searchQuery="1234"
-        summary={summary as never}
+        summary={summary}
         embedded
       />
     );

--- a/frontend/src/components/molecules/DividendInfo/__tests__/DividendInfo.test.tsx
+++ b/frontend/src/components/molecules/DividendInfo/__tests__/DividendInfo.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { DividendInfo } from '../DividendInfo';
+
+vi.mock('@/features/jquants/hooks/useDividendBatch', () => ({
+  useDividendBatch: vi.fn(() => ({
+    dividendPerShareMap: new Map<string, number>(),
+    loading: false,
+  })),
+}));
+
+vi.mock('@/features/assetBalance/hooks/useAssetBalance', () => ({
+  useAssetBalance: vi.fn(() => ({
+    assetBalanceData: [],
+    getAssetBalanceByCode: vi.fn(() => undefined),
+  })),
+}));
+
+const emptySummary = [] as const;
+
+describe('DividendInfo', () => {
+  it('searchQuery が空のとき何も描画しない', () => {
+    const { container } = render(
+      <DividendInfo searchQuery="" summary={emptySummary as never} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('searchQuery があるとき standalone モードで配当シミュレーションを表示する', () => {
+    render(
+      <DividendInfo searchQuery="1234" summary={emptySummary as never} />
+    );
+    expect(screen.getByText('配当シミュレーション')).toBeInTheDocument();
+  });
+
+  it('standalone モードで入力フィールドを表示する', () => {
+    render(
+      <DividendInfo searchQuery="1234" summary={emptySummary as never} />
+    );
+    expect(screen.getByLabelText('平均取得価格')).toBeInTheDocument();
+    expect(screen.getByLabelText('保有数量(株)')).toBeInTheDocument();
+    expect(screen.getByLabelText('一株配当')).toBeInTheDocument();
+  });
+
+  it('embedded モードで配当シミュレーション見出しを表示しない', () => {
+    render(
+      <DividendInfo searchQuery="1234" summary={emptySummary as never} embedded />
+    );
+    expect(screen.queryByText('配当シミュレーション')).not.toBeInTheDocument();
+  });
+
+  it('embedded モードで平均取得価格・保有数量・一株配当のラベルを表示する', () => {
+    render(
+      <DividendInfo searchQuery="1234" summary={emptySummary as never} embedded />
+    );
+    expect(screen.getByText('平均取得価格')).toBeInTheDocument();
+    expect(screen.getByText('保有数量(株)')).toBeInTheDocument();
+    expect(screen.getByText('一株配当')).toBeInTheDocument();
+  });
+
+  it('embedded モードでデータなし時に --- を表示する', () => {
+    render(
+      <DividendInfo searchQuery="1234" summary={emptySummary as never} embedded />
+    );
+    const dashes = screen.getAllByText('---');
+    expect(dashes.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('embedded モードで一株配当取得中に取得中... を表示する', async () => {
+    const { useDividendBatch } = await import('@/features/jquants/hooks/useDividendBatch');
+    vi.mocked(useDividendBatch).mockReturnValueOnce({
+      dividendPerShareMap: new Map(),
+      loading: true,
+    } as never);
+
+    render(
+      <DividendInfo searchQuery="1234" summary={emptySummary as never} embedded />
+    );
+    expect(screen.getByText('取得中...')).toBeInTheDocument();
+  });
+
+  it('summary データがある場合 embedded モードで集計金額を表示する', () => {
+    const summary = [
+      { dividends_before_tax: 10000, taxes: 2000, net_amount_received: 8000 },
+    ];
+
+    render(
+      <DividendInfo
+        searchQuery="1234"
+        summary={summary as never}
+        embedded
+      />
+    );
+    // 配当金額ラベルが表示される
+    expect(screen.getByText('配当金額 (配当利回り)')).toBeInTheDocument();
+    expect(screen.getByText('受取金額 (累積利回り)')).toBeInTheDocument();
+    expect(screen.getByText('税額')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要

`DividendInfo.tsx`（243行）は唯一テストのなかった molecules コンポーネント。
hooks をモックしてレンダリング挙動のテストを追加した。

## テスト内容（8件）

- `searchQuery` が空のとき何も描画しない
- standalone モードで「配当シミュレーション」見出しと入力フィールドを表示する
- embedded モードで「配当シミュレーション」見出しを表示しない
- embedded モードでラベル（平均取得価格・保有数量・一株配当）を表示する
- embedded モードでデータなし時に `---` を表示する
- embedded モードで取得中に `取得中...` を表示する
- summary データがある場合に集計ラベルを表示する

## テスト結果

```
Test Files  1 passed (1)
      Tests  8 passed (8)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * 配当シミュレーション機能の包括的なテストスイートを追加。検索条件の有無、表示モード（スタンドアロン/埋め込み）、ローディング状態、データ表示などの複数シナリオをカバーし、コンポーネントの動作品質を向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->