### PR TITLE
test: DividendPerShareBatchRequest のバリデーションテストを追加

### DIFF
--- a/backend/src/models/dividend_cache.rs
+++ b/backend/src/models/dividend_cache.rs
@@ -52,3 +52,39 @@ pub struct DividendPerShareItem {
 pub struct DividendPerShareBatchResponse {
     pub items: Vec<DividendPerShareItem>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_dividend_per_share_batch_request_validation() {
+        // 1件は OK（min = 1）
+        assert!(DividendPerShareBatchRequest {
+            security_codes: vec!["1234".to_string()],
+        }
+        .validate()
+        .is_ok());
+
+        // 100件は OK（max = 100）
+        assert!(DividendPerShareBatchRequest {
+            security_codes: vec!["1234".to_string(); 100],
+        }
+        .validate()
+        .is_ok());
+
+        // 0件は NG（min = 1）
+        assert!(DividendPerShareBatchRequest {
+            security_codes: vec![],
+        }
+        .validate()
+        .is_err());
+
+        // 101件は NG（max = 100）
+        assert!(DividendPerShareBatchRequest {
+            security_codes: vec!["1234".to_string(); 101],
+        }
+        .validate()
+        .is_err());
+    }
+}


### PR DESCRIPTION
## 概要

`DividendPerShareBatchRequest.security_codes` の長さバリデーション（min=1, max=100）に対するユニットテストを追加。

## テスト内容
- 1件（OK）、100件（OK）
- 0件（NG: min=1）、101件（NG: max=100）

🤖 Generated with Claude Code
