### PR TITLE
銘柄検索にJPX Explorerリンクを追加

### DIFF
--- a/frontend/src/components/molecules/StockInfoLinks.tsx
+++ b/frontend/src/components/molecules/StockInfoLinks.tsx
@@ -18,7 +18,8 @@ const STOCK_INFO_LINKS_OBJECTS: StockInfoLinkObject[] = [
   { name: "みんかぶ", url: "https://minkabu.jp/stock/{}/" },
   { name: "IR BANK", url: "https://irbank.net/{}" },
   { name: "銘柄スカウター", url: "https://monex.ifis.co.jp/index.php?sa=report_index&bcode={}" },
-  { name: "ザイマニ", url: "https://zaimani.com/search/?_sf_s={}" }
+  { name: "ザイマニ", url: "https://zaimani.com/search/?_sf_s={}" },
+  { name: "JPX Explorer", url: "https://jpx-explorer.com/ja-JP/{}-TSE" }
 ];
 
 export const StockInfoLinks = ({ code }: StockInfoLinksProps) => {

--- a/frontend/src/components/molecules/__tests__/StockInfoLinks.test.tsx
+++ b/frontend/src/components/molecules/__tests__/StockInfoLinks.test.tsx
@@ -19,6 +19,16 @@ describe('StockInfoLinks', () => {
     );
   });
 
+  it('JPX Explorerリンクを表示し、コードに-TSEサフィックスを付けたhrefになる', () => {
+    render(<StockInfoLinks code="7203" />);
+
+    const jpxLink = screen.getByRole('link', { name: /JPX Explorer/ });
+    expect(jpxLink).toHaveAttribute(
+      'href',
+      'https://jpx-explorer.com/ja-JP/7203-TSE'
+    );
+  });
+
   it('銘柄コードがない場合は何も表示しない', () => {
     const { container } = render(<StockInfoLinks />);
     expect(container).toBeEmptyDOMElement();


### PR DESCRIPTION
## Summary
- 銘柄検索結果の外部リンク一覧に JPX Explorer を追加
- JPX Explorer の URL は code-TSE 形式で生成
- StockInfoLinks のテストに JPX Explorer href を追加

## Verification
- cd frontend && npm run lint
- cd frontend && npm run test -- StockInfoLinks
- cd frontend && npm run build