### PR TITLE
フロントとバックエンドの冗長処理を整理

### DIFF
--- a/backend/src/services/asset_balance.rs
+++ b/backend/src/services/asset_balance.rs
@@ -7,7 +7,7 @@ use crate::services::csv_pipeline::{parse_csv_with_config, CsvParserConfig, CsvR
 use crate::services::csv_util::{
     get_row_cell, normalize_security_name, parse_number, parse_optional_string_row,
 };
-use crate::services::shared::BulkTimer;
+use crate::services::shared::{user_ids_for_bulk_insert, BulkTimer};
 use rust_decimal::Decimal;
 use sqlx::PgPool;
 use tracing::info;
@@ -60,7 +60,7 @@ pub async fn bulk_create(
     let timer = BulkTimer::new("asset_balance", total);
 
     // 各フィールドを配列に変換
-    let user_ids: Vec<Uuid> = vec![user_id; total];
+    let user_ids = user_ids_for_bulk_insert(user_id, total);
     let security_codes: Vec<&str> = items.iter().map(|i| i.security_code.as_str()).collect();
     let security_names: Vec<&str> = items.iter().map(|i| i.security_name.as_str()).collect();
     let shares: Vec<Decimal> = items.iter().map(|i| i.shares).collect();

--- a/backend/src/services/dividend.rs
+++ b/backend/src/services/dividend.rs
@@ -8,7 +8,7 @@ use crate::services::csv_util::{
     normalize_security_name, parse_optional_string_row, parse_required_date_row,
     parse_required_number_row, parse_required_string_row,
 };
-use crate::services::shared::BulkTimer;
+use crate::services::shared::{user_ids_for_bulk_insert, BulkTimer};
 use rust_decimal::Decimal;
 use sqlx::PgPool;
 use tracing::info;
@@ -65,7 +65,7 @@ pub async fn bulk_create(
     }
 
     // 各フィールドを配列に変換
-    let user_ids: Vec<Uuid> = vec![user_id; total];
+    let user_ids = user_ids_for_bulk_insert(user_id, total);
     let settlement_dates: Vec<chrono::NaiveDate> =
         items.iter().map(|i| i.settlement_date).collect();
     let products: Vec<&str> = items.iter().map(|i| i.product.as_str()).collect();

--- a/backend/src/services/domestic_stock.rs
+++ b/backend/src/services/domestic_stock.rs
@@ -8,7 +8,7 @@ use crate::services::csv_util::{
     compute_taxes, normalize_security_name, parse_required_date_row, parse_required_number_row,
     parse_required_string_row,
 };
-use crate::services::shared::BulkTimer;
+use crate::services::shared::{user_ids_for_bulk_insert, BulkTimer};
 use rust_decimal::Decimal;
 use sqlx::PgPool;
 use tracing::info;
@@ -77,7 +77,7 @@ pub async fn bulk_create(
     }
 
     // 各フィールドを配列に変換
-    let user_ids: Vec<Uuid> = vec![user_id; total];
+    let user_ids = user_ids_for_bulk_insert(user_id, total);
     let trade_dates: Vec<chrono::NaiveDate> = items.iter().map(|i| i.trade_date).collect();
     let settlement_dates: Vec<chrono::NaiveDate> =
         items.iter().map(|i| i.settlement_date).collect();

--- a/backend/src/services/mutualfund.rs
+++ b/backend/src/services/mutualfund.rs
@@ -8,7 +8,7 @@ use crate::services::csv_util::{
     compute_taxes, get_row_cell, parse_required_date_row, parse_required_number_row,
     parse_required_string_row,
 };
-use crate::services::shared::BulkTimer;
+use crate::services::shared::{user_ids_for_bulk_insert, BulkTimer};
 use rust_decimal::Decimal;
 use sqlx::PgPool;
 use tracing::info;
@@ -67,7 +67,7 @@ pub async fn bulk_create(
     }
 
     // 各フィールドを配列に変換
-    let user_ids: Vec<Uuid> = vec![user_id; total];
+    let user_ids = user_ids_for_bulk_insert(user_id, total);
     let trade_dates: Vec<chrono::NaiveDate> = items.iter().map(|i| i.trade_date).collect();
     let settlement_dates: Vec<chrono::NaiveDate> =
         items.iter().map(|i| i.settlement_date).collect();

--- a/backend/src/services/shared.rs
+++ b/backend/src/services/shared.rs
@@ -33,6 +33,11 @@ impl BulkTimer {
     }
 }
 
+/// bulk insert の UNNEST に渡す user_id 配列を生成する。
+pub fn user_ids_for_bulk_insert(user_id: Uuid, total: usize) -> Vec<Uuid> {
+    vec![user_id; total]
+}
+
 /// ユーザーに紐づく全レコードを削除する共通実装。
 /// テーブル名は呼び出し元がリテラルで指定するため SQL インジェクションの危険はない。
 pub async fn delete_all_for_user(
@@ -52,12 +57,24 @@ pub async fn delete_all_for_user(
 }
 #[cfg(test)]
 mod tests {
-    use super::BulkTimer;
+    use super::{user_ids_for_bulk_insert, BulkTimer};
+    use uuid::Uuid;
+
     #[test]
     fn test_bulk_timer_finish() {
         for (inserted, expected) in [(0, (0, 5)), (5, (5, 0)), (3, (3, 2))] {
             let response = BulkTimer::new("test", 5).finish(inserted);
             assert_eq!((response.inserted, response.skipped), expected);
         }
+    }
+
+    #[test]
+    fn test_user_ids_for_bulk_insert() {
+        let id = Uuid::new_v4();
+        let result = user_ids_for_bulk_insert(id, 3);
+        assert_eq!(result.len(), 3);
+        assert!(result.iter().all(|&v| v == id));
+
+        assert!(user_ids_for_bulk_insert(id, 0).is_empty());
     }
 }

--- a/frontend/src/components/molecules/StockInfoLinks.tsx
+++ b/frontend/src/components/molecules/StockInfoLinks.tsx
@@ -1,25 +1,25 @@
 
-interface StockInfoLinkObject {
+interface StockInfoLinkConfig {
   name: string;
-  url: string;
+  href: (code: string) => string;
 }
 
 interface StockInfoLinksProps {
   code?: string;
 }
 
-const STOCK_INFO_LINKS_OBJECTS: StockInfoLinkObject[] = [
-  { name: "楽天証券", url: "https://www.rakuten-sec.co.jp/web/market/search/quote.html?ric={}.T" },
-  { name: "SBI証券", url: "https://site3.sbisec.co.jp/ETGate/?_ControlID=WPLETsiR001Control&_DataStoreID=DSWPLETsiR001Control&_PageID=WPLETsiR001Ilst10&_ActionID=getDetailOfStockPriceJP&s_rkbn=1&i_stock_sec=%94%43%93%56%93%B0&i_dom_flg=1&i_exchange_code=JPN&i_output_type=0&stock_sec_code_mul={}" },
-  { name: "株探", url: "https://kabutan.jp/stock/?code={}" },
-  { name: "Yahoo! Finance", url: "https://finance.yahoo.co.jp/quote/{}" },
-  { name: "日経", url: "https://www.nikkei.com/nkd/company/?scode={}" },
-  { name: "バフェットコード", url: "https://www.buffett-code.com/company/{}" },
-  { name: "みんかぶ", url: "https://minkabu.jp/stock/{}/" },
-  { name: "IR BANK", url: "https://irbank.net/{}" },
-  { name: "銘柄スカウター", url: "https://monex.ifis.co.jp/index.php?sa=report_index&bcode={}" },
-  { name: "ザイマニ", url: "https://zaimani.com/search/?_sf_s={}" },
-  { name: "JPX Explorer", url: "https://jpx-explorer.com/ja-JP/{}-TSE" }
+const STOCK_INFO_LINKS: StockInfoLinkConfig[] = [
+  { name: "楽天証券", href: (code) => `https://www.rakuten-sec.co.jp/web/market/search/quote.html?ric=${code}.T` },
+  { name: "SBI証券", href: (code) => `https://site3.sbisec.co.jp/ETGate/?_ControlID=WPLETsiR001Control&_DataStoreID=DSWPLETsiR001Control&_PageID=WPLETsiR001Ilst10&_ActionID=getDetailOfStockPriceJP&s_rkbn=1&i_stock_sec=%94%43%93%56%93%B0&i_dom_flg=1&i_exchange_code=JPN&i_output_type=0&stock_sec_code_mul=${code}` },
+  { name: "株探", href: (code) => `https://kabutan.jp/stock/?code=${code}` },
+  { name: "Yahoo! Finance", href: (code) => `https://finance.yahoo.co.jp/quote/${code}` },
+  { name: "日経", href: (code) => `https://www.nikkei.com/nkd/company/?scode=${code}` },
+  { name: "バフェットコード", href: (code) => `https://www.buffett-code.com/company/${code}` },
+  { name: "みんかぶ", href: (code) => `https://minkabu.jp/stock/${code}/` },
+  { name: "IR BANK", href: (code) => `https://irbank.net/${code}` },
+  { name: "銘柄スカウター", href: (code) => `https://monex.ifis.co.jp/index.php?sa=report_index&bcode=${code}` },
+  { name: "ザイマニ", href: (code) => `https://zaimani.com/search/?_sf_s=${code}` },
+  { name: "JPX Explorer", href: (code) => `https://jpx-explorer.com/ja-JP/${code}-TSE` },
 ];
 
 export const StockInfoLinks = ({ code }: StockInfoLinksProps) => {
@@ -27,11 +27,11 @@ export const StockInfoLinks = ({ code }: StockInfoLinksProps) => {
 
   return (
     <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-2">
-      {STOCK_INFO_LINKS_OBJECTS.map((item) => (
+      {STOCK_INFO_LINKS.map((item) => (
         <a
           key={item.name}
           className="inline-flex items-center justify-between gap-1 rounded-md border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-primary hover:bg-slate-50 hover:border-primary transition-colors"
-          href={item.url.replace('{}', code)}
+          href={item.href(code)}
           target='_blank'
           rel="noopener noreferrer"
           aria-label={`${item.name}（新しいタブで開く）`}

--- a/frontend/src/components/molecules/__tests__/StockInfoLinks.test.tsx
+++ b/frontend/src/components/molecules/__tests__/StockInfoLinks.test.tsx
@@ -3,6 +3,12 @@ import { describe, expect, it } from 'vitest';
 import { StockInfoLinks } from '../StockInfoLinks';
 
 describe('StockInfoLinks', () => {
+  it('すべてのリンクを表示する（11件）', () => {
+    render(<StockInfoLinks code="7203" />);
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(11);
+  });
+
   it('楽天証券リンクとSBI証券リンクを表示する', () => {
     render(<StockInfoLinks code="7203" />);
 


### PR DESCRIPTION
## 概要
- bulk insert 用の user_id 配列生成を backend の shared helper に共通化
- 銘柄情報リンクの URL 生成を placeholder replace から型付き builder 関数に変更
- StockInfoLinks のリンク件数テストを追加

## 変更種別
- [x] リファクタリング
- [x] テスト

## テスト
- [x] `cargo fmt`
- [x] `cargo test shared`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test`
- [x] `npm run test -- StockInfoLinks`
- [x] `npm run lint`
- [x] `npm run build`

## Codexレビュー
- API パス/JSON/DB/認証/画面表示の外部挙動変更なし
- `frontend/package-lock.json` は npm 実行の副作用だったため除外済み
- 対象 7 ファイルのみを明示ステージングしてコミット