### PR TITLE
test: client.ts と encoding.ts のブランチカバレッジを追加

### DIFF
--- a/frontend/src/lib/api/__tests__/client.test.ts
+++ b/frontend/src/lib/api/__tests__/client.test.ts
@@ -382,6 +382,30 @@ describe('ApiClient', () => {
   });
 
   describe('設定', () => {
+    it('baseURL 省略時は環境変数または空文字を使う', async () => {
+      vi.stubEnv('VITE_SHOKEN_WEBAPI_API_URL', undefined);
+
+      try {
+        mockFetch.mockResolvedValue({
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve('null'),
+        });
+
+        const client = createApiClient();
+        const resultPromise = client.get('/default-base');
+        await vi.runAllTimersAsync();
+        await resultPromise;
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          '/default-base',
+          expect.objectContaining({ method: 'GET' })
+        );
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
+
     it('カスタム設定でクライアントを作成できる', async () => {
       mockFetch.mockResolvedValue({
         ok: true,
@@ -423,6 +447,38 @@ describe('ApiClient', () => {
       expect(headers['Accept']).toBe('application/json');
     });
 
+    it('withCredentials 省略時は same-origin になる', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve('{}'),
+      });
+
+      const client = createApiClient({ baseURL: 'http://api.test' });
+      const resultPromise = client.get('/credentials');
+      await vi.runAllTimersAsync();
+      await resultPromise;
+
+      const [, fetchOptions] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(fetchOptions.credentials).toBe('same-origin');
+    });
+
+    it('withCredentials が true のときは include になる', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve('{}'),
+      });
+
+      const client = createApiClient({ baseURL: 'http://api.test' });
+      const resultPromise = client.get('/credentials', { withCredentials: true });
+      await vi.runAllTimersAsync();
+      await resultPromise;
+
+      const [, fetchOptions] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(fetchOptions.credentials).toBe('include');
+    });
+
     it('認証確認用にtimeout/retryをカスタマイズできる', async () => {
       mockFetch.mockResolvedValue({
         ok: true,
@@ -460,6 +516,51 @@ describe('ApiClient', () => {
         'http://api.test/test?existing=1&key=value',
         expect.objectContaining({ method: 'GET' })
       );
+    });
+
+    it('params に undefined 値があるときはクエリから除外される', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve('{}'),
+      });
+
+      const client = createApiClient({ baseURL: 'http://api.test' });
+      const resultPromise = client.get('/search', {
+        params: {
+          foo: 'bar',
+          baz: undefined,
+          page: 2,
+          active: false,
+        },
+      });
+      await vi.runAllTimersAsync();
+      await resultPromise;
+
+      const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe('http://api.test/search?foo=bar&page=2&active=false');
+      expect(url).not.toContain('baz');
+    });
+
+    it('params がすべて undefined のときはクエリを付与しない', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve('{}'),
+      });
+
+      const client = createApiClient({ baseURL: 'http://api.test' });
+      const resultPromise = client.get('/search', {
+        params: {
+          foo: undefined,
+          bar: undefined,
+        },
+      });
+      await vi.runAllTimersAsync();
+      await resultPromise;
+
+      const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe('http://api.test/search');
     });
   });
 

--- a/frontend/src/lib/csv/__tests__/encoding.test.ts
+++ b/frontend/src/lib/csv/__tests__/encoding.test.ts
@@ -168,6 +168,35 @@ describe('encoding utilities', () => {
       expect(warnSpy).toHaveBeenCalled();
     });
 
+    it('先頭エンコーディングの TextDecoder コンストラクタが例外を投げる場合はスキップする', () => {
+      const originalTextDecoder = TextDecoder;
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      class MockTextDecoder {
+        private readonly decoder: TextDecoder;
+
+        constructor(encoding = 'utf-8', options?: TextDecoderOptions) {
+          if (encoding === 'utf-8') {
+            throw 'unsupported encoding';
+          }
+          this.decoder = new originalTextDecoder(encoding, options);
+        }
+
+        decode(input?: Uint8Array) {
+          return this.decoder.decode(input);
+        }
+      }
+      vi.stubGlobal('TextDecoder', MockTextDecoder as unknown as typeof TextDecoder);
+
+      const result = tryDecodeWithMultipleEncodings(new Uint8Array([0xB1, 0xB2, 0xB3]));
+
+      expect(result.encoding).toBe('shift-jis');
+      expect(result.text).toBe('ｱｲｳ');
+      expect(warnSpy).toHaveBeenCalledWith(
+        'エンコーディング utf-8 はサポートされていません:',
+        'unsupported encoding'
+      );
+    });
+
     it('decode で例外が発生したエンコーディングはスキップする', () => {
       const originalTextDecoder = TextDecoder;
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -195,6 +224,52 @@ describe('encoding utilities', () => {
 
       expect(result.encoding).toBe('utf-8');
       expect(warnSpy).toHaveBeenCalled();
+    });
+
+    it('先頭エンコーディングの decode が例外を投げる場合はスキップする', () => {
+      const originalTextDecoder = TextDecoder;
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      class MockTextDecoder {
+        private readonly decoder: TextDecoder;
+        private readonly encoding: string;
+
+        constructor(encoding = 'utf-8', options?: TextDecoderOptions) {
+          this.encoding = encoding;
+          this.decoder = new originalTextDecoder(encoding, options);
+        }
+
+        decode(input?: Uint8Array) {
+          if (this.encoding === 'utf-8') {
+            throw 'decode failed';
+          }
+          return this.decoder.decode(input);
+        }
+      }
+      vi.stubGlobal('TextDecoder', MockTextDecoder as unknown as typeof TextDecoder);
+
+      const result = tryDecodeWithMultipleEncodings(new Uint8Array([0xB1, 0xB2, 0xB3]));
+
+      expect(result.encoding).toBe('shift-jis');
+      expect(result.text).toBe('ｱｲｳ');
+      expect(warnSpy).toHaveBeenCalledWith(
+        'utf-8 でのデコードに失敗しました:',
+        'decode failed'
+      );
+    });
+
+    it('Error 以外の予期しない例外も外側の catch で握りつぶして継続する', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      vi.spyOn(Math, 'max').mockImplementationOnce(() => {
+        throw 'unexpected failure';
+      });
+
+      const result = tryDecodeWithMultipleEncodings(new TextEncoder().encode('hello'));
+
+      expect(result.text).toBeTruthy();
+      expect(warnSpy).toHaveBeenCalledWith(
+        'utf-8 でのデコードに失敗しました:',
+        'unexpected failure'
+      );
     });
 
     it('予期しない例外は外側の catch で握りつぶして継続する', () => {


### PR DESCRIPTION
withCredentials 省略（same-origin）、params undefined 除外、TextDecoder 例外 catch ブロックをテストでカバーする。