### PR TITLE
旧APIの未使用ハンドラを削除

### DIFF
--- a/backend/src/handlers/asset_balance.rs
+++ b/backend/src/handlers/asset_balance.rs
@@ -1,35 +1,14 @@
 use crate::{
     errors::{ApiError, ErrorResponse},
     extractors::auth::AuthenticatedUser,
-    extractors::validated_json::ValidatedJson,
-    models::asset_balance::{AssetBalance, BulkCreateAssetBalanceRequest},
-    models::common::{BulkCreateResponse, MessageResponse},
+    models::asset_balance::AssetBalance,
+    models::common::MessageResponse,
     models::csv_import::{CsvPreviewResponse, CsvUploadForm, CsvUploadResponse},
     services::asset_balance as asset_balance_service,
     services::csv_domain::AssetBalanceDomain,
     state::AppState,
 };
-use axum::{
-    extract::Multipart,
-    extract::State,
-    http::StatusCode,
-    response::IntoResponse,
-    routing::{get, post},
-    Json, Router,
-};
-
-#[allow(dead_code)]
-pub fn asset_balance_routes() -> Router<AppState> {
-    Router::new()
-        .route("/asset-balances", get(list).delete(delete_all))
-        .route("/asset-balances/bulk", post(bulk_create))
-        .route("/asset-balances/csv/preview", post(preview_csv))
-}
-
-#[allow(dead_code)]
-pub fn asset_balance_csv_upload_routes() -> Router<AppState> {
-    Router::new().route("/asset-balances/csv", post(upload_csv))
-}
+use axum::{extract::Multipart, extract::State, http::StatusCode, response::IntoResponse, Json};
 
 /// 認証ユーザーの保有銘柄一覧を取得
 #[utoipa::path(
@@ -48,30 +27,6 @@ pub async fn list(
 ) -> Result<impl IntoResponse, ApiError> {
     let balances = asset_balance_service::list(&state.pool, auth_user.id()).await?;
     Ok((StatusCode::OK, Json(balances)))
-}
-
-/// 保有銘柄を一括追加（既存は更新）
-#[utoipa::path(
-    post,
-    path = "/asset-balances/bulk",
-    operation_id = "asset_balance_bulk_create",
-    request_body = BulkCreateAssetBalanceRequest,
-    responses(
-        (status = 201, body = BulkCreateResponse),
-        (status = 400, body = ErrorResponse),
-        (status = 401, body = ErrorResponse),
-    ),
-    security(("cookieAuth" = []))
-)]
-#[allow(dead_code)]
-pub async fn bulk_create(
-    State(state): State<AppState>,
-    auth_user: AuthenticatedUser,
-    ValidatedJson(data): ValidatedJson<BulkCreateAssetBalanceRequest>,
-) -> Result<impl IntoResponse, ApiError> {
-    let response =
-        asset_balance_service::bulk_create(&state.pool, auth_user.id(), &data.items).await?;
-    Ok((StatusCode::CREATED, Json(response)))
 }
 
 /// CSV ファイルをパースして保存前プレビューを返す（DB 書き込みなし）
