### PR TITLE
fix: PR #426 で生じた react-hooks/exhaustive-deps ESLint 警告を修正

### DIFF
--- a/frontend/src/features/assetBalance/hooks/useAssetBalance.ts
+++ b/frontend/src/features/assetBalance/hooks/useAssetBalance.ts
@@ -1,5 +1,5 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import type { AssetBalanceData } from '@/types/api';
 import { assetBalanceApi } from '@/features/assetBalance/api/assetBalanceApi';
 import { useAuth } from '@/features/auth/hooks/useAuth';
@@ -40,7 +40,10 @@ export function useAssetBalance(options: UseAssetBalanceOptions = {}): UseAssetB
   }, [onLogout, queryClient]);
 
   // 未認証時はキャッシュに残存データがあっても空を返す
-  const assetBalanceData = isAuthenticated ? (query.data ?? []) : [];
+  const assetBalanceData = useMemo(
+    () => (isAuthenticated ? (query.data ?? []) : []),
+    [isAuthenticated, query.data]
+  );
 
   const getAssetBalanceByCode = useCallback(
     (code: string): AssetBalanceData | undefined => {

--- a/frontend/src/features/assetBalance/hooks/useAssetBalanceState.ts
+++ b/frontend/src/features/assetBalance/hooks/useAssetBalanceState.ts
@@ -115,9 +115,9 @@ export function useAssetBalanceState() {
     dispatch({ type: 'SET_SHOW_DELETE_CONFIRM', payload: true });
   };
 
-  const closeDeleteConfirm = () => {
+  const closeDeleteConfirm = useCallback(() => {
     dispatch({ type: 'SET_SHOW_DELETE_CONFIRM', payload: false });
-  };
+  }, []);
 
   const confirmDeleteAll = useCallback(async () => {
     closeDeleteConfirm();

--- a/frontend/src/features/auth/context/AuthContext.tsx
+++ b/frontend/src/features/auth/context/AuthContext.tsx
@@ -83,7 +83,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     locationAssigner.assign(`${apiBaseUrl}/auth/google`);
   };
 
-  const logout = async () => {
+  const logout = useCallback(async () => {
     // 登録されたコールバックを先に実行（状態クリア用）
     logoutCallbacksRef.current.forEach(callback => callback());
     let hasError = false;
@@ -98,7 +98,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     if (hasError) {
       throw caughtError;
     }
-  };
+  }, []);
 
   // ログアウト時のコールバック登録
   const onLogout = (callback: () => void) => {


### PR DESCRIPTION
## 概要

PR #426（不要な useMemo/useCallback 削除）のマージ後、CI の `npm run lint` が ESLint 警告 4 件で失敗していた問題を修正する。

## 原因

PR #426 でいくつかの `useCallback` を削除したことで、それらを依存配列に持つ他の `useCallback` が不安定な参照を受け取るようになり `react-hooks/exhaustive-deps` 警告が発生した。  
レビュー時に `vp lint`（Vite 統合の lint）を使ったが、`npm run lint`（ESLint 直接実行）とは結果が異なりこの警告が見逃された。

## 修正内容

| ファイル | 修正 |
|---|---|
| `useAssetBalance.ts` | `assetBalanceData` を `useMemo` でラップし依存配列を安定化 |
| `useAssetBalanceState.ts` | `closeDeleteConfirm` を `useCallback` でラップ |
| `AuthContext.tsx` | `logout` を `useCallback` でラップ |

## テスト結果

| コマンド | 結果 |
|---|---|
| `npm run lint` | ✅ 0 warnings |
| `npm test -- --run` | ✅ 839 tests passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)