### PR TITLE
fix: J-Quants 429 の即時再試行を止める

### DIFF
--- a/backend/src/models/dividend_cache.rs
+++ b/backend/src/models/dividend_cache.rs
@@ -15,6 +15,7 @@ use validator::Validate;
 /// | zero    | future      | false    | No      | 配当なし（有効）             |
 /// | zero    | NULL / past | true     | Yes     | stale（再取得待ち）          |
 /// | error   | NULL        | true     | Yes     | 即再取得対象                 |
+/// | error   | future      | false    | No      | 429 cooldown 中は再取得しない |
 #[derive(Debug, Clone, Serialize, FromRow)]
 pub struct DividendCache {
     pub security_code: String,

--- a/backend/src/services/dividend_cache.rs
+++ b/backend/src/services/dividend_cache.rs
@@ -12,6 +12,9 @@ use tokio::time::Duration;
 
 use logic::compute_is_stale;
 
+/// 429 発生時の全インスタンス共有 cooldown 期間（秒）
+const RATE_LIMIT_COOLDOWN_SECS: i32 = 60;
+
 /// キャッシュをバッチ取得し、未取得/TTL切れ銘柄のバックグラウンド更新をキック
 pub async fn get_batch(
     pool: &PgPool,
@@ -141,6 +144,24 @@ pub async fn acquire_rate_slot(pool: &PgPool) -> Result<(), ApiError> {
     Ok(())
 }
 
+/// 429 発生時に jquants_rate_control.next_available_at を少なくとも cooldown 分先へ延ばす
+/// 既存の future 値がある場合は後退させず、GREATEST で大きい方を維持する
+async fn push_rate_control_cooldown(pool: &PgPool) -> Result<(), ApiError> {
+    sqlx::query(
+        r#"
+        INSERT INTO jquants_rate_control (id, next_available_at)
+            VALUES (1, NOW() + $1 * INTERVAL '1 second')
+        ON CONFLICT (id) DO UPDATE
+            SET next_available_at =
+                GREATEST(jquants_rate_control.next_available_at, NOW() + $1 * INTERVAL '1 second')
+        "#,
+    )
+    .bind(RATE_LIMIT_COOLDOWN_SECS)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -245,6 +266,23 @@ mod tests {
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].status, "error");
         assert!(items[0].is_stale);
+    }
+
+    #[test]
+    fn test_cached_error_with_future_stale_at_is_not_stale() {
+        // 429 cooldown 中: status=error かつ stale_at が future の場合は
+        // is_stale=false となり refresh_codes に入らない
+        let now = fixed_now();
+        let caches = vec![make_cache("1234", "error", Some(now + Duration::hours(1)))];
+        let cache_map = make_cache_map(&caches);
+        let codes = vec!["1234".to_string()];
+
+        let (items, refresh_codes) = build_batch_items(&codes, &cache_map, now);
+
+        assert!(refresh_codes.is_empty());
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].status, "error");
+        assert!(!items[0].is_stale);
     }
 
     #[test]

