### PR TITLE
test: ページコンポーネントのブランチカバレッジを追加

### DIFF
--- a/frontend/src/pages/Receipt/__tests__/Dividend.test.tsx
+++ b/frontend/src/pages/Receipt/__tests__/Dividend.test.tsx
@@ -354,6 +354,24 @@ describe('Dividend', () => {
         }
     });
 
+    it('検索種別に一致しないクエリでも年月単位でグループ化される', () => {
+        const useReceiptBaseDataSpy = vi.spyOn(receiptHooks, 'useReceiptBaseData').mockReturnValue({
+            sortedData: mockData,
+            searchQuery: '該当なし',
+            setSearchQuery: vi.fn(),
+            filteredData: [mockData[0]],
+        } as ReturnType<typeof receiptHooks.useReceiptBaseData>);
+
+        try {
+            render(<Dividend data={mockData} />);
+
+            expect(screen.getByText('2023年1月')).toBeInTheDocument();
+            expect(screen.queryByText('2023年2月')).not.toBeInTheDocument();
+        } finally {
+            useReceiptBaseDataSpy.mockRestore();
+        }
+    });
+
     it('コード付きラベル形式の検索クエリでも銘柄詳細ヘッダーが表示される', async () => {
         const useReceiptBaseDataSpy = vi.spyOn(receiptHooks, 'useReceiptBaseData').mockReturnValue({
             sortedData: mockData,

--- a/frontend/src/pages/__tests__/AssetBalancePage.test.tsx
+++ b/frontend/src/pages/__tests__/AssetBalancePage.test.tsx
@@ -228,6 +228,22 @@ describe('AssetBalancePage 認証境界・キャッシュ境界', () => {
     expect(assetBalanceApiModule.assetBalanceApi.list).not.toHaveBeenCalled();
   });
 
+  it('未認証時: ログインボタンを押すとログイン処理が呼ばれる', async () => {
+    const login = vi.fn();
+    vi.mocked(authHook.useAuth).mockReturnValue({
+      ...makeAuthMock({}),
+      login,
+    });
+
+    await act(async () => { renderWithQuery(<AssetBalancePage />); });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'ログイン' }));
+
+    expect(login).toHaveBeenCalledTimes(1);
+    expect(assetBalanceApiModule.assetBalanceApi.list).not.toHaveBeenCalled();
+  });
+
   it('認証確認中: スピナーと案内文が表示される', async () => {
     vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({ authLoading: true }));
 

--- a/frontend/src/pages/__tests__/Search.test.tsx
+++ b/frontend/src/pages/__tests__/Search.test.tsx
@@ -184,4 +184,26 @@ describe('SearchPage', () => {
       screen.queryByText('J-Quants API の応答形式が変更された可能性があります')
     ).not.toBeInTheDocument();
   });
+
+  it('検索結果がある場合は銘柄情報を表示する', () => {
+    mockUseStockSearch.mockReturnValue({
+      stockCode: '7203',
+      setStockCode: vi.fn(),
+      stockData: { code: '7203', name: 'トヨタ自動車' },
+      error: null,
+      isLoading: false,
+      isError: false,
+      handleSearch: vi.fn(),
+      searchByCode: vi.fn(),
+    });
+
+    render(
+      <MemoryRouter>
+        <SearchPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('StockInfo')).toBeInTheDocument();
+    expect(screen.queryByText('銘柄を検索')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
AssetBalancePage ログインボタン・Search null エラー・Dividend デフォルトグループキーの3ブランチをカバーする。

## テスト結果
Tests: 864 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

このプルリクエストはテストの改善と検証ロジックの追加のみを含むため、エンドユーザーに対する新しい機能や変更は直接的にはありません。

* **Tests**
  * 複数のページコンポーネントに対するテストケースを追加し、検索機能、認証フロー、データ表示の動作をより包括的に検証するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->