### PR TITLE
DB acquire slow閾値を接続timeoutに合わせる

### DIFF
--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -7,18 +7,19 @@ pub(crate) const MAX_ATTEMPTS: u32 = 5;
 pub(crate) const CONNECT_TIMEOUT_SECS: u64 = 5;
 pub(crate) const RETRY_DELAY_SECS: u64 = 3;
 
-pub async fn connect_pool(database_url: &str, max_connections: u32) -> Result<PgPool, sqlx::Error> {
+fn pool_options(max_connections: u32) -> PgPoolOptions {
     PgPoolOptions::new()
         .max_connections(max_connections)
-        .connect(database_url)
-        .await
+        .acquire_slow_threshold(Duration::from_secs(CONNECT_TIMEOUT_SECS))
+}
+
+pub async fn connect_pool(database_url: &str, max_connections: u32) -> Result<PgPool, sqlx::Error> {
+    pool_options(max_connections).connect(database_url).await
 }
 
 #[allow(dead_code)]
 pub fn connect_pool_lazy(database_url: &str, max_connections: u32) -> Result<PgPool, sqlx::Error> {
-    PgPoolOptions::new()
-        .max_connections(max_connections)
-        .connect_lazy(database_url)
+    pool_options(max_connections).connect_lazy(database_url)
 }
 
 /// URL の設定を事前検証し、一時的な接続失敗は bounded retry する。
@@ -134,6 +135,28 @@ pub async fn run_migrations(pool: &PgPool) -> Result<(), sqlx::migrate::MigrateE
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_db_pool_options_use_connect_timeout_as_slow_acquire_threshold() {
+        let opts5 = pool_options(5);
+        assert_eq!(
+            opts5.get_acquire_slow_threshold(),
+            Duration::from_secs(CONNECT_TIMEOUT_SECS),
+            "slow acquire threshold は CONNECT_TIMEOUT_SECS と同じであること"
+        );
+        assert_eq!(
+            opts5.get_max_connections(),
+            5,
+            "max_connections が一致すること"
+        );
+
+        let opts10 = pool_options(10);
+        assert_eq!(
+            opts10.get_acquire_slow_threshold(),
+            Duration::from_secs(CONNECT_TIMEOUT_SECS),
+        );
+        assert_eq!(opts10.get_max_connections(), 10);
+    }
 
     #[tokio::test]
     async fn test_connect_pool_lazy() {


### PR DESCRIPTION
## 概要
Fly backend v190 起動後に残っていた `sqlx::pool::acquire` の slow acquire warning を抑制します。

SQLx 0.8.6 の既定 slow acquire threshold は 2 秒ですが、このアプリの起動時 DB 接続 timeout は `CONNECT_TIMEOUT_SECS = 5` です。Fly/DB の初回接続で 2 秒を少し超えるケースは現状の retry/health 設計上は異常ではないため、pool option を共通化して slow acquire threshold を 5 秒に合わせます。

## 主な変更
- `backend/src/db.rs` に `pool_options(max_connections)` helper を追加
- `connect_pool` / `connect_pool_lazy` が同じ helper を使うよう変更
- `acquire_slow_threshold` を `Duration::from_secs(CONNECT_TIMEOUT_SECS)` に設定
- `get_acquire_slow_threshold()` / `get_max_connections()` で設定値を直接検証する unit test を追加

## 非対象
- retry 回数、connect timeout、Fly 設定の変更
- SQLx warning の完全無効化
- Fly secret / `.env` / 実 `DATABASE_URL` の参照

## テスト
- [x] `cargo test db::tests::test_db_pool_options_use_connect_timeout_as_slow_acquire_threshold`
- [x] `cargo test db::tests::test_connect_pool_lazy`
- [x] `cargo test db::tests::test_connect_pool_with_retry_invalid_url`
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test`

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>