### PR TITLE
OAuth callback redirect URIをv1へ更新

### DIFF
--- a/.claude/skills/oauth-auth/SKILL.md
+++ b/.claude/skills/oauth-auth/SKILL.md
@@ -24,7 +24,7 @@ description: |
 
 ## OAuth フロー
 
-### 1. 認証開始（`/auth/google`）
+### 1. 認証開始（`/api/v1/oauth/google/authorize`）
 
 ```rust
 pub async fn google_auth(
@@ -55,7 +55,7 @@ pub async fn google_auth(
 }
 ```
 
-### 2. コールバック（`/auth/google/callback`）
+### 2. コールバック（`/api/v1/oauth/google/callback`）
 
 ```rust
 pub async fn google_callback(
@@ -186,7 +186,18 @@ let jar = jar.remove(Cookie::build(("oauth_state", "")).path("/").build());
 | `SECURE_COOKIE` | Cookie の Secure 属性を明示制御 | `true` |
 | `RUST_ENV` / `APP_ENV` | 本番環境判定 | `production` |
 
+## Google Cloud OAuth 設定
+
+Authorized redirect URI は API バージョン付きのコールバックを登録する。
+
+| 環境 | URI |
+|------|-----|
+| 本番 | `https://shoken-backend.fly.dev/api/v1/oauth/google/callback` |
+| ローカル | `http://localhost:3001/api/v1/oauth/google/callback` |
+
+旧 `/auth/google/callback` は現行 API では使用しない。旧 URI を案内したり、互換ルートとして復活させたりしない。
+
 ## 参考ファイル
 
-- `backend/src/handlers/auth.rs` - 認証ハンドラー
+- `backend/src/handlers/v1/auth.rs` - 認証ハンドラー
 - `backend/src/extractors/auth.rs` - AuthenticatedUser エクストラクター

--- a/backend/src/services/auth.rs
+++ b/backend/src/services/auth.rs
@@ -42,7 +42,7 @@ pub fn create_oauth_client(state: &AppState) -> Result<GoogleOAuthClient, ApiErr
         ApiError::ApiError("GOOGLE_CLIENT_SECRET が設定されていません".to_string())
     })?;
 
-    let redirect_url = format!("{}/auth/google/callback", config::backend_url());
+    let redirect_url = format!("{}/api/v1/oauth/google/callback", config::backend_url());
 
     let client = BasicClient::new(ClientId::new(client_id))
         .set_client_secret(ClientSecret::new(client_secret))
@@ -213,7 +213,14 @@ pub async fn delete_account(pool: &PgPool, user_id: uuid::Uuid) -> Result<(), sq
 }
 #[cfg(test)]
 mod tests {
-    use {super::*, crate::state::Secrets, std::sync::Arc};
+    use {
+        super::*,
+        crate::{
+            state::Secrets,
+            test_env::{EnvGuard, ENV_MUTEX},
+        },
+        std::sync::Arc,
+    };
     fn test_state() -> AppState {
         AppState {
             pool: crate::db::connect_pool_lazy("postgresql://user:password@localhost/test_db", 1)
@@ -297,5 +304,19 @@ mod tests {
     #[tokio::test]
     async fn test_create_oauth_client() {
         assert!(create_oauth_client(&test_state()).is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_oauth_redirect_uri_is_v1_path() {
+        let _lock = ENV_MUTEX.lock().await;
+        let _env = EnvGuard::set("BACKEND_URL", Some("https://shoken-backend.fly.dev"));
+        let client = create_oauth_client(&test_state()).unwrap();
+        let (auth_url, _csrf) = client.authorize_url(oauth2::CsrfToken::new_random).url();
+        let url_str = auth_url.to_string();
+        assert!(
+            url_str.contains("redirect_uri=https%3A%2F%2Fshoken-backend.fly.dev%2Fapi%2Fv1%2Foauth%2Fgoogle%2Fcallback"),
+            "redirect_uri が /api/v1/oauth/google/callback でない: {}",
+            url_str
+        );
     }
 }

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -76,6 +76,18 @@ fly secrets set FRONTEND_URL="https://shoken-webapp.vercel.app"
 fly secrets set BACKEND_URL="https://shoken-backend.fly.dev"
 ```
 
+## Google Cloud OAuth 設定
+
+Google Cloud Console で以下の **Authorized redirect URIs** を登録する:
+
+| 環境 | URI |
+|---|---|
+| 本番 | `https://shoken-backend.fly.dev/api/v1/oauth/google/callback` |
+| ローカル | `http://localhost:3001/api/v1/oauth/google/callback` |
+
+> **注意**: 旧 `https://shoken-backend.fly.dev/auth/google/callback` は現行 API では使用しない。
+> Google Cloud Console に登録している場合は削除する。
+
 ## セキュリティインシデント対応
 
 1. [SECURITY.md](../SECURITY.md) の手順に従って報告を受理


### PR DESCRIPTION
## Summary
- Google OAuth の redirect_uri を /api/v1/oauth/google/callback に更新
- redirect_uri の回帰テストを追加
- runbook と oauth-auth skill に Google Cloud Console の Authorized redirect URI を明記

## Verification
- cd backend && cargo fmt
- cd backend && cargo clippy -- -D warnings
- cd backend && cargo test services::auth
- cd backend && cargo test handlers::v1::auth
- bash scripts/check-openapi.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメント

* Google Cloud OAuth設定ガイドを追加し、本番環境およびローカル環境の認可リダイレクトURIを明記しました
* OAuth認証エンドポイントが `/api/v1/oauth/google/` に統一されました
* 従来の `/auth/google/callback` エンドポイントは廃止され、新しいAPIパス推奨へ移行しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->