### PR TITLE
test: dividend_per_share ハンドラーの未認証テストを追加

### DIFF
--- a/backend/src/handlers/dividend_per_share.rs
+++ b/backend/src/handlers/dividend_per_share.rs
@@ -43,3 +43,51 @@ pub async fn batch(
 
     Ok(Json(DividendPerShareBatchResponse { items }))
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        axum::{
+            body::Body,
+            http::{Request, StatusCode},
+        },
+        reqwest::Client,
+        serde_json::json,
+        std::sync::Arc,
+        tower::ServiceExt,
+    };
+
+    fn setup_test_app() -> Router<()> {
+        let pool =
+            crate::db::connect_pool_lazy("postgresql://postgres:postgres@localhost/postgres", 1)
+                .unwrap();
+        dividend_per_share_routes().with_state(crate::AppState {
+            pool,
+            secrets: Arc::new(crate::state::Secrets {
+                database_url: "postgresql://postgres:postgres@localhost/postgres".to_string(),
+                jquants_api_key: None,
+                google_client_id: None,
+                google_client_secret: None,
+                frontend_url: "http://localhost:8080".to_string(),
+            }),
+            client: Client::new(),
+            dividend_cache: crate::state::DividendCacheState::default(),
+        })
+    }
+
+    #[tokio::test]
+    async fn test_batch_unauthorized() {
+        let app = setup_test_app();
+        let body = json!({ "security_codes": ["1234"] }).to_string();
+        let request = Request::builder()
+            .method("POST")
+            .uri("/dividends/per-share/batch")
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}


### PR DESCRIPTION
## 概要
`handlers/dividend_per_share.rs` の `batch` エンドポイントに未認証アクセスが 401 を返すことを検証するテストを追加。

`handlers/stock/tests.rs` の `test_create_stock_unauthorized` と同じパターン（`connect_pool_lazy` でDBなし）。

## テスト結果
- `test_batch_unauthorized`: PASS（DBなし、Dockerなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * ソースコードのフォーマットを正規化（末尾の空白文字とCRLF形式の改行を修正）

* **テスト**
  * 配当利回りバッチAPIの認可チェック機能を検証する新しいテストケースを追加し、認可されていないリクエストに対して正しくエラーを返すことを確認

<!-- end of auto-generated comment: release notes by coderabbit.ai -->