### PR TITLE
旧API案内とdead_code運用を整理

### DIFF
--- a/.claude/skills/backend-api/SKILL.md
+++ b/.claude/skills/backend-api/SKILL.md
@@ -35,16 +35,20 @@ pub async fn list(
 }
 ```
 
-## ルート登録 (main.rs)
+## ルート登録
 
 ```rust
-use axum::routing::{get, post, delete};
+use axum::{routing::get, Router};
 
-let app = Router::new()
-    .route("/your-route", get(handlers::your::list))
-    .route("/your-route/bulk", post(handlers::your::bulk_create))
-    .route("/your-route/all", delete(handlers::your::delete_all));
+pub fn your_resource_routes() -> Router<AppState> {
+    Router::new()
+        .route("/api/v1/your-resources", get(handlers::v1::your_resources::list))
+}
 ```
+
+- ルートは `backend/src/routes.rs` または `backend/src/handlers/v1.rs` の route composition に集約する。
+- 外部公開 API は `/api/v1/<resource>` を標準にする。
+- 一括置換は `PUT /api/v1/<collection>`、全削除は `DELETE /api/v1/<collection>` を使う。`/bulk` や `/all` を新規 API の標準例にしない。
 
 ## モデル定義
 
@@ -57,7 +61,6 @@ use uuid::Uuid;
 pub struct YourModel {
     pub id: Uuid,
     #[serde(skip_serializing)]
-    #[allow(dead_code)]
     pub user_id: Uuid,
     // 他のフィールド
 }
@@ -67,6 +70,8 @@ pub struct CreateRequest {
     // リクエストフィールド
 }
 ```
+
+`#[allow(dead_code)]` はテンプレートとして追加しない。DB の所有者 ID など、`FromRow` には必要だが Rust コードから直接読まないフィールドで clippy が警告する場合だけ、構造上の理由をコメントで明記して最小範囲に付与する。
 
 ## バルク作成（重複スキップ）
 

--- a/.claude/skills/backend-refactor/references/project-structure.md
+++ b/.claude/skills/backend-refactor/references/project-structure.md
@@ -56,16 +56,18 @@ Refactor 時に「どこに何を置くか」を迷わないための、backend 
 
 ## Current Routes (Reference)
 
-`backend/src/routes.rs` で定義されている主なパス。
+`backend/src/routes.rs` で定義されている主な公開パス。旧 API ルートは削除済みで、外部 API は原則 `/api/v1` 配下に集約する。
 
-- `/stock`, `/stock/{query}`
-- `/jquants/fins/statements`
-- `/auth/google`, `/auth/google/callback`, `/auth/me`, `/auth/logout`, `/auth/delete-account`
-- `/dividends`, `/dividends/bulk`, `/dividends/all`
-- `/domestic-stocks`, `/domestic-stocks/bulk`, `/domestic-stocks/all`
-- `/mutualfunds`, `/mutualfunds/bulk`, `/mutualfunds/all`
-- `/asset-balances`, `/asset-balances/bulk`, `/asset-balances/all`
-- `/health`
+- `/health`, `/ready`
+- `/api/v1/session`
+- `/api/v1/account-deletion-confirmations`, `/api/v1/account`
+- `/api/v1/oauth/google/authorize`, `/api/v1/oauth/google/callback`
+- `/api/v1/stocks`
+- `/api/v1/dividends`, `/api/v1/dividend-import-validations`, `/api/v1/dividend-imports`, `/api/v1/dividend-per-share-estimates`
+- `/api/v1/domestic-stock-transactions`, `/api/v1/domestic-stock-import-validations`, `/api/v1/domestic-stock-imports`
+- `/api/v1/mutual-fund-transactions`, `/api/v1/mutual-fund-import-validations`, `/api/v1/mutual-fund-imports`
+- `/api/v1/asset-balances`, `/api/v1/asset-balance-import-validations`, `/api/v1/asset-balance-imports`
+- `/api/v1/financial-statements`
 
 ## Invariants To Preserve (Unless Requested)
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -19,48 +19,74 @@
 
 ## APIエンドポイント
 
-### 認証
+### プローブ
 
 | メソッド | パス | 説明 |
 |---------|------|------|
-| GET | `/auth/google` | Google OAuth開始 |
-| GET | `/auth/google/callback` | OAuthコールバック |
-| GET | `/auth/me` | 現在のユーザー情報 |
-| POST | `/auth/logout` | ログアウト |
-| DELETE | `/auth/delete-account` | アカウント削除 |
+| GET | `/health` | Liveness チェック |
+| GET | `/ready` | 起動完了チェック |
+
+### 認証・セッション
+
+| メソッド | パス | 説明 |
+|---------|------|------|
+| GET | `/api/v1/session` | 現在のセッション情報取得 |
+| DELETE | `/api/v1/session` | ログアウト |
+| POST | `/api/v1/account-deletion-confirmations` | アカウント削除確認（短命Cookie発行） |
+| DELETE | `/api/v1/account` | アカウント削除（確認Cookie必須） |
+| GET | `/api/v1/oauth/google/authorize` | Google OAuth 開始 |
+| GET | `/api/v1/oauth/google/callback` | Google OAuth コールバック |
 
 ### 証券情報
 
 | メソッド | パス | 説明 | 認証 |
 |---------|------|------|------|
