### PR TITLE
CI高速化とMarkdown最新化

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -12,6 +12,10 @@ on:
       - 'backend/**'
       - '.github/workflows/deploy-backend.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test-and-build:
     name: Test & Build

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -6,6 +6,11 @@ on:
     paths:
       - 'frontend/**'
       - '.github/workflows/deploy-frontend.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test-and-build:
@@ -32,16 +37,25 @@ jobs:
       - name: Lint
         run: npm run lint
 
-      - name: Run tests (1st)
+      - name: Run tests
         run: npm test
 
-      - name: Run tests (2nd – flaky detection)
+      - name: Run tests (flaky detection – 2nd run)
+        if: github.event_name == 'workflow_dispatch'
         run: npm test
 
       - name: Build
         run: npm run build
         env:
           VITE_SHOKEN_WEBAPI_API_URL: https://example.com
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('frontend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
 
       - name: Install Playwright browsers
         run: npx playwright install chromium --with-deps

--- a/README.md
+++ b/README.md
@@ -147,44 +147,79 @@ cargo build
 
 ## API エンドポイント
 
-### 認証
+業務 API は `/api/v1` プレフィックスを持つ。プローブ（`/health`, `/ready`）は例外としてルート直下に置く。詳細は [docs/api/v1-rest-design.md](docs/api/v1-rest-design.md) を参照。
 
-| Method | Path | 説明 |
-|---|---|---|
-| GET | `/auth/google` | Google OAuth 認証開始 |
-| GET | `/auth/google/callback` | OAuth コールバック |
-| GET | `/auth/me` | 現在ユーザー取得 |
-| POST | `/auth/logout` | ログアウト |
-| DELETE | `/auth/delete-account` | アカウント削除 |
+### プローブ
+
+| Method | Path | 説明 | 認証 |
+|---|---|---|---|
+| GET | `/health` | 生存確認 | 不要 |
+| GET | `/ready` | 起動レディネス確認 | 不要 |
+
+### セッション・アカウント
+
+| Method | Path | 説明 | 認証 |
+|---|---|---|---|
+| GET | `/api/v1/session` | 現在ユーザーのセッション取得 | 必要 |
+| DELETE | `/api/v1/session` | ログアウト | 必要 |
+| POST | `/api/v1/account-deletion-confirmations` | アカウント削除確認（確認クッキー発行） | 必要 |
+| DELETE | `/api/v1/account` | アカウント削除（確認クッキー必須） | 必要 |
+| GET | `/api/v1/oauth/google/authorize` | Google OAuth 認証開始 | 不要 |
+| GET | `/api/v1/oauth/google/callback` | Google OAuth コールバック | 不要 |
 
 ### 銘柄
 
 | Method | Path | 説明 | 認証 |
 |---|---|---|---|
-| GET | `/stock/{query}` | 銘柄検索 | 不要 |
-| POST | `/stock` | 銘柄追加 | 必要 |
+| GET | `/api/v1/stocks?query=7203` | 銘柄検索（コード・社名） | 不要 |
+| POST | `/api/v1/stocks` | 銘柄追加 | 必要 |
 
-### 明細データ（認証必須）
+### 配当金（認証必須）
 
 | Method | Path | 説明 |
 |---|---|---|
-| GET | `/dividends` | 配当金一覧取得 |
-| DELETE | `/dividends/all` | 配当金全削除 |
-| GET | `/domestic-stocks` | 国内株式一覧取得 |
-| DELETE | `/domestic-stocks/all` | 国内株式全削除 |
-| GET | `/mutualfunds` | 投資信託一覧取得 |
-| DELETE | `/mutualfunds/all` | 投資信託全削除 |
-| GET | `/asset-balances` | 保有銘柄一覧取得 |
-| POST | `/asset-balances/bulk` | 保有銘柄一括登録（全削除→再挿入） |
-| DELETE | `/asset-balances/all` | 保有銘柄全削除 |
+| GET | `/api/v1/dividends` | 配当金一覧取得 |
+| DELETE | `/api/v1/dividends` | 配当金全削除 |
+| POST | `/api/v1/dividend-import-validations` | 配当金 CSV バリデーション（DB書込なし） |
+| POST | `/api/v1/dividend-imports` | 配当金 CSV インポート |
+| POST | `/api/v1/dividend-per-share-estimates` | 配当利回り一括取得 |
 
-### J-Quants / 補助 API
+### 国内株式明細（認証必須）
+
+| Method | Path | 説明 |
+|---|---|---|
+| GET | `/api/v1/domestic-stock-transactions` | 国内株式一覧取得 |
+| DELETE | `/api/v1/domestic-stock-transactions` | 国内株式全削除 |
+| POST | `/api/v1/domestic-stock-import-validations` | 国内株式 CSV バリデーション |
+| POST | `/api/v1/domestic-stock-imports` | 国内株式 CSV インポート |
+
+### 投資信託明細（認証必須）
+
+| Method | Path | 説明 |
+|---|---|---|
+| GET | `/api/v1/mutual-fund-transactions` | 投資信託一覧取得 |
+| DELETE | `/api/v1/mutual-fund-transactions` | 投資信託全削除 |
+| POST | `/api/v1/mutual-fund-import-validations` | 投資信託 CSV バリデーション |
+| POST | `/api/v1/mutual-fund-imports` | 投資信託 CSV インポート |
+
+### 保有銘柄（認証必須）
+
+| Method | Path | 説明 |
+|---|---|---|
+| GET | `/api/v1/asset-balances` | 保有銘柄一覧取得 |
+| PUT | `/api/v1/asset-balances` | 保有銘柄全置換（CSV 全件更新） |
+| DELETE | `/api/v1/asset-balances` | 保有銘柄全削除 |
+| POST | `/api/v1/asset-balance-import-validations` | 保有銘柄 CSV バリデーション |
+| POST | `/api/v1/asset-balance-imports` | 保有銘柄 CSV インポート |
+
+### マーケットデータ
 
 | Method | Path | 説明 | 認証 |
 |---|---|---|---|
-| GET | `/jquants/fins/statements` | 決算サマリー取得 | 不要 |
-| POST | `/dividends/per-share/batch` | 配当利回り一括取得 | 不要 |
-| GET | `/health` | ヘルスチェック | 不要 |
+| GET | `/api/v1/financial-statements?code=7203` | 決算サマリー取得 | 不要 |
+
+> 旧ルート（`/auth/google`、`/stock/{query}`、`/dividends/all` 等）は v1 移行完了後に削除済み。
+> 移行履歴は [docs/api/v1-rest-design.md](docs/api/v1-rest-design.md) の「Legacy Route Migration History」を参照。
 
 ## ディレクトリ構成
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -100,6 +100,37 @@ Google Cloud Console で以下の **Authorized redirect URIs** を登録する:
 (cd frontend && npm audit)
 ```
 
+## PR マージ後のクリーンアップ
+
+worktree を使った作業ブランチをマージした後は、以下の順序で後片付けをする。
+`git branch -D` を先に実行すると worktree がそのブランチを参照中のためエラーになる場合があるので、
+必ず **worktree 削除を先に行う**こと。
+
+```bash
+# 1. PR をマージ（GitHub 側でブランチを削除してもよい）
+gh pr merge <PR番号> --squash
+
+# 2. main を最新化
+git switch main
+git pull --ff-only origin main
+
+# 3. worktree を削除（使用中ブランチを手放す）
+git worktree remove /tmp/<repo>-<topic>
+
+# 4. ローカルブランチを削除（squash merge 済み短期ブランチのみ）
+git branch -D <branch-name>
+
+# 5. リモートブランチを削除（gh pr merge --delete-branch を使わなかった場合）
+git push origin --delete <branch-name>
+
+# 6. リモート参照を整理
+git fetch origin --prune
+```
+
+> **注意**: `gh pr merge --delete-branch` はリモートブランチを削除するが、
+> ローカルに worktree が残っている状態では `git branch -D` が失敗する。
+> 上記の順序（merge → main pull → worktree remove → branch -D → push delete → fetch prune）を守ること。
+
 ## Dependabot PR 対応
 
 毎週月曜日に Dependabot PR が作成されます。

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -96,8 +96,15 @@ GitHub Actions で以下が自動実行されます（PR 時）:
 
 | ワークフロー | ファイル | ステップ |
 |---|---|---|
-| フロント | `deploy-frontend.yml` | lint / test / build |
-| バックエンド | `deploy-backend.yml` | clippy / test / check / OpenAPI 同期確認 / tsc |
+| フロント | `deploy-frontend.yml` | lint / test（1回） / build / E2E |
+| バックエンド | `deploy-backend.yml` | clippy / test / release check / OpenAPI 同期確認 / tsc |
+
+### フロントエンド CI の方針
+
+- PR CI では unit test を **1回だけ** 実行する。
+- flaky detection（unit test 2回目実行）は `workflow_dispatch` で手動トリガーする。
+  - GitHub Actions の「Run workflow」ボタン、または `gh workflow run deploy-frontend.yml` で実行できる。
+- E2E テストは PR CI に常時含める。
 
 ### セキュリティ監査（週次）
 


### PR DESCRIPTION
## Summary
- README の API エンドポイント表を REST v1 に更新
- worktree 利用時の PR 後片付け手順を runbook に追加
- Frontend CI の通常 PR unit test を1回にし、2回目の flaky detection は workflow_dispatch のみで実行
- frontend/backend workflow に concurrency を追加
- Playwright browser cache を追加

## CI短縮見込み
- Frontend CI: unit test 2回目を通常 PR から外し、約1分50秒短縮見込み
- Playwright browser cache により、2回目以降の browser install を約20〜30秒短縮見込み
- concurrency により同一 ref の古い PR 実行を自動キャンセル
- Backend CI: 必須チェックは維持し、同一 PR の古い実行だけキャンセル

## Verification
- git diff --check
- Python/PyYAML で workflow YAML parse: ok
- Claude 再レビュー: 問題なし
- 旧ルート検索: README/docs の注意書き内のみ残存

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * API エンドポイント仕様を v1 へ統一し、一覧を整理
  * PR マージ後のクリーンアップ手順を追加
  * フロントエンド CI テスト方針を明記

* **Chores**
  * ワークフロー同時実行制御を導入
  * Playwright ブラウザキャッシュで CI 実行を効率化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->