### PR TITLE
test: カバレッジ未到達エッジケース3件にテストを追加

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -180,6 +180,16 @@ mod tests {
         assert!(server_addr().starts_with("0.0.0.0:"));
         let _ = is_secure_cookie();
     }
+    #[test]
+    fn test_config_from_env_jquants_rps() {
+        let _guard = ENV_MUTEX.blocking_lock();
+        let _env = EnvGuard::set("JQUANTS_RATE_LIMIT_RPS", Some("7"));
+        let _env2 = EnvGuard::set("FRONTEND_URL", None);
+        let _env3 = EnvGuard::set("BACKEND_URL", None);
+
+        let config = Config::from_env();
+        assert_eq!(config.jquants_rate_limit_rps, 7);
+    }
     #[tokio::test]
     async fn test_config_from_env() {
         let _lock = ENV_MUTEX.lock().await;

--- a/backend/src/config/cors.rs
+++ b/backend/src/config/cors.rs
@@ -78,6 +78,7 @@ mod tests {
             ("http://127.0.0.1:8080", true),
             ("https://[::1]:3000", true),
             ("http://[0:0:0:0:0:0:0:1]:5173/path", true),
+            ("http://[::1", false),
             ("https://localhost.example.com", false),
             ("https://127.0.0.1.example.com:3000", false),
             ("https://frontend.example.com", false),

--- a/backend/src/errors.rs
+++ b/backend/src/errors.rs
@@ -181,6 +181,16 @@ mod tests {
         assert_eq!(error.into_response().status(), expected);
     }
     #[test]
+    fn test_from_request_token_error() {
+        let io_err = std::io::Error::other("test oauth error");
+        let token_err: RequestTokenError<
+            std::io::Error,
+            StandardErrorResponse<BasicErrorResponseType>,
+        > = RequestTokenError::Request(io_err);
+        let api_err: ApiError = token_err.into();
+        assert!(matches!(api_err, ApiError::OAuthError(_)));
+    }
+    #[test]
     fn test_all_error_status_codes() {
         let serde_err = serde_json::from_str::<serde_json::Value>("invalid json").unwrap_err();
         for (error, expected) in [


### PR DESCRIPTION
## 概要
- cargo tarpaulin で未到達だった3件のテストを追加

## 変更内容
- CORS の IPv6 localhost 異常系ケースを追加
- JQUANTS_RATE_LIMIT_RPS の環境変数読み込みテストを追加
- RequestTokenError から ApiError::OAuthError への変換テストを追加

## テスト
- cd backend && cargo clippy --all-targets -- -D warnings
- cd backend && cargo test