### PR TITLE
Fly.io 起動時の DB 接続を安定化

### DIFF
--- a/.claude/rules/00-general.md
+++ b/.claude/rules/00-general.md
@@ -10,20 +10,37 @@
 ## 開発フロー（標準）
 
 ### 役割分担
-- **Claude**: 設計・タスク定義・コードレビュー・マージ判断
-- **Codex**: 実装・テスト・コミット・push・PR 作成
+- **Codex**: 調査・設計・タスク定義・実装レビュー・PR レビュー
+- **Claude**: task file に基づく実装・テスト・レビュー指摘対応
 
 ### 標準フロー
-1. Claude がタスクを設計し `docs/tasks/<branch-name>.md` を作成する
-2. Claude が `.claude/skills/claude-codex-handoff/SKILL.md` で Codex に実装を委譲する
-3. Codex が実装・lint/test/build・commit・push・PR 作成を行う
-4. Claude が `/pr-review` スキルで PR をレビューし、GitHub にコメントを投稿する
-5. **修正が必要な場合**: Claude が `claude-codex-handoff` で指摘一覧（コメント ID 付き）を Codex に渡す
-6. **Codex が指摘への対応をする**: 各指摘コメントに返信 → 修正実装 → lint/test/build → push（PR 作成は不要）
-7. Claude が再レビュー（ステップ 4 に戻る）
-8. LGTM → Claude がマージ
+1. Codex が調査・設計を行い `docs/tasks/<branch-name>.md` を作成する
+2. Codex が task file に `Claude 実装依頼` セクションを作り、目的・現状・期待挙動・対象ファイル・制約・受け入れ条件・確認コマンドを明記する
+3. Codex が `claude` CLI で Claude を直接呼び出し、実装を委譲する
+4. Claude が実装・lint/test/build・task file 更新を行う
+5. Codex が差分、テスト結果、受け入れ条件をレビューする
+6. **修正が必要な場合**: Codex が task file の `レビュー指摘` に追記し、`claude` CLI で Claude に追加修正を依頼する
+7. Claude がレビュー指摘へ対応し、必要なテストを再実行する
+8. Codex が再レビュー（ステップ 5 に戻る）
+9. LGTM → PR 作成・マージはユーザー指示または task file のスコープに従う
 
-**重要: ステップ 5〜7 は LGTM が出るまで繰り返す。返信なし・未修正の指摘が 1 件でも残ればマージ禁止。**
+**重要: ステップ 5〜8 は LGTM が出るまで繰り返す。未解消のレビュー指摘が 1 件でも残ればマージ禁止。**
+
+### Codex から Claude を直接呼ぶ手順
+
+- 初回依頼:
+
+```bash
+claude -p --permission-mode acceptEdits "$(sed -n '/^## Claude 実装依頼/,$p' docs/tasks/<branch-name>.md)"
+```
+
+- レビュー指摘対応:
+
+```bash
+claude -p --continue "<Codex のレビュー指摘と修正依頼>"
+```
+
+- `claude` CLI が使えない場合は、実行できなかった理由と Claude に渡す依頼文をユーザーへ返す
 
 ### タスク管理ルール
 - `docs/tasks/<branch-name>.md` が存在する場合は、作業前に必ず読み、進捗とレビュー指摘を更新する
@@ -31,15 +48,21 @@
 - task file はローカルの一時ファイルとして扱い、ユーザー明示指示がない限りコミット・PR に含めない
 - task 完了時または作業中止時には、対応する task file を削除する
 - backend の API 契約変更時は `bash scripts/check-openapi.sh` を実行して `docs/openapi.json` と `frontend/src/generated/api.ts` を同期する
+- Codex は実装委譲前に task file の `Claude 実装依頼` を最新化する
+- Claude は実装前に task file のスコープ、非対象、受け入れ条件、タスク固有コマンドを確認する
 
 ### Codex が遵守するルール
