### PR TITLE
fix: readiness probe のログノイズを抑制

### DIFF
--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -63,37 +63,41 @@ pub fn app_router(state: AppState, config: &Config, startup_ready: Arc<AtomicBoo
                 }
             },
         ));
+
+    // /ready と /health は TraceLayer の対象外にする（startup 中の expected 503 を ERROR ログから除外）
     let ready_for_check = Arc::clone(&startup_ready);
-    gated_domain
-        .merge(
-            Router::new()
-                .route("/health", get(|| async { "OK" }))
-                .route(
-                    "/ready",
-                    get(move || {
-                        let ready = Arc::clone(&ready_for_check);
-                        async move {
-                            if ready.load(Ordering::Acquire) {
-                                StatusCode::OK.into_response()
-                            } else {
-                                StatusCode::SERVICE_UNAVAILABLE.into_response()
-                            }
-                        }
-                    }),
-                )
-                .route(
-                    "/api-docs/openapi.json",
-                    get(|| async { Json(ApiDoc::openapi()) }),
-                ),
-        )
+    let probe_routes = Router::new()
+        .route("/health", get(|| async { "OK" }))
+        .route(
+            "/ready",
+            get(move || {
+                let ready = Arc::clone(&ready_for_check);
+                async move {
+                    if ready.load(Ordering::Acquire) {
+                        StatusCode::OK.into_response()
+                    } else {
+                        StatusCode::SERVICE_UNAVAILABLE.into_response()
+                    }
+                }
+            }),
+        );
+
+    // リクエストトレース（パスのみ記録：クエリパラメータの機密情報漏洩を防ぐ）
+    let traced_inner = gated_domain
+        .merge(Router::new().route(
+            "/api-docs/openapi.json",
+            get(|| async { Json(ApiDoc::openapi()) }),
+        ))
+        .layer(TraceLayer::new_for_http().make_span_with(PathOnlyMakeSpan));
+
+    traced_inner
+        .merge(probe_routes)
         .layer(middleware::from_fn(move |req, next| {
             let origins = allowed_origins.clone();
             async move { validate_origin(origins, req, next).await }
         }))
         .layer(RequestBodyLimitLayer::new(REQUEST_BODY_LIMIT))
         .layer(build_cors_layer(&config.cors_origins))
-        // リクエストトレース（パスのみ記録：クエリパラメータの機密情報漏洩を防ぐ）
-        .layer(TraceLayer::new_for_http().make_span_with(PathOnlyMakeSpan))
         // x-request-id をレスポンスに伝播
         .layer(PropagateRequestIdLayer::x_request_id())
         // x-request-id が未設定の場合は UUID v4 を自動付与


### PR DESCRIPTION
## 概要
- `/ready` と `/health` を probe route として分離
- `TraceLayer` の適用対象から probe route を外し、startup 中の expected 503 を app error log に出さないようにする
- readiness semantics と既存 outer middleware は維持

## 変更内容
- `backend/src/routes.rs`
  - `/ready` と `/health` を `probe_routes` に分離
  - `TraceLayer::new_for_http().make_span_with(PathOnlyMakeSpan)` は domain routes と `/api-docs/openapi.json` にだけ適用
  - request-id / security headers / CORS / body limit の outer layers は全 route に維持

## テスト
- `cd backend && cargo fmt --check`
- `cd backend && cargo test routes::tests::`
- `cd backend && cargo clippy --all-targets -- -D warnings`

## 背景
`2026-04-24 09:17:40 JST` の v200 起動ログでは、Fly の `/ready` probe が startup 完了前に `503` を受けるたびに `tower_http::trace::on_failure` が `ERROR` を連続出力していた。readiness 判定自体は必要なので、今回は probe route だけを tracing 対象外にして app 側ログノイズを抑える。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * バックエンド ルーティングの構成を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->