### PR TITLE
test: formatters と ApiError のブランチカバレッジを追加

### DIFF
--- a/frontend/src/lib/types/__tests__/api.test.ts
+++ b/frontend/src/lib/types/__tests__/api.test.ts
@@ -39,6 +39,22 @@ describe('ApiError', () => {
       expect(error.requestMethod).toBe('POST');
     });
 
+    it('Error.captureStackTrace が存在しない環境ではスキップされる', () => {
+      const originalCaptureStackTrace = Error.captureStackTrace;
+      Object.defineProperty(Error, 'captureStackTrace', {
+        value: undefined,
+        configurable: true,
+      });
+      try {
+        expect(() => new ApiError(ApiErrorType.REQUEST_ERROR, 'test')).not.toThrow();
+      } finally {
+        Object.defineProperty(Error, 'captureStackTrace', {
+          value: originalCaptureStackTrace,
+          configurable: true,
+        });
+      }
+    });
+
     const captureStackTraceIt =
       typeof Error.captureStackTrace === 'function' ? it : it.skip;
 
@@ -94,6 +110,19 @@ describe('ApiError', () => {
       );
 
       expect(error.toDetailedString()).toContain('URL: POST /api/test');
+    });
+
+    it('requestUrl があり requestMethod が未指定の場合は GET を使う', () => {
+      const error = new ApiError(
+        ApiErrorType.REQUEST_ERROR,
+        'リクエストに失敗しました',
+        undefined,
+        undefined,
+        '/api/test',
+        undefined
+      );
+
+      expect(error.toDetailedString()).toContain('URL: GET /api/test');
     });
 
     it('details がある場合は Details を含む', () => {

--- a/frontend/src/lib/utils/__tests__/formatters.test.ts
+++ b/frontend/src/lib/utils/__tests__/formatters.test.ts
@@ -100,6 +100,10 @@ describe('日付関連のフォーマット関数', () => {
       const date = new Date(2023, 0, 5);
       expect(createISODateKey(date)).toBe('2023-01-05');
     });
+
+    it('無効な日付は空文字を返す', () => {
+      expect(createISODateKey(new Date('invalid'))).toBe('');
+    });
   });
 });
 


### PR DESCRIPTION
createISODateKey 無効日付、ApiError requestMethod フォールバック、Error.captureStackTrace なし環境の3ブランチをカバーする。

## テスト結果
Tests: 854 passed