### PR TITLE
test: CORS 述語 false 分岐と tracing スパンのカバレッジを追加

### DIFF
--- a/backend/src/config/cors.rs
+++ b/backend/src/config/cors.rs
@@ -65,10 +65,47 @@ pub fn is_localhost_origin(origin: &str) -> bool {
 }
 #[cfg(test)]
 mod tests {
-    use super::{is_localhost_origin, parse_cors_origins};
+    use {
+        super::{build_cors_layer, is_localhost_origin, parse_cors_origins},
+        crate::state::AppState,
+        axum::{
+            body::Body,
+            http::{header::ACCESS_CONTROL_ALLOW_ORIGIN, Method, Request},
+            routing::get,
+            Router,
+        },
+        reqwest::Client,
+        std::sync::Arc,
+        tower::ServiceExt,
+    };
+
     fn strings(origins: &[&str]) -> Vec<String> {
         origins.iter().map(|origin| (*origin).to_string()).collect()
     }
+
+    fn build_test_app(cors_origins: &[String]) -> Router {
+        let database_url = "postgresql://user:password@localhost/test_db";
+        let pool = crate::db::connect_pool_lazy(database_url, 1)
+            .expect("Failed to create connection pool");
+        let secrets = Arc::new(crate::state::Secrets {
+            database_url: database_url.to_string(),
+            jquants_api_key: None,
+            google_client_id: None,
+            google_client_secret: None,
+            frontend_url: "http://localhost:8080".to_string(),
+        });
+
+        Router::new()
+            .route("/health", get(|| async { "OK" }))
+            .layer(build_cors_layer(cors_origins))
+            .with_state(AppState {
+                pool,
+                secrets,
+                client: Client::new(),
+                dividend_cache: crate::state::DividendCacheState::default(),
+            })
+    }
+
     #[test]
     fn test_is_localhost_origin() {
         for (origin, expected) in [
@@ -106,5 +143,28 @@ mod tests {
         ] {
             assert_eq!(parse_cors_origins(input), strings(expected));
         }
+    }
+
+    #[tokio::test]
+    async fn test_cors_predicate_with_invalid_configured_origin() {
+        let app = build_test_app(&["https://frontend.example.com\n".to_string()]);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::OPTIONS)
+                    .uri("/health")
+                    .header("origin", "https://frontend.example.com")
+                    .header("access-control-request-method", "GET")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert!(response.status().is_success());
+        assert!(response
+            .headers()
+            .get(ACCESS_CONTROL_ALLOW_ORIGIN)
+            .is_none());
     }
 }

--- a/backend/src/middleware/tracing.rs
+++ b/backend/src/middleware/tracing.rs
@@ -26,3 +26,136 @@ impl<B> MakeSpan<B> for PathOnlyMakeSpan {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::PathOnlyMakeSpan,
+        axum::http::Request,
+        std::{
+            collections::BTreeMap,
+            sync::{Arc, Mutex},
+        },
+        tower_http::trace::MakeSpan,
+        tracing::{
+            field::{Field, Visit},
+            Subscriber,
+        },
+        tracing_subscriber::{
+            layer::{Context, SubscriberExt},
+            registry::LookupSpan,
+            Layer, Registry,
+        },
+    };
+
+    #[derive(Clone, Debug, Default)]
+    struct CapturedSpans(Arc<Mutex<Vec<CapturedSpan>>>);
+
+    impl CapturedSpans {
+        fn take(&self) -> Vec<CapturedSpan> {
+            self.0
+                .lock()
+                .expect("captured spans mutex poisoned")
+                .clone()
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct CapturedSpan {
+        name: String,
+        fields: BTreeMap<String, String>,
+    }
+
+    #[derive(Default)]
+    struct FieldRecorder(BTreeMap<String, String>);
+
+    impl Visit for FieldRecorder {
+        fn record_str(&mut self, field: &Field, value: &str) {
+            self.0.insert(field.name().to_string(), value.to_string());
+        }
+
+        fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+            self.0
+                .insert(field.name().to_string(), format!("{value:?}"));
+        }
+    }
+
+    impl<S> Layer<S> for CapturedSpans
+    where
+        S: Subscriber + for<'span> LookupSpan<'span>,
+    {
+        fn on_new_span(
+            &self,
+            attrs: &tracing::span::Attributes<'_>,
+            _id: &tracing::Id,
+            _ctx: Context<'_, S>,
+        ) {
+            let mut recorder = FieldRecorder::default();
+            attrs.record(&mut recorder);
+            self.0
+                .lock()
+                .expect("captured spans mutex poisoned")
+                .push(CapturedSpan {
+                    name: attrs.metadata().name().to_string(),
+                    fields: recorder.0,
+                });
+        }
+    }
+
+    #[test]
+    fn test_make_span_covers_request_id_extraction() {
+        let captured = CapturedSpans::default();
+        let subscriber = Registry::default().with(captured.clone());
+
+        tracing::subscriber::with_default(subscriber, || {
+            let mut make_span = PathOnlyMakeSpan;
+
+            let request_with_id = Request::builder()
+                .method("GET")
+                .uri("/auth/google/callback?code=secret&state=opaque")
+                .header("x-request-id", "req-123")
+                .body(())
+                .unwrap();
+            let span = make_span.make_span(&request_with_id);
+            drop(span);
+
+            let request_without_id = Request::builder()
+                .method("POST")
+                .uri("/health?foo=bar")
+                .body(())
+                .unwrap();
+            let span = make_span.make_span(&request_without_id);
+            drop(span);
+        });
+
+        let spans = captured.take();
+        assert_eq!(spans.len(), 2);
+
+        assert_eq!(spans[0].name, "http_request");
+        assert_eq!(
+            spans[0].fields.get("request_id").map(String::as_str),
+            Some("req-123")
+        );
+        assert_eq!(
+            spans[0].fields.get("path").map(String::as_str),
+            Some("/auth/google/callback")
+        );
+        assert_eq!(
+            spans[0].fields.get("method").map(String::as_str),
+            Some("GET")
+        );
+
+        assert_eq!(
+            spans[1].fields.get("request_id").map(String::as_str),
+            Some("-")
+        );
+        assert_eq!(
+            spans[1].fields.get("path").map(String::as_str),
+            Some("/health")
+        );
+        assert_eq!(
+            spans[1].fields.get("method").map(String::as_str),
+            Some("POST")
+        );
+    }
+}


### PR DESCRIPTION
## 概要
- cargo tarpaulin で未カバーだった CORS 述語の false 分岐に対するテストを追加
- PathOnlyMakeSpan::make_span の request_id 抽出と path-only span 生成を確認するテストを追加

## テスト
- cd backend && cargo clippy --all-targets -- -D warnings
- cd backend && cargo test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * CORS オリジン検証機能の統合テストカバレッジを拡張しました。無効なオリジン設定時の動作確認テストを追加しました。
  * リクエストトレーシング機能のテストカバレッジを強化しました。リクエストID およびメタデータの正確な記録を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->