### PR TITLE
市場データAPIをv1へ移行

### DIFF
--- a/frontend/e2e/a11y.spec.ts
+++ b/frontend/e2e/a11y.spec.ts
@@ -18,7 +18,7 @@ const ROUTES = {
   domesticStocks: /\/api\/v1\/domestic-stock-transactions$/,
   mutualfunds: /\/api\/v1\/mutual-fund-transactions$/,
   assetBalances: /\/api\/v1\/asset-balances$/,
-  stock: /\/stocks\/[^/]+$/,
+  stock: /\/api\/v1\/stocks(?:\?.*)?$/,
 };
 
 async function setupAuthMocks(page: import('@playwright/test').Page) {

--- a/frontend/e2e/assetbalance-flow.spec.ts
+++ b/frontend/e2e/assetbalance-flow.spec.ts
@@ -14,7 +14,7 @@ const ROUTES = {
   assetBalances: /\/api\/v1\/asset-balances$/,
   assetBalancePreview: /\/api\/v1\/asset-balance-import-validations$/,
   assetBalanceUpload: /\/api\/v1\/asset-balance-imports$/,
-  dividendPerShareBatch: /\/dividends\/per-share\/batch$/,
+  dividendPerShareBatch: /\/api\/v1\/dividend-per-share-estimates(?:\?.*)?$/,
 };
 
 const MOCK_ASSET = {

--- a/frontend/e2e/search-flow.spec.ts
+++ b/frontend/e2e/search-flow.spec.ts
@@ -21,8 +21,8 @@ const MOCK_STOCK = {
 
 const ROUTES = {
   authMe: /\/api\/v1\/session$/,
-  // API エンドポイントのみ一致させる（Vite のソースファイルパスと衝突しないよう末尾を限定）
-  stock: /\/stocks\/\d+$/,
+  // query string を含む URL でも一致するよう path 部分のみでマッチ
+  stock: /\/api\/v1\/stocks(?:\?.*)?$/,
 };
 
 async function setupAuthMocks(page: Page) {

--- a/frontend/src/features/jquants/api/__tests__/client.test.ts
+++ b/frontend/src/features/jquants/api/__tests__/client.test.ts
@@ -28,8 +28,9 @@ describe('JQuantsApiClient', () => {
 
       const result = await client.getSummary('1234');
 
-      expect(apiClient.get).toHaveBeenCalledWith('/jquants/fins/summary', {
+      expect(apiClient.get).toHaveBeenCalledWith('/api/v1/financial-statements', {
         params: { code: '1234' },
+        withCredentials: true,
       });
       expect(result).toEqual(mockResponse);
     });
@@ -40,8 +41,9 @@ describe('JQuantsApiClient', () => {
 
       await client.getSummary('1234', '2024-01-01', '2024-12-31');
 
-      expect(apiClient.get).toHaveBeenCalledWith('/jquants/fins/summary', {
+      expect(apiClient.get).toHaveBeenCalledWith('/api/v1/financial-statements', {
         params: { code: '1234', from: '2024-01-01', to: '2024-12-31' },
+        withCredentials: true,
       });
     });
 

--- a/frontend/src/features/jquants/api/__tests__/dividendPerShareApi.test.ts
+++ b/frontend/src/features/jquants/api/__tests__/dividendPerShareApi.test.ts
@@ -27,7 +27,7 @@ describe('fetchDividendPerShareBatch', () => {
 
     const result = await fetchDividendPerShareBatch(['7203']);
 
-    expect(apiClient.post).toHaveBeenCalledWith('/dividends/per-share/batch', {
+    expect(apiClient.post).toHaveBeenCalledWith('/api/v1/dividend-per-share-estimates', {
       security_codes: ['7203'],
     }, { withCredentials: true });
     expect(result).toEqual(mockItems);
@@ -38,7 +38,7 @@ describe('fetchDividendPerShareBatch', () => {
 
     const result = await fetchDividendPerShareBatch([]);
 
-    expect(apiClient.post).toHaveBeenCalledWith('/dividends/per-share/batch', {
+    expect(apiClient.post).toHaveBeenCalledWith('/api/v1/dividend-per-share-estimates', {
       security_codes: [],
     }, { withCredentials: true });
     expect(result).toEqual([]);
@@ -57,7 +57,7 @@ describe('fetchDividendPerShareBatch', () => {
 
     const result = await fetchDividendPerShareBatch(securityCodes);
 
-    expect(apiClient.post).toHaveBeenCalledWith('/dividends/per-share/batch', {
+    expect(apiClient.post).toHaveBeenCalledWith('/api/v1/dividend-per-share-estimates', {
       security_codes: securityCodes,
     }, { withCredentials: true });
     expect(result).toEqual(mockItems);

--- a/frontend/src/features/jquants/api/client.ts
+++ b/frontend/src/features/jquants/api/client.ts
@@ -24,8 +24,8 @@ export class JQuantsApiClient {
       if (to) params.to = to;
 
       const response = await apiClient.get<JQuantsFinSummaryResponse>(
-        '/jquants/fins/summary',
-        { params }
+        '/api/v1/financial-statements',
+        { params, withCredentials: true }
       );
 
       return response;

--- a/frontend/src/features/jquants/api/dividendPerShareApi.ts
+++ b/frontend/src/features/jquants/api/dividendPerShareApi.ts
@@ -18,7 +18,7 @@ export async function fetchDividendPerShareBatch(
   securityCodes: string[]
 ): Promise<DividendPerShareItem[]> {
   const response = await apiClient.post<BatchResponse>(
-    '/dividends/per-share/batch',
+    '/api/v1/dividend-per-share-estimates',
     { security_codes: securityCodes },
     { withCredentials: true }
   );

--- a/frontend/src/features/stock/__tests__/api.test.ts
+++ b/frontend/src/features/stock/__tests__/api.test.ts
@@ -15,6 +15,27 @@ describe('Stock API', () => {
   });
 
   describe('fetchStockData', () => {
+    it('成功した場合、v1銘柄検索APIをquery param付きで呼び出して結果を返す', async () => {
+      const mockStock = {
+        date: '2024-03-01',
+        code: '7974',
+        name: '任天堂',
+        market_category: 'プライム',
+        industry_code_33: '37',
+        industry_category_33: '情報・通信業',
+        industry_code_17: '10',
+        industry_category_17: '情報通信・サービスその他',
+        size_code: '7',
+        size_category: 'TOPIX Large70',
+      };
+      (apiClient.get as ReturnType<typeof vi.fn>).mockResolvedValue(mockStock);
+
+      const result = await fetchStockData('7974');
+
+      expect(apiClient.get).toHaveBeenCalledWith('/api/v1/stocks', { params: { query: '7974' } });
+      expect(result).toEqual(mockStock);
+    });
+
     it('ApiErrorの場合、同じエラーをそのまま再スローする', async () => {
       const apiError = new ApiError(ApiErrorType.NOT_FOUND_ERROR, 'リソースが見つかりません');
       (apiClient.get as ReturnType<typeof vi.fn>).mockRejectedValue(apiError);

--- a/frontend/src/features/stock/api.ts
+++ b/frontend/src/features/stock/api.ts
@@ -9,7 +9,7 @@ import { ApiError, ApiErrorType } from '../../lib/types/api';
  */
 export async function fetchStockData(query: string): Promise<StockData> {
   try {
-    const response = await apiClient.get<StockData>(`/stocks/${query}`);
+    const response = await apiClient.get<StockData>('/api/v1/stocks', { params: { query } });
     return response;
   } catch (error) {
     if (error instanceof ApiError) {


### PR DESCRIPTION
## 概要
- 銘柄検索を GET /api/v1/stocks?query=... に移行
- J-Quants 決算サマリーを GET /api/v1/financial-statements に移行し Cookie 認証を付与
- 配当予想一括取得を POST /api/v1/dividend-per-share-estimates に移行
- 関連 unit / E2E mock を v1 API に更新

## 非対象
- backend 実装変更
- OpenAPI / generated type の再生成
- UI 変更

## 検証
- cd frontend && npm run lint
- cd frontend && npx tsc --noEmit
- cd frontend && npm test -- --run src/features/stock/__tests__/api.test.ts src/features/jquants/api/__tests__/client.test.ts src/features/jquants/api/__tests__/dividendPerShareApi.test.ts
- cd frontend && npx playwright test search-flow.spec.ts assetbalance-flow.spec.ts a11y.spec.ts --config playwright.ci.config.ts --reporter=list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * API エンドポイントパスを新しい `v1` 形式へ統一しました。

* **Tests**
  * 株価検索、財務情報、配当データ取得の各テストを更新し、新しいエンドポイント仕様に対応させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->