### PR TITLE
Tighten asset summary visual density

### DIFF
--- a/frontend/src/components/molecules/PortfolioPieChart/PortfolioPieChart.tsx
+++ b/frontend/src/components/molecules/PortfolioPieChart/PortfolioPieChart.tsx
@@ -106,7 +106,7 @@ function PortfolioItemCard({ item, index, dividendPerShareMap, dividendStatusMap
   const color = COLORS[index % COLORS.length];
 
   return (
-    <div className="rounded-[1.35rem] border border-slate-200/90 bg-white px-3.5 py-3 shadow-[0_18px_36px_-34px_rgba(15,23,42,0.38)]">
+    <div className="rounded-lg border border-slate-200 bg-white px-3.5 py-3 shadow-sm">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2.5 min-w-0">
@@ -137,7 +137,7 @@ function PortfolioItemCard({ item, index, dividendPerShareMap, dividendStatusMap
       </div>
 
       <div
-        className="mt-2.5 grid grid-cols-3 overflow-hidden rounded-[1rem] bg-slate-50"
+        className="mt-2.5 grid grid-cols-3 overflow-hidden rounded-md bg-slate-50"
         data-testid="portfolio-card-acquisition-stats"
       >
         <div className="min-w-0 px-3 py-2">
@@ -154,7 +154,7 @@ function PortfolioItemCard({ item, index, dividendPerShareMap, dividendStatusMap
         </div>
       </div>
 
-      <div className="mt-2.5 grid grid-cols-3 overflow-hidden rounded-[1rem] bg-emerald-50/55">
+      <div className="mt-2.5 grid grid-cols-3 overflow-hidden rounded-md bg-emerald-50/55">
         <div className="min-w-0 px-3 py-2 text-xs text-slate-600">
           <p className="truncate text-[10px] font-medium text-slate-500">1株配当</p>
           <p className={`mt-0.5 truncate text-sm font-semibold ${divInfo?.perShare !== null && divInfo?.perShare !== undefined ? 'text-emerald-600' : 'text-slate-500'}`}>

--- a/frontend/src/components/organisms/AssetPortfolioSummary/AssetPortfolioSummary.tsx
+++ b/frontend/src/components/organisms/AssetPortfolioSummary/AssetPortfolioSummary.tsx
@@ -107,7 +107,7 @@ export const AssetPortfolioSummary: React.FC<AssetPortfolioSummaryProps> = ({
   return (
     <div className="mb-3 space-y-4" data-testid="asset-portfolio-summary">
       <section
-        className="rounded-[2rem] border border-slate-200/90 bg-white/85 px-5 py-5 shadow-[0_22px_48px_-36px_rgba(15,23,42,0.45)]"
+        className="rounded-xl border border-slate-200 bg-white px-5 py-5 shadow-sm"
         data-testid="portfolio-kpi-strip"
       >
         <div className="flex flex-col gap-3 border-b border-slate-200/80 pb-4 sm:flex-row sm:items-end sm:justify-between">
@@ -132,25 +132,25 @@ export const AssetPortfolioSummary: React.FC<AssetPortfolioSummaryProps> = ({
           ) : null}
         </div>
         <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
-          <div className="rounded-[1.35rem] border border-slate-200/90 bg-white px-4 py-4 shadow-[0_12px_24px_-28px_rgba(15,23,42,0.4)]">
+          <div className="rounded-lg border border-slate-200 bg-white px-4 py-4">
             <p className="mb-1 text-xs font-medium text-slate-600">合計取得総額</p>
             <p className="text-3xl font-bold text-primary tabular-nums" data-negative={totalPurchaseAmount < 0 ? 'true' : undefined}>
               {formatCurrency(totalPurchaseAmount)}
             </p>
           </div>
-          <div className="rounded-[1.35rem] border border-emerald-100 bg-emerald-50/90 px-4 py-4 shadow-[0_12px_24px_-28px_rgba(5,150,105,0.35)]">
+          <div className="rounded-lg border border-emerald-100 bg-emerald-50 px-4 py-4">
             <p className="mb-1 text-xs font-medium text-slate-600">年間配当金額</p>
             <p className="text-3xl font-bold text-emerald-600 tabular-nums" data-testid="portfolio-annual-dividends">
               {totalAnnualDividends !== null ? formatCurrency(totalAnnualDividends) : '---'}
             </p>
           </div>
-          <div className="rounded-[1.35rem] border border-emerald-100 bg-emerald-50/90 px-4 py-4 shadow-[0_12px_24px_-28px_rgba(5,150,105,0.35)]">
+          <div className="rounded-lg border border-emerald-100 bg-emerald-50 px-4 py-4">
             <p className="mb-1 text-xs font-medium text-slate-600">配当利回り</p>
             <p className="text-3xl font-bold text-emerald-600 tabular-nums" data-testid="portfolio-dividend-yield">
               {portfolioDividendYield !== null ? formatPercentageValue(portfolioDividendYield) : '---'}
             </p>
           </div>
-          <div className="rounded-[1.35rem] border border-slate-200/90 bg-white px-4 py-4 shadow-[0_12px_24px_-28px_rgba(15,23,42,0.4)]">
+          <div className="rounded-lg border border-slate-200 bg-white px-4 py-4">
             <p className="mb-1 text-xs font-medium text-slate-600">保有銘柄数</p>
             <p className="text-3xl font-bold text-slate-700 tabular-nums">
               {isFiltered
@@ -163,11 +163,11 @@ export const AssetPortfolioSummary: React.FC<AssetPortfolioSummaryProps> = ({
         </div>
       </section>
 
-      <Card className="overflow-hidden rounded-[1.75rem] border-slate-200 bg-white/95 shadow-sm">
+      <Card className="overflow-hidden rounded-xl border-slate-200 bg-white shadow-sm">
         <CardBody className="p-0">
           <div className="flex flex-col gap-3 border-b border-slate-200 px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
             <div>
-              <h3 className="text-sm font-semibold text-slate-700">銘柄別構成比</h3>
+              <h3 className="text-sm font-semibold text-slate-700">保有内訳</h3>
             </div>
           </div>
           <div className="p-4">

--- a/frontend/src/components/organisms/AssetPortfolioSummary/__tests__/AssetPortfolioSummary.test.tsx
+++ b/frontend/src/components/organisms/AssetPortfolioSummary/__tests__/AssetPortfolioSummary.test.tsx
@@ -68,7 +68,7 @@ describe('AssetPortfolioSummary', () => {
     render(<AssetPortfolioSummary assetBalanceData={mockData} />);
 
     expect(screen.getByTestId('portfolio-pie-chart')).toBeInTheDocument();
-    expect(screen.getByText('銘柄別構成比')).toBeInTheDocument();
+    expect(screen.getByText('保有内訳')).toBeInTheDocument();
     expect(screen.queryByText('保有比率と配当効率をまとめて確認できます。')).not.toBeInTheDocument();
   });
 

--- a/frontend/src/pages/__tests__/AssetBalance.test.tsx
+++ b/frontend/src/pages/__tests__/AssetBalance.test.tsx
@@ -140,10 +140,10 @@ describe('AssetBalanceInfo', { timeout: 20000 }, () => {
     }, waitOpts);
   });
 
-  it('銘柄別構成比が表示される', async () => {
+  it('保有内訳が表示される', async () => {
     render(<AssetBalanceInfo {...defaultProps} />);
     await waitFor(() => {
-      expect(screen.getByText('銘柄別構成比')).toBeInTheDocument();
+      expect(screen.getByText('保有内訳')).toBeInTheDocument();
     }, waitOpts);
   });
 });


### PR DESCRIPTION
## Summary
- Reduce oversized rounding and heavy presentation styling in the asset summary area
- Keep KPI, dividend, filtering, and holding-card behavior unchanged
- Rename the holdings composition heading from chart-focused copy to an operational portfolio label

## Verification
- cd frontend && npx vitest run src/components/organisms/AssetPortfolioSummary/__tests__/AssetPortfolioSummary.test.tsx src/components/molecules/PortfolioPieChart/__tests__/PortfolioPieChart.test.tsx
- cd frontend && npm run lint
- cd frontend && npm run test:e2e:ci -- --grep "資産管理ページ"