-- 実装後は必ず lint/test/build を通してからコミットする
-- push 後に PR を作成し、Claude のレビューを待つ
-- Claude からレビュー指摘が来たら、**まず各指摘コメントに返信し、その後修正して再 push する**
-  - 返信なしで修正だけするのは禁止
-  - 修正しない場合（スコープ外など）も「対応しない理由」を必ずコメントに返信する
-- CodeRabbit 等の自動レビューコメントにも同様に返信する
-- Codex から Claude に設計相談・調査依頼する場合は `.claude/skills/codex-claude-handoff/SKILL.md` を使用する
+- 実装前に調査結果、設計方針、非対象、受け入れ条件を task file に書く
+- Claude 実装後は `git diff`、関連テスト、受け入れ条件を確認する
+- レビュー指摘は task file の `レビュー指摘` に具体的に書く
+- 未解消の指摘がある場合は `claude` CLI で Claude に追加修正を依頼する
+- Codex が実装本体を直接変更するのは、ユーザーが明示した場合、または Claude 呼び出しが利用できずユーザーが続行を許可した場合に限る
+
+### Claude が遵守するルール
+- task file のスコープと非対象を守って実装する
+- 指定された lint/test/build を実行し、結果を返答に含める
+- 追加の設計変更が必要な場合は、実装前に Codex へ確認する
+- 実装完了後は task file の進捗と必要なメモを更新する
 
 ## 出力制約
 

--- a/.claude/skills/claude-codex-handoff/SKILL.md
+++ b/.claude/skills/claude-codex-handoff/SKILL.md
@@ -1,129 +1,20 @@
 ---
 name: claude-codex-handoff
 description: |
-  Claude から Codex に実装タスクを委譲するときの依頼文を作成して Codex に渡す。
-  Use when: 実装・テスト作業を Codex に委譲したいとき。
-  タスクファイルが存在する場合や、設計方針が固まった後の実装フェーズで使う。
+  Legacy: Claude から Codex に作業を委譲する旧フロー用。
+  標準フローでは使用しない。通常は codex-claude-handoff を使う。
+  Use only when: ユーザーが明示的に Claude から Codex へ委譲すると指定した時。
 ---
 
-# Claude Codex Handoff
+# Claude Codex Handoff（Legacy）
 
 ## Goal
