### PR TITLE
refactor: frontend API境界をOpenAPI型に寄せる

### DIFF
--- a/frontend/src/features/assetBalance/api/assetBalanceApi.ts
+++ b/frontend/src/features/assetBalance/api/assetBalanceApi.ts
@@ -1,15 +1,24 @@
 import { apiClient } from '@/lib/api/client';
 import { uploadCsvFile, previewCsvFile } from '@/lib/api/csvHelpers';
-import type { AssetBalanceApiData } from '@/types/api';
+import type { paths } from '@/generated/api';
+
+const API_PATHS = {
+  assetBalanceList: '/api/v1/asset-balances',
+  assetBalancePreview: '/api/v1/asset-balance-import-validations',
+  assetBalanceImport: '/api/v1/asset-balance-imports',
+} as const satisfies Record<string, keyof paths>;
+
+type AssetBalanceListResponse = paths['/api/v1/asset-balances']['get']['responses'][200]['content']['application/json'];
+type AssetBalanceDeleteResponse = paths['/api/v1/asset-balances']['delete']['responses'][200]['content']['application/json'];
 
 export const assetBalanceApi = {
   list: () =>
-    apiClient.get<AssetBalanceApiData[]>('/api/v1/asset-balances', { withCredentials: true }),
+    apiClient.get<AssetBalanceListResponse>(API_PATHS.assetBalanceList, { withCredentials: true }),
 
-  previewCsv: (file: File) => previewCsvFile('/api/v1/asset-balance-import-validations', file),
+  previewCsv: (file: File) => previewCsvFile(API_PATHS.assetBalancePreview, file),
 
-  uploadCsv: (file: File) => uploadCsvFile('/api/v1/asset-balance-imports', file),
+  uploadCsv: (file: File) => uploadCsvFile(API_PATHS.assetBalanceImport, file),
 
   deleteAll: async () =>
-    apiClient.delete('/api/v1/asset-balances', { withCredentials: true }),
+    apiClient.delete<AssetBalanceDeleteResponse>(API_PATHS.assetBalanceList, { withCredentials: true }),
 };

--- a/frontend/src/features/receipt/api/receiptApi.ts
+++ b/frontend/src/features/receipt/api/receiptApi.ts
@@ -1,46 +1,61 @@
 import { apiClient } from '@/lib/api/client';
 import { uploadCsvFile, previewCsvFile } from '@/lib/api/csvHelpers';