--- a/backend/src/services/dividend_cache/background.rs
+++ b/backend/src/services/dividend_cache/background.rs
@@ -1,3 +1,4 @@
+use crate::errors::ApiError;
 use reqwest::Client;
 use sqlx::PgPool;
 use std::sync::{
@@ -6,7 +7,12 @@ use std::sync::{
 };
 
 use super::acquire_rate_slot;
-use super::persistence::{fetch_and_cache, update_cache_error};
+use super::persistence::{fetch_and_cache, update_cache_error, update_cache_error_with_cooldown};
+
+/// 429 レートリミットエラーの場合に background refresh を打ち切るべきか判定する
+pub(crate) fn should_abort_on_error(e: &ApiError) -> bool {
+    matches!(e, ApiError::RateLimitError(_))
+}
 
 /// バックグラウンドで未取得/TTL切れ銘柄を順次更新する（1分5回レート制御）
 pub fn spawn_background_refresh(
@@ -55,8 +61,22 @@ pub fn spawn_background_refresh(
                     tracing::info!("配当キャッシュ更新完了: code={}, status={}", code, status);
                 }
                 Err(e) => {
+                    if should_abort_on_error(&e) {
+                        tracing::warn!(
+                            "配当キャッシュ更新: レートリミット超過 code={}, バックグラウンド更新を中断",
+                            code
+                        );
+                        let _ = update_cache_error_with_cooldown(
+                            &pool,
+                            code,
+                            &e.to_string(),
+                            super::RATE_LIMIT_COOLDOWN_SECS,
+                        )
+                        .await;
+                        let _ = super::push_rate_control_cooldown(&pool).await;
+                        break;
+                    }
                     tracing::error!("配当キャッシュ更新エラー: code={}, err={}", code, e);
-                    // エラーをキャッシュに記録
                     let _ = update_cache_error(&pool, code, &e.to_string()).await;
                 }
             }
@@ -69,6 +89,24 @@ pub fn spawn_background_refresh(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_should_abort_on_rate_limit_error() {
+        let e = ApiError::RateLimitError("429 Too Many Requests".to_string());
+        assert!(should_abort_on_error(&e));
+    }
+
+    #[test]
+    fn test_should_not_abort_on_other_api_error() {
+        let e = ApiError::ApiError("500 Internal Server Error".to_string());
+        assert!(!should_abort_on_error(&e));
+    }
+
+    #[test]
+    fn test_should_not_abort_on_network_error() {
+        let e = ApiError::NetworkError("connection refused".to_string());
+        assert!(!should_abort_on_error(&e));
+    }
 
     #[tokio::test]
     async fn test_spawn_skips_if_already_running() {

--- a/backend/src/services/dividend_cache/logic.rs
+++ b/backend/src/services/dividend_cache/logic.rs
@@ -132,6 +132,8 @@ mod tests {
         for (status, stale_at, expected) in [
             ("pending", None, false),
             ("error", None, true),
+            // 429 cooldown 中は error + future stale_at でも stale 扱いしない
+            ("error", future, false),
             ("ok", past, true),
             ("ok", future, false),
             ("ok", None, true),

--- a/backend/src/services/dividend_cache/persistence.rs
+++ b/backend/src/services/dividend_cache/persistence.rs
@@ -48,6 +48,37 @@ pub async fn fetch_and_cache(
     Ok(status)
 }
 
+/// 429 レートリミット発生時のエラーを cooldown 付きでキャッシュに記録する
+/// stale_at を future に設定することで cooldown 中の即時再取得を防ぐ
+pub async fn update_cache_error_with_cooldown(
+    pool: &PgPool,
+    code: &str,
+    error_msg: &str,
+    cooldown_secs: i32,
+) -> Result<(), ApiError> {
+    let truncated = truncate_error_message(error_msg);
+
+    sqlx::query(
+        r#"
+        INSERT INTO jquants_dividend_cache
+            (security_code, dividend_per_share, status, error_message, stale_at, source, updated_at)
+        VALUES ($1, NULL, 'error', $2, NOW() + $3 * INTERVAL '1 second', 'jquants', NOW())
+        ON CONFLICT (security_code) DO UPDATE
+            SET status        = 'error',
+                error_message = EXCLUDED.error_message,
+                stale_at      = NOW() + $3 * INTERVAL '1 second',
+                updated_at    = NOW()
+        "#,
+    )
+    .bind(code)
+    .bind(truncated)
+    .bind(cooldown_secs)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
 /// エラーメッセージを最大 200 文字に切り捨てる（マルチバイト文字境界を考慮）
 fn truncate_error_message(msg: &str) -> &str {
     if msg.len() <= 200 {


### PR DESCRIPTION
## Summary
- stop dividend cache background refresh when J-Quants returns 429
- persist rate-limit errors with a cooldown stale_at and advance shared rate control without moving it backward
- add stale/error and abort-decision tests around the cooldown behavior

## Test
- cargo fmt --check
- cargo test dividend_cache -- --nocapture
- cargo clippy --all-targets -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * API レート制限エラー時のクールダウン機構を実装し、短期間の再試行を防止
  * キャッシュエラー処理を改善し、レート制限エラーの特別な処理を追加

* **テスト**
  * レート制限時のキャッシュ動作とエラーハンドリングに関するテストを拡張

<!-- end of auto-generated comment: release notes by coderabbit.ai -->