-Codex が最短で実装に着手できる依頼文を作成し、`codex exec --sandbox danger-full-access "<依頼文>"` で渡す。
-
-## Workflow
-
-### 1. 依頼文を組み立てる
-
-**A. 新規実装の場合**（以下の要素をすべて含める）:
-
-```markdown
-## タスク概要
-<1〜2文で何をするか>
-
-## 実装対象ファイル
-- `path/to/file.ts`: <何を変えるか>
-- `path/to/other.rs`: <何を変えるか>
-
-## 期待する挙動
-- 変更前: <現状>
-- 変更後: <期待結果>
-
-## 制約・非対象
-- <やってはいけないこと>
-- <スコープ外>
-
-## 受け入れ条件
-- [ ] <検証可能な条件1>
-- [ ] <検証可能な条件2>
-
-## 確認コマンド
-```bash
-# フロントエンド変更がある場合
-cd frontend && npm run lint && npm test && vp build
-
-# バックエンド変更がある場合
-cd backend && cargo clippy --all-targets -- -D warnings && cargo test
-```
-
-## 完了後の作業
-1. コミット・push (`git add <files>; git commit; git push`)
-2. PR 作成 (`gh pr create --base main`)
-```
-
-**B. レビュー指摘の修正依頼の場合**（以下の要素をすべて含める）:
-
-```markdown
-## タスク概要
-PR #<番号> のレビュー指摘に対応する。各指摘に返信してから修正を実装すること。
-
-## 対応手順（順番厳守）
-1. 各指摘コメントに返信する（修正前に返信する）
-2. 修正を実装する
-3. 確認コマンドを通す
-4. push する（PR は作成済みのため gh pr create は不要）
-
-## 指摘一覧（全件対応必須）
-
-| # | 重大度 | 内容 | ファイル:行 | 返信コマンド |
-|---|--------|------|-----------|------------|
-| 1 | [high] | <指摘内容> | path/to/file.ts:42 | `gh api repos/zaichu/shoken-webapp/issues/comments/<id> --method PATCH -f body='対応しました。<一言>'` |
-| 2 | [low]  | <指摘内容> | path/to/other.rs:10 | `gh api repos/zaichu/shoken-webapp/pulls/comments/<id>/replies --method POST --field 'body=対応しました。<一言>'` |
-
-※ 対応しない場合（スコープ外など）も返信は必須。理由を明記すること。
-※ CodeRabbit など自動レビューのコメントも同様に返信すること。
-
-## 確認コマンド
-```bash
-# フロントエンド変更がある場合
-cd frontend && npm run lint && npx tsc --noEmit && npm test -- --run && vp build
-
-# バックエンド変更がある場合
-cd backend && cargo fmt --check && cargo clippy --all-targets -- -D warnings && cargo test
-```
-```
-
-### 2. Codex に渡す
-
-**worktree を使って独立した作業ディレクトリで実行する（並列実行・競合防止）:**
-
-```bash
-BRANCH="<branch-name>"           # 例: feature/add-login, fix/csv-parse
-WORKTREE="/tmp/codex-${BRANCH//\//-}"  # スラッシュをハイフンに変換
-
-# worktree 作成（main から新ブランチ）
-git worktree add "$WORKTREE" -b "$BRANCH" main
-
-# Codex を worktree で実行（バックグラウンド可）
-codex exec --sandbox danger-full-access -C "$WORKTREE" "<依頼文をここに貼る>" &
-
-# 完了後の後片付け（PR マージ後）
-# git worktree remove "$WORKTREE"
-# git branch -d "$BRANCH"
-```
-
-**複数タスクを並列実行する場合:**
-```bash
-# タスク1
-git worktree add /tmp/codex-task1 -b feature/task1 main
-codex exec --sandbox danger-full-access -C /tmp/codex-task1 "<依頼文1>" &
-
-# タスク2（同時に実行）
-git worktree add /tmp/codex-task2 -b fix/task2 main
-codex exec --sandbox danger-full-access -C /tmp/codex-task2 "<依頼文2>" &
-```
-
-**注意:**
-- worktree ごとに独立したファイル・git index を持つため競合しない
-- 各 Codex は worktree 内でブランチを作成・push・PR 作成まで完結する
-- 非対話モードで実行するため `exec` サブコマンドを必ず使う（`codex "..."` は TTY なしで失敗する）
+旧フロー互換用。標準フローは `Codex が設計する → Claude が実装する → Codex がレビューする`。
 
 ## Rules
-- 曖昧語を避ける（「いい感じに」「必要なら」は禁止）
-- ファイルパスを必ず明示する（Codex が探索コストをかけないようにする）
-- 非対象を明記する（ついでの変更を防ぐ）
-- 受け入れ条件を検証可能に書く（テスト名、コマンド結果を具体化）
-- レビュー指摘対応時は**コメント ID と返信コマンドを必ず含める**（返信漏れ防止）
+- 標準フローでは使用しない
+- Codex へ実装を委譲する依頼を作らない
+- ユーザーが明示した場合のみ、例外的な逆方向 handoff として扱う
 
 ## Output
-`codex exec` に渡す依頼文（Markdown）を出力し、そのまま実行する。
+標準フローでは `codex-claude-handoff` を使うよう案内する。

--- a/.claude/skills/codex-claude-handoff/SKILL.md
+++ b/.claude/skills/codex-claude-handoff/SKILL.md
@@ -6,7 +6,7 @@ description: "Codex から Claude に修正実装を依頼するときのベー�
 # Codex Claude Handoff
 
 ## Goal
-Claude が最短で実装に着手できる依頼文を作成する。
+Claude が最短で実装に着手できる依頼文を作成し、Codex から `claude` CLI で直接渡す。
 
 ## Workflow
 1. 依頼の目的を1文で確定する。
@@ -15,6 +15,8 @@ Claude が最短で実装に着手できる依頼文を作成する。
 4. 制約と非対象を明記する。
 5. 受け入れ条件と確認コマンドを明記する。
 6. `references/base_prompt_template.md` のテンプレートに埋め込む。
