### PR TITLE
chore: encodingテストの改行コードをLFに正規化

### DIFF
--- a/frontend/src/lib/csv/__tests__/encoding.test.ts
+++ b/frontend/src/lib/csv/__tests__/encoding.test.ts
@@ -84,9 +84,9 @@ describe('encoding utilities', () => {
 
     it('空の配列の場合は適切にハンドリングする', () => {
       const uint8Array = new Uint8Array(0);
-      
+
       const result = tryDecodeWithMultipleEncodings(uint8Array);
-      
+
       expect(result.text).toBe('');
       expect(result.confidence).toBeGreaterThanOrEqual(0);
     });


### PR DESCRIPTION
## 概要
- `frontend/src/lib/csv/__tests__/encoding.test.ts` の CRLF を LF に正規化
- LF化で `git diff --check` に出る空白だけの行を完全な空行に整理
- テスト内容・期待値・import 順・encoding ロジックは変更なし

## 背景
- PR #449 で、このファイルが `i/crlf w/crlf` のため行末正規化を別タスクにする、と補足されていたもの

## テスト
- `git ls-files --eol frontend/src/lib/csv/__tests__/encoding.test.ts`
- `git diff --cached --check`
- `cd frontend && npx vitest run src/lib/csv/__tests__/encoding.test.ts`
- `cd frontend && npm run lint`
- `cd frontend && npx tsc --noEmit`

## Codex review
- 初回レビューで trailing whitespace を検出し、Claude に修正依頼済み
- 修正後 LGTM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * テストスイートの構造を更新しました。機能的な変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->