### PR TITLE
chore: スキルの lint コマンドを vp lint から npm run lint に統一

### DIFF
--- a/.claude/skills/claude-codex-handoff/SKILL.md
+++ b/.claude/skills/claude-codex-handoff/SKILL.md
@@ -40,7 +40,7 @@ Codex が最短で実装に着手できる依頼文を作成し、`codex exec --
 ## 確認コマンド
 ```bash
 # フロントエンド変更がある場合
-cd frontend && vp lint && npm test && vp build
+cd frontend && npm run lint && npm test && vp build
 
 # バックエンド変更がある場合
 cd backend && cargo clippy --all-targets -- -D warnings && cargo test
@@ -76,7 +76,7 @@ PR #<番号> のレビュー指摘に対応する。各指摘に返信してか�
 ## 確認コマンド
 ```bash
 # フロントエンド変更がある場合
-cd frontend && vp lint && npx tsc --noEmit && npm test -- --run && vp build
+cd frontend && npm run lint && npx tsc --noEmit && npm test -- --run && vp build
 
 # バックエンド変更がある場合
 cd backend && cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -33,7 +33,7 @@ Codex が実装して push した PR を Claude がレビューする。
 変更範囲に応じて実行:
 
 - フロントエンド変更がある場合:
-  - `cd frontend && vp lint`
+  - `cd frontend && npm run lint`
   - `cd frontend && npx tsc --noEmit`
   - `cd frontend && npm test`
   - `cd frontend && vp build`


### PR DESCRIPTION
## 概要
- `.claude/skills/pr-review/SKILL.md` のフロントエンド lint コマンドを `npm run lint` に変更
- `.claude/skills/claude-codex-handoff/SKILL.md` の確認コマンド例 2 箇所を `npm run lint` に変更

## 背景
- `vp lint` と CI の `npm run lint` でルールセットが異なり、ローカル確認では見逃した警告で CI が失敗していたため
- スキル内の lint コマンドを CI と同じ `npm run lint` に統一して再発を防ぐため

## テスト
- `rg -n "vp lint" .claude/skills/pr-review/SKILL.md .claude/skills/claude-codex-handoff/SKILL.md` が 0 件
- `rg -n "npm run lint" .claude/skills/pr-review/SKILL.md .claude/skills/claude-codex-handoff/SKILL.md`