+7. 初回依頼は `claude -p --permission-mode acceptEdits "<依頼文>"` で実行する。
+8. レビュー指摘対応は `claude -p --continue "<修正依頼>"` で同じ文脈に渡す。
 
 ## Rules
 - 曖昧語を避ける。: 「いい感じ」「必要なら」などを使わない。
@@ -24,4 +26,4 @@ Claude が最短で実装に着手できる依頼文を作成する。
 - 実行コマンドを先に渡す。: lint/test/build の実施範囲を固定する。
 
 ## Output
-Claude に渡す最終プロンプトを Markdown で返す。
+Claude に渡す最終プロンプトと実行した `claude` コマンドの結果を返す。

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,33 +1,34 @@
 ---
 name: pr-review
 description: |
-  Codex が実装・push した PR を Claude が自動検出してレビューする。
+  Claude が実装した差分または PR を Codex がレビューする。
   Use when: 「PRをレビューして」「レビューしてください」と依頼された時。
-  または Codex から PR 作成完了の通知を受けた後。
+  または Claude 実装完了後に Codex が実装レビューする時。
 ---
 
-# PR Review（Claude 実行）
+# PR Review（Codex 実行）
 
 ## Overview
-Codex が実装して push した PR を Claude がレビューする。
+Claude が実装した差分または PR を Codex がレビューする。
 全体開発ルール（`.claude/rules/00-general.md`）における標準フローは
-`Codex が実装する → Claude がレビューする` とし、本スキルで運用する。
+`Codex が設計する → Claude が実装する → Codex がレビューする` とし、本スキルで運用する。
 
 ブランチ運用の基準は `.claude/rules/03-git.md` を参照する。
 
 ## Workflow
 
-### 1. レビュー対象 PR を自動検出する
+### 1. レビュー対象を確認する
+- `docs/tasks/<branch-name>.md` が存在する場合は読む
 - `git fetch origin` で比較元を最新化する
 - `git branch --show-current` で現在ブランチを確認する
 - `gh pr list --state open --head "$(git branch --show-current)" --json number,title,url,body` で open PR を探す
-- 見つからない場合は、ユーザーに PR 番号 or URL を確認する
+- PR がない場合は、現在ブランチの `origin/main...HEAD` 差分をレビュー対象にする
 
 ### 2. レビュー材料を収集する
 - `git diff origin/main...HEAD --name-status`
 - `git diff origin/main...HEAD --stat`
 - `git diff origin/main...HEAD`
-- `gh pr view <PR番号> --json number,title,url,body`
+- PR がある場合: `gh pr view <PR番号> --json number,title,url,body`
 
 ### 3. 検証結果を確定する
 変更範囲に応じて実行:
@@ -52,53 +53,40 @@ findings first で重大度順に出す:
 2. **Open questions / assumptions**（あれば）
 3. **判定**: LGTM / 要修正
 
-### 5. レビュー結果を PR にコメントする
-- 既存の `🤖 Claude review` コメントを確認: `gh api repos/{owner}/{repo}/issues/<PR番号>/comments --jq '[.[] | select(.body | startswith("🤖 Claude review"))] | last | .id'`
-- 存在する場合は更新: `gh api repos/{owner}/{repo}/issues/comments/<comment_id> -X PATCH -f body="..."`
-- 存在しない場合は新規投稿: `gh pr comment <PR番号> --body "..."`
-- コメント先頭は `🤖 Claude review` で始める
-- **inline レビューコメントも必ず確認・返信する**:
-  - 取得: `gh api repos/{owner}/{repo}/pulls/<PR番号>/comments --jq '.[] | {id, path, body}'`
-  - 返信: `gh api repos/{owner}/{repo}/pulls/comments/<comment_id>/replies --method POST --field 'body=...'`
+### 5. レビュー結果を記録する
+- task file がある場合は `レビュー指摘` に findings と判定を追記する
+- PR がある場合は必要に応じて `🤖 Codex review` コメントとして投稿する
+- 投稿済みコメントを更新する場合は、先頭が `🤖 Codex review` の最新コメントを更新する
 
 ### 6. 修正が必要な場合
