### PR TITLE
fix: Fly readiness check を /ready に分離

### DIFF
--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -26,7 +26,7 @@ primary_region = 'nrt'
     timeout = '3s'
     grace_period = '40s'
     method = 'GET'
-    path = '/health'
+    path = '/ready'
 
 [[vm]]
   memory = '256mb'

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -63,10 +63,24 @@ pub fn app_router(state: AppState, config: &Config, startup_ready: Arc<AtomicBoo
                 }
             },
         ));
+    let ready_for_check = Arc::clone(&startup_ready);
     gated_domain
         .merge(
             Router::new()
                 .route("/health", get(|| async { "OK" }))
+                .route(
+                    "/ready",
+                    get(move || {
+                        let ready = Arc::clone(&ready_for_check);
+                        async move {
+                            if ready.load(Ordering::Acquire) {
+                                StatusCode::OK.into_response()
+                            } else {
+                                StatusCode::SERVICE_UNAVAILABLE.into_response()
+                            }
+                        }
+                    }),
+                )
                 .route(
                     "/api-docs/openapi.json",
                     get(|| async { Json(ApiDoc::openapi()) }),
@@ -355,6 +369,48 @@ mod tests {
         .unwrap();
         assert_ne!(resp.status(), axum::http::StatusCode::TOO_MANY_REQUESTS);
     }
+    #[tokio::test]
+    async fn test_ready_returns_503_during_startup() {
+        let startup_ready = Arc::new(AtomicBool::new(false));
+        let router = app_router(
+            make_test_state(),
+            &Config::from_env(),
+            Arc::clone(&startup_ready),
+        );
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/ready")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), axum::http::StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn test_ready_returns_200_after_startup() {
+        let startup_ready = Arc::new(AtomicBool::new(true));
+        let router = app_router(
+            make_test_state(),
+            &Config::from_env(),
+            Arc::clone(&startup_ready),
+        );
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/ready")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+    }
+
     #[tokio::test]
     async fn test_health_returns_200_during_startup() {
         let startup_ready = Arc::new(AtomicBool::new(false));


### PR DESCRIPTION
## 概要
- Fly の service-level check を `/health` から `/ready` に切り替え
- backend に readiness endpoint を追加し、startup 中は `503`、完了後は `200` を返す
- `/health` は liveness 用として起動直後から `200` を維持

## 変更内容
- `backend/src/routes.rs`
  - `/ready` endpoint を追加
  - startup 中 `503 Service Unavailable`、startup 完了後 `200 OK` を返す
  - `/ready` の routes test を 2 件追加
- `backend/fly.toml`
  - `[[http_service.checks]] path = '/ready'` に変更

## テスト
- `cd backend && cargo fmt --check`
- `cd backend && cargo test routes::tests::`
- `cd backend && cargo clippy --all-targets -- -D warnings`

## 背景
`/health` を startup gate 対象外にしたことで listener 起動直後から `200 OK` を返すようになったが、Fly の service-level check は routing 可否の判定に使われるため、readiness 完了前に healthy 扱いになる余地があった。今回 `/health` と `/ready` を分離し、routing 判定は readiness に寄せる。