### PR TITLE
test: csv_pipeline 空バイト入力のエッジケーステストを追加

### DIFF
--- a/backend/src/services/csv_pipeline.rs
+++ b/backend/src/services/csv_pipeline.rs
@@ -105,6 +105,20 @@ mod tests {
         row.get("name").is_some_and(|name| name.contains("合計"))
     }
 
+    // `parse_csv_with_config` always hands csv::Reader valid UTF-8 bytes from an in-memory
+    // buffer. Combined with `flexible(true)`, we could not reproduce header/record read errors
+    // in a unit test, including inputs containing `\0`, so only the empty-input edge case is
+    // covered here.
+    #[test]
+    fn test_parse_csv_empty_bytes() {
+        let result = parse_csv_with_config(b"", &BASIC_CONFIG);
+
+        assert!(matches!(
+            result,
+            Err(ApiError::ValidationError(msg)) if msg == "CSVが空です"
+        ));
+    }
+
     #[test]
     fn test_parse_csv_with_config() {
         let rows = parse_csv_with_config(


### PR DESCRIPTION
## 概要
- `parse_csv_with_config` の空バイト入力に対する `ValidationError("CSVが空です")` の回帰テストを追加
- ヘッダー/行読み込み失敗は、`decode_bytes` が入力を UTF-8 `String` に正規化し、`flexible(true)` とメモリ上の reader を使う現状の経路では再現できないため、理由をコメントで補足

## テスト
- `cd backend && cargo clippy --all-targets -- -D warnings`
- `cd backend && cargo test csv_pipeline`