### PR TITLE
chore: startup summary の精度を改善

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -80,10 +80,10 @@ async fn main() {
         .await
         .expect("TCPリスナーのバインドに失敗しました");
 
-    let listener_bind_ms = t0.elapsed().as_millis();
+    let listener_bind_us = t0.elapsed().as_micros();
     tracing::info!(
         target: "startup",
-        elapsed_ms = listener_bind_ms,
+        elapsed_ms = listener_bind_us / 1000,
         "サーバーを {} で起動します [listener bind 完了]",
         addr
     );
@@ -123,10 +123,12 @@ async fn main() {
 
         tracing::info!(
             target: "startup",
-            listener_bind_ms = listener_bind_ms,
-            db_connect_ms = db_connect_ms,
-            migrations_ms = migrations_ms,
-            startup_ready_ms = startup_ready_ms,
+            listener_bind_phase_us = listener_bind_us,
+            db_connect_phase_ms = db_connect_ms - listener_bind_us / 1000,
+            db_connect_total_ms = db_connect_ms,
+            migrations_phase_ms = migrations_ms - db_connect_ms,
+            migrations_total_ms = migrations_ms,
+            startup_ready_total_ms = startup_ready_ms,
             "[startup summary] 全フェーズ完了"
         );
     });


### PR DESCRIPTION
## 概要
- startup summary の bind phase を microseconds で記録
- summary に phase duration と cumulative total を意味どおりの field 名で整理
- startup flow と startup target logging 方針は維持

## 確認
- cd backend && cargo fmt --check
- cd backend && cargo test routes::tests::
- cd backend && cargo clippy --all-targets -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * スタートアップメトリクスの追跡が強化されました。リスナーバインドからマイグレーション完了までの各段階の時間が、段階別および累積メトリクスとしてより詳細に報告されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->