-| GET | `/stocks/{query}` | 株式情報を検索 | 不要 |
-| POST | `/stocks` | 株式情報を追加 | **必須** |
+| GET | `/api/v1/stocks?query=7203` | 株式情報を検索 | 不要 |
+| POST | `/api/v1/stocks` | 株式情報を追加 | **必須** |
 
-### データ管理（すべて認証必須）
-
-| メソッド | パス | 説明 |
-|---------|------|------|
-| GET | `/dividends` | 配当金一覧を取得 |
-| DELETE | `/dividends` | 配当金を全削除 |
-| GET | `/domestic-stocks` | 国内株式一覧を取得 |
-| DELETE | `/domestic-stocks` | 国内株式を全削除 |
-| GET | `/mutualfunds` | 投資信託一覧を取得 |
-| DELETE | `/mutualfunds` | 投資信託を全削除 |
-| GET | `/asset-balances` | 保有銘柄一覧を取得 |
-| POST | `/asset-balances/bulk` | 保有銘柄を一括登録（全削除→再挿入） |
-| DELETE | `/asset-balances` | 保有銘柄を全削除 |
-
-### J-Quants API
+### 配当金（すべて認証必須）
 
 | メソッド | パス | 説明 |
 |---------|------|------|
-| GET | `/jquants/fins/statements` | 決算サマリーを取得 |
+| GET | `/api/v1/dividends` | 配当金一覧を取得 |
+| DELETE | `/api/v1/dividends` | 配当金を全削除 |
+| POST | `/api/v1/dividend-import-validations` | 配当金CSV バリデーション（DB書き込みなし） |
+| POST | `/api/v1/dividend-imports` | 配当金CSV 取り込み |
+| POST | `/api/v1/dividend-per-share-estimates` | 1株配当一括推計 |
 
-### その他
+### 国内株式取引（すべて認証必須）
 
 | メソッド | パス | 説明 |
 |---------|------|------|
-| GET | `/health` | ヘルスチェック |
+| GET | `/api/v1/domestic-stock-transactions` | 国内株式取引一覧を取得 |
+| DELETE | `/api/v1/domestic-stock-transactions` | 国内株式取引を全削除 |
+| POST | `/api/v1/domestic-stock-import-validations` | 国内株式CSV バリデーション |
+| POST | `/api/v1/domestic-stock-imports` | 国内株式CSV 取り込み |
+
+### 投資信託取引（すべて認証必須）
+
+| メソッド | パス | 説明 |
+|---------|------|------|
+| GET | `/api/v1/mutual-fund-transactions` | 投資信託取引一覧を取得 |
+| DELETE | `/api/v1/mutual-fund-transactions` | 投資信託取引を全削除 |
+| POST | `/api/v1/mutual-fund-import-validations` | 投資信託CSV バリデーション |
+| POST | `/api/v1/mutual-fund-imports` | 投資信託CSV 取り込み |
+
+### 保有銘柄（すべて認証必須）
+
+| メソッド | パス | 説明 |
+|---------|------|------|
+| GET | `/api/v1/asset-balances` | 保有銘柄一覧を取得 |
+| PUT | `/api/v1/asset-balances` | 保有銘柄を全件置換 |
+| DELETE | `/api/v1/asset-balances` | 保有銘柄を全削除 |
+| POST | `/api/v1/asset-balance-import-validations` | 保有銘柄CSV バリデーション |
+| POST | `/api/v1/asset-balance-imports` | 保有銘柄CSV 取り込み |
+
+### 市場データ（認証必須）
+
+| メソッド | パス | 説明 |
+|---------|------|------|
+| GET | `/api/v1/financial-statements?code=7203` | 財務サマリーを取得 |
 
 ## 開発
 
@@ -192,9 +218,8 @@ backend/
 │   ├── errors.rs        # エラーハンドリング
 │   ├── extractors/      # Axumエクストラクター
 │   ├── handlers/        # リクエストハンドラー
-│   │   ├── auth.rs      # 認証
-│   │   ├── jquants.rs   # J-Quants API
-│   │   └── stock.rs     # 株式検索
+│   │   ├── v1/          # v1 APIハンドラー
+│   │   └── csv_import.rs # CSV取り込み共通処理
 │   ├── models/          # データモデル
 │   ├── services/        # ビジネスロジック
 │   └── state.rs         # アプリケーション状態

