### PR TITLE
旧認証API参照をv1へ整理

### DIFF
--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -1,6 +1,5 @@
 use crate::config;
-use crate::errors::{ApiError, ErrorResponse};
-use crate::models::common::MessageResponse;
+use crate::errors::ApiError;
 use crate::models::user::{GoogleUserInfo, UserResponse};
 use crate::services::auth::{self as auth_service, create_oauth_client};
 use crate::state::AppState;
@@ -114,16 +113,6 @@ pub async fn google_callback(
 }
 
 /// 現在ログイン中のユーザー情報を取得
-#[utoipa::path(
-    get,
-    path = "/auth/me",
-    operation_id = "auth_me",
-    responses(
-        (status = 200, body = UserResponse),
-        (status = 401, body = ErrorResponse),
-    ),
-    security(("cookieAuth" = []))
-)]
 pub async fn get_current_user(
     State(state): State<AppState>,
     jar: CookieJar,
@@ -139,15 +128,6 @@ pub async fn get_current_user(
 }
 
 /// ログアウト処理
-#[utoipa::path(
-    post,
-    path = "/auth/logout",
-    operation_id = "auth_logout",
-    responses(
-        (status = 200, body = MessageResponse),
-    ),
-    security(("cookieAuth" = []))
-)]
 pub async fn logout(State(state): State<AppState>, jar: CookieJar) -> impl IntoResponse {
     // セッションをデータベースから削除
     if let Some(session_token) = jar
@@ -179,8 +159,7 @@ mod tests {
     };
     use axum::{
         body::{to_bytes, Body},
-        http::{Request, StatusCode},
-        routing::{get, post},
+        http::{Method, Request, StatusCode},
         Router,
     };
     use {reqwest::Client, serde::de::DeserializeOwned, std::sync::Arc, tower::ServiceExt};
@@ -203,16 +182,13 @@ mod tests {
         }
     }
     fn test_app() -> Router {
-        Router::new()
-            .route("/auth/me", get(super::get_current_user))
-            .route("/auth/logout", post(super::logout))
-            .with_state(make_test_state())
+        crate::handlers::v1::auth_routes().with_state(make_test_state())
     }
     async fn read_json_response<T: DeserializeOwned>(response: axum::response::Response) -> T {
         let body = to_bytes(response.into_body(), BODY_LIMIT).await.unwrap();
         serde_json::from_slice(&body).unwrap()
     }
-    async fn request_json<T: DeserializeOwned>(method: &str, uri: &str) -> (StatusCode, T) {
+    async fn request_json<T: DeserializeOwned>(method: Method, uri: &str) -> (StatusCode, T) {
         let response = test_app()
             .oneshot(
                 Request::builder()
@@ -228,7 +204,7 @@ mod tests {
     }
     #[tokio::test]
     async fn test_auth_endpoints_without_cookie() {
-        let (status, error) = request_json::<ErrorResponse>("GET", "/auth/me").await;
+        let (status, error) = request_json::<ErrorResponse>(Method::GET, "/api/v1/session").await;
         assert_eq!(
             (
                 status,
@@ -237,7 +213,8 @@ mod tests {
             ),
             (StatusCode::UNAUTHORIZED, "UNAUTHORIZED", true)
         );
-        let (status, message) = request_json::<MessageResponse>("POST", "/auth/logout").await;
+        let (status, message) =
+            request_json::<MessageResponse>(Method::DELETE, "/api/v1/session").await;
         assert_eq!(
             (status, message.message.as_str()),
             (StatusCode::OK, "ログアウトしました")

--- a/backend/src/handlers/v1/asset_balances.rs
+++ b/backend/src/handlers/v1/asset_balances.rs
@@ -37,7 +37,6 @@ pub async fn list(
 }
 
 /// 保有銘柄を全置換（v1）
-/// ステータスコード 200 を返す（既存 POST /asset-balances/bulk は 201）
 #[utoipa::path(
     put,
     path = "/api/v1/asset-balances",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,11 +56,11 @@ shoken-webapp/
 ## 認証フロー
 
 ```
-1. フロント → GET /auth/google
+1. フロント → GET /api/v1/oauth/google/authorize
 2. バックエンド → Google OAuth 認証ページへリダイレクト
-3. Google → GET /auth/google/callback?code=...&state=...
+3. Google → GET /api/v1/oauth/google/callback?code=...&state=...
 4. バックエンド → セッション Cookie 発行（session_token, Max-Age=7日）
-5. フロント → GET /auth/me でユーザー情報取得
+5. フロント → GET /api/v1/session でユーザー情報取得
 ```
 
 CSRF 対策: `Origin` / `Referer` ヘッダーによるオリジン検証

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -255,7 +255,7 @@
         "tags": [
           "handlers::v1::asset_balances"
         ],
-        "summary": "保有銘柄を全置換（v1）\nステータスコード 200 を返す（既存 POST /asset-balances/bulk は 201）",
+        "summary": "保有銘柄を全置換（v1）",
         "operationId": "v1_asset_balance_replace",
         "requestBody": {
           "content": {

--- a/frontend/src/generated/api.ts
+++ b/frontend/src/generated/api.ts
@@ -81,10 +81,7 @@ export interface paths {
         };
         /** 保有銘柄一覧を取得（v1） */
         get: operations["v1_asset_balance_list"];
-        /**
-         * 保有銘柄を全置換（v1）
-         *     ステータスコード 200 を返す（既存 POST /asset-balances/bulk は 201）
-         */
+        /** 保有銘柄を全置換（v1） */
         put: operations["v1_asset_balance_replace"];
         post?: never;
         /** 保有銘柄を全削除（v1） */


### PR DESCRIPTION
## 概要
- 内部 helper 化した auth handler から旧 /auth/me / /auth/logout の OpenAPI 注釈を削除
- auth handler テストを /api/v1/session 経由に更新
- architecture の認証フローを v1 API に更新
- asset balances replace の OpenAPI summary から旧 /asset-balances/bulk 比較を削除
- docs/openapi.json と frontend/src/generated/api.ts を同期

## レビュー
- Claude 実装は長時間差分なしのため停止
- Codex 実装後、Claude に差分レビューを依頼し問題なしを確認

## テスト
- cargo fmt
- cargo clippy -- -D warnings
- cargo test handlers::auth
- cargo test handlers::v1::auth
- cargo test routes::tests::test_legacy_paths_return_404
- bash scripts/check-openapi.sh