-`claude-codex-handoff` スキルを使って Codex に修正を依頼する。依頼文には**以下を必ず含める**:
+`codex-claude-handoff` スキルを使って Claude に修正を依頼する。依頼文には**以下を必ず含める**:
 
 ```markdown
-## レビュー指摘への対応（全件返信 + 修正）
+## レビュー指摘への対応
 
-以下の各指摘を順番に処理する:
-1. PR コメントに返信する
-2. 修正を実装する
-3. lint/test/build を通す
-4. push する（PR は既に作成済みのため gh pr create は不要）
+以下の各指摘を順番に処理する。
+1. 修正を実装する
+2. lint/test/build を通す
+3. task file の進捗とメモを更新する
 
 ### 指摘一覧
 
-| # | 重大度 | 内容 | ファイル:行 | コメントID | 返信コマンド |
-|---|--------|------|-----------|-----------|------------|
-| 1 | [high] | <内容> | path/to/file.ts:42 | issue_comment:<id> | `gh api repos/{owner}/{repo}/issues/comments/<id> --method PATCH -f body='対応しました。<一言>'` |
-| 2 | [low]  | <内容> | path/to/other.rs:10 | pulls_comment:<id> | `gh api repos/{owner}/{repo}/pulls/comments/<id>/replies --method POST --field 'body=対応しました。<一言>'` |
-
-対応しない場合（スコープ外など）も「対応しない理由」を必ずコメントに返信すること。
-CodeRabbit 等の自動レビューコメントも同様に返信すること。
+| # | 重大度 | 内容 | ファイル:行 | 受け入れ条件 |
+|---|--------|------|-----------|--------------|
+| 1 | [high] | <内容> | path/to/file.ts:42 | <確認方法> |
 ```
 
-修正 push 後は本スキルで再レビューする（LGTM まで繰り返す）。
+依頼は `claude -p --continue "<修正依頼>"` で送る。
+修正後は本スキルで再レビューする（LGTM まで繰り返す）。
 
 ### 7. LGTM 後
-- **全コメント返信済みか最終確認する**:
-  - `gh api repos/{owner}/{repo}/issues/<PR番号>/comments` — issue コメントに未返信がないか
-  - `gh api repos/{owner}/{repo}/pulls/<PR番号>/comments` — inline コメントに未返信がないか
-  - 未返信があれば返信してからマージする
-- PR をマージする: `gh pr merge <PR番号> --squash --delete-branch`
-- main を更新: `git switch main && git pull --ff-only origin main`
+- PR 作成、push、マージはユーザー指示または task file のスコープに従う
+- マージ前に未解消のレビュー指摘がないことを確認する
 
 ## Review Rules
 - findings first / 重大度順 / ファイルパスと行番号を必須とする
 - 検証コマンドと pass/fail を必ず記録する
-- issue コメント・inline コメント・CodeRabbit コメントすべてに返信する
-- **未返信の指摘が 1 件でも残ればマージしない**
+- **未解消の指摘が 1 件でも残ればマージしない**
 
 ## Output
-レビュー結果（findings first）を出力し、PR にコメントする。
+レビュー結果（findings first）を出力し、必要に応じて task file または PR に記録する。

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -24,7 +24,7 @@ primary_region = 'nrt'
   [[http_service.checks]]
     interval = '60s'
     timeout = '3s'
-    grace_period = '10s'
+    grace_period = '40s'
     method = 'GET'
     path = '/health'
 

--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -1,4 +1,10 @@
 use sqlx::{postgres::PgPoolOptions, PgPool};
+use std::time::Duration;
+
+// 起動時 DB 接続の retry パラメータ。fly.toml の grace_period と整合すること
+pub(crate) const MAX_ATTEMPTS: u32 = 5;
+pub(crate) const CONNECT_TIMEOUT_SECS: u64 = 5;
+pub(crate) const RETRY_DELAY_SECS: u64 = 3;
 
 pub async fn connect_pool(database_url: &str, max_connections: u32) -> Result<PgPool, sqlx::Error> {
     PgPoolOptions::new()
@@ -14,18 +20,172 @@ pub fn connect_pool_lazy(database_url: &str, max_connections: u32) -> Result<PgP
         .connect_lazy(database_url)
 }
 
