### PR TITLE
Frontend CI を unit/build と E2E に分割

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -13,8 +13,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-and-build:
-    name: Test & Build
+  unit-test-build:
+    name: Unit Test & Build
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -48,6 +48,27 @@ jobs:
         run: npm run build
         env:
           VITE_SHOKEN_WEBAPI_API_URL: https://example.com
+
+  e2e:
+    name: E2E
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Cache Playwright browsers
         uses: actions/cache@v5


### PR DESCRIPTION
## 概要
- Frontend CI の単一 `Test & Build` job を `Unit Test & Build` と `E2E` に分割
- lint/unit/build と Playwright E2E を別 check にして、失敗箇所を明確化
- `needs` は付けず、並列実行できる構成に変更

## 変更種別
- [x] CI / workflow

## テスト
- [x] `git diff --check`
- [x] `rg "unit-test-build|name: Unit Test & Build|e2e:|name: E2E" .github/workflows/deploy-frontend.yml`
- [x] workflow 全体を `sed -n '1,180p'` で確認

## Codexレビュー
- workflow trigger / concurrency / paths は維持
- Node version / npm cache / Playwright cache / artifact 設定は維持
- coverage は削らず job 境界だけを分割