### PR TITLE
フロント認証APIをv1へ移行

### DIFF
--- a/frontend/e2e/a11y.spec.ts
+++ b/frontend/e2e/a11y.spec.ts
@@ -13,7 +13,7 @@ import AxeBuilder from '@axe-core/playwright';
 const MOCK_USER = { id: 1, email: 'test@example.com', name: 'テストユーザー' };
 
 const ROUTES = {
-  authMe: /\/auth\/me$/,
+  authMe: /\/api\/v1\/session$/,
   dividends: /\/dividends$/,
   domesticStocks: /\/domestic-stocks$/,
   mutualfunds: /\/mutualfunds$/,

--- a/frontend/e2e/assetbalance-flow.spec.ts
+++ b/frontend/e2e/assetbalance-flow.spec.ts
@@ -10,7 +10,7 @@ const MOCK_USER = {
 };
 
 const ROUTES = {
-  authMe: /\/auth\/me$/,
+  authMe: /\/api\/v1\/session$/,
   assetBalances: /\/asset-balances$/,
   assetBalancePreview: /\/asset-balances\/csv\/preview$/,
   assetBalanceUpload: /\/asset-balances\/csv$/,

--- a/frontend/e2e/auth-flow.spec.ts
+++ b/frontend/e2e/auth-flow.spec.ts
@@ -7,7 +7,7 @@ const MOCK_USER = {
 };
 
 const ROUTES = {
-  authMe: /\/auth\/me$/,
+  authMe: /\/api\/v1\/session$/,
 };
 
 async function mockUnauthorizedAuth(page: Page) {

--- a/frontend/e2e/error-scenarios.spec.ts
+++ b/frontend/e2e/error-scenarios.spec.ts
@@ -20,7 +20,7 @@ const MOCK_USER = { id: 1, email: 'test@example.com', name: 'テストユーザ�
 
 // ホスト非依存のパターン（VITE_SHOKEN_WEBAPI_API_URL の値に関わらず一致する）
 const ROUTES = {
-  authMe: /\/auth\/me$/,
+  authMe: /\/api\/v1\/session$/,
   dividends: /\/dividends$/,
   dividendsCsvPreview: /\/dividends\/csv\/preview$/,
   domesticStocks: /\/domestic-stocks$/,

--- a/frontend/e2e/receipt-flow.spec.ts
+++ b/frontend/e2e/receipt-flow.spec.ts
@@ -7,7 +7,7 @@ const MOCK_USER = {
 };
 
 const ROUTES = {
-  authMe: /\/auth\/me$/,
+  authMe: /\/api\/v1\/session$/,
   dividends: /\/dividends$/,
   domesticStocks: /\/domestic-stocks$/,
   mutualfunds: /\/mutualfunds$/,

--- a/frontend/e2e/search-flow.spec.ts
+++ b/frontend/e2e/search-flow.spec.ts
@@ -20,7 +20,7 @@ const MOCK_STOCK = {
 };
 
 const ROUTES = {
-  authMe: /\/auth\/me$/,
+  authMe: /\/api\/v1\/session$/,
   // API エンドポイントのみ一致させる（Vite のソースファイルパスと衝突しないよう末尾を限定）
   stock: /\/stocks\/\d+$/,
 };

--- a/frontend/src/features/auth/context/AuthContext.tsx
+++ b/frontend/src/features/auth/context/AuthContext.tsx
@@ -46,7 +46,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const controller = new AbortController();
 
     const checkSession = async () => {
-      await authApiClient.get<UserInfo>('/auth/me', {
+      await authApiClient.get<UserInfo>('/api/v1/session', {
         withCredentials: true,
         signal: controller.signal,
       }).then((userInfo) => {
@@ -80,7 +80,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // バックエンドの認証エンドポイントに直接リダイレクト
     // バックエンドがGoogleの認証ページにリダイレクトする
     const apiBaseUrl = import.meta.env.VITE_SHOKEN_WEBAPI_API_URL;
-    locationAssigner.assign(`${apiBaseUrl}/auth/google`);
+    locationAssigner.assign(`${apiBaseUrl}/api/v1/oauth/google/authorize`);
   };
 
   const logout = useCallback(async () => {
@@ -88,7 +88,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     logoutCallbacksRef.current.forEach(callback => callback());
     let hasError = false;
     let caughtError: unknown;
-    await apiClient.post('/auth/logout', {}, {
+    await apiClient.delete('/api/v1/session', {
       withCredentials: true,
     }).catch((error: unknown) => {
       hasError = true;
@@ -114,12 +114,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     logoutCallbacksRef.current.forEach(callback => callback());
     let hasError = false;
     let caughtError: unknown;
-    await apiClient.delete('/auth/delete-account', {
-      withCredentials: true,
-    }).catch((error: unknown) => {
+    try {
+      await apiClient.post('/api/v1/account-deletion-confirmations', {}, {
+        withCredentials: true,
+      });
+      await apiClient.delete('/api/v1/account', {
+        withCredentials: true,
+      });
+    } catch (error: unknown) {
       hasError = true;
       caughtError = error;
-    });
+    }
     setSession(s => ({ ...s, user: null }));
     if (hasError) {
       throw caughtError;

--- a/frontend/src/features/auth/context/AuthContext.tsx
+++ b/frontend/src/features/auth/context/AuthContext.tsx
@@ -117,6 +117,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     try {
       await apiClient.post('/api/v1/account-deletion-confirmations', {}, {
         withCredentials: true,
+        retry: { maxRetries: 0 },
       });
       await apiClient.delete('/api/v1/account', {
         withCredentials: true,

--- a/frontend/src/features/auth/context/__tests__/AuthContext.test.tsx
+++ b/frontend/src/features/auth/context/__tests__/AuthContext.test.tsx
@@ -243,6 +243,7 @@ describe('AuthProvider', () => {
     await waitFor(() => {
       expect(apiClient.post).toHaveBeenCalledWith('/api/v1/account-deletion-confirmations', {}, {
         withCredentials: true,
+        retry: { maxRetries: 0 },
       });
       expect(apiClient.delete).toHaveBeenCalledWith('/api/v1/account', {
         withCredentials: true,
@@ -280,7 +281,10 @@ describe('AuthProvider', () => {
     await waitFor(() => {
       expect(screen.getByTestId('error').textContent).toBe('delete failed');
     });
-    expect(apiClient.post).toHaveBeenCalledWith('/api/v1/account-deletion-confirmations', {}, { withCredentials: true });
+    expect(apiClient.post).toHaveBeenCalledWith('/api/v1/account-deletion-confirmations', {}, {
+      withCredentials: true,
+      retry: { maxRetries: 0 },
+    });
     expect(screen.getByTestId('user-name').textContent).toBe('none');
   });
 

--- a/frontend/src/features/auth/context/__tests__/AuthContext.test.tsx
+++ b/frontend/src/features/auth/context/__tests__/AuthContext.test.tsx
@@ -143,7 +143,7 @@ describe('AuthProvider', () => {
     expect(screen.getByTestId('authenticated').textContent).toBe('true');
     expect(screen.getByTestId('user-name').textContent).toBe('テストユーザー');
     expect(mockGet).toHaveBeenCalledTimes(1);
-    expect(mockGet).toHaveBeenCalledWith('/auth/me', expect.objectContaining({
+    expect(mockGet).toHaveBeenCalledWith('/api/v1/session', expect.objectContaining({
       withCredentials: true,
       signal: expect.any(AbortSignal),
     }));
@@ -203,19 +203,19 @@ describe('AuthProvider', () => {
       expect(screen.getByTestId('loading').textContent).toBe('false');
     });
 
-    expect(mockGet).toHaveBeenCalledWith('/auth/me', expect.objectContaining({
+    expect(mockGet).toHaveBeenCalledWith('/api/v1/session', expect.objectContaining({
       withCredentials: true,
       signal: expect.any(AbortSignal),
     }));
   });
 
-  it('logoutがauth/logoutを呼びuserをnullにする', async () => {
+  it('logoutがapi/v1/sessionを削除しuserをnullにする', async () => {
     const { user } = await renderAuthProvider();
 
     await user.click(screen.getByRole('button', { name: 'logout' }));
 
     await waitFor(() => {
-      expect(apiClient.post).toHaveBeenCalledWith('/auth/logout', {}, {
+      expect(apiClient.delete).toHaveBeenCalledWith('/api/v1/session', {
         withCredentials: true,
       });
     });
@@ -224,7 +224,7 @@ describe('AuthProvider', () => {
   });
 
   it('logoutがAPIエラーの場合はthrowしてcatch可能', async () => {
-    vi.mocked(apiClient.post).mockRejectedValueOnce(new Error('logout failed'));
+    vi.mocked(apiClient.delete).mockRejectedValueOnce(new Error('logout failed'));
     const { user } = await renderAuthProvider();
 
     await user.click(screen.getByRole('button', { name: 'logout' }));
@@ -235,21 +235,43 @@ describe('AuthProvider', () => {
     expect(screen.getByTestId('user-name').textContent).toBe('none');
   });
 
-  it('deleteAccountがauth/delete-accountを呼びuserをnullにする', async () => {
+  it('deleteAccountが確認APIを先に呼んでから削除APIを呼びuserをnullにする', async () => {
     const { user } = await renderAuthProvider();
 
     await user.click(screen.getByRole('button', { name: 'delete-account' }));
 
     await waitFor(() => {
-      expect(apiClient.delete).toHaveBeenCalledWith('/auth/delete-account', {
+      expect(apiClient.post).toHaveBeenCalledWith('/api/v1/account-deletion-confirmations', {}, {
+        withCredentials: true,
+      });
+      expect(apiClient.delete).toHaveBeenCalledWith('/api/v1/account', {
         withCredentials: true,
       });
     });
+
+    // 確認APIが削除APIより先に呼ばれることを検証
+    const postCallOrder = vi.mocked(apiClient.post).mock.invocationCallOrder[0];
+    const deleteCallOrder = vi.mocked(apiClient.delete).mock.invocationCallOrder[0];
+    expect(postCallOrder).toBeLessThan(deleteCallOrder);
+
     expect(screen.getByTestId('user-name').textContent).toBe('none');
     expect(screen.getByTestId('authenticated').textContent).toBe('false');
   });
 
-  it('deleteAccountがAPIエラーの場合はthrowしてcatch可能', async () => {
+  it('deleteAccountで確認APIが失敗した場合は削除APIを呼ばずuserをnullにする', async () => {
+    vi.mocked(apiClient.post).mockRejectedValueOnce(new Error('confirmation failed'));
+    const { user } = await renderAuthProvider();
+
+    await user.click(screen.getByRole('button', { name: 'delete-account' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('error').textContent).toBe('confirmation failed');
+    });
+    expect(apiClient.delete).not.toHaveBeenCalled();
+    expect(screen.getByTestId('user-name').textContent).toBe('none');
+  });
+
+  it('deleteAccountで削除APIが失敗した場合はthrowしてcatch可能', async () => {
     vi.mocked(apiClient.delete).mockRejectedValueOnce(new Error('delete failed'));
     const { user } = await renderAuthProvider();
 
@@ -258,6 +280,7 @@ describe('AuthProvider', () => {
     await waitFor(() => {
       expect(screen.getByTestId('error').textContent).toBe('delete failed');
     });
+    expect(apiClient.post).toHaveBeenCalledWith('/api/v1/account-deletion-confirmations', {}, { withCredentials: true });
     expect(screen.getByTestId('user-name').textContent).toBe('none');
   });
 
@@ -276,7 +299,7 @@ describe('AuthProvider', () => {
     idleOptions?.onIdle();
 
     await waitFor(() => {
-      expect(apiClient.post).toHaveBeenCalledWith('/auth/logout', {}, {
+      expect(apiClient.delete).toHaveBeenCalledWith('/api/v1/session', {
         withCredentials: true,
       });
     });
@@ -289,7 +312,7 @@ describe('AuthProvider', () => {
 
     await user.click(screen.getByRole('button', { name: 'login' }));
 
-    expect(assignSpy).toHaveBeenCalledWith('https://api.example.com/auth/google');
+    expect(assignSpy).toHaveBeenCalledWith('https://api.example.com/api/v1/oauth/google/authorize');
 
     assignSpy.mockRestore();
   });
@@ -371,7 +394,7 @@ describe('AuthProvider', () => {
     idleOptions?.onIdle();
 
     // userがnullなのでlogoutは呼ばれない
-    expect(apiClient.post).not.toHaveBeenCalled();
+    expect(apiClient.delete).not.toHaveBeenCalled();
   });
 
   it('onLogoutでコールバックを登録解除できる', async () => {
@@ -389,7 +412,7 @@ describe('AuthProvider', () => {
     await user.click(screen.getByRole('button', { name: 'logout' }));
 
     await waitFor(() => {
-      expect(apiClient.post).toHaveBeenCalledTimes(2);
+      expect(apiClient.delete).toHaveBeenCalledTimes(2);
     });
     expect(onLogoutCallback).toHaveBeenCalledTimes(1);
   });

--- a/frontend/src/lib/api/__tests__/client.test.ts
+++ b/frontend/src/lib/api/__tests__/client.test.ts
@@ -442,6 +442,24 @@ describe('ApiClient', () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
+    it('per-requestのretry: { maxRetries: 0 }でリトライが無効化される', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      mockFetch.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+
+      const client = createApiClient({
+        baseURL: 'http://api.test',
+        retry: { maxRetries: 3, retryDelay: 100, retryDelayMultiplier: 1 },
+      });
+
+      await expect(
+        client.post('/confirm', {}, { retry: { maxRetries: 0 } }),
+      ).rejects.toBeInstanceOf(ApiError);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
     it('baseURLに既存クエリがある場合は追加パラメータを&で連結する', async () => {
       mockFetch.mockResolvedValue({
         ok: true,

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -1,17 +1,18 @@
 import { ApiError, ApiErrorType } from '../types/api';
 
+export interface RetryConfig {
+  maxRetries: number;
+  retryDelay: number;
+  retryDelayMultiplier: number;
+  shouldRetry?: (error: ApiError) => boolean;
+}
+
 export interface RequestConfig {
   params?: Record<string, string | number | boolean | undefined>;
   headers?: Record<string, string>;
   withCredentials?: boolean;
   signal?: AbortSignal;
-}
-
-interface RetryConfig {
-  maxRetries: number;
-  retryDelay: number;
-  retryDelayMultiplier: number;
-  shouldRetry?: (error: ApiError) => boolean;
+  retry?: Partial<RetryConfig>;
 }
 
 interface ApiClientConfig {
@@ -79,7 +80,10 @@ class ApiClient {
     config: RequestConfig = {},
     retryCount = 0
   ): Promise<T> {
-    const { params, withCredentials, signal: externalSignal } = config;
+    const { params, withCredentials, signal: externalSignal, retry: perRequestRetry } = config;
+    const effectiveRetryConfig = perRequestRetry
+      ? { ...this.retryConfig, ...perRequestRetry }
+      : this.retryConfig;
 
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort('timeout'), this.timeout);
@@ -158,13 +162,19 @@ class ApiClient {
 
       // 統一リトライ判定
       if (
-        retryCount < this.retryConfig.maxRetries &&
-        this.retryConfig.shouldRetry!(apiError)
+        retryCount < effectiveRetryConfig.maxRetries &&
+        effectiveRetryConfig.shouldRetry!(apiError)
       ) {
-        const delay = this.retryConfig.retryDelay *
-          Math.pow(this.retryConfig.retryDelayMultiplier, retryCount);
+        const delay = effectiveRetryConfig.retryDelay *
+          Math.pow(effectiveRetryConfig.retryDelayMultiplier, retryCount);
         console.warn(
-          `Retrying request (${retryCount + 1}/${this.retryConfig.maxRetries}) after ${delay}ms:`,
+          'Retrying request',
+          retryCount + 1,
+          'of',
+          effectiveRetryConfig.maxRetries,
+          'after',
+          delay,
+          'ms:',
           apiError.message
         );
         await new Promise(resolve => setTimeout(resolve, delay));


### PR DESCRIPTION
## 概要
- フロントエンドの認証API呼び出しを /api/v1 に移行
- logout を DELETE /api/v1/session に変更
- account delete は確認APIを呼んでから DELETE /api/v1/account を呼ぶ
- 関連 unit test の期待pathを更新

## 非対象
- 取引/CSV/資産残高/株式/J-Quants API の移行
- 旧バックエンドAPIの削除
- UI変更

## 検証
- npm run lint
- npx tsc --noEmit
- npm test -- --run src/features/auth/context/__tests__/AuthContext.test.tsx src/features/auth/context/__tests__/locationAssigner.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 認証関連APIの呼び先と処理を整理・統一しました（セッション取得、ログイン遷移、ログアウト、アカウント削除）。外部から見たユーザー体験に変更はありませんが、安定性と一貫性が向上します。
  * APIクライアントのリトライ設定をリクエスト単位で上書き可能にし、通信の信頼性調整が容易になりました。

* **Tests**
  * 新API仕様に合わせてユニット／E2Eテストを更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->