### PR TITLE
Tighten receipts workspace visuals

### DIFF
--- a/frontend/src/components/templates/ReceiptTemplate.tsx
+++ b/frontend/src/components/templates/ReceiptTemplate.tsx
@@ -51,7 +51,7 @@ const ReceiptTemplateContent: React.FC<ReceiptTemplateProps> = ({
   ) : null;
 
   const mainCard = (
-    <Card className="mt-1 overflow-hidden rounded-[2rem] border-slate-200/90 bg-white/95 shadow-[0_22px_48px_-36px_rgba(15,23,42,0.45)]" data-testid="receipt-card">
+    <Card className="mt-1 overflow-hidden rounded-xl border-slate-200/90 bg-white/95 shadow-[0_4px_12px_-4px_rgba(15,23,42,0.12)]" data-testid="receipt-card">
       <CardBody className="p-0" data-testid="receipt-card-body">
         {children}
       </CardBody>

--- a/frontend/src/features/receipt/components/ReceiptsTabNav.tsx
+++ b/frontend/src/features/receipt/components/ReceiptsTabNav.tsx
@@ -37,9 +37,9 @@ export function ReceiptsTabNav({
             <button
               key={tab}
               id={`tab-${tab}`}
-              className={`-mb-px inline-flex items-center gap-2 rounded-t-2xl border border-transparent border-b-0 px-4 py-3 text-sm font-medium transition-[color,background-color,border-color,box-shadow] ${
+              className={`-mb-px inline-flex items-center gap-2 rounded-t-lg border border-transparent border-b-0 px-4 py-3 text-sm font-medium transition-[color,background-color,border-color,box-shadow] ${
                 isActive
-                  ? 'border-slate-200 bg-white text-slate-900 shadow-[0_-1px_0_0_rgba(255,255,255,1),0_18px_32px_-30px_rgba(15,23,42,0.7)]'
+                  ? 'border-slate-200 bg-white text-slate-900 shadow-[0_-1px_0_0_rgba(255,255,255,1),0_4px_8px_-6px_rgba(15,23,42,0.35)]'
                   : 'text-slate-500 hover:bg-white/80 hover:text-slate-800'
               }`}
               onClick={() => onTabChange(tab)}

--- a/frontend/src/pages/__tests__/Receipts.test.tsx
+++ b/frontend/src/pages/__tests__/Receipts.test.tsx
@@ -805,6 +805,6 @@ describe('ReceiptsPage', () => {
     }, waitOpts);
 
     expect(screen.getByRole('tablist').className).toContain('border-b');
-    expect(screen.getByRole('tab', { name: /^配当金/ }).className).toContain('rounded-t-2xl');
+    expect(screen.getByRole('tab', { name: /^配当金/ }).className).toContain('rounded-t-lg');
   });
 });


### PR DESCRIPTION
## Summary
- Reduce oversized rounding on the receipt table container
- Make receipt tabs use a smaller active shape and quieter shadow
- Preserve tab behavior, accessibility, counts, and data/test hooks

## Verification
- cd frontend && npx vitest run src/components/templates/__tests__/ReceiptTemplate.test.tsx src/features/receipt/components/__tests__/ReceiptsTabNav.test.tsx src/pages/__tests__/Receipts.test.tsx
- cd frontend && npm run lint
- cd frontend && npm run test:e2e:ci -- --grep "取引明細ページ"