--- a/backend/src/models/asset_balance.rs
+++ b/backend/src/models/asset_balance.rs
@@ -11,7 +11,7 @@ use validator::Validate;
 pub struct AssetBalance {
     pub id: Uuid,
     #[serde(skip_serializing)]
-    #[allow(dead_code)]
+    #[allow(dead_code)] // SELECT * で取得されるがRust側では参照しない行所有者ID
     pub user_id: Uuid,
     pub security_code: String,
     pub security_name: String,

--- a/backend/src/models/dividend.rs
+++ b/backend/src/models/dividend.rs
@@ -11,7 +11,7 @@ use validator::Validate;
 pub struct Dividend {
     pub id: Uuid,
     #[serde(skip_serializing)]
-    #[allow(dead_code)]
+    #[allow(dead_code)] // SELECT * で取得されるがRust側では参照しない行所有者ID
     pub user_id: Uuid,
     pub settlement_date: NaiveDate,
     pub product: String,

--- a/backend/src/models/domestic_stock.rs
+++ b/backend/src/models/domestic_stock.rs
@@ -11,7 +11,7 @@ use validator::Validate;
 pub struct DomesticStock {
     pub id: Uuid,
     #[serde(skip_serializing)]
-    #[allow(dead_code)]
+    #[allow(dead_code)] // SELECT * で取得されるがRust側では参照しない行所有者ID
     pub user_id: Uuid,
     pub trade_date: NaiveDate,
     pub settlement_date: NaiveDate,

--- a/backend/src/models/mutualfund.rs
+++ b/backend/src/models/mutualfund.rs
@@ -11,7 +11,7 @@ use validator::Validate;
 pub struct Mutualfund {
     pub id: Uuid,
     #[serde(skip_serializing)]
-    #[allow(dead_code)]
+    #[allow(dead_code)] // SELECT * で取得されるがRust側では参照しない行所有者ID
     pub user_id: Uuid,
     pub trade_date: NaiveDate,
     pub settlement_date: NaiveDate,

--- a/docs/api/v1-rest-design.md
+++ b/docs/api/v1-rest-design.md
@@ -4,7 +4,6 @@
 
 - Keep the backend in Rust and Axum.
 - Introduce RESTful, versioned routes under `/api/v1`.
-- Keep old routes working during migration.
 - Make destructive and import operations explicit resources.
 - Hide external provider names such as J-Quants from first-class API resources
   unless provider-specific behavior is intentionally exposed.
@@ -47,8 +46,8 @@ API identifiers and must not collide with legacy operation IDs.
 
 ## Destructive Operation Guard
 
-`DELETE /api/v1/account` is intentionally stricter than the legacy
-`DELETE /auth/delete-account` route. A client must first call
+`DELETE /api/v1/account` is intentionally stricter than the retired
+`DELETE /auth/delete-account` route was. A client must first call
 `POST /api/v1/account-deletion-confirmations`, which sets a short-lived
 HttpOnly confirmation cookie scoped to `/api/v1/account`. The delete endpoint
 requires both a valid session cookie and that confirmation cookie.
@@ -124,9 +123,11 @@ requires both a valid session cookie and that confirmation cookie.
 |---|---|---|
 | GET | `/api/v1/financial-statements?code=7203` | Get financial statement summary |
 
-## Compatibility Map
+## Legacy Route Migration History
 
-| Current Route | v1 Route |
+旧ルートは v1 移行完了後に削除済み。以下は移行履歴（参照用）。
+
+| 廃止済み旧ルート | 移行先 v1 ルート |
 |---|---|
 | `GET /auth/me` | `GET /api/v1/session` |
 | `POST /auth/logout` | `DELETE /api/v1/session` |
@@ -154,15 +155,4 @@ requires both a valid session cookie and that confirmation cookie.
 | `POST /asset-balances/csv` | `POST /api/v1/asset-balance-imports` |
 | `GET /jquants/fins/summary` | `GET /api/v1/financial-statements` |
 | `POST /dividends/per-share/batch` | `POST /api/v1/dividend-per-share-estimates` |
-
-## Migration Order
-
-1. Harden current security behavior.
-2. Add `/api/v1/session` and OAuth aliases.
-3. Add `/api/v1/stocks`.
-4. Add read/delete aliases for existing collections.
-5. Add import validation/import aliases.
-6. Move frontend API client to `/api/v1`.
-7. Mark old routes as deprecated.
-8. Remove old routes only after a separate deprecation decision.
 


### PR DESCRIPTION
## 概要
- backend README の API 一覧を現行 /api/v1 ルートへ更新
- backend 関連スキルの旧APIテンプレートを v1 REST 前提へ更新
- v1 REST 設計ドキュメントを旧ルート削除後の移行履歴として整理
- モデルの #[allow(dead_code)] は必要箇所に理由を明記

## レビュー
- Claude 実装後、Codex が不足分を補完
- Claude に補完差分レビューを依頼し、問題なしを確認

## テスト
- cargo fmt
- cargo clippy -- -D warnings
- cargo test
- bash scripts/check-openapi.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **Documentation**
  * APIドキュメントを再構成し、すべてのエンドポイントを `/api/v1` 配下に統一して記載。
  * バックエンド開発ガイドにルート登録の標準パターンと規約を追加。
  * プロジェクト構造ドキュメントを更新し、公開パスの参照一覧を整備。

* **Chores**
  * コード内のコメント表記を改善し、保守性を向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->