### PR TITLE
test: add client and encoding fallback coverage

### DIFF
--- a/frontend/src/lib/api/__tests__/client.test.ts
+++ b/frontend/src/lib/api/__tests__/client.test.ts
@@ -589,6 +589,22 @@ describe('ApiClient', () => {
         expect.objectContaining({ credentials: 'same-origin' })
       );
     });
+
+    it('withCredentials: true のとき credentials が include になる', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve('{}'),
+      });
+      const client = createApiClient({ baseURL: 'http://api.test' });
+      const resultPromise = client.get('/test', { withCredentials: true });
+      await vi.runAllTimersAsync();
+      await resultPromise;
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ credentials: 'include' })
+      );
+    });
   });
 });
 

--- a/frontend/src/lib/csv/__tests__/encoding.test.ts
+++ b/frontend/src/lib/csv/__tests__/encoding.test.ts
@@ -143,6 +143,66 @@ describe('encoding utilities', () => {
       expect(result.text).toBeDefined();
     });
 
+    it('先頭候補 utf-8 の TextDecoder constructor が例外を投げた場合に shift-jis へ fallback する', () => {
+      const originalTextDecoder = TextDecoder;
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      class MockTextDecoder {
+        private readonly decoder: TextDecoder;
+
+        constructor(encoding = 'utf-8', options?: TextDecoderOptions) {
+          if (encoding === 'utf-8') {
+            throw new TypeError('unsupported encoding');
+          }
+          this.decoder = new originalTextDecoder(encoding, options);
+        }
+
+        decode(input?: Uint8Array) {
+          return this.decoder.decode(input);
+        }
+      }
+      vi.stubGlobal('TextDecoder', MockTextDecoder as unknown as typeof TextDecoder);
+
+      // 半角カタカナ「ｱｲｳ」の Shift-JIS バイト
+      const shiftJisBytes = new Uint8Array([0xB1, 0xB2, 0xB3]);
+      const result = tryDecodeWithMultipleEncodings(shiftJisBytes);
+
+      expect(result.encoding).toBe('shift-jis');
+      expect(result.text).toBe('ｱｲｳ');
+      expect(warnSpy).toHaveBeenCalled();
+    });
+
+    it('先頭候補 utf-8 の decode が例外を投げた場合に shift-jis へ fallback する', () => {
+      const originalTextDecoder = TextDecoder;
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      class MockTextDecoder {
+        private readonly decoder?: TextDecoder;
+        private readonly shouldThrow: boolean;
+
+        constructor(encoding = 'utf-8', options?: TextDecoderOptions) {
+          this.shouldThrow = encoding === 'utf-8';
+          if (!this.shouldThrow) {
+            this.decoder = new originalTextDecoder(encoding, options);
+          }
+        }
+
+        decode(input?: Uint8Array) {
+          if (this.shouldThrow) {
+            throw new TypeError('decode failed');
+          }
+          return this.decoder!.decode(input);
+        }
+      }
+      vi.stubGlobal('TextDecoder', MockTextDecoder as unknown as typeof TextDecoder);
+
+      // 半角カタカナ「ｱｲｳ」の Shift-JIS バイト
+      const shiftJisBytes = new Uint8Array([0xB1, 0xB2, 0xB3]);
+      const result = tryDecodeWithMultipleEncodings(shiftJisBytes);
+
+      expect(result.encoding).toBe('shift-jis');
+      expect(result.text).toBe('ｱｲｳ');
+      expect(warnSpy).toHaveBeenCalled();
+    });
+
     it('未サポートのエンコーディングはスキップして他の結果を使う', () => {
       const originalTextDecoder = TextDecoder;
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});


### PR DESCRIPTION
## 変更内容

- `ApiClient` の `withCredentials: true` が `credentials: 'include'` になる coverage を追加
- CSV encoding 判定で、先頭候補 `utf-8` の constructor / decode が失敗した場合に `shift-jis` へ fallback する coverage を追加
- conflict している #438 の有効な不足 coverage だけを最新 `main` 上に再適用

## テスト

- `cd frontend && npx vitest run src/lib/api/__tests__/client.test.ts src/lib/csv/__tests__/encoding.test.ts`
- `cd frontend && npm run lint`
- `cd frontend && npx tsc --noEmit`

## 補足

- Supersedes #438
- `frontend/src/lib/csv/__tests__/encoding.test.ts` は既存から `i/crlf w/crlf` のため、`git diff --check` は追加行の CRLF を trailing whitespace として報告します。全体改行変換は別タスクで扱うのが適切なため、この PR では行末正規化を行っていません。