-import type {
-  DividendApiData,
-  DomesticStockApiData,
-  MutualfundApiData,
-} from '@/features/receipt/types';
+import type { paths } from '@/generated/api';
+
+const API_PATHS = {
+  dividendList: '/api/v1/dividends',
+  dividendPreview: '/api/v1/dividend-import-validations',
+  dividendImport: '/api/v1/dividend-imports',
+  domesticStockList: '/api/v1/domestic-stock-transactions',
+  domesticStockPreview: '/api/v1/domestic-stock-import-validations',
+  domesticStockImport: '/api/v1/domestic-stock-imports',
+  mutualfundList: '/api/v1/mutual-fund-transactions',
+  mutualfundPreview: '/api/v1/mutual-fund-import-validations',
+  mutualfundImport: '/api/v1/mutual-fund-imports',
+} as const satisfies Record<string, keyof paths>;
+
+type DividendListResponse = paths['/api/v1/dividends']['get']['responses'][200]['content']['application/json'];
+type DividendDeleteResponse = paths['/api/v1/dividends']['delete']['responses'][200]['content']['application/json'];
+type DomesticStockListResponse = paths['/api/v1/domestic-stock-transactions']['get']['responses'][200]['content']['application/json'];
+type DomesticStockDeleteResponse = paths['/api/v1/domestic-stock-transactions']['delete']['responses'][200]['content']['application/json'];
+type MutualfundListResponse = paths['/api/v1/mutual-fund-transactions']['get']['responses'][200]['content']['application/json'];
+type MutualfundDeleteResponse = paths['/api/v1/mutual-fund-transactions']['delete']['responses'][200]['content']['application/json'];
 
 // 配当金API
 export const dividendApi = {
   list: () =>
-    apiClient.get<DividendApiData[]>('/api/v1/dividends', { withCredentials: true }),
+    apiClient.get<DividendListResponse>(API_PATHS.dividendList, { withCredentials: true }),
 
-  previewCsv: (file: File) => previewCsvFile('/api/v1/dividend-import-validations', file),
+  previewCsv: (file: File) => previewCsvFile(API_PATHS.dividendPreview, file),
 
-  uploadCsv: (file: File) => uploadCsvFile('/api/v1/dividend-imports', file),
+  uploadCsv: (file: File) => uploadCsvFile(API_PATHS.dividendImport, file),
 
   deleteAll: async () =>
-    apiClient.delete('/api/v1/dividends', { withCredentials: true }),
+    apiClient.delete<DividendDeleteResponse>(API_PATHS.dividendList, { withCredentials: true }),
 };
 
 // 国内株式API
 export const domesticStockApi = {
   list: () =>
-    apiClient.get<DomesticStockApiData[]>('/api/v1/domestic-stock-transactions', { withCredentials: true }),
+    apiClient.get<DomesticStockListResponse>(API_PATHS.domesticStockList, { withCredentials: true }),
 
-  previewCsv: (file: File) => previewCsvFile('/api/v1/domestic-stock-import-validations', file),
+  previewCsv: (file: File) => previewCsvFile(API_PATHS.domesticStockPreview, file),
 
-  uploadCsv: (file: File) => uploadCsvFile('/api/v1/domestic-stock-imports', file),
+  uploadCsv: (file: File) => uploadCsvFile(API_PATHS.domesticStockImport, file),
 
   deleteAll: async () =>
-    apiClient.delete('/api/v1/domestic-stock-transactions', { withCredentials: true }),
+    apiClient.delete<DomesticStockDeleteResponse>(API_PATHS.domesticStockList, { withCredentials: true }),
 };
 
 // 投資信託API
 export const mutualfundApi = {
   list: () =>
-    apiClient.get<MutualfundApiData[]>('/api/v1/mutual-fund-transactions', { withCredentials: true }),
+    apiClient.get<MutualfundListResponse>(API_PATHS.mutualfundList, { withCredentials: true }),
 
-  previewCsv: (file: File) => previewCsvFile('/api/v1/mutual-fund-import-validations', file),
+  previewCsv: (file: File) => previewCsvFile(API_PATHS.mutualfundPreview, file),
 
-  uploadCsv: (file: File) => uploadCsvFile('/api/v1/mutual-fund-imports', file),
+  uploadCsv: (file: File) => uploadCsvFile(API_PATHS.mutualfundImport, file),
 
   deleteAll: async () =>
-    apiClient.delete('/api/v1/mutual-fund-transactions', { withCredentials: true }),
+    apiClient.delete<MutualfundDeleteResponse>(API_PATHS.mutualfundList, { withCredentials: true }),
 };

--- a/frontend/src/pages/__tests__/Receipts.test.tsx
+++ b/frontend/src/pages/__tests__/Receipts.test.tsx
@@ -670,7 +670,7 @@ describe('ReceiptsPage', () => {
     vi.mocked(receiptApi.dividendApi.list).mockResolvedValue([mockDbRow] as any);
     vi.mocked(receiptApi.domesticStockApi.list).mockResolvedValue([]);
     vi.mocked(receiptApi.mutualfundApi.list).mockResolvedValue([]);
-    vi.mocked(receiptApi.dividendApi.deleteAll).mockResolvedValue({});
+    vi.mocked(receiptApi.dividendApi.deleteAll).mockResolvedValue({ message: '' });
 
     renderWithQuery(<ReceiptsPage />);
 
@@ -706,7 +706,7 @@ describe('ReceiptsPage', () => {
     vi.mocked(receiptApi.dividendApi.list).mockResolvedValue([mockDbRow] as any);
     vi.mocked(receiptApi.domesticStockApi.list).mockResolvedValue([]);
     vi.mocked(receiptApi.mutualfundApi.list).mockResolvedValue([]);
-    vi.mocked(receiptApi.dividendApi.deleteAll).mockResolvedValue({});
+    vi.mocked(receiptApi.dividendApi.deleteAll).mockResolvedValue({ message: '' });
 
     renderWithQuery(<ReceiptsPage />);
 


### PR DESCRIPTION
## 概要
- receipt / assetBalance のフロントAPIラッパーで、list/delete のレスポンス型を OpenAPI generated paths から取得するように変更
- API パスを型付き API_PATHS に集約し、存在しないパスを型で検出できる形に整理
- deleteAll の戻り値が MessageResponse 形状になるため、該当テストモックを更新

## 整理理由
- フロント独自型と OpenAPI generated 型の二重管理を減らすため
- API パス文字列の散在を抑え、REST API 変更時の追従箇所を明確にするため
- backend / OpenAPI / generated file には変更なし

## 検証
- cd frontend && npm run lint
- cd frontend && npm test
- cd frontend && npm run build