### PR TITLE
取引明細APIをv1へ移行

### DIFF
--- a/frontend/e2e/a11y.spec.ts
+++ b/frontend/e2e/a11y.spec.ts
@@ -14,9 +14,9 @@ const MOCK_USER = { id: 1, email: 'test@example.com', name: 'テストユーザ�
 
 const ROUTES = {
   authMe: /\/api\/v1\/session$/,
-  dividends: /\/dividends$/,
-  domesticStocks: /\/domestic-stocks$/,
-  mutualfunds: /\/mutualfunds$/,
+  dividends: /\/api\/v1\/dividends$/,
+  domesticStocks: /\/api\/v1\/domestic-stock-transactions$/,
+  mutualfunds: /\/api\/v1\/mutual-fund-transactions$/,
   assetBalances: /\/asset-balances$/,
   stock: /\/stocks\/[^/]+$/,
 };

--- a/frontend/e2e/error-scenarios.spec.ts
+++ b/frontend/e2e/error-scenarios.spec.ts
@@ -21,10 +21,10 @@ const MOCK_USER = { id: 1, email: 'test@example.com', name: 'テストユーザ�
 // ホスト非依存のパターン（VITE_SHOKEN_WEBAPI_API_URL の値に関わらず一致する）
 const ROUTES = {
   authMe: /\/api\/v1\/session$/,
-  dividends: /\/dividends$/,
-  dividendsCsvPreview: /\/dividends\/csv\/preview$/,
-  domesticStocks: /\/domestic-stocks$/,
-  mutualfunds: /\/mutualfunds$/,
+  dividends: /\/api\/v1\/dividends$/,
+  dividendsCsvPreview: /\/api\/v1\/dividend-import-validations$/,
+  domesticStocks: /\/api\/v1\/domestic-stock-transactions$/,
+  mutualfunds: /\/api\/v1\/mutual-fund-transactions$/,
   assetBalances: /\/asset-balances$/,
 };
 

--- a/frontend/e2e/receipt-flow.spec.ts
+++ b/frontend/e2e/receipt-flow.spec.ts
@@ -8,9 +8,9 @@ const MOCK_USER = {
 
 const ROUTES = {
   authMe: /\/api\/v1\/session$/,
-  dividends: /\/dividends$/,
-  domesticStocks: /\/domestic-stocks$/,
-  mutualfunds: /\/mutualfunds$/,
+  dividends: /\/api\/v1\/dividends$/,
+  domesticStocks: /\/api\/v1\/domestic-stock-transactions$/,
+  mutualfunds: /\/api\/v1\/mutual-fund-transactions$/,
 };
 
 const DIVIDEND_RECORD = [

--- a/frontend/src/features/receipt/api/__tests__/receiptApi.test.ts
+++ b/frontend/src/features/receipt/api/__tests__/receiptApi.test.ts
@@ -20,26 +20,26 @@ describe('dividendApi', () => {
     vi.clearAllMocks();
   });
 
-  it('list が /dividends に GET リクエストを送る', () => {
+  it('list が /api/v1/dividends に GET リクエストを送る', () => {
     dividendApi.list();
-    expect(apiClient.get).toHaveBeenCalledWith('/dividends', { withCredentials: true });
+    expect(apiClient.get).toHaveBeenCalledWith('/api/v1/dividends', { withCredentials: true });
   });
 
-  it('previewCsv が /dividends/csv/preview にプレビューリクエストを送る', () => {
+  it('previewCsv が /api/v1/dividend-import-validations にプレビューリクエストを送る', () => {
     const file = new File(['content'], 'test.csv', { type: 'text/csv' });
     dividendApi.previewCsv(file);
-    expect(csvHelpers.previewCsvFile).toHaveBeenCalledWith('/dividends/csv/preview', file);
+    expect(csvHelpers.previewCsvFile).toHaveBeenCalledWith('/api/v1/dividend-import-validations', file);
   });
 
-  it('uploadCsv が /dividends/csv にアップロードリクエストを送る', () => {
+  it('uploadCsv が /api/v1/dividend-imports にアップロードリクエストを送る', () => {
     const file = new File(['content'], 'test.csv', { type: 'text/csv' });
     dividendApi.uploadCsv(file);
-    expect(csvHelpers.uploadCsvFile).toHaveBeenCalledWith('/dividends/csv', file);
+    expect(csvHelpers.uploadCsvFile).toHaveBeenCalledWith('/api/v1/dividend-imports', file);
   });
 
-  it('deleteAll が /dividends に DELETE リクエストを送る', () => {
+  it('deleteAll が /api/v1/dividends に DELETE リクエストを送る', () => {
     dividendApi.deleteAll();
-    expect(apiClient.delete).toHaveBeenCalledWith('/dividends', { withCredentials: true });
+    expect(apiClient.delete).toHaveBeenCalledWith('/api/v1/dividends', { withCredentials: true });
   });
 });
 
@@ -48,26 +48,26 @@ describe('domesticStockApi', () => {
     vi.clearAllMocks();
   });
 
-  it('list が /domestic-stocks に GET リクエストを送る', () => {
+  it('list が /api/v1/domestic-stock-transactions に GET リクエストを送る', () => {
     domesticStockApi.list();
-    expect(apiClient.get).toHaveBeenCalledWith('/domestic-stocks', { withCredentials: true });
+    expect(apiClient.get).toHaveBeenCalledWith('/api/v1/domestic-stock-transactions', { withCredentials: true });
   });
 
-  it('previewCsv が /domestic-stocks/csv/preview にプレビューリクエストを送る', () => {
+  it('previewCsv が /api/v1/domestic-stock-import-validations にプレビューリクエストを送る', () => {
     const file = new File(['content'], 'test.csv', { type: 'text/csv' });
     domesticStockApi.previewCsv(file);
-    expect(csvHelpers.previewCsvFile).toHaveBeenCalledWith('/domestic-stocks/csv/preview', file);
+    expect(csvHelpers.previewCsvFile).toHaveBeenCalledWith('/api/v1/domestic-stock-import-validations', file);
   });
 
-  it('uploadCsv が /domestic-stocks/csv にアップロードリクエストを送る', () => {
+  it('uploadCsv が /api/v1/domestic-stock-imports にアップロードリクエストを送る', () => {
     const file = new File(['content'], 'test.csv', { type: 'text/csv' });
     domesticStockApi.uploadCsv(file);
-    expect(csvHelpers.uploadCsvFile).toHaveBeenCalledWith('/domestic-stocks/csv', file);
+    expect(csvHelpers.uploadCsvFile).toHaveBeenCalledWith('/api/v1/domestic-stock-imports', file);
   });
 
-  it('deleteAll が /domestic-stocks に DELETE リクエストを送る', () => {
+  it('deleteAll が /api/v1/domestic-stock-transactions に DELETE リクエストを送る', () => {
     domesticStockApi.deleteAll();
-    expect(apiClient.delete).toHaveBeenCalledWith('/domestic-stocks', { withCredentials: true });
+    expect(apiClient.delete).toHaveBeenCalledWith('/api/v1/domestic-stock-transactions', { withCredentials: true });
   });
 });
 
@@ -76,25 +76,25 @@ describe('mutualfundApi', () => {
     vi.clearAllMocks();
   });
 
-  it('list が /mutualfunds に GET リクエストを送る', () => {
+  it('list が /api/v1/mutual-fund-transactions に GET リクエストを送る', () => {
     mutualfundApi.list();
-    expect(apiClient.get).toHaveBeenCalledWith('/mutualfunds', { withCredentials: true });
+    expect(apiClient.get).toHaveBeenCalledWith('/api/v1/mutual-fund-transactions', { withCredentials: true });
   });
 
-  it('previewCsv が /mutualfunds/csv/preview にプレビューリクエストを送る', () => {
+  it('previewCsv が /api/v1/mutual-fund-import-validations にプレビューリクエストを送る', () => {
     const file = new File(['content'], 'test.csv', { type: 'text/csv' });
     mutualfundApi.previewCsv(file);
-    expect(csvHelpers.previewCsvFile).toHaveBeenCalledWith('/mutualfunds/csv/preview', file);
+    expect(csvHelpers.previewCsvFile).toHaveBeenCalledWith('/api/v1/mutual-fund-import-validations', file);
   });
 
-  it('uploadCsv が /mutualfunds/csv にアップロードリクエストを送る', () => {
+  it('uploadCsv が /api/v1/mutual-fund-imports にアップロードリクエストを送る', () => {
     const file = new File(['content'], 'test.csv', { type: 'text/csv' });
     mutualfundApi.uploadCsv(file);
-    expect(csvHelpers.uploadCsvFile).toHaveBeenCalledWith('/mutualfunds/csv', file);
+    expect(csvHelpers.uploadCsvFile).toHaveBeenCalledWith('/api/v1/mutual-fund-imports', file);
   });
 
-  it('deleteAll が /mutualfunds に DELETE リクエストを送る', () => {
+  it('deleteAll が /api/v1/mutual-fund-transactions に DELETE リクエストを送る', () => {
     mutualfundApi.deleteAll();
-    expect(apiClient.delete).toHaveBeenCalledWith('/mutualfunds', { withCredentials: true });
+    expect(apiClient.delete).toHaveBeenCalledWith('/api/v1/mutual-fund-transactions', { withCredentials: true });
   });
 });

--- a/frontend/src/features/receipt/api/receiptApi.ts
+++ b/frontend/src/features/receipt/api/receiptApi.ts
@@ -9,38 +9,38 @@ import type {
 // 配当金API
 export const dividendApi = {
   list: () =>
-    apiClient.get<DividendApiData[]>('/dividends', { withCredentials: true }),
+    apiClient.get<DividendApiData[]>('/api/v1/dividends', { withCredentials: true }),
 
-  previewCsv: (file: File) => previewCsvFile('/dividends/csv/preview', file),
+  previewCsv: (file: File) => previewCsvFile('/api/v1/dividend-import-validations', file),
 
-  uploadCsv: (file: File) => uploadCsvFile('/dividends/csv', file),
+  uploadCsv: (file: File) => uploadCsvFile('/api/v1/dividend-imports', file),
 
   deleteAll: async () =>
-    apiClient.delete('/dividends', { withCredentials: true }),
+    apiClient.delete('/api/v1/dividends', { withCredentials: true }),
 };
 
 // 国内株式API
 export const domesticStockApi = {
   list: () =>
-    apiClient.get<DomesticStockApiData[]>('/domestic-stocks', { withCredentials: true }),
+    apiClient.get<DomesticStockApiData[]>('/api/v1/domestic-stock-transactions', { withCredentials: true }),
 
-  previewCsv: (file: File) => previewCsvFile('/domestic-stocks/csv/preview', file),
+  previewCsv: (file: File) => previewCsvFile('/api/v1/domestic-stock-import-validations', file),
 
-  uploadCsv: (file: File) => uploadCsvFile('/domestic-stocks/csv', file),
+  uploadCsv: (file: File) => uploadCsvFile('/api/v1/domestic-stock-imports', file),
 
   deleteAll: async () =>
-    apiClient.delete('/domestic-stocks', { withCredentials: true }),
+    apiClient.delete('/api/v1/domestic-stock-transactions', { withCredentials: true }),
 };
 
 // 投資信託API
 export const mutualfundApi = {
   list: () =>
-    apiClient.get<MutualfundApiData[]>('/mutualfunds', { withCredentials: true }),
+    apiClient.get<MutualfundApiData[]>('/api/v1/mutual-fund-transactions', { withCredentials: true }),
 
-  previewCsv: (file: File) => previewCsvFile('/mutualfunds/csv/preview', file),
+  previewCsv: (file: File) => previewCsvFile('/api/v1/mutual-fund-import-validations', file),
 
-  uploadCsv: (file: File) => uploadCsvFile('/mutualfunds/csv', file),
+  uploadCsv: (file: File) => uploadCsvFile('/api/v1/mutual-fund-imports', file),
 
   deleteAll: async () =>
-    apiClient.delete('/mutualfunds', { withCredentials: true }),
+    apiClient.delete('/api/v1/mutual-fund-transactions', { withCredentials: true }),
 };


### PR DESCRIPTION
## 概要
- 取引明細系フロント API を /api/v1 の REST API パスへ移行
- 配当金、国内株式取引、投資信託の一覧、削除、CSV validation/import を対象に更新
- 関連 unit test と E2E API モックを v1 に追従

## 非対象
- 資産管理 API
- 銘柄検索 API
- J-Quants API
- 旧 backend route 削除

## 検証
- cd frontend && npm run lint
- cd frontend && npx tsc --noEmit
- cd frontend && npm test -- --run src/features/receipt/api/__tests__/receiptApi.test.ts
- cd frontend && npx playwright test receipt-flow.spec.ts error-scenarios.spec.ts a11y.spec.ts --config playwright.ci.config.ts --reporter=list