@@ -151,6 +106,8 @@ mod tests {
         axum::{
             body::Body,
             http::{Request, StatusCode},
+            routing::get,
+            Router,
         },
         reqwest::Client,
         std::sync::Arc,
@@ -161,18 +118,20 @@ mod tests {
         let pool =
             crate::db::connect_pool_lazy("postgresql://postgres:postgres@localhost/postgres", 1)
                 .unwrap();
-        asset_balance_routes().with_state(crate::AppState {
-            pool,
-            secrets: Arc::new(crate::state::Secrets {
-                database_url: "postgresql://postgres:postgres@localhost/postgres".to_string(),
-                jquants_api_key: None,
-                google_client_id: None,
-                google_client_secret: None,
-                frontend_url: "http://localhost:8080".to_string(),
-            }),
-            client: Client::new(),
-            dividend_cache: crate::state::DividendCacheState::default(),
-        })
+        Router::new()
+            .route("/asset-balances", get(list).delete(delete_all))
+            .with_state(crate::AppState {
+                pool,
+                secrets: Arc::new(crate::state::Secrets {
+                    database_url: "postgresql://postgres:postgres@localhost/postgres".to_string(),
+                    jquants_api_key: None,
+                    google_client_id: None,
+                    google_client_secret: None,
+                    frontend_url: "http://localhost:8080".to_string(),
+                }),
+                client: Client::new(),
+                dividend_cache: crate::state::DividendCacheState::default(),
+            })
     }
 
     #[tokio::test]

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -7,24 +7,12 @@ use crate::state::AppState;
 use axum::{
     extract::{Query, State},
     response::{IntoResponse, Json, Redirect, Response},
-    routing::{delete, get, post},
-    Router,
 };
 use axum_extra::extract::CookieJar;
 use oauth2::{AuthorizationCode, CsrfToken, Scope, TokenResponse};
 use serde::Deserialize;
 
 const GOOGLE_USERINFO_URL: &str = "https://www.googleapis.com/oauth2/v3/userinfo";
-
-#[allow(dead_code)]
-pub fn auth_routes() -> Router<AppState> {
-    Router::new()
-        .route("/auth/google", get(google_auth))
-        .route("/auth/google/callback", get(google_callback))
-        .route("/auth/me", get(get_current_user))
-        .route("/auth/logout", post(logout))
-        .route("/auth/delete-account", delete(delete_account))
-}
 /// コールバック時のクエリパラメータ
 #[derive(Debug, Deserialize)]
 pub struct AuthCallbackQuery {
@@ -181,46 +169,6 @@ pub async fn logout(State(state): State<AppState>, jar: CookieJar) -> impl IntoR
         Json(serde_json::json!({"message": "ログアウトしました"})),
     )
 }
