### PR TITLE
test: compute_taxes のユニットテストを追加

### DIFF
--- a/backend/src/services/csv_util.rs
+++ b/backend/src/services/csv_util.rs
@@ -461,4 +461,22 @@ mod tests {
             }
         });
     }
+
+    #[test]
+    fn test_compute_taxes() {
+        assert_eq!(
+            compute_taxes("特定口座", dec!(10000)),
+            (dec!(2031), dec!(7969))
+        );
+        assert_eq!(compute_taxes("特定口座", dec!(0)), (dec!(0), dec!(0)));
+        assert_eq!(compute_taxes("特定口座", dec!(-500)), (dec!(0), dec!(-500)));
+        assert_eq!(
+            compute_taxes("NISA口座", dec!(10000)),
+            (dec!(0), dec!(10000))
+        );
+        assert_eq!(
+            compute_taxes("一般口座", dec!(10000)),
+            (dec!(0), dec!(10000))
+        );
+    }
 }


### PR DESCRIPTION
## 概要
`services/csv_util.rs` の `compute_taxes` 関数に対するユニットテストを追加。

特定口座（課税あり）、ゼロ・マイナス金額、NISA口座・一般口座（非課税）の5ケースを検証。

## テスト結果
- `test_compute_taxes`: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)