### PR TITLE
test: 主要ハンドラー5件の未認証テストを追加

### DIFF
--- a/backend/src/handlers/asset_balance.rs
+++ b/backend/src/handlers/asset_balance.rs
@@ -140,3 +140,67 @@ pub async fn delete_all(
         }),
     ))
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        axum::{
+            body::Body,
+            http::{Request, StatusCode},
+        },
+        reqwest::Client,
+        std::sync::Arc,
+        tower::ServiceExt,
+    };
+
+    fn setup_test_app() -> Router<()> {
+        let pool =
+            crate::db::connect_pool_lazy("postgresql://postgres:postgres@localhost/postgres", 1)
+                .unwrap();
+        asset_balance_routes().with_state(crate::AppState {
+            pool,
+            secrets: Arc::new(crate::state::Secrets {
+                database_url: "postgresql://postgres:postgres@localhost/postgres".to_string(),
+                jquants_api_key: None,
+                google_client_id: None,
+                google_client_secret: None,
+                frontend_url: "http://localhost:8080".to_string(),
+            }),
+            client: Client::new(),
+            dividend_cache: crate::state::DividendCacheState::default(),
+        })
+    }
+
+    #[tokio::test]
+    async fn test_list_unauthorized() {
+        let app = setup_test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/asset-balances")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_delete_all_unauthorized() {
+        let app = setup_test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/asset-balances")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/backend/src/handlers/dividend.rs
+++ b/backend/src/handlers/dividend.rs
@@ -115,3 +115,67 @@ pub async fn delete_all(
         }),
     ))
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        axum::{
+            body::Body,
+            http::{Request, StatusCode},
+        },
+        reqwest::Client,
+        std::sync::Arc,
+        tower::ServiceExt,
+    };
+
+    fn setup_test_app() -> Router<()> {
+        let pool =
+            crate::db::connect_pool_lazy("postgresql://postgres:postgres@localhost/postgres", 1)
+                .unwrap();
+        dividend_routes().with_state(crate::AppState {
+            pool,
+            secrets: Arc::new(crate::state::Secrets {
+                database_url: "postgresql://postgres:postgres@localhost/postgres".to_string(),
+                jquants_api_key: None,
+                google_client_id: None,
+                google_client_secret: None,
+                frontend_url: "http://localhost:8080".to_string(),
+            }),
+            client: Client::new(),
+            dividend_cache: crate::state::DividendCacheState::default(),
+        })
+    }
+
+    #[tokio::test]
+    async fn test_list_unauthorized() {
+        let app = setup_test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/dividends")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_delete_all_unauthorized() {
+        let app = setup_test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/dividends")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/backend/src/handlers/domestic_stock.rs
+++ b/backend/src/handlers/domestic_stock.rs
@@ -115,3 +115,67 @@ pub async fn delete_all(
         }),
     ))
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        axum::{
+            body::Body,
+            http::{Request, StatusCode},
+        },
+        reqwest::Client,
+        std::sync::Arc,
+        tower::ServiceExt,
+    };
+
+    fn setup_test_app() -> Router<()> {
+        let pool =
+            crate::db::connect_pool_lazy("postgresql://postgres:postgres@localhost/postgres", 1)
+                .unwrap();
+        domestic_stock_routes().with_state(crate::AppState {
+            pool,
+            secrets: Arc::new(crate::state::Secrets {
+                database_url: "postgresql://postgres:postgres@localhost/postgres".to_string(),
+                jquants_api_key: None,
+                google_client_id: None,
+                google_client_secret: None,
+                frontend_url: "http://localhost:8080".to_string(),
+            }),
+            client: Client::new(),
+            dividend_cache: crate::state::DividendCacheState::default(),
+        })
+    }
+
+    #[tokio::test]
+    async fn test_list_unauthorized() {
+        let app = setup_test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/domestic-stocks")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_delete_all_unauthorized() {
+        let app = setup_test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/domestic-stocks")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/backend/src/handlers/jquants.rs
+++ b/backend/src/handlers/jquants.rs
@@ -49,3 +49,51 @@ pub async fn get_fin_summary(
         JQuantsService::get_fin_summary(&state.client, params, api_key, FIN_SUMMARY_URL).await?;
     Ok(Json(response))
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        axum::{
+            body::Body,
+            http::{Request, StatusCode},
+        },
+        reqwest::Client,
+        std::sync::Arc,
+        tower::ServiceExt,
+    };
+
+    fn setup_test_app() -> Router<()> {
+        let pool =
+            crate::db::connect_pool_lazy("postgresql://postgres:postgres@localhost/postgres", 1)
+                .unwrap();
+        jquants_routes().with_state(crate::AppState {
+            pool,
+            secrets: Arc::new(crate::state::Secrets {
+                database_url: "postgresql://postgres:postgres@localhost/postgres".to_string(),
+                jquants_api_key: None,
+                google_client_id: None,
+                google_client_secret: None,
+                frontend_url: "http://localhost:8080".to_string(),
+            }),
+            client: Client::new(),
+            dividend_cache: crate::state::DividendCacheState::default(),
+        })
+    }
+
+    #[tokio::test]
+    async fn test_get_fin_summary_unauthorized() {
+        let app = setup_test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/jquants/fins/summary?code=1234")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/backend/src/handlers/mutualfund.rs
+++ b/backend/src/handlers/mutualfund.rs
@@ -115,3 +115,67 @@ pub async fn delete_all(
         }),
     ))
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        axum::{
+            body::Body,
+            http::{Request, StatusCode},
+        },
+        reqwest::Client,
+        std::sync::Arc,
+        tower::ServiceExt,
+    };
+
+    fn setup_test_app() -> Router<()> {
+        let pool =
+            crate::db::connect_pool_lazy("postgresql://postgres:postgres@localhost/postgres", 1)
+                .unwrap();
+        mutualfund_routes().with_state(crate::AppState {
+            pool,
+            secrets: Arc::new(crate::state::Secrets {
+                database_url: "postgresql://postgres:postgres@localhost/postgres".to_string(),
+                jquants_api_key: None,
+                google_client_id: None,
+                google_client_secret: None,
+                frontend_url: "http://localhost:8080".to_string(),
+            }),
+            client: Client::new(),
+            dividend_cache: crate::state::DividendCacheState::default(),
+        })
+    }
+
+    #[tokio::test]
+    async fn test_list_unauthorized() {
+        let app = setup_test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/mutualfunds")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_delete_all_unauthorized() {
+        let app = setup_test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/mutualfunds")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/backend/src/services/dividend_cache/persistence.rs
+++ b/backend/src/services/dividend_cache/persistence.rs
@@ -48,24 +48,26 @@ pub async fn fetch_and_cache(
     Ok(status)
 }
 
+/// エラーメッセージを最大 200 文字に切り捨てる（マルチバイト文字境界を考慮）
+fn truncate_error_message(msg: &str) -> &str {
+    if msg.len() <= 200 {
+        return msg;
+    }
+    let end = msg
+        .char_indices()
+        .nth(200)
+        .map(|(i, _)| i)
+        .unwrap_or(msg.len());
+    &msg[..end]
+}
+
 /// エラー情報をキャッシュに記録する
 pub async fn update_cache_error(
     pool: &PgPool,
     code: &str,
     error_msg: &str,
 ) -> Result<(), ApiError> {
-    // エラーメッセージは最大 200 文字に切り捨て（機密情報混入を防ぐため短く保つ）
-    // char_indices で文字境界を求めてスライスし、マルチバイト文字での panic を防ぐ
-    let truncated = if error_msg.len() > 200 {
-        let end = error_msg
-            .char_indices()
-            .nth(200)
-            .map(|(i, _)| i)
-            .unwrap_or(error_msg.len());
-        &error_msg[..end]
-    } else {
-        error_msg
-    };
+    let truncated = truncate_error_message(error_msg);
 
     sqlx::query(
         r#"
@@ -85,4 +87,34 @@ pub async fn update_cache_error(
     .await?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_truncate_error_message() {
+        // 200文字以下はそのまま
+        let short = "エラー";
+        assert_eq!(truncate_error_message(short), short);
+
+        // 200文字ちょうどもそのまま
+        let exact = "a".repeat(200);
+        assert_eq!(truncate_error_message(&exact), exact);
+
+        // 201文字は200文字に切り捨て
+        let long = "a".repeat(201);
+        assert_eq!(truncate_error_message(&long), "a".repeat(200));
+
+        // マルチバイト文字（3バイト）は文字境界で切り捨て
+        // 'あ' は3バイトなので len() > 200 になるが、200文字目で正しく切る
+        let japanese = "あ".repeat(201);
+        let result = truncate_error_message(&japanese);
+        assert_eq!(result.chars().count(), 200);
+        assert!(result.is_char_boundary(result.len()));
+
+        // 空文字はそのまま
+        assert_eq!(truncate_error_message(""), "");
+    }
 }


### PR DESCRIPTION
## 概要
`asset_balance`, `dividend`, `domestic_stock`, `mutualfund`, `jquants` の各ハンドラーに未認証アクセスが 401 を返すことを検証するテストを追加。

`handlers/stock/tests.rs` のパターン（`connect_pool_lazy` でDBなし）に統一。

## テスト結果
- `test_list_unauthorized` × 4（asset_balance, dividend, domestic_stock, mutualfund）
- `test_delete_all_unauthorized` × 4
- `test_get_fin_summary_unauthorized` × 1（jquants）
- 計 9テスト、全 PASS（Dockerなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **Tests**
  * バックエンドの複数のエンドポイントに対する認可チェック機能のテストカバレッジを追加しました。
  * 認証なしのリクエストが適切に拒否されることを検証するテストを実装しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->