+/// URL の設定を事前検証し、一時的な接続失敗は bounded retry する。
+/// 設定エラーは retry しない。秘密情報はエラー文字列に含めない。
+pub async fn connect_pool_with_retry(
+    database_url: &str,
+    max_connections: u32,
+) -> Result<PgPool, String> {
+    let database_url = database_url.trim();
+    validate_database_url(database_url)?;
+
+    let connect_timeout = Duration::from_secs(CONNECT_TIMEOUT_SECS);
+    let retry_delay = Duration::from_secs(RETRY_DELAY_SECS);
+
+    for attempt in 1..=MAX_ATTEMPTS {
+        match tokio::time::timeout(connect_timeout, connect_pool(database_url, max_connections))
+            .await
+        {
+            Ok(Ok(pool)) => return Ok(pool),
+            Ok(Err(e)) if is_transient_error(&e) => {
+                tracing::warn!(
+                    attempt,
+                    max_attempts = MAX_ATTEMPTS,
+                    "DB接続の一時的なエラー、リトライします"
+                );
+            }
+            Ok(Err(_)) => {
+                return Err("データベース接続の設定が不正です".to_string());
+            }
+            Err(_) => {
+                tracing::warn!(
+                    attempt,
+                    max_attempts = MAX_ATTEMPTS,
+                    "DB接続がタイムアウト、リトライします"
+                );
+            }
+        }
+
+        if attempt < MAX_ATTEMPTS {
+            tokio::time::sleep(retry_delay).await;
+        }
+    }
+
+    Err("データベースへの接続に失敗しました（リトライ上限超過）".to_string())
+}
+
+fn validate_database_url(url: &str) -> Result<(), String> {
+    if url.is_empty() {
+        return Err("DATABASE_URL が空です".to_string());
+    }
+    let lower = url.to_lowercase();
+    if !lower.starts_with("postgres://") && !lower.starts_with("postgresql://") {
+        return Err(
+            "DATABASE_URL のスキームが不正です（postgres:// または postgresql:// が必要です）"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+fn is_transient_error(e: &sqlx::Error) -> bool {
+    matches!(e, sqlx::Error::PoolTimedOut | sqlx::Error::Io(_))
+}
+
 /// `migrations/` を適用してスキーマを最新化する。
 /// 本番 DB・ローカル DB・テスト全て同じ経路を使用する。
 pub async fn run_migrations(pool: &PgPool) -> Result<(), sqlx::migrate::MigrateError> {
     sqlx::migrate!().run(pool).await
 }
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
     #[tokio::test]
     async fn test_connect_pool_lazy() {
         let database_url = "postgresql://user:password@localhost/test_db";
         assert!(connect_pool_lazy(database_url, 5).is_ok());
         assert!(connect_pool_lazy(database_url, 10).is_ok());
+    }
+
+    #[test]
+    fn test_validate_database_url_empty() {
+        let err = validate_database_url("").unwrap_err();
+        assert!(!err.contains("://"), "エラーに URL を含めない: {err}");
+    }
+
+    #[test]
+    fn test_validate_database_url_relative() {
+        let err = validate_database_url("/relative").unwrap_err();
+        assert!(
+            !err.contains("/relative"),
+            "エラーに URL 値を含めない: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_database_url_wrong_scheme() {
+        let err = validate_database_url("http://example.com/db").unwrap_err();
+        assert!(
+            !err.contains("example.com"),
+            "エラーにホスト名を含めない: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_database_url_valid() {
+        assert!(validate_database_url("postgres://user:password@localhost/db").is_ok());
+        assert!(validate_database_url("postgresql://user:password@localhost/db").is_ok());
+        assert!(validate_database_url("POSTGRES://localhost/db").is_ok());
+    }
+
+    #[test]
+    fn test_is_transient_error() {
+        assert!(is_transient_error(&sqlx::Error::PoolTimedOut));
+        assert!(!is_transient_error(&sqlx::Error::RowNotFound));
+        assert!(!is_transient_error(&sqlx::Error::ColumnNotFound(
+            "col".to_string()
+        )));
+    }
+
+    #[tokio::test]
+    async fn test_connect_pool_with_retry_invalid_url() {
+        // 空
+        let err = connect_pool_with_retry("", 5).await.unwrap_err();
+        assert!(err.contains("空"), "空URLのエラーメッセージが適切: {err}");
+        assert!(!err.contains("://"), "URLをエラーに含めない: {err}");
+
+        // 空白のみ（trim 後に空として拒否）
+        let err = connect_pool_with_retry("   ", 5).await.unwrap_err();
+        assert!(err.contains("空"), "空白のみは空として拒否: {err}");
+
+        // 相対 URL
+        let err = connect_pool_with_retry("/relative", 5).await.unwrap_err();
+        assert!(
+            !err.contains("/relative"),
+            "相対URLをエラーに含めない: {err}"
+        );
+
+        // HTTP スキーム
+        let err = connect_pool_with_retry("http://example.com/db", 5)
+            .await
+            .unwrap_err();
+        assert!(
+            !err.contains("example.com"),
+            "ホスト名をエラーに含めない: {err}"
+        );
+
+        // 前後空白 + HTTP スキーム（trim 後にスキームエラー）
+        let err = connect_pool_with_retry("  http://example.com/db  ", 5)
+            .await
+            .unwrap_err();
+        assert!(
+            !err.contains("example.com"),
+            "trim後のURLをエラーに含めない: {err}"
+        );
+    }
+
+    /// 最大待機時間が fly.toml の grace_period を超えないことを保証する。
+    /// grace_period を変更した場合はこのテストも更新すること。
+    #[test]
+    fn test_retry_budget_fits_grace_period() {
+        const GRACE_PERIOD_SECS: u64 = 40; // fly.toml [[http_service.checks]] grace_period と同期
+        let max_wait_secs = MAX_ATTEMPTS as u64 * CONNECT_TIMEOUT_SECS
+            + (MAX_ATTEMPTS as u64 - 1) * RETRY_DELAY_SECS;
+        assert!(
+            max_wait_secs < GRACE_PERIOD_SECS,
+            "最大待機時間 {max_wait_secs}s が grace_period {GRACE_PERIOD_SECS}s を超える"
+        );
     }
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -14,7 +14,7 @@ mod state;
 mod test_env;
 
 use config::Config;
-use db::{connect_pool, run_migrations};
+use db::{connect_pool_with_retry, run_migrations};
 use dotenvy::dotenv;
 use reqwest::Client;
 use routes::app_router;
@@ -50,9 +50,12 @@ async fn main() {
     let config = Config::from_env();
 
     tracing::info!("データベースに接続中...");
-    let pool = connect_pool(&secrets.database_url, config.database_max_connections)
+    let pool = connect_pool_with_retry(&secrets.database_url, config.database_max_connections)
         .await
-        .expect("データベースへの接続に失敗しました");
+        .unwrap_or_else(|e| {
+            tracing::error!("{e}");
+            std::process::exit(1);
+        });
 
     // マイグレーションの実行
     tracing::info!("マイグレーションを実行中...");


### PR DESCRIPTION
## 概要
- Fly.io 起動時の DB 接続で、設定エラーを sanitized error として扱うよう修正
- 一時的な DB 接続失敗に bounded retry を追加し、health check grace period と整合
- Claude/Codex の役割分担を Codex 設計・レビュー、Claude 実装の標準フローへ更新

## 変更内容
- `DATABASE_URL` の trim と scheme 検証を追加
- 起動時 DB 接続に 5 秒 timeout × 5 回、3 秒 delay の retry を追加
- Fly.io health check `grace_period` を 40 秒に変更
- .claude の開発フロー/skill 記述を新運用へ更新

## テスト
- `cd backend && cargo fmt --check`
- `cd backend && cargo test db::tests`
- `cd backend && cargo test state::tests`
- `cd backend && cargo test`
- `cd backend && cargo clippy --all-targets -- -D warnings`
- push hook: OpenAPI/api.ts 再生成差分なし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * データベース接続の堅牢性を向上。接続失敗時の自動再試行機構とタイムアウト制御を実装し、データベース接続時の一時的な問題への耐性が強化されました。
  * サービスのヘルスチェック判定猶予時間を拡張し、デプロイメント中のサービス中断が削減されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->