### PR TITLE
資産管理APIをv1へ移行

### DIFF
--- a/frontend/e2e/a11y.spec.ts
+++ b/frontend/e2e/a11y.spec.ts
@@ -17,7 +17,7 @@ const ROUTES = {
   dividends: /\/api\/v1\/dividends$/,
   domesticStocks: /\/api\/v1\/domestic-stock-transactions$/,
   mutualfunds: /\/api\/v1\/mutual-fund-transactions$/,
-  assetBalances: /\/asset-balances$/,
+  assetBalances: /\/api\/v1\/asset-balances$/,
   stock: /\/stocks\/[^/]+$/,
 };
 

--- a/frontend/e2e/assetbalance-flow.spec.ts
+++ b/frontend/e2e/assetbalance-flow.spec.ts
@@ -11,9 +11,9 @@ const MOCK_USER = {
 
 const ROUTES = {
   authMe: /\/api\/v1\/session$/,
-  assetBalances: /\/asset-balances$/,
-  assetBalancePreview: /\/asset-balances\/csv\/preview$/,
-  assetBalanceUpload: /\/asset-balances\/csv$/,
+  assetBalances: /\/api\/v1\/asset-balances$/,
+  assetBalancePreview: /\/api\/v1\/asset-balance-import-validations$/,
+  assetBalanceUpload: /\/api\/v1\/asset-balance-imports$/,
   dividendPerShareBatch: /\/dividends\/per-share\/batch$/,
 };
 

--- a/frontend/e2e/error-scenarios.spec.ts
+++ b/frontend/e2e/error-scenarios.spec.ts
@@ -25,7 +25,7 @@ const ROUTES = {
   dividendsCsvPreview: /\/api\/v1\/dividend-import-validations$/,
   domesticStocks: /\/api\/v1\/domestic-stock-transactions$/,
   mutualfunds: /\/api\/v1\/mutual-fund-transactions$/,
-  assetBalances: /\/asset-balances$/,
+  assetBalances: /\/api\/v1\/asset-balances$/,
 };
 
 async function setupCommonMocks(page: Page) {

--- a/frontend/src/features/assetBalance/api/__tests__/assetBalanceApi.test.ts
+++ b/frontend/src/features/assetBalance/api/__tests__/assetBalanceApi.test.ts
@@ -25,7 +25,7 @@ describe('assetBalanceApi', () => {
   it('list() は asset-balances 一覧取得 API を呼ぶ', () => {
     assetBalanceApi.list();
 
-    expect(apiClient.get).toHaveBeenCalledWith('/asset-balances', {
+    expect(apiClient.get).toHaveBeenCalledWith('/api/v1/asset-balances', {
       withCredentials: true,
     });
   });
@@ -35,7 +35,7 @@ describe('assetBalanceApi', () => {
 
     assetBalanceApi.previewCsv(file);
 
-    expect(previewCsvFile).toHaveBeenCalledWith('/asset-balances/csv/preview', file);
+    expect(previewCsvFile).toHaveBeenCalledWith('/api/v1/asset-balance-import-validations', file);
   });
 
   it('uploadCsv(file) は uploadCsvFile を呼ぶ', () => {
@@ -43,13 +43,13 @@ describe('assetBalanceApi', () => {
 
     assetBalanceApi.uploadCsv(file);
 
-    expect(uploadCsvFile).toHaveBeenCalledWith('/asset-balances/csv', file);
+    expect(uploadCsvFile).toHaveBeenCalledWith('/api/v1/asset-balance-imports', file);
   });
 
   it('deleteAll() は全件削除 API を呼ぶ', async () => {
     await assetBalanceApi.deleteAll();
 
-    expect(apiClient.delete).toHaveBeenCalledWith('/asset-balances', {
+    expect(apiClient.delete).toHaveBeenCalledWith('/api/v1/asset-balances', {
       withCredentials: true,
     });
   });

--- a/frontend/src/features/assetBalance/api/assetBalanceApi.ts
+++ b/frontend/src/features/assetBalance/api/assetBalanceApi.ts
@@ -4,12 +4,12 @@ import type { AssetBalanceApiData } from '@/types/api';
 
 export const assetBalanceApi = {
   list: () =>
-    apiClient.get<AssetBalanceApiData[]>('/asset-balances', { withCredentials: true }),
+    apiClient.get<AssetBalanceApiData[]>('/api/v1/asset-balances', { withCredentials: true }),
 
-  previewCsv: (file: File) => previewCsvFile('/asset-balances/csv/preview', file),
+  previewCsv: (file: File) => previewCsvFile('/api/v1/asset-balance-import-validations', file),
 
-  uploadCsv: (file: File) => uploadCsvFile('/asset-balances/csv', file),
+  uploadCsv: (file: File) => uploadCsvFile('/api/v1/asset-balance-imports', file),
 
   deleteAll: async () =>
-    apiClient.delete('/asset-balances', { withCredentials: true }),
+    apiClient.delete('/api/v1/asset-balances', { withCredentials: true }),
 };


### PR DESCRIPTION
## 概要
- 資産管理フロント API を /api/v1 の REST API パスへ移行
- 一覧、削除、CSV validation/import を対象に更新
- 関連 unit test と E2E API モックを v1 に追従

## 非対象
- 認証 API
- 取引明細 API
- 銘柄検索 API
- J-Quants API
- 旧 backend route 削除

## 検証
- cd frontend && npm run lint
- cd frontend && npx tsc --noEmit
- cd frontend && npm test -- --run src/features/assetBalance/api/__tests__/assetBalanceApi.test.ts
- cd frontend && npx playwright test assetbalance-flow.spec.ts error-scenarios.spec.ts a11y.spec.ts --config playwright.ci.config.ts --reporter=list