### PR TITLE
test: ApiClient のブランチカバレッジを追加

### DIFF
--- a/frontend/src/lib/api/__tests__/client.test.ts
+++ b/frontend/src/lib/api/__tests__/client.test.ts
@@ -520,6 +520,76 @@ describe('ApiClient', () => {
       );
     });
   });
+
+  describe('カバレッジ補完', () => {
+    it('baseURL 省略時は VITE_SHOKEN_WEBAPI_API_URL または空文字を使う', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve('null'),
+      });
+      const client = createApiClient({});
+      const resultPromise = client.get('/health');
+      await vi.runAllTimersAsync();
+      await resultPromise;
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/health'),
+        expect.objectContaining({ method: 'GET' })
+      );
+    });
+
+    it('params に undefined 値があるときはクエリから除外される', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve('{}'),
+      });
+      const client = createApiClient({ baseURL: 'http://api.test' });
+      const resultPromise = client.get('/test', {
+        params: { foo: 'bar', baz: undefined },
+      });
+      await vi.runAllTimersAsync();
+      await resultPromise;
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://api.test/test?foo=bar',
+        expect.objectContaining({ method: 'GET' })
+      );
+    });
+
+    it('params がすべて undefined のときはクエリなしの URL になる', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve('{}'),
+      });
+      const client = createApiClient({ baseURL: 'http://api.test' });
+      const resultPromise = client.get('/test', {
+        params: { foo: undefined },
+      });
+      await vi.runAllTimersAsync();
+      await resultPromise;
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://api.test/test',
+        expect.objectContaining({ method: 'GET' })
+      );
+    });
+
+    it('withCredentials 省略時は credentials が same-origin になる', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve('{}'),
+      });
+      const client = createApiClient({ baseURL: 'http://api.test' });
+      const resultPromise = client.get('/test');
+      await vi.runAllTimersAsync();
+      await resultPromise;
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ credentials: 'same-origin' })
+      );
+    });
+  });
 });
 
 // Rustテスト

--- a/frontend/src/lib/csv/__tests__/encoding.test.ts
+++ b/frontend/src/lib/csv/__tests__/encoding.test.ts
@@ -243,5 +243,78 @@ describe('encoding utilities', () => {
         confidence: 0.1
       });
     });
+
+    it('TextDecoder コンストラクタが非 Error 値を投げた場合は String() で警告する', () => {
+      const originalTextDecoder = TextDecoder;
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      class MockTextDecoder {
+        constructor(encoding = 'utf-8', options?: TextDecoderOptions) {
+          if (encoding === 'shift-jis') {
+            // eslint-disable-next-line @typescript-eslint/no-throw-literal
+            throw 'non-error string';
+          }
+          return new originalTextDecoder(encoding, options);
+        }
+        decode(input?: Uint8Array) {
+          return new originalTextDecoder('utf-8').decode(input);
+        }
+      }
+      vi.stubGlobal('TextDecoder', MockTextDecoder as unknown as typeof TextDecoder);
+
+      const result = tryDecodeWithMultipleEncodings(new TextEncoder().encode('hello'));
+
+      expect(result.encoding).toBe('utf-8');
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('はサポートされていません'),
+        'non-error string'
+      );
+    });
+
+    it('decode() が非 Error 値を投げた場合は String() で警告する', () => {
+      const originalTextDecoder = TextDecoder;
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      class MockTextDecoder {
+        private readonly decoder?: TextDecoder;
+        private readonly shouldThrow: boolean;
+        constructor(encoding = 'utf-8', options?: TextDecoderOptions) {
+          this.shouldThrow = encoding === 'iso-8859-1';
+          if (!this.shouldThrow) {
+            this.decoder = new originalTextDecoder(encoding, options);
+          }
+        }
+        decode(input?: Uint8Array) {
+          if (this.shouldThrow) {
+            // eslint-disable-next-line @typescript-eslint/no-throw-literal
+            throw 'decode-non-error';
+          }
+          return this.decoder!.decode(input);
+        }
+      }
+      vi.stubGlobal('TextDecoder', MockTextDecoder as unknown as typeof TextDecoder);
+
+      const result = tryDecodeWithMultipleEncodings(new TextEncoder().encode('hello'));
+
+      expect(result.encoding).toBe('utf-8');
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('でのデコードに失敗しました'),
+        'decode-non-error'
+      );
+    });
+
+    it('外側 catch が非 Error 値を受け取った場合は String() で警告する', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      vi.spyOn(Math, 'max').mockImplementationOnce(() => {
+        // eslint-disable-next-line @typescript-eslint/no-throw-literal
+        throw 'outer-non-error';
+      });
+
+      const result = tryDecodeWithMultipleEncodings(new TextEncoder().encode('hello'));
+
+      expect(result.text).toBeTruthy();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('でのデコードに失敗しました'),
+        'outer-non-error'
+      );
+    });
   });
 });

--- a/frontend/src/lib/csv/__tests__/encoding.test.ts
+++ b/frontend/src/lib/csv/__tests__/encoding.test.ts
@@ -250,7 +250,6 @@ describe('encoding utilities', () => {
       class MockTextDecoder {
         constructor(encoding = 'utf-8', options?: TextDecoderOptions) {
           if (encoding === 'shift-jis') {
-            // eslint-disable-next-line @typescript-eslint/no-throw-literal
             throw 'non-error string';
           }
           return new originalTextDecoder(encoding, options);
@@ -284,7 +283,6 @@ describe('encoding utilities', () => {
         }
         decode(input?: Uint8Array) {
           if (this.shouldThrow) {
-            // eslint-disable-next-line @typescript-eslint/no-throw-literal
             throw 'decode-non-error';
           }
           return this.decoder!.decode(input);
@@ -304,7 +302,6 @@ describe('encoding utilities', () => {
     it('外側 catch が非 Error 値を受け取った場合は String() で警告する', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       vi.spyOn(Math, 'max').mockImplementationOnce(() => {
-        // eslint-disable-next-line @typescript-eslint/no-throw-literal
         throw 'outer-non-error';
       });
 


### PR DESCRIPTION
baseURL 省略（VITE_SHOKEN_WEBAPI_API_URL ?? ''）、params undefined 除外、全 undefined 時の空 qs、withCredentials 省略（same-origin）の4ブランチをカバーする。

## テスト結果
Tests: 855 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

このプルリクエストはテストの充実強化を含む内部的な変更となります。ユーザーに直接影響する機能や仕様の変更はありません。

* **Tests**
  * API クライアントのテストカバレッジを拡張

<!-- end of auto-generated comment: release notes by coderabbit.ai -->