### PR TITLE
docs: Codex/Claude の worktree 運用を明文化

### DIFF
--- a/.claude/rules/00-general.md
+++ b/.claude/rules/00-general.md
@@ -11,20 +11,21 @@
 
 ### 役割分担
 - **Codex**: 調査・設計・タスク定義・実装レビュー・PR レビュー
-- **Claude**: task file に基づく実装・テスト・レビュー指摘対応
+- **Claude**: Codex が用意した専用 worktree 内での実装・テスト・レビュー指摘対応
 
 ### 標準フロー
 1. Codex が調査・設計を行い `docs/tasks/<branch-name>.md` を作成する
 2. Codex が task file に `Claude 実装依頼` セクションを作り、目的・現状・期待挙動・対象ファイル・制約・受け入れ条件・確認コマンドを明記する
-3. Codex が `claude` CLI で Claude を直接呼び出し、実装を委譲する
-4. Claude が実装・lint/test/build・task file 更新を行う
-5. Codex が差分、テスト結果、受け入れ条件をレビューする
-6. **修正が必要な場合**: Codex が task file の `レビュー指摘` に追記し、`claude` CLI で Claude に追加修正を依頼する
-7. Claude がレビュー指摘へ対応し、必要なテストを再実行する
-8. Codex が再レビュー（ステップ 5 に戻る）
-9. LGTM → PR 作成・マージはユーザー指示または task file のスコープに従う
+3. Codex が `main` を clean に保ったまま、Claude 実装用の作業ブランチと専用 worktree を作成する
+4. Codex が worktree 内で `claude` CLI を直接呼び出し、実装を委譲する
+5. Claude がその worktree 内で実装・lint/test/build・task file 更新を行う
+6. Codex が差分、テスト結果、受け入れ条件をレビューする
+7. **修正が必要な場合**: Codex が task file の `レビュー指摘` に追記し、`claude` CLI で Claude に追加修正を依頼する
+8. Claude がレビュー指摘へ対応し、必要なテストを再実行する
+9. Codex が再レビュー（ステップ 6 に戻る）
+10. LGTM → PR 作成・マージはユーザー指示または task file のスコープに従う
 
-**重要: ステップ 5〜8 は LGTM が出るまで繰り返す。未解消のレビュー指摘が 1 件でも残ればマージ禁止。**
+**重要: ステップ 6〜9 は LGTM が出るまで繰り返す。未解消のレビュー指摘が 1 件でも残ればマージ禁止。**
 
 ### Codex から Claude を直接呼ぶ手順
 
@@ -46,6 +47,7 @@ claude -p --continue "<Codex のレビュー指摘と修正依頼>"
 - `docs/tasks/<branch-name>.md` が存在する場合は、作業前に必ず読み、進捗とレビュー指摘を更新する
 - 中規模以上のタスクでは `docs/tasks/TEMPLATE.md` を元に task file を作成する
 - task file はローカルの一時ファイルとして扱い、ユーザー明示指示がない限りコミット・PR に含めない
+- task file の更新は原則として対象 worktree 側で行い、main 作業ツリーへ残さない
 - task 完了時または作業中止時には、対応する task file を削除する
 - backend の API 契約変更時は `bash scripts/check-openapi.sh` を実行して `docs/openapi.json` と `frontend/src/generated/api.ts` を同期する
 - Codex は実装委譲前に task file の `Claude 実装依頼` を最新化する
@@ -53,6 +55,7 @@ claude -p --continue "<Codex のレビュー指摘と修正依頼>"
 
 ### Codex が遵守するルール
 - 実装前に調査結果、設計方針、非対象、受け入れ条件を task file に書く
+- `main` をレビュー/統合用に clean に保ち、Claude 実装前に専用 worktree を用意する
 - Claude 実装後は `git diff`、関連テスト、受け入れ条件を確認する
 - レビュー指摘は task file の `レビュー指摘` に具体的に書く
 - 未解消の指摘がある場合は `claude` CLI で Claude に追加修正を依頼する
@@ -60,6 +63,7 @@ claude -p --continue "<Codex のレビュー指摘と修正依頼>"
 
 ### Claude が遵守するルール
 - task file のスコープと非対象を守って実装する
+- Codex が用意した専用 worktree 内でのみ実装する
 - 指定された lint/test/build を実行し、結果を返答に含める
 - 追加の設計変更が必要な場合は、実装前に Codex へ確認する
 - 実装完了後は task file の進捗と必要なメモを更新する

--- a/.claude/rules/03-git.md
+++ b/.claude/rules/03-git.md
@@ -21,6 +21,13 @@ README や skills の記載と衝突した場合は、本ドキュメントを�
 - `chore/<topic>`
 - `hotfix/<topic>`
 
+### worktree 運用
+
+- Claude 実装を委譲するタスクは、原則として専用 `git worktree` を作ってその中で行う
+- Codex は repo ルートの `main` をレビュー/統合用に clean に保つ
+- worktree の配置先は `/tmp/<repo>-<topic>` のような一時パスを標準とする
+- 1 作業ブランチ = 1 worktree を守る
+
 ## コミットルール
 
 - `git add .` / `git add -A` は使わず、`git add <path>` または `git add -p` を使う
@@ -51,7 +58,7 @@ Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
 - PR は作業ブランチから `main` へ作成する
 - PR マージ前に Codex レビュー（`.claude/skills/pr-review/SKILL.md`）を実施する
 - タイトルと説明は日本語で、変更内容とテスト結果を明記する
-- マージ方式は `Squash and merge` を推奨
+- マージ方式は `Squash and merge` を標準とする
 - マージ後は `main` を更新して作業ブランチを削除する
 
 ## 標準フロー
@@ -61,10 +68,11 @@ Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
 git switch main
 git pull --ff-only origin main
 
-# 2) 1タスク1ブランチを作成
-git switch -c feature/<topic>
+# 2) 1タスク1ブランチ + 1worktree を作成
+git worktree add -b feature/<topic> /tmp/<repo>-<topic> main
 
-# 3) 変更を選択してコミット
+# 3) worktree で変更を選択してコミット
+cd /tmp/<repo>-<topic>
 git add -p
 git commit -m "feat: <変更内容の要約>"
 
@@ -73,11 +81,13 @@ git push -u origin feature/<topic>
 gh pr create --base main --head feature/<topic>
 
 # 5) マージ後の後片付け
+cd <repo-root>
 git switch main
 git pull --ff-only origin main
-git branch -d feature/<topic>
 git push origin --delete feature/<topic>
 git fetch origin --prune
+git worktree remove /tmp/<repo>-<topic>
+git branch -D feature/<topic>  # squash merge 済みの短期ブランチのみ
 ```
 
 ## 禁止事項
@@ -85,4 +95,4 @@ git fetch origin --prune
 - `main` への直接コミット / 直接 push
 - 1つの作業ブランチに複数タスクを混在させること
 - 不要な `--force` push
-- ユーザーの明示指示なしでの `git branch -D`
+- squash merge 済み・remote 削除済み・worktree 削除済みの短期ブランチ cleanup 以外で `git branch -D` を使うこと


### PR DESCRIPTION
## 概要
- Codex/Claude 分担に専用 worktree 前提を追記
- task file を worktree 側で扱う前提を明記
- squash merge 後の cleanup 手順と branch -D の限定条件を追記

## 検証
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * 開発ワークフローの標準手順を更新しました
  * Git ワークツリーを使用した統合開発プロセスを導入しました
  * ブランチ管理とマージ手順の規則を整備しました

*注: これらは内部開発プロセスのドキュメント更新です。ユーザー向け機能の変更はありません。*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->