### PR TITLE
chore: rustls-webpki を 0.103.13 に更新

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3283,9 +3283,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## 概要
- `cargo audit` で検出された `RUSTSEC-2026-0104` 対応として `rustls-webpki` を `0.103.12` から `0.103.13` へ最小更新
- `Cargo.toml` の直接依存追加や周辺依存の大規模更新は未実施

## 根拠
- `cargo audit` が `rustls-webpki 0.103.12` に対して `RUSTSEC-2026-0104` を検出
- audit の解決策は `>=0.103.13, <0.104.0-alpha.1`

## テスト
- `cd backend && cargo audit`
- `cd backend && cargo fmt --check`
- `cd backend && cargo clippy --all-targets -- -D warnings`
- `cd backend && cargo test`

## Codex review
- LGTM。変更は `backend/Cargo.lock` の `rustls-webpki` 1パッケージ更新のみ。