### PR TITLE
test: 認証フックのカバレッジを追加

### DIFF
--- a/frontend/src/features/auth/context/__tests__/locationAssigner.test.ts
+++ b/frontend/src/features/auth/context/__tests__/locationAssigner.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { locationAssigner } from '../locationAssigner';
+
+describe('locationAssigner', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('assign が window.location.assign にURLを渡す', () => {
+    const assign = vi.fn();
+
+    vi.stubGlobal('window', {
+      location: {
+        assign,
+      },
+    });
+
+    locationAssigner.assign('https://api.example.com/auth/google');
+
+    expect(assign).toHaveBeenCalledWith('https://api.example.com/auth/google');
+  });
+});

--- a/frontend/src/features/auth/hooks/__tests__/useIdleTimer.test.ts
+++ b/frontend/src/features/auth/hooks/__tests__/useIdleTimer.test.ts
@@ -34,9 +34,39 @@ describe('useIdleTimer', () => {
   it('enabled=false のとき onIdle を呼ばない', () => {
     const onIdle = vi.fn();
 
-    renderHook(() => useIdleTimer({ timeout: 1000, onIdle, enabled: false }));
+    const { result } = renderHook(() => useIdleTimer({ timeout: 1000, onIdle, enabled: false }));
 
     act(() => {
+      result.current.resetTimer();
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(onIdle).not.toHaveBeenCalled();
+  });
+
+  it('enabled が true から false に切り替わると既存タイマーを解除する', () => {
+    const onIdle = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ enabled }) => useIdleTimer({ timeout: 1000, onIdle, enabled }),
+      { initialProps: { enabled: true } }
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    rerender({ enabled: false });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(onIdle).not.toHaveBeenCalled();
+
+    act(() => {
+      document.dispatchEvent(new MouseEvent('mousedown'));
       vi.advanceTimersByTime(1000);
     });
     expect(onIdle).not.toHaveBeenCalled();


### PR DESCRIPTION
## 概要
- `locationAssigner.assign` が `window.location.assign` に URL を渡すことをテスト
- `useIdleTimer` で `enabled` を true から false に切り替えたとき既存タイマーが解除されることをテスト

## テスト
- `npm test -- src/features/auth/context/__tests__/locationAssigner.test.ts src/features/auth/hooks/__tests__/useIdleTimer.test.ts`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test -- --run`
- `npm run build`