### PR TITLE
chore: keep Fly backend machine warm

### DIFF
--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -18,7 +18,7 @@ primary_region = 'nrt'
   force_https = true
   auto_stop_machines = 'stop'
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1 # cold start proxy error 回避のため常時 1 台を維持
   processes = ['app']
 
   [[http_service.checks]]


### PR DESCRIPTION
## 変更内容

- Fly.io backend の `min_machines_running` を `0` から `1` に変更
- auto-stop 後の cold start で DB 接続完了前に Fly proxy が到達不能扱いにするケースを避ける

## 背景

Fly logs で以下を確認しました。

- auto-stop 後、machine 起動中に DB 接続 retry / slow acquire が発生
- HTTP listener が bind される前に proxy が約 8 秒で `failed to connect to machine` を出す
- その後 health check は passing になり、steady state の `/health` は 200

このため、問題は通常稼働中ではなく cold start 初回到達性です。

## コスト影響

`min_machines_running = 1` により、backend machine を常時 1 台維持します。
scale-to-zero しないため稼働コストは増えますが、cold start proxy error を避けることを優先します。

## テスト

- `cd backend && /home/zaichu/.fly/bin/flyctl config validate`
- `cd backend && cargo test db::tests::test_retry_budget_fits_grace_period`
- `cd backend && cargo test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **パフォーマンス向上**
  * インフラストラクチャ構成を最適化し、サービスの応答時間を改善しました。サーバーが常時稼働状態を維持することで、起動時の遅延が解消され、より迅速で安定したレスポンスを提供し、ユーザー体験を向上させます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->