### PR TITLE
feat: 保有株総評プロンプトをコピーできるようにする

### DIFF
--- a/frontend/src/features/assetBalance/components/AssetBalanceUtilityRail.tsx
+++ b/frontend/src/features/assetBalance/components/AssetBalanceUtilityRail.tsx
@@ -4,7 +4,9 @@ import {
   type DataActionRailProps,
 } from '@/components/organisms/DataActionRail/DataActionRail';
 import { SearchCard } from '@/components/organisms/SearchCard/SearchCard';
+import type { AssetBalanceData } from '@/types/api';
 import type { SearchCategories } from '@/types/common';
+import { AssetReviewPromptCard } from './AssetReviewPromptCard';
 
 export interface AssetBalanceUtilityRailProps {
   actionRailProps: DataActionRailProps;
@@ -15,12 +17,17 @@ export interface AssetBalanceUtilityRailProps {
     value: string;
     onSearch: (query: string) => void;
   };
+  reviewPromptCardProps: {
+    assetBalanceData: AssetBalanceData[];
+    dividendPerShareMap: Map<string, number>;
+  };
 }
 
 export function AssetBalanceUtilityRail({
   actionRailProps,
   error,
   searchCardProps,
+  reviewPromptCardProps,
 }: AssetBalanceUtilityRailProps) {
   return (
     <>
@@ -42,6 +49,8 @@ export function AssetBalanceUtilityRail({
           compact
         />
       )}
+
+      <AssetReviewPromptCard {...reviewPromptCardProps} />
     </>
   );
 }

