### PR TITLE
refactor: CSV import flowを共通化

### DIFF
--- a/backend/src/services/asset_balance.rs
+++ b/backend/src/services/asset_balance.rs
@@ -2,8 +2,10 @@ use crate::errors::ApiError;
 use crate::models::asset_balance::{AssetBalance, CreateAssetBalanceRequest};
 use crate::models::common::BulkCreateResponse;
 use crate::models::csv_import::{CsvPreviewResponse, CsvRowError, CsvUploadResponse};
-use crate::services::csv_import::{build_preview_response, finish_csv_upload, validate_csv_rows};
-use crate::services::csv_pipeline::{parse_csv_with_config, CsvParserConfig, CsvRow};
+use crate::services::csv_import::{build_csv_preview, run_csv_upload, validate_csv_rows};
+#[cfg(test)]
+use crate::services::csv_pipeline::parse_csv_with_config;
+use crate::services::csv_pipeline::{CsvParserConfig, CsvRow};
 use crate::services::csv_util::{
     get_row_cell, normalize_security_name, parse_number, parse_optional_string_row,
 };
@@ -123,9 +125,11 @@ pub async fn bulk_create(
 /// CSV bytes をパースしてプレビュー情報を返す（DB 書き込みなし）
 /// 現在の取込対象形式では、先頭6行はメタデータのためスキップ
 pub fn preview_csv(bytes: &[u8]) -> Result<CsvPreviewResponse, ApiError> {
-    let rows = parse_asset_balance_csv(bytes)?;
-    let (items, errors) = transform_asset_balance_rows(&rows);
-    Ok(build_preview_response(&items, errors))
+    build_csv_preview(
+        bytes,
+        &ASSET_BALANCE_CSV_CONFIG,
+        transform_asset_balance_rows,
+    )
 }
 
 /// CSV bytes をパースして保有銘柄を一括登録
@@ -134,21 +138,19 @@ pub async fn upload_csv(
     user_id: Uuid,
     bytes: &[u8],
 ) -> Result<CsvUploadResponse, ApiError> {
-    let rows = parse_asset_balance_csv(bytes)?;
-    let (items, errors) = transform_asset_balance_rows(&rows);
-    let result = bulk_create(pool, user_id, &items).await?;
-    Ok(finish_csv_upload(result, errors))
+    run_csv_upload(
+        bytes,
+        &ASSET_BALANCE_CSV_CONFIG,
+        transform_asset_balance_rows,
+        |items| async move { bulk_create(pool, user_id, &items).await },
+    )
+    .await
 }
 
 /// 認証ユーザーの保有銘柄を全削除
 pub async fn delete_all(pool: &PgPool, user_id: Uuid) -> Result<u64, ApiError> {
     crate::services::shared::delete_all_for_user(pool, user_id, "asset_balances", "asset_balance")
         .await
-}
-
-/// 保有銘柄 CSV bytes をパース段階まで共通化して返す
-fn parse_asset_balance_csv(bytes: &[u8]) -> Result<Vec<CsvRow>, ApiError> {
-    parse_csv_with_config(bytes, &ASSET_BALANCE_CSV_CONFIG)
 }
 
 fn transform_asset_balance_rows(
@@ -371,7 +373,11 @@ mod tests {
                 &["1605", "7974"][..],
             ),
         ] {
-            let rows = parse_asset_balance_csv(make_asset_balance_csv(rows).as_bytes()).unwrap();
+            let rows = parse_csv_with_config(
+                make_asset_balance_csv(rows).as_bytes(),
+                &ASSET_BALANCE_CSV_CONFIG,
+            )
+            .unwrap();
             let (items, errors) = transform_asset_balance_rows(&rows);
 
             assert!(errors.is_empty(), "unexpected errors: {errors:?}");

--- a/backend/src/services/csv_import.rs
+++ b/backend/src/services/csv_import.rs
@@ -1,12 +1,12 @@
-#[cfg(test)]
 use crate::errors::ApiError;
 use crate::models::common::BulkCreateResponse;
 use crate::models::csv_import::{CsvPreviewResponse, CsvRowError, CsvUploadResponse};
-use crate::services::csv_pipeline::CsvRow;
+use crate::services::csv_pipeline::{parse_csv_with_config, CsvParserConfig, CsvRow};
 #[cfg(test)]
 use crate::services::csv_util::decode_bytes;
 #[cfg(test)]
 use std::collections::HashMap;
+use std::future::Future;
 
 /// CSV bytes をデコードして行ごとにパース
 /// parse_row が Err を返した行はエラーとして収集し、items には含めない
@@ -105,6 +105,39 @@ pub fn finish_csv_upload(
         skipped: result.skipped,
         errors,
     }
+}
+
+/// CSV bytes をパース → 行 transform → preview response 化を共通化する
+pub fn build_csv_preview<T, F>(
+    bytes: &[u8],
+    config: &CsvParserConfig,
+    transform_rows: F,
+) -> Result<CsvPreviewResponse, ApiError>
+where
+    T: serde::Serialize,
+    F: FnOnce(&[CsvRow]) -> (Vec<T>, Vec<CsvRowError>),
+{
+    let rows = parse_csv_with_config(bytes, config)?;
+    let (items, errors) = transform_rows(&rows);
+    Ok(build_preview_response(&items, errors))
+}
+
+/// CSV bytes をパース → 行 transform → bulk_create → upload response 化を共通化する
+pub async fn run_csv_upload<T, F, BulkFn, BulkFut>(
+    bytes: &[u8],
+    config: &CsvParserConfig,
+    transform_rows: F,
+    bulk_create: BulkFn,
+) -> Result<CsvUploadResponse, ApiError>
+where
+    F: FnOnce(&[CsvRow]) -> (Vec<T>, Vec<CsvRowError>),
+    BulkFn: FnOnce(Vec<T>) -> BulkFut,
+    BulkFut: Future<Output = Result<BulkCreateResponse, ApiError>>,
+{
+    let rows = parse_csv_with_config(bytes, config)?;
+    let (items, errors) = transform_rows(&rows);
+    let result = bulk_create(items).await?;
+    Ok(finish_csv_upload(result, errors))
 }
 #[cfg(test)]
 mod tests {
@@ -225,6 +258,102 @@ mod tests {
 
         let (items, errors): (Vec<String>, _) = validate_csv_rows(&[], |_, _| Ok("".to_string()));
         assert_eq!((items.is_empty(), errors.is_empty()), (true, true));
+    }
+
+    const PREVIEW_TEST_CONFIG: CsvParserConfig = CsvParserConfig {
+        skip_header_rows: 0,
+        exclude_row_fn: None,
+        required_columns: &["name", "amount"],
+    };
+
+    fn collect_names(rows: &[CsvRow]) -> (Vec<String>, Vec<CsvRowError>) {
+        let mut items = Vec::new();
+        let mut errors = Vec::new();
+        for (index, row) in rows.iter().enumerate() {
+            let name = row.get("name").cloned().unwrap_or_default();
+            if name.is_empty() {
+                errors.push(CsvRowError {
+                    row: index + 1,
+                    message: "name is empty".to_string(),
+                });
+            } else {
+                items.push(name);
+            }
+        }
+        (items, errors)
+    }
+
+    #[test]
+    fn test_build_csv_preview() {
+        let preview = build_csv_preview(
+            "name,amount\nfoo,100\n,200\nbar,300\n".as_bytes(),
+            &PREVIEW_TEST_CONFIG,
+            collect_names,
+        )
+        .unwrap();
+        assert_eq!(
+            (
+                preview.total_rows,
+                preview.valid_rows,
+                preview.errors.len(),
+                preview.errors.first().map(|error| error.row),
+                preview.rows.len(),
+            ),
+            (3, 2, 1, Some(2), 2)
+        );
+
+        assert!(matches!(
+            build_csv_preview(b"", &PREVIEW_TEST_CONFIG, collect_names),
+            Err(ApiError::ValidationError(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_run_csv_upload() {
+        let response = run_csv_upload(
+            "name,amount\nfoo,1\n,2\nbar,3\n".as_bytes(),
+            &PREVIEW_TEST_CONFIG,
+            collect_names,
+            |items| async move {
+                Ok(BulkCreateResponse {
+                    inserted: items.len(),
+                    skipped: 0,
+                })
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            (
+                response.inserted,
+                response.skipped,
+                response.errors.len(),
+                response.errors.first().map(|error| error.row),
+            ),
+            (2, 0, 1, Some(2))
+        );
+
+        let bulk_invoked = std::cell::Cell::new(false);
+        let result = run_csv_upload(
+            b"",
+            &PREVIEW_TEST_CONFIG,
+            collect_names,
+            |_items: Vec<String>| {
+                bulk_invoked.set(true);
+                async {
+                    Ok(BulkCreateResponse {
+                        inserted: 0,
+                        skipped: 0,
+                    })
+                }
+            },
+        )
+        .await;
+        assert!(matches!(result, Err(ApiError::ValidationError(_))));
+        assert!(
+            !bulk_invoked.get(),
+            "bulk_create must not run when parse fails"
+        );
     }
 
     #[test]

--- a/backend/src/services/dividend.rs
+++ b/backend/src/services/dividend.rs
@@ -2,8 +2,8 @@ use crate::errors::ApiError;
 use crate::models::common::BulkCreateResponse;
 use crate::models::csv_import::{CsvPreviewResponse, CsvRowError, CsvUploadResponse};
 use crate::models::dividend::{CreateDividendRequest, Dividend};
-use crate::services::csv_import::{build_preview_response, finish_csv_upload, validate_csv_rows};
-use crate::services::csv_pipeline::{parse_csv_with_config, CsvParserConfig, CsvRow};
+use crate::services::csv_import::{build_csv_preview, run_csv_upload, validate_csv_rows};
+use crate::services::csv_pipeline::{CsvParserConfig, CsvRow};
 use crate::services::csv_util::{
     normalize_security_name, parse_optional_string_row, parse_required_date_row,
     parse_required_number_row, parse_required_string_row,
@@ -114,9 +114,7 @@ pub async fn bulk_create(
 
 /// CSV バイト列から配当金をパースしてプレビュー情報を返す（DB 書き込みなし）
 pub fn preview_csv(bytes: &[u8]) -> Result<CsvPreviewResponse, ApiError> {
-    let rows = parse_dividend_csv(bytes)?;
-    let (items, errors) = transform_dividend_rows(&rows);
-    Ok(build_preview_response(&items, errors))
+    build_csv_preview(bytes, &DIVIDEND_CSV_CONFIG, transform_dividend_rows)
 }
 
 /// CSV バイト列から配当金をパースして一括挿入
@@ -125,14 +123,13 @@ pub async fn upload_csv(
     user_id: Uuid,
     bytes: &[u8],
 ) -> Result<CsvUploadResponse, ApiError> {
-    let rows = parse_dividend_csv(bytes)?;
-    let (items, errors) = transform_dividend_rows(&rows);
-    let result = bulk_create(pool, user_id, &items).await?;
-    Ok(finish_csv_upload(result, errors))
-}
-
-fn parse_dividend_csv(bytes: &[u8]) -> Result<Vec<CsvRow>, ApiError> {
-    parse_csv_with_config(bytes, &DIVIDEND_CSV_CONFIG)
+    run_csv_upload(
+        bytes,
+        &DIVIDEND_CSV_CONFIG,
+        transform_dividend_rows,
+        |items| async move { bulk_create(pool, user_id, &items).await },
+    )
+    .await
 }
 
 fn transform_dividend_rows(rows: &[CsvRow]) -> (Vec<CreateDividendRequest>, Vec<CsvRowError>) {

--- a/backend/src/services/domestic_stock.rs
+++ b/backend/src/services/domestic_stock.rs
@@ -2,8 +2,8 @@ use crate::errors::ApiError;
 use crate::models::common::BulkCreateResponse;
 use crate::models::csv_import::{CsvPreviewResponse, CsvRowError, CsvUploadResponse};
 use crate::models::domestic_stock::{CreateDomesticStockRequest, DomesticStock};
-use crate::services::csv_import::{build_preview_response, finish_csv_upload, validate_csv_rows};
-use crate::services::csv_pipeline::{parse_csv_with_config, CsvParserConfig, CsvRow};
+use crate::services::csv_import::{build_csv_preview, run_csv_upload, validate_csv_rows};
+use crate::services::csv_pipeline::{CsvParserConfig, CsvRow};
 use crate::services::csv_util::{
     compute_taxes, normalize_security_name, parse_required_date_row, parse_required_number_row,
     parse_required_string_row,
@@ -178,9 +178,11 @@ pub async fn bulk_create(
 
 /// CSV バイト列から国内株式取引をパースしてプレビュー情報を返す（DB 書き込みなし）
 pub fn preview_csv(bytes: &[u8]) -> Result<CsvPreviewResponse, ApiError> {
-    let rows = parse_domestic_stock_csv(bytes)?;
-    let (items, errors) = transform_domestic_stock_rows(&rows);
-    Ok(build_preview_response(&items, errors))
+    build_csv_preview(
+        bytes,
+        &DOMESTIC_STOCK_CSV_CONFIG,
+        transform_domestic_stock_rows,
+    )
 }
 
 /// CSV バイト列から国内株式取引をパースして一括挿入
@@ -189,14 +191,13 @@ pub async fn upload_csv(
     user_id: Uuid,
     bytes: &[u8],
 ) -> Result<CsvUploadResponse, ApiError> {
-    let rows = parse_domestic_stock_csv(bytes)?;
-    let (items, errors) = transform_domestic_stock_rows(&rows);
-    let result = bulk_create(pool, user_id, &items).await?;
-    Ok(finish_csv_upload(result, errors))
-}
-
-fn parse_domestic_stock_csv(bytes: &[u8]) -> Result<Vec<CsvRow>, ApiError> {
-    parse_csv_with_config(bytes, &DOMESTIC_STOCK_CSV_CONFIG)
+    run_csv_upload(
+        bytes,
+        &DOMESTIC_STOCK_CSV_CONFIG,
+        transform_domestic_stock_rows,
+        |items| async move { bulk_create(pool, user_id, &items).await },
+    )
+    .await
 }
 
 fn transform_domestic_stock_rows(

--- a/backend/src/services/mutualfund.rs
+++ b/backend/src/services/mutualfund.rs
@@ -2,8 +2,8 @@ use crate::errors::ApiError;
 use crate::models::common::BulkCreateResponse;
 use crate::models::csv_import::{CsvPreviewResponse, CsvRowError, CsvUploadResponse};
 use crate::models::mutualfund::{CreateMutualfundRequest, Mutualfund};
-use crate::services::csv_import::{build_preview_response, finish_csv_upload, validate_csv_rows};
-use crate::services::csv_pipeline::{parse_csv_with_config, CsvParserConfig, CsvRow};
+use crate::services::csv_import::{build_csv_preview, run_csv_upload, validate_csv_rows};
+use crate::services::csv_pipeline::{CsvParserConfig, CsvRow};
 use crate::services::csv_util::{
     compute_taxes, get_row_cell, parse_required_date_row, parse_required_number_row,
     parse_required_string_row,
@@ -132,9 +132,7 @@ pub async fn bulk_create(
 
 /// CSV バイト列から投資信託をパースしてプレビュー情報を返す（DB 書き込みなし）
 pub fn preview_csv(bytes: &[u8]) -> Result<CsvPreviewResponse, ApiError> {
-    let rows = parse_mutualfund_csv(bytes)?;
-    let (items, errors) = transform_mutualfund_rows(&rows);
-    Ok(build_preview_response(&items, errors))
+    build_csv_preview(bytes, &MUTUALFUND_CSV_CONFIG, transform_mutualfund_rows)
 }
 
 /// CSV バイト列から投資信託をパースして一括挿入
@@ -143,14 +141,13 @@ pub async fn upload_csv(
     user_id: Uuid,
     bytes: &[u8],
 ) -> Result<CsvUploadResponse, ApiError> {
-    let rows = parse_mutualfund_csv(bytes)?;
-    let (items, errors) = transform_mutualfund_rows(&rows);
-    let result = bulk_create(pool, user_id, &items).await?;
-    Ok(finish_csv_upload(result, errors))
-}
-
-fn parse_mutualfund_csv(bytes: &[u8]) -> Result<Vec<CsvRow>, ApiError> {
-    parse_csv_with_config(bytes, &MUTUALFUND_CSV_CONFIG)
+    run_csv_upload(
+        bytes,
+        &MUTUALFUND_CSV_CONFIG,
+        transform_mutualfund_rows,
+        |items| async move { bulk_create(pool, user_id, &items).await },
+    )
+    .await
 }
 
 fn transform_mutualfund_rows(rows: &[CsvRow]) -> (Vec<CreateMutualfundRequest>, Vec<CsvRowError>) {


### PR DESCRIPTION
## 概要
- CSV preview/upload の parse -> transform -> response flow を csv_import helper に集約
- dividend / domestic_stock / mutualfund / asset_balance の同型重複を削減
- 共通 helper の単体テストを追加

## テスト
- cd backend && cargo fmt
- cd backend && cargo test services::csv_import
- cd backend && cargo test services::csv_domain
- cd backend && cargo test services::asset_balance
- cd backend && cargo clippy -- -D warnings
- push hook: scripts/check-openapi.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * CSV取込処理の共通化ユーティリティを導入し、資産残高・配当金・国内株式・投資信託の各機能の実装を統一しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->