### PR TITLE
test: DividendSimulationForm 計算ロジックと background 二重起動防止のテストを追加

### DIFF
--- a/backend/src/services/dividend_cache/background.rs
+++ b/backend/src/services/dividend_cache/background.rs
@@ -65,3 +65,27 @@ pub fn spawn_background_refresh(
         tracing::info!("配当キャッシュ バックグラウンド更新完了");
     });
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_spawn_skips_if_already_running() {
+        let pool =
+            crate::db::connect_pool_lazy("postgresql://postgres:postgres@localhost/postgres", 1)
+                .unwrap();
+        let running = Arc::new(AtomicBool::new(true));
+
+        spawn_background_refresh(
+            pool,
+            Client::new(),
+            "dummy_key".to_string(),
+            vec!["1234".to_string()],
+            Arc::clone(&running),
+        );
+
+        // 既に実行中のためタスクを起動せず、フラグは true のまま
+        assert!(running.load(Ordering::SeqCst));
+    }
+}

--- a/frontend/src/components/molecules/DividendInfo/__tests__/DividendInfo.test.tsx
+++ b/frontend/src/components/molecules/DividendInfo/__tests__/DividendInfo.test.tsx
@@ -117,13 +117,24 @@ describe('DividendInfo', () => {
     const { useAssetBalance } = await import('@/features/assetBalance/hooks/useAssetBalance');
     vi.mocked(useAssetBalance).mockReturnValueOnce({
       assetBalanceData: [],
+      isLoading: false,
       getAssetBalanceByCode: vi.fn(() => ({
         average_purchase_price: 1000,
+        created_at: '2024-01-01T00:00:00Z',
+        current_price: 1100,
+        daily_change: 0.5,
+        executing_shares: 0,
+        id: '00000000-0000-0000-0000-000000000001',
+        market_value: 110000,
+        profit_loss_rate: 10,
         shares: 100,
         security_code: '1234',
         security_name: 'テスト株式会社',
-        total_purchase_price: 100000,
+        total_purchase_amount: 100000,
+        updated_at: '2024-01-01T00:00:00Z',
       })),
+      getTotalMarketValue: vi.fn(() => 0),
+      refetch: vi.fn(),
     });
 
     render(

--- a/frontend/src/components/molecules/DividendInfo/__tests__/DividendInfo.test.tsx
+++ b/frontend/src/components/molecules/DividendInfo/__tests__/DividendInfo.test.tsx
@@ -96,6 +96,43 @@ describe('DividendInfo', () => {
     expect(screen.getByText('取得中...')).toBeInTheDocument();
   });
 
+  it('standalone モードで一株配当取得中に入力欄が disabled になりプレースホルダーを表示する', async () => {
+    const { useDividendBatch } = await import('@/features/jquants/hooks/useDividendBatch');
+    vi.mocked(useDividendBatch).mockReturnValueOnce(createMockDividendBatchResult({
+      loading: true,
+    }));
+
+    render(
+      <DividendInfo searchQuery="1234" summary={emptySummary} />
+    );
+    const input = screen.getByPlaceholderText('データ取得中...');
+    expect(input).toBeDisabled();
+  });
+
+  it('standalone モードで一株配当と平均取得価格が揃ったとき配当利回りを計算して表示する', async () => {
+    const { useDividendBatch } = await import('@/features/jquants/hooks/useDividendBatch');
+    vi.mocked(useDividendBatch).mockReturnValueOnce(createMockDividendBatchResult({
+      dividendPerShareMap: new Map([['1234', 30]]),
+    }));
+    const { useAssetBalance } = await import('@/features/assetBalance/hooks/useAssetBalance');
+    vi.mocked(useAssetBalance).mockReturnValueOnce({
+      assetBalanceData: [],
+      getAssetBalanceByCode: vi.fn(() => ({
+        average_purchase_price: 1000,
+        shares: 100,
+        security_code: '1234',
+        security_name: 'テスト株式会社',
+        total_purchase_price: 100000,
+      })),
+    });
+
+    render(
+      <DividendInfo searchQuery="1234" summary={emptySummary} />
+    );
+    // dividendYield = 30 / 1000 * 100 = 3%, annualDividendAmount = 100 * 30 = ¥ 3,000
+    expect(screen.getByText('¥ 3,000 (3.00%)')).toBeInTheDocument();
+  });
+
   it('summary データがある場合 embedded モードで集計金額を表示する', () => {
     const summary: ComponentProps<typeof DividendInfo>['summary'] = [
       {


### PR DESCRIPTION
## 変更内容

### フロントエンド
- `DividendInfo.test.tsx` に2テスト追加（計10件）
  - `standalone` モードで `apiLoading=true` のとき一株配当フィールドが `disabled` かつ `データ取得中...` プレースホルダーを表示することを検証
  - `standalone` モードで平均取得価格=1000・保有数量=100・一株配当=30 が揃ったとき、配当利回り3.00% と年間配当金額 ¥3,000 を正しく計算して表示することを検証（PR #426 で抽出した `DividendSimulationForm` の計算ロジックのカバレッジ）

### バックエンド
- `background.rs` に1テスト追加（合計86件）
  - `running=true` のとき `spawn_background_refresh` が二重起動をスキップしてフラグを維持することを検証

## テスト結果

| コマンド | 結果 |
|---|---|
| `npm test -- --run` | ✅ 839 tests passed |
| `cargo test` | ✅ 86 passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * バックグラウンドリフレッシュプロセスの制御フローに関するテストを追加
  * 配当情報コンポーネントのローディング状態時の入力フィールド無効化、および計算結果の表示に関するテストケースを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->