### PR TITLE
refactor: React Compiler 環境での不要な useMemo / useCallback を削除

### DIFF
--- a/frontend/src/components/atoms/EmptyState.tsx
+++ b/frontend/src/components/atoms/EmptyState.tsx
@@ -49,7 +49,7 @@ export function EmptyState({
       {description && (
         <p className="mt-1.5 max-w-md text-sm text-slate-600">{description}</p>
       )}
-      {action && <div className="mt-4">{action}</div>}
+      {action ? <div className="mt-4">{action}</div> : null}
     </div>
   );
 }

--- a/frontend/src/components/atoms/InputField.tsx
+++ b/frontend/src/components/atoms/InputField.tsx
@@ -56,7 +56,7 @@ const InputField = forwardRef<HTMLInputElement, InputFieldProps>(
     const labelElement = label && (
       <label htmlFor={inputId} className="block mb-1 text-sm font-medium text-dark">
         {label}
-        {required && <span className="text-danger ml-1">*</span>}
+        {required ? <span className="text-danger ml-1">*</span> : null}
       </label>
     );
 

--- a/frontend/src/components/atoms/PageHeader.tsx
+++ b/frontend/src/components/atoms/PageHeader.tsx
@@ -18,11 +18,11 @@ export function PageHeader({ title, description, actions, className }: PageHeade
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-xl font-bold text-slate-900">{title}</h1>
-          {description && (
+          {description ? (
             <p className="mt-0.5 text-sm text-slate-600">{description}</p>
-          )}
+          ) : null}
         </div>
-        {actions && <div className="flex items-center gap-2">{actions}</div>}
+        {actions ? <div className="flex items-center gap-2">{actions}</div> : null}
       </div>
     </div>
   );

--- a/frontend/src/components/molecules/DividendInfo/DividendInfo.tsx
+++ b/frontend/src/components/molecules/DividendInfo/DividendInfo.tsx
@@ -16,6 +16,84 @@ const AssetBadge = () => (
 const ASSET_BALANCE_HINT = '資産管理にCSVを取り込むと表示されます';
 const JQUANTS_HINT = '自動で取得されます';
 
+interface DividendSimulationFormProps {
+  hasAssetBalanceData: boolean;
+  initialAverageUnitPrice: number | undefined;
+  initialHoldingQuantity: number | undefined;
+  initialDividendPerShare: number | undefined;
+  totalNetAmountReceived: number;
+  apiLoading: boolean;
+}
+
+const DividendSimulationForm: React.FC<DividendSimulationFormProps> = ({
+  hasAssetBalanceData,
+  initialAverageUnitPrice,
+  initialHoldingQuantity,
+  initialDividendPerShare,
+  totalNetAmountReceived,
+  apiLoading,
+}) => {
+  const [averageUnitPrice, setAverageUnitPrice] = useState(initialAverageUnitPrice);
+  const [holdingQuantity, setHoldingQuantity] = useState(initialHoldingQuantity);
+  const [dividendPerShare, setDividendPerShare] = useState(initialDividendPerShare);
+
+  const dividendYield = (() => {
+    if (averageUnitPrice && dividendPerShare) {
+      return (dividendPerShare / averageUnitPrice) * 100;
+    }
+    return 0;
+  })();
+
+  const annualDividendAmount = parseNumber(holdingQuantity) * parseNumber(dividendPerShare);
+  const totalInvestment = parseNumber(averageUnitPrice) * parseNumber(holdingQuantity);
+  const dividendReturnRate = (() => {
+    if (totalInvestment > 0 && totalNetAmountReceived > 0) {
+      return (totalNetAmountReceived / totalInvestment) * 100;
+    }
+    return 0;
+  })();
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm border border-border mt-1">
+      <div className="bg-slate-600 text-white px-3 py-1.5 rounded-t-lg">
+        <h5 className="text-sm font-medium">配当シミュレーション</h5>
+      </div>
+      <div className="p-3">
+        <div className="stat-grid">
+          <div>
+            <NumberInputField
+              label={<>平均取得価格{hasAssetBalanceData ? <AssetBadge /> : null}</>}
+              value={averageUnitPrice}
+              onChange={setAverageUnitPrice}
+            />
+          </div>
+          <div>
+            <NumberInputField
+              label={<>保有数量(株){hasAssetBalanceData ? <AssetBadge /> : null}</>}
+              value={holdingQuantity}
+              onChange={setHoldingQuantity}
+            />
+          </div>
+          <div>
+            <NumberInputField
+              label={<>一株配当</>}
+              value={dividendPerShare}
+              onChange={setDividendPerShare}
+              disabled={apiLoading}
+              placeholder={apiLoading ? 'データ取得中...' : ''}
+            />
+          </div>
+        </div>
+        <div className="stat-grid mt-4">
+          <StatItem title="取得総額" value={formatCurrency(totalInvestment)} />
+          <StatItemWithRate title="合計受取金額 (累積利回り)" value={totalNetAmountReceived} rate={dividendReturnRate} format={formatCurrency} />
+          <StatItemWithRate title="年間配当金額 (配当利回り)" value={annualDividendAmount} rate={dividendYield} format={formatCurrency} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
 interface DividendInfoProps {
   searchQuery: string;
   securityCode?: string;
@@ -29,72 +107,32 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({
   summary,
   embedded = false
 }) => {
-  const [averageUnitPrice, setAverageUnitPrice] = useState<number | undefined>(undefined);
-  const [holdingQuantity, setHoldingQuantity] = useState<number | undefined>(undefined);
-  const [dividendPerShare, setDividendPerShare] = useState<number | undefined>(undefined);
-  const effectiveSecurityCode = React.useMemo(() => {
+  const effectiveSecurityCode = (() => {
     if (securityCode) return normalizeSecurityCode(securityCode);
     const match = searchQuery.match(/^\\s*([0-9A-Za-z]+)\\s*[:：]/);
     return normalizeSecurityCode(match?.[1] || searchQuery);
-  }, [securityCode, searchQuery]);
-
-  const isValidSecurityCode = React.useMemo(() => {
-    return !!effectiveSecurityCode && SECURITY_CODE_REGEX.test(effectiveSecurityCode);
-  }, [effectiveSecurityCode]);
-
-  const { assetBalanceData: assetBalances, getAssetBalanceByCode } = useAssetBalance({ enabled: isValidSecurityCode });
-
-  const dividendBatchCodes = React.useMemo(
-    () => (isValidSecurityCode ? [effectiveSecurityCode] : []),
-    [effectiveSecurityCode, isValidSecurityCode]
-  );
-  const { dividendPerShareMap, loading: apiLoading } = useDividendBatch(dividendBatchCodes, isValidSecurityCode);
-  const apiDividendPerShare = dividendPerShareMap.get(effectiveSecurityCode);
-
-  React.useEffect(() => {
-    if (isValidSecurityCode) {
-      const assetBalanceData = getAssetBalanceByCode(effectiveSecurityCode);
-      if (assetBalanceData) {
-        setAverageUnitPrice(assetBalanceData.average_purchase_price);
-        setHoldingQuantity(assetBalanceData.shares);
-      } else {
-        setAverageUnitPrice(undefined);
-        setHoldingQuantity(undefined);
-      }
-    } else {
-      setAverageUnitPrice(undefined);
-      setHoldingQuantity(undefined);
-    }
-  }, [effectiveSecurityCode, isValidSecurityCode, getAssetBalanceByCode, assetBalances]);
-
-  React.useEffect(() => {
-    setDividendPerShare(undefined);
-    if (isValidSecurityCode && apiDividendPerShare !== undefined && apiDividendPerShare > 0) {
-      setDividendPerShare(apiDividendPerShare);
-    }
-  }, [apiDividendPerShare, isValidSecurityCode]);
-
-  const dividendYield = (() => {
-    if (averageUnitPrice && dividendPerShare) {
-      return (dividendPerShare / averageUnitPrice) * 100;
-    }
-    return 0;
   })();
 
-  const annualDividendAmount = parseNumber(holdingQuantity) * parseNumber(dividendPerShare);
+  const isValidSecurityCode = !!effectiveSecurityCode && SECURITY_CODE_REGEX.test(effectiveSecurityCode);
+
+  const { getAssetBalanceByCode } = useAssetBalance({ enabled: isValidSecurityCode });
+
+  const dividendBatchCodes = isValidSecurityCode ? [effectiveSecurityCode] : [];
+  const { dividendPerShareMap, loading: apiLoading } = useDividendBatch(dividendBatchCodes, isValidSecurityCode);
+  const apiDividendPerShare = dividendPerShareMap.get(effectiveSecurityCode);
+  const assetBalanceData = isValidSecurityCode
+    ? getAssetBalanceByCode(effectiveSecurityCode)
+    : undefined;
+  const averageUnitPrice = assetBalanceData?.average_purchase_price;
+  const holdingQuantity = assetBalanceData?.shares;
+  const dividendPerShare = isValidSecurityCode && apiDividendPerShare !== undefined && apiDividendPerShare > 0
+    ? apiDividendPerShare
+    : undefined;
   const totalInvestment = parseNumber(averageUnitPrice) * parseNumber(holdingQuantity);
 
-  const totalNetAmountReceived = React.useMemo(() => {
-    return summary.reduce((sum, item) => sum + (item.net_amount_received || 0), 0);
-  }, [summary]);
-
-  const totalDividendsBeforeTax = React.useMemo(() => {
-    return summary.reduce((sum, item) => sum + (item.dividends_before_tax || 0), 0);
-  }, [summary]);
-
-  const totalTaxes = React.useMemo(() => {
-    return summary.reduce((sum, item) => sum + (item.taxes || 0), 0);
-  }, [summary]);
+  const totalNetAmountReceived = summary.reduce((sum, item) => sum + (item.net_amount_received || 0), 0);
+  const totalDividendsBeforeTax = summary.reduce((sum, item) => sum + (item.dividends_before_tax || 0), 0);
+  const totalTaxes = summary.reduce((sum, item) => sum + (item.taxes || 0), 0);
 
   const grossDividendReturnRate = (() => {
     if (totalInvestment > 0 && totalDividendsBeforeTax > 0) {
@@ -114,10 +152,6 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({
     return null;
   }
 
-  const assetBalanceData = isValidSecurityCode
-    ? getAssetBalanceByCode(effectiveSecurityCode)
-    : undefined;
-
   // embedded モード: 資産管理・J-Quants データを read-only KPI カードで表示
   if (embedded) {
     return (
@@ -126,7 +160,7 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({
         <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
           <div className="rounded-lg bg-slate-50 px-4 py-3">
             <p className="text-xs font-medium text-slate-600 mb-1">
-              平均取得価格{assetBalanceData && <AssetBadge />}
+              平均取得価格{assetBalanceData ? <AssetBadge /> : null}
             </p>
             <p
               className="text-2xl font-bold tabular-nums text-primary"
@@ -140,7 +174,7 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({
           </div>
           <div className="rounded-lg bg-slate-50 px-4 py-3">
             <p className="text-xs font-medium text-slate-600 mb-1">
-              保有数量(株){assetBalanceData && <AssetBadge />}
+              保有数量(株){assetBalanceData ? <AssetBadge /> : null}
             </p>
             <p
               className="text-2xl font-bold tabular-nums text-primary"
@@ -202,42 +236,14 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({
 
   // standalone モード: シミュレーション（入力フォーム）
   return (
-    <div className="bg-white rounded-lg shadow-sm border border-border mt-1">
-      <div className="bg-slate-600 text-white px-3 py-1.5 rounded-t-lg">
-        <h5 className="text-sm font-medium">配当シミュレーション</h5>
-      </div>
-      <div className="p-3">
-        <div className="stat-grid">
-          <div>
-            <NumberInputField
-              label={<>平均取得価格{assetBalanceData && <AssetBadge />}</>}
-              value={averageUnitPrice}
-              onChange={setAverageUnitPrice}
-            />
-          </div>
-          <div>
-            <NumberInputField
-              label={<>保有数量(株){assetBalanceData && <AssetBadge />}</>}
-              value={holdingQuantity}
-              onChange={setHoldingQuantity}
-            />
-          </div>
-          <div>
-            <NumberInputField
-              label={<>一株配当</>}
-              value={dividendPerShare}
-              onChange={setDividendPerShare}
-              disabled={apiLoading}
-              placeholder={apiLoading ? "データ取得中..." : ""}
-            />
-          </div>
-        </div>
-        <div className="stat-grid mt-4">
-          <StatItem title="取得総額" value={formatCurrency(totalInvestment)} />
-          <StatItemWithRate title="合計受取金額 (累積利回り)" value={totalNetAmountReceived} rate={dividendReturnRate} format={formatCurrency} />
-          <StatItemWithRate title="年間配当金額 (配当利回り)" value={annualDividendAmount} rate={dividendYield} format={formatCurrency} />
-        </div>
-      </div>
-    </div>
+    <DividendSimulationForm
+      key={`${effectiveSecurityCode}:${averageUnitPrice ?? ''}:${holdingQuantity ?? ''}:${dividendPerShare ?? ''}`}
+      hasAssetBalanceData={!!assetBalanceData}
+      initialAverageUnitPrice={averageUnitPrice}
+      initialHoldingQuantity={holdingQuantity}
+      initialDividendPerShare={dividendPerShare}
+      totalNetAmountReceived={totalNetAmountReceived}
+      apiLoading={apiLoading}
+    />
   );
 };

--- a/frontend/src/components/molecules/PortfolioPieChart/PortfolioPieChart.tsx
+++ b/frontend/src/components/molecules/PortfolioPieChart/PortfolioPieChart.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useState } from 'react';
 import { SecurityCodeLink } from '@/components/atoms/SecurityCodeLink';
 import { formatCurrency, formatNumber, formatPercentageValue } from '@/lib/utils/formatters';
 import { DividendStatus } from '@/features/jquants/api/dividendPerShareApi';
@@ -192,26 +192,26 @@ export const PortfolioPieChart: React.FC<PortfolioPieChartProps> = ({
   const [showAll, setShowAll] = useState(false);
 
   // パーセンテージを計算してデータに追加（降順ソート済み）
-  const chartData: ChartDataItem[] = useMemo(() => {
+  const chartData: ChartDataItem[] = (() => {
     const total = data.reduce((sum, item) => sum + item.value, 0);
     if (total === 0) return [];
 
     return data
       .map((item) => ({ ...item, percentage: (item.value / total) * 100 }))
       .sort((a, b) => b.percentage - a.percentage);
-  }, [data]);
+  })();
 
   // 表示データ（Top N または全件）
-  const displayData = useMemo(() => {
+  const displayData = (() => {
     if (showAll || chartData.length <= TOP_N) return chartData;
     return chartData.slice(0, TOP_N);
-  }, [chartData, showAll]);
+  })();
 
   // その他の合計（Top N以外）
-  const othersPercentage = useMemo(() => {
+  const othersPercentage = (() => {
     if (showAll || chartData.length <= TOP_N) return 0;
     return chartData.slice(TOP_N).reduce((sum, item) => sum + item.percentage, 0);
-  }, [chartData, showAll]);
+  })();
 
   if (chartData.length === 0) return null;
 

--- a/frontend/src/components/organisms/AssetPortfolioSummary/AssetPortfolioSummary.tsx
+++ b/frontend/src/components/organisms/AssetPortfolioSummary/AssetPortfolioSummary.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { Card, CardBody } from '@/components/atoms/Card';
 import { EmptyState } from '@/components/atoms/EmptyState';
 import { PortfolioPieChart, PortfolioItem } from '@/components/molecules/PortfolioPieChart';
@@ -33,16 +33,14 @@ export const AssetPortfolioSummary: React.FC<AssetPortfolioSummaryProps> = ({
   dividendStatusMap,
 }) => {
   // 合計取得総額を計算（null/undefinedは0として扱う）
-  const totalPurchaseAmount = useMemo(() => {
-    return assetBalanceData.reduce(
-      (sum, item) => safeAdd(sum, item.total_purchase_amount || 0),
-      0
-    );
-  }, [assetBalanceData]);
+  const totalPurchaseAmount = assetBalanceData.reduce(
+    (sum, item) => safeAdd(sum, item.total_purchase_amount || 0),
+    0
+  );
 
   // ポートフォリオ全体の年間配当金額と配当利回り（%）
   // 年間配当 = Σ(1株配当 × 保有株数)、配当利回り = 年間配当 / 取得総額 × 100
-  const { totalAnnualDividends, portfolioDividendYield } = useMemo(() => {
+  const { totalAnnualDividends, portfolioDividendYield } = (() => {
     if (!dividendPerShareMap || dividendPerShareMap.size === 0) {
       return { totalAnnualDividends: null, portfolioDividendYield: null };
     }
@@ -56,21 +54,19 @@ export const AssetPortfolioSummary: React.FC<AssetPortfolioSummaryProps> = ({
     if (total === 0) return { totalAnnualDividends: null, portfolioDividendYield: null };
     const yieldValue = totalPurchaseAmount > 0 ? (total / totalPurchaseAmount) * 100 : null;
     return { totalAnnualDividends: total, portfolioDividendYield: yieldValue };
-  }, [dividendPerShareMap, assetBalanceData, totalPurchaseAmount]);
+  })();
 
   // 横棒グラフ用データを生成（詳細情報付き）
-  const chartData: PortfolioItem[] = useMemo(() => {
-    return assetBalanceData
-      .filter((item) => (item.total_purchase_amount || 0) > 0)
-      .map((item) => ({
-        name: normalizeSecurityName(item.security_name || item.security_code),
-        value: item.total_purchase_amount || 0,
-        securityCode: item.security_code,
-        shares: item.shares,
-        averagePrice: item.average_purchase_price,
-      }))
-      .sort((a, b) => b.value - a.value);
-  }, [assetBalanceData]);
+  const chartData: PortfolioItem[] = assetBalanceData
+    .filter((item) => (item.total_purchase_amount || 0) > 0)
+    .map((item) => ({
+      name: normalizeSecurityName(item.security_name || item.security_code),
+      value: item.total_purchase_amount || 0,
+      securityCode: item.security_code,
+      shares: item.shares,
+      averagePrice: item.average_purchase_price,
+    }))
+    .sort((a, b) => b.value - a.value);
 
   const displayCount = assetBalanceData.length;
   const actualTotalCount = totalCount ?? displayCount;
@@ -118,12 +114,12 @@ export const AssetPortfolioSummary: React.FC<AssetPortfolioSummaryProps> = ({
           <div>
             <h2 className="text-sm font-semibold text-slate-800">資産サマリー</h2>
           </div>
-          {isFiltered && (
+          {isFiltered ? (
             <div className="flex flex-wrap items-center gap-2">
               <span className="inline-flex items-center rounded-full bg-blue-50 px-3 py-1 text-sm font-semibold text-blue-700">
                 絞り込み中: {displayCount}/{actualTotalCount}件
               </span>
-              {onClearFilter && (
+              {onClearFilter ? (
                 <button
                   type="button"
                   onClick={onClearFilter}
@@ -131,9 +127,9 @@ export const AssetPortfolioSummary: React.FC<AssetPortfolioSummaryProps> = ({
                 >
                   解除
                 </button>
-              )}
+              ) : null}
             </div>
-          )}
+          ) : null}
         </div>
         <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
           <div className="rounded-[1.35rem] border border-slate-200/90 bg-white px-4 py-4 shadow-[0_12px_24px_-28px_rgba(15,23,42,0.4)]">

--- a/frontend/src/components/templates/ReceiptTemplate.tsx
+++ b/frontend/src/components/templates/ReceiptTemplate.tsx
@@ -67,7 +67,7 @@ const ReceiptTemplateContent: React.FC<ReceiptTemplateProps> = ({
           main={<>{header}{mainCard}</>}
           rail={<>{utilityRail}{searchCard}</>}
         />
-        {footer && <div>{footer}</div>}
+        {footer ? <div>{footer}</div> : null}
       </div>
     );
   }
@@ -75,9 +75,9 @@ const ReceiptTemplateContent: React.FC<ReceiptTemplateProps> = ({
   return (
     <div className="space-y-2" data-testid="receipt-container">
       {searchCard}
-      {header && <div className="mt-1">{header}</div>}
+      {header ? <div className="mt-1">{header}</div> : null}
       {mainCard}
-      {footer && <div>{footer}</div>}
+      {footer ? <div>{footer}</div> : null}
     </div >
   );
 };

--- a/frontend/src/features/assetBalance/hooks/useAssetBalance.ts
+++ b/frontend/src/features/assetBalance/hooks/useAssetBalance.ts
@@ -1,5 +1,5 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect } from 'react';
 import type { AssetBalanceData } from '@/types/api';
 import { assetBalanceApi } from '@/features/assetBalance/api/assetBalanceApi';
 import { useAuth } from '@/features/auth/hooks/useAuth';
@@ -40,10 +40,7 @@ export function useAssetBalance(options: UseAssetBalanceOptions = {}): UseAssetB
   }, [onLogout, queryClient]);
 
   // 未認証時はキャッシュに残存データがあっても空を返す
-  const assetBalanceData = useMemo(
-    () => (isAuthenticated ? (query.data ?? []) : []),
-    [isAuthenticated, query.data]
-  );
+  const assetBalanceData = isAuthenticated ? (query.data ?? []) : [];
 
   const getAssetBalanceByCode = useCallback(
     (code: string): AssetBalanceData | undefined => {

--- a/frontend/src/features/assetBalance/hooks/useAssetBalanceDataSource.ts
+++ b/frontend/src/features/assetBalance/hooks/useAssetBalanceDataSource.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import type { AssetBalanceData } from '@/types/api';
 import { assetBalanceApi } from '@/features/assetBalance/api/assetBalanceApi';
@@ -127,7 +127,7 @@ export function useAssetBalanceDataSourceCore({
     await deleteAllMutation.mutateAsync();
   }, [deleteAllMutation, isAuthenticated]);
 
-  const dbData = useMemo(() => dbQuery.data ?? [], [dbQuery.data]);
+  const dbData = dbQuery.data ?? [];
   const queryError = dbQuery.error;
   const mutationError = uploadCsvMutation.error ?? deleteAllMutation.error ?? previewMutation.error;
   const error = queryError

--- a/frontend/src/features/assetBalance/hooks/useAssetBalanceState.ts
+++ b/frontend/src/features/assetBalance/hooks/useAssetBalanceState.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useReducer } from 'react';
+import { useCallback, useEffect, useReducer } from 'react';
 import type { DataActionRailProps } from '@/components/organisms/DataActionRail/DataActionRail';
 import type { DividendStatus } from '@/features/jquants/api/dividendPerShareApi';
 import { useDividendBatch } from '@/features/jquants/hooks/useDividendBatch';
@@ -103,101 +103,67 @@ export function useAssetBalanceState() {
     });
   }, [onLogout, resetState]);
 
-  const handleSearch = useCallback((query: string) => {
+  const handleSearch = (query: string) => {
     dispatch({ type: 'SET_SEARCH_QUERY', payload: query });
-  }, []);
+  };
 
-  const clearSearch = useCallback(() => {
+  const clearSearch = () => {
     dispatch({ type: 'SET_SEARCH_QUERY', payload: '' });
-  }, []);
+  };
 
-  const openDeleteConfirm = useCallback(() => {
+  const openDeleteConfirm = () => {
     dispatch({ type: 'SET_SHOW_DELETE_CONFIRM', payload: true });
-  }, []);
+  };
 
-  const closeDeleteConfirm = useCallback(() => {
+  const closeDeleteConfirm = () => {
     dispatch({ type: 'SET_SHOW_DELETE_CONFIRM', payload: false });
-  }, []);
+  };
 
   const confirmDeleteAll = useCallback(async () => {
     closeDeleteConfirm();
     await deleteAll();
   }, [closeDeleteConfirm, deleteAll]);
 
-  const assetBalanceData = useMemo(() => {
-    return hasCsvFile ? previewRows : dbData;
-  }, [hasCsvFile, previewRows, dbData]);
-
-  const securityCodes = useMemo(
-    () => (saving || loading ? [] : assetBalanceData.map((item) => item.security_code)),
-    [saving, loading, assetBalanceData]
-  );
+  const assetBalanceData = hasCsvFile ? previewRows : dbData;
+  const securityCodes = saving || loading ? [] : assetBalanceData.map((item) => item.security_code);
 
   const { dividendPerShareMap, dividendStatusMap } = useDividendBatch(securityCodes, isAuthenticated);
 
-  const filteredData = useMemo(
-    () => filterByConfig(assetBalanceData, state.searchQuery, filterConfig),
-    [assetBalanceData, state.searchQuery]
-  );
-
-  const searchCategories = useMemo<SearchCategories>(
-    () => ({
-      securities: createSearchOptions(assetBalanceData, 'security_code', 'security_name', true),
-    }),
-    [assetBalanceData]
-  );
+  const filteredData = filterByConfig(assetBalanceData, state.searchQuery, filterConfig);
+  const searchCategories: SearchCategories = {
+    securities: createSearchOptions(assetBalanceData, 'security_code', 'security_name', true),
+  };
 
   const saveLabel = previewRows.length > 0
     ? `${previewRows.length}件 全件置換で保存`
     : '全件置換で保存';
 
-  const actionRailProps = useMemo<DataActionRailProps>(
-    () => ({
-      onFileSelect: selectFile,
-      selectedFileName: csvFileName ?? undefined,
-      fileInputDisabled: loading || saving || deleting || previewing,
-      hasCsvFile,
-      saveLabel: saving ? '保存中...' : previewing ? '解析中...' : saveLabel,
-      onSave: saveToDB,
-      saveDisabled: saving || deleting || previewing || previewRows.length === 0,
-      hasDbData,
-      deleteLabel: deleting ? '削除中...' : `全件削除 (${dbData.length}件)`,
-      onDeleteRequest: openDeleteConfirm,
-      deleteDisabled: saving || deleting || loading,
-      saveResult: lastSavedResult,
-      saveModeLabel: '全件置換',
-    }),
-    [
-      selectFile,
-      csvFileName,
-      loading,
-      saving,
-      deleting,
-      previewing,
-      hasCsvFile,
-      saveLabel,
-      saveToDB,
-      previewRows.length,
-      hasDbData,
-      dbData.length,
-      openDeleteConfirm,
-      lastSavedResult,
-    ]
-  );
+  const actionRailProps: DataActionRailProps = {
+    onFileSelect: selectFile,
+    selectedFileName: csvFileName ?? undefined,
+    fileInputDisabled: loading || saving || deleting || previewing,
+    hasCsvFile,
+    saveLabel: saving ? '保存中...' : previewing ? '解析中...' : saveLabel,
+    onSave: saveToDB,
+    saveDisabled: saving || deleting || previewing || previewRows.length === 0,
+    hasDbData,
+    deleteLabel: deleting ? '削除中...' : `全件削除 (${dbData.length}件)`,
+    onDeleteRequest: openDeleteConfirm,
+    deleteDisabled: saving || deleting || loading,
+    saveResult: lastSavedResult,
+    saveModeLabel: '全件置換',
+  };
 
-  const utilityRailProps = useMemo<AssetBalanceUtilityRailProps>(
-    () => ({
-      actionRailProps,
-      error,
-      searchCardProps: {
-        visible: assetBalanceData.length > 0,
-        categories: searchCategories,
-        value: state.searchQuery,
-        onSearch: handleSearch,
-      },
-    }),
-    [actionRailProps, error, assetBalanceData.length, searchCategories, state.searchQuery, handleSearch]
-  );
+  const utilityRailProps: AssetBalanceUtilityRailProps = {
+    actionRailProps,
+    error,
+    searchCardProps: {
+      visible: assetBalanceData.length > 0,
+      categories: searchCategories,
+      value: state.searchQuery,
+      onSearch: handleSearch,
+    },
+  };
 
   const mainStatusMessage = getMainStatusMessage({ loading, saving, deleting, previewing });
 

--- a/frontend/src/features/auth/context/AuthContext.tsx
+++ b/frontend/src/features/auth/context/AuthContext.tsx
@@ -35,9 +35,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const user = session.user;
   const isLoading = session.isLoading;
   // コンテキスト互換のsetUserラッパー（単一のstate更新でカスケードを防止）
-  const setUser = useCallback((u: UserInfo | null) => {
+  const setUser = (u: UserInfo | null) => {
     setSession(s => ({ ...s, user: u }));
-  }, []);
+  };
   // ログアウト時に呼び出されるコールバックのリスト
   const logoutCallbacksRef = useRef<Set<() => void>>(new Set());
   // 初期化時にバックエンドからセッションを確認
@@ -83,7 +83,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     locationAssigner.assign(`${apiBaseUrl}/auth/google`);
   };
 
-  const logout = useCallback(async () => {
+  const logout = async () => {
     // 登録されたコールバックを先に実行（状態クリア用）
     logoutCallbacksRef.current.forEach(callback => callback());
     let hasError = false;
@@ -98,18 +98,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     if (hasError) {
       throw caughtError;
     }
-  }, []);
+  };
 
   // ログアウト時のコールバック登録
-  const onLogout = useCallback((callback: () => void) => {
+  const onLogout = (callback: () => void) => {
     logoutCallbacksRef.current.add(callback);
     // クリーンアップ関数を返す
     return () => {
       logoutCallbacksRef.current.delete(callback);
     };
-  }, []);
+  };
 
-  const deleteAccount = useCallback(async () => {
+  const deleteAccount = async () => {
     // 登録されたコールバックを先に実行（状態クリア用）
     logoutCallbacksRef.current.forEach(callback => callback());
     let hasError = false;
@@ -124,7 +124,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     if (hasError) {
       throw caughtError;
     }
-  }, []);
+  };
 
   // 自動ログアウト処理
   const handleIdle = useCallback(() => {

--- a/frontend/src/features/stock/hooks/useStockSearch.ts
+++ b/frontend/src/features/stock/hooks/useStockSearch.ts
@@ -25,15 +25,15 @@ export function useStockSearch(initialCode?: string) {
   }, [stockCode]);
 
   // 検索を直接実行（URLパラメータからの自動検索用）
-  const searchByCode = useCallback((code: string) => {
+  const searchByCode = (code: string) => {
     setStockCode(code);
     setSearchQuery(code);
-  }, []);
+  };
 
-  const resetSearch = useCallback(() => {
+  const resetSearch = () => {
     setStockCode('');
     setSearchQuery('');
-  }, []);
+  };
 
   return {
     stockCode,

--- a/frontend/src/hooks/receipt/useReceiptData.ts
+++ b/frontend/src/hooks/receipt/useReceiptData.ts
@@ -23,7 +23,7 @@ export function useReceiptBaseData<T>(
   filterConfig: FilterConfig<T>,
 ) {
   const displayData = previewData && previewData.length > 0 ? previewData : data;
-  const sortedData = useMemo(() => sort(displayData), [sort, displayData]);
+  const sortedData = sort(displayData);
   const { searchQuery, setSearchQuery, filteredData } = useReceiptPageState(sortedData, filterConfig);
   return { sortedData, searchQuery, setSearchQuery, filteredData };
 }

--- a/frontend/src/hooks/receipt/useReceiptPageState.ts
+++ b/frontend/src/hooks/receipt/useReceiptPageState.ts
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState } from 'react';
 import { filterByConfig, FilterConfig } from '@/lib/utils/searchUtils';
 
 /**
@@ -11,9 +11,6 @@ export function useReceiptPageState<T>(
     filterConfig: FilterConfig<T>
 ) {
     const [searchQuery, setSearchQuery] = useState('');
-    const filteredData = useMemo(
-        () => filterByConfig(data, searchQuery, filterConfig),
-        [data, searchQuery, filterConfig]
-    );
+    const filteredData = filterByConfig(data, searchQuery, filterConfig);
     return { searchQuery, setSearchQuery, filteredData } as const;
 }

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { Layout } from '../components/templates/Layout';
 import { SearchForm } from '../components/organisms/SearchForm';
@@ -16,11 +16,11 @@ export function SearchPage() {
 
   const [searchParams] = useSearchParams();
   const codeParam = searchParams.get('code');
-  const normalizedCodeParam = useMemo(() => {
+  const normalizedCodeParam = (() => {
     if (!codeParam) return '';
     const trimmed = codeParam.trim();
     return SECURITY_CODE_REGEX.test(trimmed) ? trimmed : '';
-  }, [codeParam]);
+  })();
   const hasInvalidCodeParam = !!codeParam && !normalizedCodeParam;
 
   const {


### PR DESCRIPTION
## 概要
- React Compiler 環境で不要な useMemo / useCallback を削除
- DividendInfo の派生 state を useEffect からレンダー時計算へ置換
- 指定箇所の条件レンダリングを三項演算子へ統一

## テスト
- `cd frontend && vp lint`
- `cd frontend && npm test -- --run`