### PR TITLE
architecture docs の CSV API 記述を v1 に更新

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -81,17 +81,32 @@ CSRF 対策: `Origin` / `Referer` ヘッダーによるオリジン検証
 
 ## CSV インポート設計
 
-CSV ファイルのアップロードは2段階:
+CSV ファイルのアップロードは2段階。詳細な API 契約は `docs/api/v1-rest-design.md` を参照。
 
-1. **プレビュー** `POST /xxx/csv/preview`: ファイルをパースして行エラー一覧を返す（DB 書き込みなし）
-2. **確定保存** `POST /xxx/csv`: パース + DB 挿入（ON CONFLICT DO NOTHING / occurrence_index）
+1. **バリデーション** `POST /api/v1/{resource}-import-validations`: ファイルをパースして行エラー一覧を返す（DB 書き込みなし）
+2. **確定インポート** `POST /api/v1/{resource}-imports`: パース + DB 挿入（ON CONFLICT DO NOTHING / occurrence_index）
+
+エンドポイント例:
+
+| リソース | バリデーション | インポート |
+|---|---|---|
+| 配当金 | `POST /api/v1/dividend-import-validations` | `POST /api/v1/dividend-imports` |
+| 国内株式 | `POST /api/v1/domestic-stock-import-validations` | `POST /api/v1/domestic-stock-imports` |
+| 投資信託 | `POST /api/v1/mutual-fund-import-validations` | `POST /api/v1/mutual-fund-imports` |
+| 保有銘柄 | `POST /api/v1/asset-balance-import-validations` | `POST /api/v1/asset-balance-imports` |
 
 ## データフロー（保有銘柄 CSV の場合）
 
 ```
-Client → POST /asset-balances/csv
+Client → POST /api/v1/asset-balance-import-validations  # バリデーション（DB 書き込みなし）
   → middleware stack
-  → handler::asset_balance::upload_csv
+  → handlers::v1::asset_balances::validate_import
+  → services::csv_import::parse_csv (with parse_asset_balance_row)
+  → 200 { errors: [...] }
+
+Client → POST /api/v1/asset-balance-imports             # 確定インポート
+  → middleware stack
+  → handlers::v1::asset_balances::import
   → services::csv_import::parse_csv (with parse_asset_balance_row)
   → services::asset_balance::bulk_create (DELETE ALL → INSERT)
   → 201 { inserted, skipped, errors }


### PR DESCRIPTION
## 概要
- `docs/architecture.md` に残っていた旧 CSV API パス例を現行 `/api/v1` REST API に更新
- バリデーション/確定インポートの endpoint 表を追加
- 保有銘柄 CSV のデータフロー例を `asset-balance-import-validations` / `asset-balance-imports` に更新

## 変更種別
- [x] ドキュメント

## テスト
- [x] `rg "csv/preview|/asset-balances/csv|/xxx/csv|create_import" docs/architecture.md` がマッチなし
- [x] `git diff --check`

## Codexレビュー
- コード/API/OpenAPI/CI 変更なし
- 実装上の handler 名に合わせて `handlers::v1::asset_balances::import` と記載

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * CSVファイルのアップロード方式を2段階プロセス（バリデーション→確定インポート）として整理しました
  * API仕様ドキュメントをバージョン付きエンドポイント形式に更新し、より明確な構造になりました
  * 資産情報のインポート処理に関するデータフロー図を最新の仕様に基づいて更新しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->