--- a/frontend/src/features/assetBalance/components/AssetReviewPromptCard.tsx
+++ b/frontend/src/features/assetBalance/components/AssetReviewPromptCard.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import { Button } from '@/components/atoms/Button';
+import type { AssetBalanceData } from '@/types/api';
+import { generateAssetReviewPrompt } from '../utils/assetReviewPrompt';
+export interface AssetReviewPromptCardProps {
+  assetBalanceData: AssetBalanceData[];
+  dividendPerShareMap: Map<string, number>;
+}
+type CopyStatus = 'idle' | 'success' | 'error';
+export function AssetReviewPromptCard({
+  assetBalanceData,
+  dividendPerShareMap,
+}: AssetReviewPromptCardProps) {
+  const [status, setStatus] = useState<CopyStatus>('idle');
+  const handleCopy = async () => {
+    const prompt = generateAssetReviewPrompt(assetBalanceData, dividendPerShareMap);
+    try {
+      await navigator.clipboard.writeText(prompt);
+      setStatus('success');
+      setTimeout(() => setStatus('idle'), 3000);
+    } catch {
+      setStatus('error');
+      setTimeout(() => setStatus('idle'), 3000);
+    }
+  };
+  const disabled = assetBalanceData.length === 0;
+  const buttonLabel =
+    status === 'success' ? 'コピーしました！' : 'AI総評プロンプトをコピー';
+  return (
+    <div className="px-5 py-4">
+      <p className="text-xs font-medium text-secondary mb-2">AI総評プロンプト</p>
+      <Button
+        variant="outline-secondary"
+        size="sm"
+        fullWidth
+        onClick={handleCopy}
+        disabled={disabled}
+        className="truncate"
+        aria-label={buttonLabel}
+      >
+        {buttonLabel}
+      </Button>
+      <p role="status" aria-live="polite" className="text-xs mt-1 min-h-[1rem]">
+        {status === 'success' && 'コピーしました'}
+        {status === 'error' && 'コピーに失敗しました。手動でテキストをコピーしてください。'}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/features/assetBalance/components/__tests__/AssetBalanceUtilityRail.test.tsx
+++ b/frontend/src/features/assetBalance/components/__tests__/AssetBalanceUtilityRail.test.tsx
@@ -12,6 +12,10 @@ vi.mock('@/components/organisms/SearchCard/SearchCard', () => ({
   SearchCard: ({ value }: { value: string }) => <div data-testid="search-card">{value}</div>,
 }));
 
+vi.mock('../AssetReviewPromptCard', () => ({
+  AssetReviewPromptCard: () => <div data-testid="asset-review-prompt-card" />,
+}));
+
 const actionRailProps = {
   onFileSelect: vi.fn(),
   selectedFileName: 'assetbalance.csv',
@@ -28,6 +32,11 @@ const actionRailProps = {
   saveModeLabel: '全件置換',
 };
 
+const reviewPromptCardProps = {
+  assetBalanceData: [],
+  dividendPerShareMap: new Map<string, number>(),
+};
+
 describe('AssetBalanceUtilityRail', () => {
   it('データ操作、エラー、検索カードを表示する', () => {
     render(
@@ -42,6 +51,7 @@ describe('AssetBalanceUtilityRail', () => {
           value: '7203',
           onSearch: vi.fn(),
         }}
+        reviewPromptCardProps={reviewPromptCardProps}
       />
     );
 
@@ -61,6 +71,7 @@ describe('AssetBalanceUtilityRail', () => {
           value: '',
           onSearch: vi.fn(),
         }}
+        reviewPromptCardProps={reviewPromptCardProps}
       />
     );
 

--- a/frontend/src/features/assetBalance/components/__tests__/AssetReviewPromptCard.test.tsx
+++ b/frontend/src/features/assetBalance/components/__tests__/AssetReviewPromptCard.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { AssetBalanceData } from '@/types/api';
+import { AssetReviewPromptCard } from '../AssetReviewPromptCard';
+
+function makeAsset(overrides: Partial<AssetBalanceData> = {}): AssetBalanceData {
+  return {
+    id: 'id-1',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    security_code: '7203',
+    security_name: 'トヨタ自動車',
+    shares: 100,
+    executing_shares: 0,
+    average_purchase_price: 2500,
+    total_purchase_amount: 250000,
+    current_price: 2600,
+    daily_change: 50,
+    market_value: 260000,
+    profit_loss_rate: 4.0,
+    ...overrides,
+  };
+}
+
+const singleAsset = [makeAsset()];
+
+describe('AssetReviewPromptCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('保有データありのときコピーボタンを表示する', () => {
+    render(
+      <AssetReviewPromptCard
+        assetBalanceData={singleAsset}
+        dividendPerShareMap={new Map()}
+      />
+    );
+    expect(screen.getByRole('button', { name: /AI総評プロンプトをコピー/ })).toBeInTheDocument();
+  });
+
+  it('保有データ0件のときボタンをdisabledにする', () => {
+    render(
+      <AssetReviewPromptCard
+        assetBalanceData={[]}
+        dividendPerShareMap={new Map()}
+      />
+    );
+    expect(screen.getByRole('button', { name: /AI総評プロンプトをコピー/ })).toBeDisabled();
+  });
+
+  it('コピー成功時に成功メッセージを表示する', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(
+      <AssetReviewPromptCard
+        assetBalanceData={singleAsset}
+        dividendPerShareMap={new Map()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /AI総評プロンプトをコピー/ }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toHaveTextContent('コピーしました');
+    });
+    expect(writeText).toHaveBeenCalledTimes(1);
+  });
+
+  it('コピー成功時に writeText が1回呼ばれる', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(
+      <AssetReviewPromptCard
+        assetBalanceData={singleAsset}
+        dividendPerShareMap={new Map()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /AI総評プロンプトをコピー/ }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    const [calledText] = writeText.mock.calls[0] as [string];
+    expect(calledText).toContain('トヨタ自動車');
+  });
+
+  it('Clipboard API 失敗時にエラーメッセージを表示する', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'));
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(
+      <AssetReviewPromptCard
+        assetBalanceData={singleAsset}
+        dividendPerShareMap={new Map()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /AI総評プロンプトをコピー/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/コピーに失敗しました/)).toBeInTheDocument();
+    });
+  });
+
+  it('aria-live 領域が存在する', () => {
+    render(
+      <AssetReviewPromptCard
+        assetBalanceData={singleAsset}
+        dividendPerShareMap={new Map()}
+      />
+    );
+    const liveRegion = screen.getByRole('status');
+    expect(liveRegion).toHaveAttribute('aria-live');
+  });
+});

