### PR TITLE
fix: Fly起動時のhealth check failureを抑止

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -104,6 +104,7 @@ mod tests {
                 dividend_cache: crate::state::DividendCacheState::default(),
             },
             config,
+            Arc::new(std::sync::atomic::AtomicBool::new(true)),
         )
     }
     async fn preflight(app: Router, origin: &str) -> axum::response::Response {

--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -22,9 +22,13 @@ pub async fn connect_pool(database_url: &str, max_connections: u32) -> Result<Pg
     pool_options(max_connections).connect(database_url).await
 }
 
-#[allow(dead_code)]
-pub fn connect_pool_lazy(database_url: &str, max_connections: u32) -> Result<PgPool, sqlx::Error> {
-    pool_options(max_connections).connect_lazy(database_url)
+pub fn connect_pool_lazy(database_url: &str, max_connections: u32) -> Result<PgPool, String> {
+    let database_url = database_url.trim();
+    validate_database_url(database_url)?;
+    let sanitized_url = sanitize_database_url_for_sqlx(database_url)?;
+    pool_options(max_connections)
+        .connect_lazy(&sanitized_url)
+        .map_err(|e| format!("DB pool の初期化に失敗しました: {e}"))
 }
 
 /// URL の設定を事前検証し、一時的な接続失敗は bounded retry する。
@@ -178,6 +182,26 @@ mod tests {
         let database_url = "postgresql://user:password@localhost/test_db";
         assert!(connect_pool_lazy(database_url, 5).is_ok());
         assert!(connect_pool_lazy(database_url, 10).is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_connect_pool_lazy_invalid_url() {
+        let err = connect_pool_lazy("", 5).unwrap_err();
+        assert!(err.contains("空"), "空URLを拒否すること: {err}");
+        let err = connect_pool_lazy("http://example.com/db", 5).unwrap_err();
+        assert!(
+            !err.contains("example.com"),
+            "エラーにホスト名を含めない: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_connect_pool_lazy_sanitizes_channel_binding() {
+        let url = "postgresql://user:password@localhost/test_db?channel_binding=require";
+        assert!(
+            connect_pool_lazy(url, 5).is_ok(),
+            "channel_binding 付きでも pool 作成できる"
+        );
     }
 
     #[test]

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -259,7 +259,11 @@ mod tests {
             jquants_rate_limit_rps: 0,
             ..Config::default()
         };
-        app_router(make_test_state(), &config)
+        app_router(
+            make_test_state(),
+            &config,
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
+        )
     }
     async fn read_json_response<T: DeserializeOwned>(response: axum::response::Response) -> T {
         let body = to_bytes(response.into_body(), BODY_LIMIT).await.unwrap();

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -14,12 +14,15 @@ mod state;
 mod test_env;
 
 use config::Config;
-use db::{connect_pool_with_retry, run_migrations};
+use db::{connect_pool_lazy, connect_pool_with_retry, run_migrations};
 use dotenvy::dotenv;
 use reqwest::Client;
 use routes::app_router;
 use state::{AppState, DividendCacheState, Secrets};
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 use tokio::net::TcpListener;
 
 #[tokio::main]
@@ -49,37 +52,55 @@ async fn main() {
 
     let config = Config::from_env();
 
-    tracing::info!("データベースに接続中...");
-    let pool = connect_pool_with_retry(&secrets.database_url, config.database_max_connections)
-        .await
+    let startup_ready = Arc::new(AtomicBool::new(false));
+
+    // URL 検証のみ行い、実接続は行わない lazy pool
+    let pool = connect_pool_lazy(&secrets.database_url, config.database_max_connections)
         .unwrap_or_else(|e| {
             tracing::error!("{e}");
             std::process::exit(1);
         });
 
-    // マイグレーションの実行
-    tracing::info!("マイグレーションを実行中...");
-    run_migrations(&pool)
-        .await
-        .expect("マイグレーションの実行に失敗しました");
-
     let client = Client::new();
     let state = AppState {
         pool,
-        secrets,
+        secrets: Arc::clone(&secrets),
         client,
         dividend_cache: DividendCacheState::default(),
     };
 
-    let router = app_router(state, &config);
+    let router = app_router(state, &config, Arc::clone(&startup_ready));
 
     let addr = config::server_addr();
-
-    tracing::info!("サーバーを {} で起動します", addr);
 
     let listener = TcpListener::bind(&addr)
         .await
         .expect("TCPリスナーのバインドに失敗しました");
+
+    tracing::info!("サーバーを {} で起動します", addr);
+
+    // DB 接続と migration をバックグラウンドで実行し、完了後に startup_ready を立てる
+    let db_url = secrets.database_url.clone();
+    let max_connections = config.database_max_connections;
+    let startup_ready_bg = Arc::clone(&startup_ready);
+    tokio::spawn(async move {
+        tracing::info!("データベースに接続中...");
+        let pool = connect_pool_with_retry(&db_url, max_connections)
+            .await
+            .unwrap_or_else(|e| {
+                tracing::error!("{e}");
+                std::process::exit(1);
+            });
+
+        tracing::info!("マイグレーションを実行中...");
+        if let Err(e) = run_migrations(&pool).await {
+            tracing::error!("マイグレーション失敗: {e}");
+            std::process::exit(1);
+        }
+
+        tracing::info!("起動完了");
+        startup_ready_bg.store(true, Ordering::Release);
+    });
 
     axum::serve(listener, router)
         .await

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -1,6 +1,9 @@
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 
-use axum::{middleware, routing::get, Json, Router};
+use axum::{http::StatusCode, middleware, response::IntoResponse, routing::get, Json, Router};
 use tower_http::{
     limit::RequestBodyLimitLayer,
     request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer},
@@ -37,7 +40,7 @@ fn spawn_keyed_limiter_cleanup(
     }
 }
 
-pub fn app_router(state: AppState, config: &Config) -> Router {
+pub fn app_router(state: AppState, config: &Config, startup_ready: Arc<AtomicBool>) -> Router {
     // auth は IP 単位の keyed limiter（ブルートフォース/DoS 対策）
     let auth_limiter = build_keyed_rate_limiter(config.auth_rate_limit_rps);
     let csv_limiter = build_keyed_rate_limiter(config.csv_rate_limit_rps);
@@ -46,7 +49,21 @@ pub fn app_router(state: AppState, config: &Config) -> Router {
     spawn_keyed_limiter_cleanup(&csv_limiter);
 
     let allowed_origins = Arc::new(config.cors_origins.clone());
-    domain_routes(jquants_limiter, auth_limiter, csv_limiter)
+    let ready = Arc::clone(&startup_ready);
+    let gated_domain =
+        domain_routes(jquants_limiter, auth_limiter, csv_limiter).layer(middleware::from_fn(
+            move |req: axum::extract::Request, next: axum::middleware::Next| {
+                let ready = Arc::clone(&ready);
+                async move {
+                    if ready.load(Ordering::Acquire) {
+                        next.run(req).await
+                    } else {
+                        StatusCode::SERVICE_UNAVAILABLE.into_response()
+                    }
+                }
+            },
+        ));
+    gated_domain
         .merge(
             Router::new()
                 .route("/health", get(|| async { "OK" }))
@@ -132,7 +149,7 @@ mod tests {
             body::Body,
             http::{Method, Request},
         },
-        std::sync::Arc,
+        std::sync::{atomic::AtomicBool, Arc},
         tower::ServiceExt,
     };
     fn make_test_state() -> AppState {
@@ -310,26 +327,97 @@ mod tests {
             ("/asset-balances/csv", "1.2.3.7"),
         ] {
             assert_rate_limited(
-                app_router(make_test_state(), &Config::from_env()),
+                app_router(
+                    make_test_state(),
+                    &Config::from_env(),
+                    Arc::new(AtomicBool::new(true)),
+                ),
                 Method::POST,
                 path,
                 Some(ip),
             )
             .await;
         }
-        let resp = app_router(make_test_state(), &Config::from_env())
+        let resp = app_router(
+            make_test_state(),
+            &Config::from_env(),
+            Arc::new(AtomicBool::new(true)),
+        )
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/domestic-stocks/csv/preview")
+                .header("fly-client-ip", "1.2.3.4")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+        assert_ne!(resp.status(), axum::http::StatusCode::TOO_MANY_REQUESTS);
+    }
+    #[tokio::test]
+    async fn test_health_returns_200_during_startup() {
+        let startup_ready = Arc::new(AtomicBool::new(false));
+        let router = app_router(
+            make_test_state(),
+            &Config::from_env(),
+            Arc::clone(&startup_ready),
+        );
+        let resp = router
             .oneshot(
                 Request::builder()
-                    .method(Method::POST)
-                    .uri("/domestic-stocks/csv/preview")
-                    .header("fly-client-ip", "1.2.3.4")
+                    .method(Method::GET)
+                    .uri("/health")
                     .body(Body::empty())
                     .unwrap(),
             )
             .await
             .unwrap();
-        assert_ne!(resp.status(), axum::http::StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
     }
+
+    #[tokio::test]
+    async fn test_domain_route_returns_503_during_startup() {
+        let startup_ready = Arc::new(AtomicBool::new(false));
+        let router = app_router(
+            make_test_state(),
+            &Config::from_env(),
+            Arc::clone(&startup_ready),
+        );
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/auth/me")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), axum::http::StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn test_domain_route_returns_401_after_startup() {
+        let startup_ready = Arc::new(AtomicBool::new(true));
+        let router = app_router(
+            make_test_state(),
+            &Config::from_env(),
+            Arc::clone(&startup_ready),
+        );
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/auth/me")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), axum::http::StatusCode::UNAUTHORIZED);
+    }
+
     #[tokio::test]
     async fn test_request_id_propagated_to_response() {
         use {

--- a/backend/tests/db_integration.rs
+++ b/backend/tests/db_integration.rs
@@ -125,7 +125,11 @@ async fn db_integration_with_docker_and_migrations() {
     };
 
     let config = Config::from_env();
-    let app = app_router(state, &config);
+    let app = app_router(
+        state,
+        &config,
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
+    );
 
     let req = Request::builder()
         .method(Method::GET)
@@ -721,7 +725,11 @@ async fn unauthenticated_requests_return_401() {
         client: Client::new(),
         dividend_cache: backend::state::DividendCacheState::default(),
     };
-    let app = app_router(state, &config);
+    let app = app_router(
+        state,
+        &config,
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
+    );
 
     for path in [
         "/dividends",


### PR DESCRIPTION
## Summary
- listener-first 構成に変更し、DB 接続と migration より先に port 8080 を bind
- startup 中は domain routes を `503 Service Unavailable` で gate し、`/health` と `/api-docs/openapi.json` は即時応答
- `connect_pool_lazy` に URL 検証と sanitize を追加
- startup 中 `/health=200`、domain route `503`、startup 完了後 `/auth/me=401` のテストを追加

## Context
Fly v198 は `started / 1 passing` でしたが、deploy 直後に `Health check 'servicecheck-00-http-8080' ... failed` が残っていました。原因は `main.rs` が `connect_pool_with_retry -> run_migrations -> bind -> serve` の順で、DB/migration 完了まで listener が立たないことでした。

## Verification
- `cd backend && cargo fmt --check`
- `cd backend && cargo test routes::tests::`
- `cd backend && cargo test db::tests::`
- `cd backend && cargo clippy --all-targets -- -D warnings`
- push hook: OpenAPI/generated types up to date

Co-authored-by: Claude Opus 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * サーバー起動時、ヘルスチェックエンドポイントは即座にアクセス可能になります。起動完了までは、認証が必要なエンドポイントは503 Service Unavailableを返すようになりました。

* **バグ修正**
  * データベースURL入力の検証とサニタイズ処理が追加されました。データベース接続エラーのエラーメッセージが改善されました。

* **改善**
  * データベース接続が起動をブロックしなくなり、サーバーはすぐにリッスンを開始します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->