-
-/// アカウント削除処理
-/// ユーザーとすべての関連データ（sessions, dividends, domestic_stocks, mutualfunds, asset_balances）を削除
-#[utoipa::path(
-    delete,
-    path = "/auth/delete-account",
-    operation_id = "auth_delete_account",
-    responses(
-        (status = 200, body = MessageResponse),
-        (status = 401, body = ErrorResponse),
-        (status = 500, body = ErrorResponse),
-    ),
-    security(("cookieAuth" = []))
-)]
-#[allow(dead_code)]
-pub async fn delete_account(
-    State(state): State<AppState>,
-    jar: CookieJar,
-) -> Result<impl IntoResponse, ApiError> {
-    let session_id = auth_service::get_session_id_from_jar(&jar)?;
-
-    // セッションからユーザーIDを取得
-    let user_id = auth_service::select_user_id_by_session(&state.pool, session_id)
-        .await?
-        .ok_or_else(|| ApiError::Unauthorized("セッションが無効または期限切れです".to_string()))?;
-
-    // ユーザーを削除（CASCADE により関連データも削除）
-    auth_service::delete_account(&state.pool, user_id).await?;
-
-    // セッションCookieを削除
-    let is_secure = config::is_secure_cookie();
-    let cookie = auth_service::clear_session_cookie(is_secure);
-
-    let jar = jar.remove(cookie);
-
-    Ok((
-        jar,
-        Json(serde_json::json!({"message": "アカウントを削除しました"})),
-    ))
-}
 #[cfg(test)]
 mod tests {
     use crate::{
@@ -232,6 +180,7 @@ mod tests {
     use axum::{
         body::{to_bytes, Body},
         http::{Request, StatusCode},
+        routing::{get, post},
         Router,
     };
     use {reqwest::Client, serde::de::DeserializeOwned, std::sync::Arc, tower::ServiceExt};
@@ -254,7 +203,10 @@ mod tests {
         }
     }
     fn test_app() -> Router {
-        super::auth_routes().with_state(make_test_state())
+        Router::new()
+            .route("/auth/me", get(super::get_current_user))
+            .route("/auth/logout", post(super::logout))
+            .with_state(make_test_state())
     }
     async fn read_json_response<T: DeserializeOwned>(response: axum::response::Response) -> T {
         let body = to_bytes(response.into_body(), BODY_LIMIT).await.unwrap();

--- a/backend/src/handlers/dividend.rs
+++ b/backend/src/handlers/dividend.rs
@@ -8,26 +8,7 @@ use crate::{
     services::dividend as dividend_service,
     state::AppState,
 };
-use axum::{
-    extract::Multipart,
-    extract::State,
-    http::StatusCode,
-    response::IntoResponse,
-    routing::{get, post},
-    Json, Router,
-};
-
-#[allow(dead_code)]
-pub fn dividend_routes() -> Router<AppState> {
-    Router::new()
-        .route("/dividends", get(list).delete(delete_all))
-        .route("/dividends/csv/preview", post(preview_csv))
-}
-
-#[allow(dead_code)]
-pub fn dividend_csv_upload_routes() -> Router<AppState> {
-    Router::new().route("/dividends/csv", post(upload_csv))
-}
+use axum::{extract::Multipart, extract::State, http::StatusCode, response::IntoResponse, Json};
 
 /// 認証ユーザーの配当金一覧を取得
 #[utoipa::path(
@@ -125,6 +106,8 @@ mod tests {
         axum::{
             body::Body,
             http::{Request, StatusCode},
+            routing::get,
+            Router,
         },
         reqwest::Client,
         std::sync::Arc,
@@ -135,18 +118,20 @@ mod tests {
         let pool =
             crate::db::connect_pool_lazy("postgresql://postgres:postgres@localhost/postgres", 1)
                 .unwrap();
-        dividend_routes().with_state(crate::AppState {
-            pool,
-            secrets: Arc::new(crate::state::Secrets {
-                database_url: "postgresql://postgres:postgres@localhost/postgres".to_string(),
-                jquants_api_key: None,
-                google_client_id: None,
-                google_client_secret: None,
-                frontend_url: "http://localhost:8080".to_string(),
-            }),
-            client: Client::new(),
-            dividend_cache: crate::state::DividendCacheState::default(),
-        })
+        Router::new()
+            .route("/dividends", get(list).delete(delete_all))
+            .with_state(crate::AppState {
+                pool,
+                secrets: Arc::new(crate::state::Secrets {
+                    database_url: "postgresql://postgres:postgres@localhost/postgres".to_string(),
+                    jquants_api_key: None,
+                    google_client_id: None,
+                    google_client_secret: None,
+                    frontend_url: "http://localhost:8080".to_string(),
+                }),
+                client: Client::new(),
+                dividend_cache: crate::state::DividendCacheState::default(),
+            })
     }
 
     #[tokio::test]

--- a/backend/src/handlers/dividend_per_share.rs
+++ b/backend/src/handlers/dividend_per_share.rs
@@ -6,12 +6,7 @@ use crate::{
     services::dividend_cache as dividend_cache_service,
     AppState,
 };
-use axum::{extract::State, response::IntoResponse, routing::post, Json, Router};
-
-#[allow(dead_code)]
-pub fn dividend_per_share_routes() -> Router<AppState> {
-    Router::new().route("/dividends/per-share/batch", post(batch))
-}
+use axum::{extract::State, response::IntoResponse, Json};
 
 /// 配当利回り一括取得
 #[utoipa::path(
@@ -52,6 +47,8 @@ mod tests {
         axum::{
             body::Body,
             http::{Request, StatusCode},
+            routing::post,
+            Router,
         },
         reqwest::Client,
         serde_json::json,
@@ -63,18 +60,20 @@ mod tests {
         let pool =
             crate::db::connect_pool_lazy("postgresql://postgres:postgres@localhost/postgres", 1)
                 .unwrap();
-        dividend_per_share_routes().with_state(crate::AppState {
-            pool,
-            secrets: Arc::new(crate::state::Secrets {
-                database_url: "postgresql://postgres:postgres@localhost/postgres".to_string(),
-                jquants_api_key: None,
-                google_client_id: None,
-                google_client_secret: None,
-                frontend_url: "http://localhost:8080".to_string(),
-            }),
-            client: Client::new(),
-            dividend_cache: crate::state::DividendCacheState::default(),
-        })
+        Router::new()
+            .route("/dividends/per-share/batch", post(batch))
+            .with_state(crate::AppState {
+                pool,
+                secrets: Arc::new(crate::state::Secrets {
+                    database_url: "postgresql://postgres:postgres@localhost/postgres".to_string(),
+                    jquants_api_key: None,
+                    google_client_id: None,
+                    google_client_secret: None,
+                    frontend_url: "http://localhost:8080".to_string(),
+                }),
+                client: Client::new(),
+                dividend_cache: crate::state::DividendCacheState::default(),
+            })
     }
 
     #[tokio::test]

--- a/backend/src/handlers/domestic_stock.rs
+++ b/backend/src/handlers/domestic_stock.rs
@@ -8,26 +8,7 @@ use crate::{
     services::domestic_stock as domestic_stock_service,
     state::AppState,
 };
-use axum::{
-    extract::Multipart,
-    extract::State,
-    http::StatusCode,
-    response::IntoResponse,
-    routing::{get, post},
-    Json, Router,
-};
-
-#[allow(dead_code)]
-pub fn domestic_stock_routes() -> Router<AppState> {
-    Router::new()
-        .route("/domestic-stocks", get(list).delete(delete_all))
-        .route("/domestic-stocks/csv/preview", post(preview_csv))
-}
-
-#[allow(dead_code)]
-pub fn domestic_stock_csv_upload_routes() -> Router<AppState> {
-    Router::new().route("/domestic-stocks/csv", post(upload_csv))
-}
+use axum::{extract::Multipart, extract::State, http::StatusCode, response::IntoResponse, Json};
 
 /// 認証ユーザーの国内株式取引一覧を取得
 #[utoipa::path(
@@ -125,6 +106,8 @@ mod tests {
         axum::{
             body::Body,
             http::{Request, StatusCode},
+            routing::get,
+            Router,
         },
         reqwest::Client,
         std::sync::Arc,
@@ -135,18 +118,20 @@ mod tests {
         let pool =
             crate::db::connect_pool_lazy("postgresql://postgres:postgres@localhost/postgres", 1)
                 .unwrap();
-        domestic_stock_routes().with_state(crate::AppState {
-            pool,
-            secrets: Arc::new(crate::state::Secrets {
-                database_url: "postgresql://postgres:postgres@localhost/postgres".to_string(),
-                jquants_api_key: None,
-                google_client_id: None,
-                google_client_secret: None,
-                frontend_url: "http://localhost:8080".to_string(),
-            }),
-            client: Client::new(),
-            dividend_cache: crate::state::DividendCacheState::default(),
-        })
+        Router::new()
+            .route("/domestic-stocks", get(list).delete(delete_all))
+            .with_state(crate::AppState {
+                pool,
+                secrets: Arc::new(crate::state::Secrets {
+                    database_url: "postgresql://postgres:postgres@localhost/postgres".to_string(),
+                    jquants_api_key: None,
+                    google_client_id: None,
+                    google_client_secret: None,
+                    frontend_url: "http://localhost:8080".to_string(),
+                }),
+                client: Client::new(),
+                dividend_cache: crate::state::DividendCacheState::default(),
+            })
     }
 
     #[tokio::test]

--- a/backend/src/handlers/jquants.rs
+++ b/backend/src/handlers/jquants.rs
@@ -6,14 +6,7 @@ use crate::state::AppState;
 use axum::{
     extract::{Query, State},
     response::Json,
-    routing::get,
-    Router,
 };
-
-#[allow(dead_code)]
-pub fn jquants_routes() -> Router<AppState> {
-    Router::new().route("/jquants/fins/summary", get(get_fin_summary))
-}
 
 /// 決算サマリーを取得（J-Quants API V2）
 #[utoipa::path(
@@ -58,6 +51,8 @@ mod tests {
         axum::{
             body::Body,
             http::{Request, StatusCode},
+            routing::get,
+            Router,
         },
         reqwest::Client,
         std::sync::Arc,
@@ -68,18 +63,20 @@ mod tests {
         let pool =
             crate::db::connect_pool_lazy("postgresql://postgres:postgres@localhost/postgres", 1)
                 .unwrap();
-        jquants_routes().with_state(crate::AppState {
-            pool,
-            secrets: Arc::new(crate::state::Secrets {
-                database_url: "postgresql://postgres:postgres@localhost/postgres".to_string(),
-                jquants_api_key: None,
-                google_client_id: None,
-                google_client_secret: None,
-                frontend_url: "http://localhost:8080".to_string(),
-            }),
-            client: Client::new(),
-            dividend_cache: crate::state::DividendCacheState::default(),
-        })
+        Router::new()
+            .route("/jquants/fins/summary", get(get_fin_summary))
+            .with_state(crate::AppState {
+                pool,
+                secrets: Arc::new(crate::state::Secrets {
+                    database_url: "postgresql://postgres:postgres@localhost/postgres".to_string(),
+                    jquants_api_key: None,
+                    google_client_id: None,
+                    google_client_secret: None,
+                    frontend_url: "http://localhost:8080".to_string(),
+                }),
+                client: Client::new(),
+                dividend_cache: crate::state::DividendCacheState::default(),
+            })
     }
 
     #[tokio::test]

--- a/backend/src/handlers/mutualfund.rs
+++ b/backend/src/handlers/mutualfund.rs
@@ -8,26 +8,7 @@ use crate::{
     services::mutualfund as mutualfund_service,
     state::AppState,
 };
-use axum::{
-    extract::Multipart,
-    extract::State,
-    http::StatusCode,
-    response::IntoResponse,
-    routing::{get, post},
-    Json, Router,
-};
-
-#[allow(dead_code)]
-pub fn mutualfund_routes() -> Router<AppState> {
-    Router::new()
-        .route("/mutualfunds", get(list).delete(delete_all))
-        .route("/mutualfunds/csv/preview", post(preview_csv))
-}
-
-#[allow(dead_code)]
-pub fn mutualfund_csv_upload_routes() -> Router<AppState> {
-    Router::new().route("/mutualfunds/csv", post(upload_csv))
-}
+use axum::{extract::Multipart, extract::State, http::StatusCode, response::IntoResponse, Json};
 
 /// 認証ユーザーの投資信託一覧を取得
 #[utoipa::path(
@@ -125,6 +106,8 @@ mod tests {
         axum::{
             body::Body,
             http::{Request, StatusCode},
+            routing::get,
+            Router,
         },
         reqwest::Client,
         std::sync::Arc,
@@ -135,18 +118,20 @@ mod tests {
         let pool =
             crate::db::connect_pool_lazy("postgresql://postgres:postgres@localhost/postgres", 1)
                 .unwrap();
-        mutualfund_routes().with_state(crate::AppState {
-            pool,
-            secrets: Arc::new(crate::state::Secrets {
-                database_url: "postgresql://postgres:postgres@localhost/postgres".to_string(),
-                jquants_api_key: None,
-                google_client_id: None,
-                google_client_secret: None,
-                frontend_url: "http://localhost:8080".to_string(),
-            }),
-            client: Client::new(),
-            dividend_cache: crate::state::DividendCacheState::default(),
-        })
+        Router::new()
+            .route("/mutualfunds", get(list).delete(delete_all))
+            .with_state(crate::AppState {
+                pool,
+                secrets: Arc::new(crate::state::Secrets {
+                    database_url: "postgresql://postgres:postgres@localhost/postgres".to_string(),
+                    jquants_api_key: None,
+                    google_client_id: None,
+                    google_client_secret: None,
+                    frontend_url: "http://localhost:8080".to_string(),
+                }),
+                client: Client::new(),
+                dividend_cache: crate::state::DividendCacheState::default(),
+            })
     }
 
     #[tokio::test]

--- a/backend/src/handlers/stock.rs
+++ b/backend/src/handlers/stock.rs
@@ -5,42 +5,7 @@ use crate::{
     services::stock as stock_service,
     AppState,
 };
-use axum::{
-    extract::{Path, State},
-    http::StatusCode,
-    response::IntoResponse,
-    routing::{get, post},
-    Json, Router,
-};
-
-#[allow(dead_code)]
-pub fn stock_routes() -> Router<AppState> {
-    Router::new()
-        .route("/stocks", post(create_stock))
-        .route("/stocks/{query}", get(search_stock))
-}
-
-/// 銘柄情報を検索（コードまたは名前）
-#[utoipa::path(
-    get,
-    path = "/stocks/{query}",
-    operation_id = "stock_search",
-    params(
-        ("query" = String, Path, description = "銘柄コードまたは銘柄名")
-    ),
-    responses(
-        (status = 200, body = Stock),
-        (status = 404, body = ErrorResponse),
-    ),
-)]
-#[allow(dead_code)]
-pub async fn search_stock(
-    Path(search_query): Path<String>,
-    State(state): State<AppState>,
-) -> Result<impl IntoResponse, ApiError> {
-    let stock = stock_service::search(&state.pool, &search_query).await?;
-    Ok((StatusCode::OK, Json(stock)))
-}
+use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
 
 /// 銘柄情報を追加（認証必須）
 #[utoipa::path(

--- a/backend/src/handlers/stock/tests.rs
+++ b/backend/src/handlers/stock/tests.rs
@@ -4,7 +4,7 @@ use {
     axum::{
         body::Body,
         http::{Request, StatusCode},
-        routing::{get, post},
+        routing::get,
         Router,
     },
     chrono::NaiveDate,
@@ -76,8 +76,10 @@ async fn setup_test_db() -> (Pool<Postgres>, impl Drop) {
 
 fn setup_test_app(pool: Pool<Postgres>) -> Router {
     Router::new()
-        .route("/stocks/{search_query}", get(search_stock))
-        .route("/stocks", post(create_stock))
+        .route(
+            "/api/v1/stocks",
+            get(crate::handlers::v1::stocks::search).post(create_stock),
+        )
         .with_state(crate::AppState {
             pool: pool.clone(),
             secrets: Arc::new(Secrets {
@@ -139,7 +141,7 @@ async fn test_search_stock() {
     let (pool, _node) = setup_test_db().await;
     let app = setup_test_app(pool);
 
-    let response = call(app.clone(), "GET", "/stocks/1234", None).await;
+    let response = call(app.clone(), "GET", "/api/v1/stocks?query=1234", None).await;
     assert_eq!(response.status(), StatusCode::OK);
 
     let stock = read_json(response).await;
@@ -149,8 +151,8 @@ async fn test_search_stock() {
     );
 
     for (uri, expected_status) in [
-        ("/stocks/テスト", StatusCode::OK),
-        ("/stocks/9999", StatusCode::NOT_FOUND),
+        ("/api/v1/stocks?query=テスト", StatusCode::OK),
+        ("/api/v1/stocks?query=9999", StatusCode::NOT_FOUND),
     ] {
         assert_eq!(
             call(app.clone(), "GET", uri, None).await.status(),
@@ -168,7 +170,7 @@ async fn test_create_stock() {
     let response = call(
         app.clone(),
         "POST",
-        "/stocks",
+        "/api/v1/stocks",
         Some(stock_payload("5678", "新規テスト株式会社")),
     )
     .await;
@@ -183,7 +185,7 @@ async fn test_create_stock() {
     let mut invalid_data = stock_payload("5678", "新規テスト株式会社");
     invalid_data["code"] = json!("");
     assert_eq!(
-        call(app, "POST", "/stocks", Some(invalid_data))
+        call(app, "POST", "/api/v1/stocks", Some(invalid_data))
             .await
             .status(),
         StatusCode::BAD_REQUEST
@@ -200,7 +202,7 @@ async fn test_create_stock_unauthorized() {
         call(
             app,
             "POST",
-            "/stocks",
+            "/api/v1/stocks",
             Some(stock_payload("9999", "未認証テスト"))
         )
         .await


### PR DESCRIPTION
## 概要
- v1 移行後に未使用化した旧API route builder と旧ハンドラを削除
- テストは必要なハンドラだけを直接 Router に登録する形へ更新
- stock テストは v1 の query 形式に合わせて更新

## テスト
- cargo fmt
- cargo clippy -- -D warnings
- cargo test handlers
- cargo test routes
- bash scripts/check-openapi.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified backend API endpoint structure for improved maintainability
  * Reorganized stock API routing paths to `/api/v1/stocks` format
  * Removed bulk asset balance creation endpoint
  * Removed account deletion endpoint
  * Streamlined internal API architecture across multiple handlers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->