### PR TITLE
fix: Fly起動時DB接続timeout budgetを調整

### DIFF
--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -366,6 +366,7 @@ mod tests {
         );
     }
 
+    /// test_startup_connect_timeout_covers_fly_observed_latency は CONNECT_TIMEOUT_SECS の下限ガード（上限は test_retry_budget_fits_grace_period が担う）。
     /// Fly 起動直後に観測された ~8-10 秒の接続遅延をカバーできることを保証する。
     /// CONNECT_TIMEOUT_SECS が短すぎると attempt=1,2 で recoverable WARN が出る。
     #[allow(clippy::assertions_on_constants)]

--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -3,13 +3,14 @@ use std::time::Duration;
 use url::Url;
 
 // 起動時 DB 接続の retry パラメータ。fly.toml の grace_period と整合すること
-pub(crate) const MAX_ATTEMPTS: u32 = 5;
-pub(crate) const CONNECT_TIMEOUT_SECS: u64 = 5;
+// 最大待機 = MAX_ATTEMPTS * CONNECT_TIMEOUT_SECS + (MAX_ATTEMPTS-1) * RETRY_DELAY_SECS = 3*10 + 2*3 = 36s < 40s
+pub(crate) const MAX_ATTEMPTS: u32 = 3;
+pub(crate) const CONNECT_TIMEOUT_SECS: u64 = 10;
 pub(crate) const RETRY_DELAY_SECS: u64 = 3;
 
 // runtime の Pool::acquire() slow warning 閾値。Fly + 外部 PG ではアイドル後再接続が
 // CONNECT_TIMEOUT_SECS を超えることがあるため、起動 retry timeout とは別定数にする。
-pub(crate) const ACQUIRE_SLOW_THRESHOLD_SECS: u64 = 10;
+pub(crate) const ACQUIRE_SLOW_THRESHOLD_SECS: u64 = 15;
 
 fn pool_options(max_connections: u32) -> PgPoolOptions {
     PgPoolOptions::new()
@@ -141,10 +142,9 @@ mod tests {
     use super::*;
 
     // 定数の大小関係をコンパイル時に保証する
-    const _: () = assert!(
-        ACQUIRE_SLOW_THRESHOLD_SECS > CONNECT_TIMEOUT_SECS,
-        "ACQUIRE_SLOW_THRESHOLD_SECS は CONNECT_TIMEOUT_SECS より大きくなければならない"
-    );
+    const _: () = if ACQUIRE_SLOW_THRESHOLD_SECS <= CONNECT_TIMEOUT_SECS {
+        panic!("ACQUIRE_SLOW_THRESHOLD_SECS は CONNECT_TIMEOUT_SECS より大きくなければならない")
+    };
 
     #[test]
     fn test_db_pool_options_use_acquire_slow_threshold() {
@@ -363,6 +363,18 @@ mod tests {
         assert!(
             !err.contains("not-a-valid-url"),
             "エラーに URL 値を含めない: {err}"
+        );
+    }
+
+    /// Fly 起動直後に観測された ~8-10 秒の接続遅延をカバーできることを保証する。
+    /// CONNECT_TIMEOUT_SECS が短すぎると attempt=1,2 で recoverable WARN が出る。
+    #[allow(clippy::assertions_on_constants)]
+    #[test]
+    fn test_startup_connect_timeout_covers_fly_observed_latency() {
+        assert!(
+            CONNECT_TIMEOUT_SECS >= 10,
+            "CONNECT_TIMEOUT_SECS={} は Fly 実測遅延（~8-10s）をカバーするため 10 以上が必要",
+            CONNECT_TIMEOUT_SECS
         );
     }
 


### PR DESCRIPTION
## Summary
- Fly 起動時の DB 接続 timeout を 5 秒から 10 秒へ延長
- retry 回数を 5 回から 3 回へ調整し、最大待機を 36 秒に維持
- runtime acquire slow threshold を 15 秒へ引き上げ、startup connect timeout より大きい値を維持
- Fly 実測の起動直後 DB 遅延をカバーするテストを追加

## Context
PR #457 merge 後の Fly v195 は health passing になりましたが、deploy 直後に `DB接続がタイムアウト、リトライします` が attempt 1,2 で出ていました。現在の server bind は DB 接続と migration 後なので、短すぎる startup connect timeout が recoverable WARN を生んでいました。

## Verification
- `cd backend && cargo fmt --check`
- `cd backend && cargo test db::tests::`
- `cd backend && cargo clippy --all-targets -- -D warnings`
- push hook: OpenAPI/generated types up to date

Co-authored-by: Claude Opus 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * データベース接続のタイムアウト値を調整し、ネットワーク遅延への耐性を向上させました
  * 接続信頼性を検証するテストを追加しました
  * 接続警告のしきい値を最適化し、より正確な監視を実現しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->