### PR TITLE
生成物を git 管理対象から除外

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,9 @@ CLAUDE.local.md
 backend/CLAUDE.local.md
 frontend/CLAUDE.local.md
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 docs/tasks/*.md
 !docs/tasks/TEMPLATE.md
 output/
 scripts/__pycache__/
+backend/tarpaulin-report.json


### PR DESCRIPTION
## 概要
- ローカル作業後に残る生成物を .gitignore に追加
- Claude の lock file と tarpaulin coverage report が git status に出ないようにする

## 変更内容
- `.claude/scheduled_tasks.lock` を ignore
- `backend/tarpaulin-report.json` を ignore

## テスト
- `git status --short --ignored .claude/scheduled_tasks.lock backend/tarpaulin-report.json .gitignore` で対象2ファイルが ignored 表示になることを確認