### PR TITLE
Improve Home dashboard entry UI

### DIFF
--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -98,7 +98,7 @@ export function HomePage() {
                 className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3"
               >
                 {inner}
-                <p className="text-xs text-slate-400 mt-1">各ページから取込可能</p>
+                <p className="text-xs text-slate-600 mt-1">各ページから取込可能</p>
               </div>
             );
           })}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,50 +1,60 @@
 import { Link } from 'react-router-dom';
 import { Layout } from '../components/templates/Layout';
-import { Card, CardBody } from '../components/atoms/Card';
-import { PageHeader } from '../components/atoms/PageHeader';
 import { usePageTitle } from '../hooks/usePageTitle';
 
-// クイックアクション（ショートカット）
-const QUICK_ACTIONS = [
-  { label: '取引明細', to: '/receipts', icon: '💰' },
-  { label: '資産管理', to: '/assetbalance', icon: '📊' },
-  { label: '銘柄検索', to: '/search', icon: '🔍' },
-] as const;
-
-const FEATURES = [
+const STATUS_ITEMS = [
   {
-    title: '銘柄検索',
-    description: '日本の株式銘柄情報を検索できます。',
-    detail: '銘柄コード・会社名で検索し、各証券サイトへのリンクを一覧表示。',
-    to: '/search',
+    label: '銘柄検索',
+    sub: '検索',
+    to: '/search' as string | null,
     icon: (
-      <svg className="h-6 w-6 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true" focusable="false">
+      <svg className="h-5 w-5 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true" focusable="false">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
       </svg>
     ),
   },
   {
-    title: '資産管理',
-    description: '保有している銘柄の一覧と評価額を確認できます。',
-    detail: 'CSVをインポートして取得単価・時価・配当利回りをまとめて管理。',
-    to: '/assetbalance',
+    label: '資産管理',
+    sub: '一覧確認',
+    to: '/assetbalance' as string | null,
     icon: (
-      <svg className="h-6 w-6 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true" focusable="false">
+      <svg className="h-5 w-5 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true" focusable="false">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
       </svg>
     ),
   },
   {
-    title: '取引明細',
-    description: '配当金や分配金の記録を管理できます。',
-    detail: '配当金・国内株式・投資信託の取引履歴を年別・銘柄別で絞り込み確認。',
-    to: '/receipts',
+    label: '取引明細',
+    sub: '明細確認',
+    to: '/receipts' as string | null,
     icon: (
-      <svg className="h-6 w-6 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true" focusable="false">
+      <svg className="h-5 w-5 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true" focusable="false">
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
       </svg>
     ),
   },
+  {
+    label: 'CSV取込',
+    sub: 'CSV反映',
+    to: null as string | null,
+    icon: (
+      <svg className="h-5 w-5 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true" focusable="false">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
+      </svg>
+    ),
+  },
+] as const;
+
+const NEXT_ACTIONS = [
+  { label: '銘柄検索', to: '/search' },
+  { label: '資産管理', to: '/assetbalance' },
+  { label: '取引明細', to: '/receipts' },
+] as const;
+
+const FLOW_STEPS = [
+  { step: '1', text: '証券会社からCSVをダウンロード' },
+  { step: '2', text: '各ページのCSV取込から反映' },
+  { step: '3', text: '資産・配当金・取引明細を確認' },
 ] as const;
 
 export function HomePage() {
@@ -52,67 +62,81 @@ export function HomePage() {
 
   return (
     <Layout>
-      <div className="page-surface">
-        <PageHeader
-          title="証券Webへようこそ"
-          description="銘柄検索や取引明細の管理ができます。"
-        />
-
-        <div className="grid gap-6 md:grid-cols-3">
-          {FEATURES.map(({ title, description, detail, to, icon }) => (
-            <Link key={to} to={to} className="block group">
-              <Card className="h-full transition-shadow hover:shadow-md">
-                <CardBody className="space-y-3 p-4">
-                  <div className="flex items-center gap-2">
-                    {icon}
-                    <h3 className="text-base font-semibold text-slate-900 group-hover:text-primary transition-colors">
-                      {title}
-                    </h3>
-                  </div>
-                  <p className="text-sm text-slate-700 font-medium">{description}</p>
-                  <p className="text-xs text-slate-500">{detail}</p>
-                  <div className="pt-1 text-xs text-primary font-medium group-hover:underline">
-                    開く →
-                  </div>
-                </CardBody>
-              </Card>
-            </Link>
-          ))}
+      <div className="page-surface space-y-6">
+        {/* ダッシュボードヘッダー */}
+        <div>
+          <h1 className="text-xl font-bold text-slate-900">証券Web</h1>
+          <p className="mt-0.5 text-sm text-slate-500">日々の資産・取引を確認する</p>
         </div>
 
-        {/* クイックアクション */}
-        <div className="mt-8 pt-5 border-t border-slate-200">
-          <h2 className="text-sm font-medium text-slate-500 mb-3">クイックアクション</h2>
+        {/* ステータス／アクションストリップ */}
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          {STATUS_ITEMS.map(({ label, sub, to, icon }) => {
+            const inner = (
+              <>
+                <div className="mb-2">{icon}</div>
+                <p className="text-sm font-semibold text-slate-800">{label}</p>
+                <p className="text-xs text-slate-500 mt-0.5">{sub}</p>
+              </>
+            );
+
+            if (to !== null) {
+              return (
+                <Link
+                  key={label}
+                  to={to}
+                  className="rounded-lg border border-slate-200 bg-white px-4 py-3 hover:border-primary hover:shadow-sm transition-all group"
+                >
+                  {inner}
+                </Link>
+              );
+            }
+
+            return (
+              <div
+                key={label}
+                className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3"
+              >
+                {inner}
+                <p className="text-xs text-slate-400 mt-1">各ページから取込可能</p>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* 次に行う操作 */}
+        <div className="pt-4 border-t border-slate-200">
+          <h2 className="text-sm font-medium text-slate-500 mb-3">次に行う操作</h2>
           <div className="flex flex-wrap gap-2">
-            {QUICK_ACTIONS.map(({ label, to, icon }) => (
+            {NEXT_ACTIONS.map(({ label, to }) => (
               <Link
                 key={to}
                 to={to}
-                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-slate-100 hover:bg-slate-200 text-slate-700 rounded-full transition-colors"
+                className="inline-flex items-center px-3 py-1.5 text-sm bg-slate-100 hover:bg-slate-200 text-slate-700 rounded-full transition-colors"
               >
-                <span aria-hidden="true">{icon}</span>
                 {label}
               </Link>
             ))}
           </div>
         </div>
 
-        {/* はじめかた */}
-        <div className="mt-8 pt-5 border-t border-slate-200">
-          <h2 className="text-sm font-medium text-slate-500 mb-3">はじめかた</h2>
-          <div className="grid gap-3 sm:grid-cols-3">
-            <div className="rounded-lg border border-slate-200 bg-slate-50 p-3">
-              <p className="text-xs font-semibold text-slate-500 mb-1">STEP 1</p>
-              <p className="text-sm text-slate-700">証券会社からCSVをダウンロード</p>
-            </div>
-            <div className="rounded-lg border border-slate-200 bg-slate-50 p-3">
-              <p className="text-xs font-semibold text-slate-500 mb-1">STEP 2</p>
-              <p className="text-sm text-slate-700">各ページでCSVファイルを取り込み</p>
-            </div>
-            <div className="rounded-lg border border-slate-200 bg-slate-50 p-3">
-              <p className="text-xs font-semibold text-slate-500 mb-1">STEP 3</p>
-              <p className="text-sm text-slate-700">配当金や資産管理の情報を確認</p>
-            </div>
+        {/* データ確認フロー */}
+        <div className="pt-4 border-t border-slate-200">
+          <h2 className="text-sm font-medium text-slate-500 mb-3">データ確認フロー</h2>
+          <div className="flex flex-wrap gap-2 items-center">
+            {FLOW_STEPS.map(({ step, text }, i) => (
+              <div key={step} className="flex items-center gap-2">
+                <div className="flex items-center gap-1.5">
+                  <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
+                    {step}
+                  </span>
+                  <span className="text-sm text-slate-700">{text}</span>
+                </div>
+                {i < FLOW_STEPS.length - 1 && (
+                  <span className="text-slate-300 text-sm" aria-hidden="true">→</span>
+                )}
+              </div>
+            ))}
           </div>
         </div>
       </div>

--- a/frontend/src/pages/__tests__/Home.test.tsx
+++ b/frontend/src/pages/__tests__/Home.test.tsx
@@ -19,100 +19,110 @@ describe('HomePage', () => {
     expect(document.title).toContain('ホーム');
   });
 
-  it('クイックアクションリンクを表示する', () => {
+  it('ダッシュボードヘッダーを表示する', () => {
     render(
       <MemoryRouter>
         <HomePage />
       </MemoryRouter>
     );
 
-    const quickActionSection = screen
-      .getByRole('heading', { name: 'クイックアクション' })
-      .parentElement;
-
-    expect(quickActionSection).not.toBeNull();
-
-    const scoped = within(quickActionSection as HTMLElement);
-
-    expect(scoped.getByRole('link', { name: '銘柄検索' })).toBeInTheDocument();
-    expect(scoped.getByRole('link', { name: '資産管理' })).toBeInTheDocument();
-    expect(scoped.getByRole('link', { name: '取引明細' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1, name: '証券Web' })).toBeInTheDocument();
+    expect(screen.getByText('日々の資産・取引を確認する')).toBeInTheDocument();
   });
 
-  it('クイックアクションリンクの遷移先が正しい', () => {
+  it('ステータスストリップに4件のタイルを表示する', () => {
     render(
       <MemoryRouter>
         <HomePage />
       </MemoryRouter>
     );
 
-    const quickActionSection = screen
-      .getByRole('heading', { name: 'クイックアクション' })
+    expect(screen.getAllByText('銘柄検索').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('資産管理').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('取引明細').length).toBeGreaterThan(0);
+    expect(screen.getByText('CSV取込')).toBeInTheDocument();
+  });
+
+  it('ステータスストリップの各タイルにセカンダリ行を表示する', () => {
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('検索')).toBeInTheDocument();
+    expect(screen.getByText('一覧確認')).toBeInTheDocument();
+    expect(screen.getByText('明細確認')).toBeInTheDocument();
+    expect(screen.getByText('CSV反映')).toBeInTheDocument();
+  });
+
+  it('CSV取込タイルはリンクではなく、各ページから取込可能と表示する', () => {
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('各ページから取込可能')).toBeInTheDocument();
+    // /csv へのリンクは存在しない
+    const allLinks = screen.getAllByRole('link');
+    expect(allLinks.every((l) => l.getAttribute('href') !== '/csv')).toBe(true);
+  });
+
+  it('ストリップの銘柄検索・資産管理・取引明細タイルがリンクになっている', () => {
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>
+    );
+
+    const searchLinks = screen.getAllByRole('link').filter((l) => l.getAttribute('href') === '/search');
+    expect(searchLinks.length).toBeGreaterThan(0);
+
+    const assetLinks = screen.getAllByRole('link').filter((l) => l.getAttribute('href') === '/assetbalance');
+    expect(assetLinks.length).toBeGreaterThan(0);
+
+    const receiptLinks = screen.getAllByRole('link').filter((l) => l.getAttribute('href') === '/receipts');
+    expect(receiptLinks.length).toBeGreaterThan(0);
+  });
+
+  it('次に行う操作セクションのリンクを表示する', () => {
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>
+    );
+
+    const nextSection = screen
+      .getByRole('heading', { name: '次に行う操作' })
       .parentElement;
 
-    expect(quickActionSection).not.toBeNull();
+    expect(nextSection).not.toBeNull();
 
-    const scoped = within(quickActionSection as HTMLElement);
+    const scoped = within(nextSection as HTMLElement);
 
     expect(scoped.getByRole('link', { name: '銘柄検索' })).toHaveAttribute('href', '/search');
     expect(scoped.getByRole('link', { name: '資産管理' })).toHaveAttribute('href', '/assetbalance');
     expect(scoped.getByRole('link', { name: '取引明細' })).toHaveAttribute('href', '/receipts');
   });
 
-  it('フィーチャーカードを3件表示する', () => {
+  it('データ確認フローセクションのステップを表示する', () => {
     render(
       <MemoryRouter>
         <HomePage />
       </MemoryRouter>
     );
 
-    expect(screen.getByRole('heading', { name: '銘柄検索' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: '資産管理' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: '取引明細' })).toBeInTheDocument();
-  });
+    const flowSection = screen
+      .getByRole('heading', { name: 'データ確認フロー' })
+      .parentElement;
 
-  it('フィーチャーカードの説明文を表示する', () => {
-    render(
-      <MemoryRouter>
-        <HomePage />
-      </MemoryRouter>
-    );
+    expect(flowSection).not.toBeNull();
 
-    expect(screen.getByText('日本の株式銘柄情報を検索できます。')).toBeInTheDocument();
-    expect(screen.getByText('保有している銘柄の一覧と評価額を確認できます。')).toBeInTheDocument();
-    expect(screen.getByText('配当金や分配金の記録を管理できます。')).toBeInTheDocument();
-  });
+    const scoped = within(flowSection as HTMLElement);
 
-  it('フィーチャーカードのリンク先が正しい', () => {
-    render(
-      <MemoryRouter>
-        <HomePage />
-      </MemoryRouter>
-    );
-
-    // フィーチャーカードはクイックアクションと同名リンクがあるため、すべてのリンクを取得して確認する
-    const links = screen.getAllByRole('link', { name: /銘柄検索/ });
-    expect(links.some((l) => l.getAttribute('href') === '/search')).toBe(true);
-
-    const assetLinks = screen.getAllByRole('link', { name: /資産管理/ });
-    expect(assetLinks.some((l) => l.getAttribute('href') === '/assetbalance')).toBe(true);
-
-    const receiptLinks = screen.getAllByRole('link', { name: /取引明細/ });
-    expect(receiptLinks.some((l) => l.getAttribute('href') === '/receipts')).toBe(true);
-  });
-
-  it('はじめかたセクションのSTEPを表示する', () => {
-    render(
-      <MemoryRouter>
-        <HomePage />
-      </MemoryRouter>
-    );
-
-    expect(screen.getByText('STEP 1')).toBeInTheDocument();
-    expect(screen.getByText('証券会社からCSVをダウンロード')).toBeInTheDocument();
-    expect(screen.getByText('STEP 2')).toBeInTheDocument();
-    expect(screen.getByText('各ページでCSVファイルを取り込み')).toBeInTheDocument();
-    expect(screen.getByText('STEP 3')).toBeInTheDocument();
-    expect(screen.getByText('配当金や資産管理の情報を確認')).toBeInTheDocument();
+    expect(scoped.getByText('証券会社からCSVをダウンロード')).toBeInTheDocument();
+    expect(scoped.getByText('各ページのCSV取込から反映')).toBeInTheDocument();
+    expect(scoped.getByText('資産・配当金・取引明細を確認')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Rework Home from feature-introduction cards into a compact daily dashboard entry point
- Add a 4-item status/action strip for search, asset balance, receipts, and CSV import status
- Keep direct next-action links to search, asset balance, and receipts
- Update Home tests for the new visible structure

## Verification
- cd frontend && npx vitest run src/pages/__tests__/Home.test.tsx
- cd frontend && npm run lint

## Notes
- UI screenshot E2E was attempted, but local stack could not start because backend secrets were unavailable: DATABASE_URL is not set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **UI改善**
  * ホームページのレイアウトを再構成し、新しいダッシュボードヘッダーとステータスストリップを追加しました
  * 「次に行う操作」セクションと「データ確認フロー」セクションの表示を最適化しました
  * ナビゲーション機能を強化し、各セクションからの操作をより直感的にしました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->