--- a/frontend/src/features/assetBalance/hooks/__tests__/useAssetBalanceState.test.ts
+++ b/frontend/src/features/assetBalance/hooks/__tests__/useAssetBalanceState.test.ts
@@ -117,6 +117,7 @@ describe('useAssetBalanceState', () => {
     expect(result.current.utilityRailProps.actionRailProps.saveLabel).toBe('2件 全件置換で保存');
     expect(result.current.utilityRailProps.actionRailProps.deleteLabel).toBe('全件削除 (1件)');
     expect(result.current.utilityRailProps.searchCardProps.visible).toBe(true);
+    expect(result.current.utilityRailProps.reviewPromptCardProps.assetBalanceData).toEqual(previewRows);
 
     act(() => {
       result.current.utilityRailProps.searchCardProps.onSearch('6758');
@@ -124,6 +125,7 @@ describe('useAssetBalanceState', () => {
 
     expect(result.current.utilityRailProps.searchCardProps.value).toBe('6758');
     expect(result.current.filteredData).toEqual([previewRows[1]]);
+    expect(result.current.utilityRailProps.reviewPromptCardProps.assetBalanceData).toEqual(previewRows);
   });
 
   it('削除確認を開き、confirmDeleteAll で閉じて削除処理を実行する', async () => {

--- a/frontend/src/features/assetBalance/hooks/useAssetBalanceState.ts
+++ b/frontend/src/features/assetBalance/hooks/useAssetBalanceState.ts
@@ -163,6 +163,10 @@ export function useAssetBalanceState() {
       value: state.searchQuery,
       onSearch: handleSearch,
     },
+    reviewPromptCardProps: {
+      assetBalanceData,
+      dividendPerShareMap: dividendPerShareMap as Map<string, number>,
+    },
   };
 
   const mainStatusMessage = getMainStatusMessage({ loading, saving, deleting, previewing });

--- a/frontend/src/features/assetBalance/utils/__tests__/assetReviewPrompt.test.ts
+++ b/frontend/src/features/assetBalance/utils/__tests__/assetReviewPrompt.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import type { AssetBalanceData } from '@/types/api';
+import { generateAssetReviewPrompt } from '../assetReviewPrompt';
+
+function makeAsset(overrides: Partial<AssetBalanceData> = {}): AssetBalanceData {
+  return {
+    id: 'id-1',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    security_code: '7203',
+    security_name: 'トヨタ自動車',
+    shares: 100,
+    executing_shares: 0,
+    average_purchase_price: 2500,
+    total_purchase_amount: 250000,
+    current_price: 2600,
+    daily_change: 50,
+    market_value: 260000,
+    profit_loss_rate: 4.0,
+    ...overrides,
+  };
+}
+
+describe('generateAssetReviewPrompt', () => {
+  const singleAsset = [makeAsset()];
+  const multiAssets = [
+    makeAsset(),
+    makeAsset({
+      id: 'id-2',
+      security_code: '6758',
+      security_name: 'ソニーグループ',
+      shares: 50,
+      average_purchase_price: 12000,
+      total_purchase_amount: 600000,
+      current_price: 11500,
+      daily_change: -100,
+      market_value: 575000,
+      profit_loss_rate: -4.17,
+    }),
+  ];
+
+  it('投資助言ではなく判断材料整理である旨を含む', () => {
+    const result = generateAssetReviewPrompt(singleAsset, new Map());
+    expect(result).toMatch(/投資助言|売買推奨/);
+    expect(result).toMatch(/判断材料/);
+  });
+
+  it('ポートフォリオレビューの役割指定を含む', () => {
+    const result = generateAssetReviewPrompt(singleAsset, new Map());
+    expect(result).toMatch(/ポートフォリオ/);
+  });
+
+  it('全銘柄コードと銘柄名を含む', () => {
+    const result = generateAssetReviewPrompt(multiAssets, new Map());
+    expect(result).toContain('7203');
+    expect(result).toContain('トヨタ自動車');
+    expect(result).toContain('6758');
+    expect(result).toContain('ソニーグループ');
+  });
+
+  it('集計値（銘柄数・合計取得金額・合計評価額・評価損益額）を含む', () => {
+    const result = generateAssetReviewPrompt(multiAssets, new Map());
+    // 銘柄数
+    expect(result).toMatch(/2\s*銘柄|銘柄数.+2/);
+    // 合計取得金額: 250,000 + 600,000 = 850,000
+    expect(result).toMatch(/850,000|850000/);
+    // 合計評価額: 260,000 + 575,000 = 835,000
+    expect(result).toMatch(/835,000|835000/);
+    // 評価損益額: 835,000 - 850,000 = -15,000
+    expect(result).toMatch(/-15,000|-15000/);
+  });
+
+  it('dividendPerShareMap がある銘柄は配当値を含む', () => {
+    const divMap = new Map([['7203', 80]]);
+    const result = generateAssetReviewPrompt(singleAsset, divMap);
+    expect(result).toMatch(/80/);
+  });
+
+  it('dividendPerShareMap にない銘柄は「不明」と表示する', () => {
+    const result = generateAssetReviewPrompt(singleAsset, new Map());
+    expect(result).toMatch(/不明/);
+  });
+
+  it('データが空の場合でもエラーを出さず空プロンプトを返す', () => {
+    expect(() => generateAssetReviewPrompt([], new Map())).not.toThrow();
+    const result = generateAssetReviewPrompt([], new Map());
+    expect(typeof result).toBe('string');
+  });
+
+  it('個人識別情報（メール・ユーザーID）を含まない', () => {
+    const result = generateAssetReviewPrompt(multiAssets, new Map());
+    expect(result).not.toMatch(/@/);
+    expect(result).not.toMatch(/user_id|userId/);
+  });
+
+  it('保有株数・平均取得単価・現在値・取得額・評価額・損益率を含む', () => {
+    const result = generateAssetReviewPrompt(singleAsset, new Map());
+    expect(result).toMatch(/100/);   // shares
+    expect(result).toMatch(/2,500|2500/); // average_purchase_price
+    expect(result).toMatch(/2,600|2600/); // current_price
+    expect(result).toMatch(/250,000|250000/); // total_purchase_amount
+    expect(result).toMatch(/260,000|260000/); // market_value
+    expect(result).toMatch(/4\.0|4\.00/);  // profit_loss_rate
+  });
+
+  it('各銘柄の評価損益額（market_value - total_purchase_amount）を含む', () => {
+    // トヨタ: 260,000 - 250,000 = 10,000
+    const result = generateAssetReviewPrompt(singleAsset, new Map());
+    expect(result).toMatch(/10,000|10000/);
+  });
+
+  it('外部AIへ不足情報の質問を促す文言を含む', () => {
+    const result = generateAssetReviewPrompt(singleAsset, new Map());
+    expect(result).toMatch(/質問|不足|情報/);
+  });
+});

--- a/frontend/src/features/assetBalance/utils/assetReviewPrompt.ts
+++ b/frontend/src/features/assetBalance/utils/assetReviewPrompt.ts
@@ -1,0 +1,86 @@
+import type { AssetBalanceData } from '@/types/api';
+
+function fmt(value: number): string {
+  return value.toLocaleString('ja-JP');
+}
+
+function fmtRate(value: number): string {
+  return `${value.toFixed(2)}%`;
+}
+
+export function generateAssetReviewPrompt(
+  assets: AssetBalanceData[],
+  dividendPerShareMap: Map<string, number>
+): string {
+  const totalPurchase = assets.reduce((sum, a) => sum + a.total_purchase_amount, 0);
+  const totalMarketValue = assets.reduce((sum, a) => sum + a.market_value, 0);
+  const totalProfitLoss = totalMarketValue - totalPurchase;
+  const totalProfitLossRate =
+    totalPurchase > 0 ? (totalProfitLoss / totalPurchase) * 100 : 0;
+
+  const summaryLines = [
+    `- 保有銘柄数: ${assets.length}銘柄`,
+    `- 合計取得金額: ¥${fmt(totalPurchase)}`,
+    `- 合計評価額: ¥${fmt(totalMarketValue)}`,
+    `- 評価損益額: ¥${fmt(totalProfitLoss)}`,
+    `- 評価損益率: ${fmtRate(totalProfitLossRate)}`,
+  ].join('\n');
+
+  const header = [
+    '銘柄コード',
+    '銘柄名',
+    '保有株数',
+    '平均取得単価',
+    '現在値',
+    '取得額',
+    '評価額',
+    '評価損益額',
+    '損益率',
+    '推定1株配当',
+  ].join(' | ');
+
+  const rows = assets.map((a) => {
+    const profitLossAmount = a.market_value - a.total_purchase_amount;
+    const div = dividendPerShareMap.has(a.security_code)
+      ? `¥${dividendPerShareMap.get(a.security_code)}`
+      : '不明';
+    return [
+      a.security_code,
+      a.security_name,
+      fmt(a.shares),
+      `¥${fmt(a.average_purchase_price)}`,
+      `¥${fmt(a.current_price)}`,
+      `¥${fmt(a.total_purchase_amount)}`,
+      `¥${fmt(a.market_value)}`,
+      `¥${fmt(profitLossAmount)}`,
+      fmtRate(a.profit_loss_rate),
+      div,
+    ].join(' | ');
+  });
+
+  return `あなたは日本株ポートフォリオをレビューする投資分析アシスタントです。
+以下の保有銘柄データをもとに、ポートフォリオ全体の総評をしてください。
+
+【重要な注意事項】
+このプロンプトで求めるのは投資助言・売買推奨ではありません。
+判断材料の整理・リスク観点・確認事項として回答してください。
+確定的な予測や断定的な表現は避け、検討観点と質問リストを提示してください。
+
+【お願いしたい分析項目】
+1. ポートフォリオ全体の総評
+2. 集中リスク・業種偏り・銘柄偏りの読み取り
+3. 損益状況の読み取り（含み益/損の分布）
+4. 配当観点のコメント（推定配当が不明な銘柄は不明として扱う）
+5. 追加で確認すべきIR・決算・ニュース・指標
+6. 売買指示ではなく、検討すべき観点と質問リスト
+
+【保有銘柄データ】
+集計:
+${summaryLines}
+
+各銘柄:
+${header}
+${rows.join('\n')}
+
+不足している情報があれば、分析に必要な情報として質問してください。`;
+}


### PR DESCRIPTION
## 概要
- 資産管理ページの右レールに「AI総評プロンプトをコピー」ボタンを追加
- 保有銘柄データ、集計値、推定1株配当を含む日本語プロンプトを生成
- 生成プロンプトは外部AIへ手動貼り付けする運用を前提とし、アプリ内でAI APIは呼ばない

## AI-DLC上の位置づけ
- Codexが仕様/taskを定義し、Claudeが実装
- Codexレビューで銘柄別評価損益額の不足と未定義CSS classを修正
- 投資助言ではなく、判断材料整理・リスク観点・確認事項の整理としてプロンプトを設計

## 主な変更
- `generateAssetReviewPrompt` を追加し、プロンプト生成を pure function 化
- `AssetReviewPromptCard` を追加し、Clipboard APIでコピーできるUIを追加
- 検索で絞り込み中でもAIプロンプト用データは全保有銘柄を保持するようテスト補強
- 既存 `DataActionRail` にはAI責務を入れず、資産管理専用railに閉じ込めた

## 非対象
- backend/API/OpenAPI変更
- OpenAI/Claude API連携
- 生成プロンプトのサーバー保存
- アプリ内での売買推奨表示

## 検証
- `cd frontend && npm test -- --run src/features/assetBalance`
- `cd frontend && npm test -- --run src/pages/__tests__/AssetBalance.test.tsx`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- `cd frontend && npx playwright test --config playwright.ci.config.ts e2e/assetbalance-flow.spec.ts`

## 補足
- 直接 `npx playwright test e2e/assetbalance-flow.spec.ts` は通常設定がサーバー手動起動前提のため timeout。CI configで再実行し通過確認済み
- 初回E2E実行前にローカルPlaywright Chromiumが不足していたため `npx playwright install chromium` を実行

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* ポートフォリオの詳細な評価プロンプトをワンクリックでコピーできる機能を追加しました。保有資産の詳細情報と集計データを含むプロンプトをクリップボードにコピーでき、外部のAIツールで活用できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->