### PR TITLE
fix: 保有株総評プロンプトの入力情報を絞る

### DIFF
--- a/frontend/src/features/assetBalance/components/AssetBalanceUtilityRail.tsx
+++ b/frontend/src/features/assetBalance/components/AssetBalanceUtilityRail.tsx
@@ -19,7 +19,6 @@ export interface AssetBalanceUtilityRailProps {
   };
   reviewPromptCardProps: {
     assetBalanceData: AssetBalanceData[];
-    dividendPerShareMap: Map<string, number>;
   };
 }
 

--- a/frontend/src/features/assetBalance/components/AssetReviewPromptCard.tsx
+++ b/frontend/src/features/assetBalance/components/AssetReviewPromptCard.tsx
@@ -4,16 +4,12 @@ import type { AssetBalanceData } from '@/types/api';
 import { generateAssetReviewPrompt } from '../utils/assetReviewPrompt';
 export interface AssetReviewPromptCardProps {
   assetBalanceData: AssetBalanceData[];
-  dividendPerShareMap: Map<string, number>;
 }
 type CopyStatus = 'idle' | 'success' | 'error';
-export function AssetReviewPromptCard({
-  assetBalanceData,
-  dividendPerShareMap,
-}: AssetReviewPromptCardProps) {
+export function AssetReviewPromptCard({ assetBalanceData }: AssetReviewPromptCardProps) {
   const [status, setStatus] = useState<CopyStatus>('idle');
   const handleCopy = async () => {
-    const prompt = generateAssetReviewPrompt(assetBalanceData, dividendPerShareMap);
+    const prompt = generateAssetReviewPrompt(assetBalanceData);
     try {
       await navigator.clipboard.writeText(prompt);
       setStatus('success');
@@ -24,8 +20,11 @@ export function AssetReviewPromptCard({
     }
   };
   const disabled = assetBalanceData.length === 0;
-  const buttonLabel =
-    status === 'success' ? 'コピーしました！' : 'AI総評プロンプトをコピー';
+  const buttonLabel = status === 'success'
+    ? 'コピーしました！'
+    : status === 'error'
+      ? 'コピーに失敗しました'
+      : 'AI総評プロンプトをコピー';
   return (
     <div className="px-5 py-4">
       <p className="text-xs font-medium text-secondary mb-2">AI総評プロンプト</p>
@@ -40,10 +39,6 @@ export function AssetReviewPromptCard({
       >
         {buttonLabel}
       </Button>
-      <p role="status" aria-live="polite" className="text-xs mt-1 min-h-[1rem]">
-        {status === 'success' && 'コピーしました'}
-        {status === 'error' && 'コピーに失敗しました。手動でテキストをコピーしてください。'}
-      </p>
     </div>
   );
 }

--- a/frontend/src/features/assetBalance/components/__tests__/AssetBalanceUtilityRail.test.tsx
+++ b/frontend/src/features/assetBalance/components/__tests__/AssetBalanceUtilityRail.test.tsx
@@ -34,7 +34,6 @@ const actionRailProps = {
 
 const reviewPromptCardProps = {
   assetBalanceData: [],
-  dividendPerShareMap: new Map<string, number>(),
 };
 
 describe('AssetBalanceUtilityRail', () => {

--- a/frontend/src/features/assetBalance/components/__tests__/AssetReviewPromptCard.test.tsx
+++ b/frontend/src/features/assetBalance/components/__tests__/AssetReviewPromptCard.test.tsx
@@ -30,40 +30,25 @@ describe('AssetReviewPromptCard', () => {
   });
 
   it('保有データありのときコピーボタンを表示する', () => {
-    render(
-      <AssetReviewPromptCard
-        assetBalanceData={singleAsset}
-        dividendPerShareMap={new Map()}
-      />
-    );
+    render(<AssetReviewPromptCard assetBalanceData={singleAsset} />);
     expect(screen.getByRole('button', { name: /AI総評プロンプトをコピー/ })).toBeInTheDocument();
   });
 
   it('保有データ0件のときボタンをdisabledにする', () => {
-    render(
-      <AssetReviewPromptCard
-        assetBalanceData={[]}
-        dividendPerShareMap={new Map()}
-      />
-    );
+    render(<AssetReviewPromptCard assetBalanceData={[]} />);
     expect(screen.getByRole('button', { name: /AI総評プロンプトをコピー/ })).toBeDisabled();
   });
 
-  it('コピー成功時に成功メッセージを表示する', async () => {
+  it('コピー成功時にボタン文言で成功状態を表示する', async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     Object.assign(navigator, { clipboard: { writeText } });
 
-    render(
-      <AssetReviewPromptCard
-        assetBalanceData={singleAsset}
-        dividendPerShareMap={new Map()}
-      />
-    );
+    render(<AssetReviewPromptCard assetBalanceData={singleAsset} />);
 
     fireEvent.click(screen.getByRole('button', { name: /AI総評プロンプトをコピー/ }));
 
     await waitFor(() => {
-      expect(screen.getByRole('status')).toHaveTextContent('コピーしました');
+      expect(screen.getByRole('button', { name: /コピーしました！/ })).toBeInTheDocument();
     });
     expect(writeText).toHaveBeenCalledTimes(1);
   });
@@ -72,12 +57,7 @@ describe('AssetReviewPromptCard', () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     Object.assign(navigator, { clipboard: { writeText } });
 
-    render(
-      <AssetReviewPromptCard
-        assetBalanceData={singleAsset}
-        dividendPerShareMap={new Map()}
-      />
-    );
+    render(<AssetReviewPromptCard assetBalanceData={singleAsset} />);
 
     fireEvent.click(screen.getByRole('button', { name: /AI総評プロンプトをコピー/ }));
 
@@ -90,28 +70,12 @@ describe('AssetReviewPromptCard', () => {
     const writeText = vi.fn().mockRejectedValue(new Error('denied'));
     Object.assign(navigator, { clipboard: { writeText } });
 
-    render(
-      <AssetReviewPromptCard
-        assetBalanceData={singleAsset}
-        dividendPerShareMap={new Map()}
-      />
-    );
+    render(<AssetReviewPromptCard assetBalanceData={singleAsset} />);
 
     fireEvent.click(screen.getByRole('button', { name: /AI総評プロンプトをコピー/ }));
 
     await waitFor(() => {
-      expect(screen.getByText(/コピーに失敗しました/)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /コピーに失敗しました/ })).toBeInTheDocument();
     });
-  });
-
-  it('aria-live 領域が存在する', () => {
-    render(
-      <AssetReviewPromptCard
-        assetBalanceData={singleAsset}
-        dividendPerShareMap={new Map()}
-      />
-    );
-    const liveRegion = screen.getByRole('status');
-    expect(liveRegion).toHaveAttribute('aria-live');
   });
 });

--- a/frontend/src/features/assetBalance/hooks/useAssetBalanceState.ts
+++ b/frontend/src/features/assetBalance/hooks/useAssetBalanceState.ts
@@ -165,7 +165,6 @@ export function useAssetBalanceState() {
     },
     reviewPromptCardProps: {
       assetBalanceData,
-      dividendPerShareMap: dividendPerShareMap as Map<string, number>,
     },
   };
 

--- a/frontend/src/features/assetBalance/utils/__tests__/assetReviewPrompt.test.ts
+++ b/frontend/src/features/assetBalance/utils/__tests__/assetReviewPrompt.test.ts
@@ -39,78 +39,77 @@ describe('generateAssetReviewPrompt', () => {
     }),
   ];
 
-  it('投資助言ではなく判断材料整理である旨を含む', () => {
-    const result = generateAssetReviewPrompt(singleAsset, new Map());
-    expect(result).toMatch(/投資助言|売買推奨/);
-    expect(result).toMatch(/判断材料/);
+  it('金融商品取引業者・投資顧問の助言ではないこと、売買指示・断定的推奨を避けることを明記する', () => {
+    const result = generateAssetReviewPrompt(singleAsset);
+    expect(result).toMatch(/金融商品取引業者|投資顧問/);
+    expect(result).toMatch(/売買指示|断定的推奨/);
   });
 
-  it('ポートフォリオレビューの役割指定を含む', () => {
-    const result = generateAssetReviewPrompt(singleAsset, new Map());
-    expect(result).toMatch(/ポートフォリオ/);
+  it('リサーチアシスタントの役割指定を含む', () => {
+    const result = generateAssetReviewPrompt(singleAsset);
+    expect(result).toMatch(/リサーチアシスタント/);
   });
 
   it('全銘柄コードと銘柄名を含む', () => {
-    const result = generateAssetReviewPrompt(multiAssets, new Map());
+    const result = generateAssetReviewPrompt(multiAssets);
     expect(result).toContain('7203');
     expect(result).toContain('トヨタ自動車');
     expect(result).toContain('6758');
     expect(result).toContain('ソニーグループ');
   });
 
-  it('集計値（銘柄数・合計取得金額・合計評価額・評価損益額）を含む', () => {
-    const result = generateAssetReviewPrompt(multiAssets, new Map());
-    // 銘柄数
-    expect(result).toMatch(/2\s*銘柄|銘柄数.+2/);
-    // 合計取得金額: 250,000 + 600,000 = 850,000
-    expect(result).toMatch(/850,000|850000/);
-    // 合計評価額: 260,000 + 575,000 = 835,000
-    expect(result).toMatch(/835,000|835000/);
-    // 評価損益額: 835,000 - 850,000 = -15,000
-    expect(result).toMatch(/-15,000|-15000/);
+  it('集計セクションを含まず、保有銘柄テーブルだけを入力情報として渡す', () => {
+    const result = generateAssetReviewPrompt(multiAssets);
+    expect(result).not.toContain('集計:');
+    expect(result).not.toContain('保有銘柄数');
   });
 
-  it('dividendPerShareMap がある銘柄は配当値を含む', () => {
-    const divMap = new Map([['7203', 80]]);
-    const result = generateAssetReviewPrompt(singleAsset, divMap);
-    expect(result).toMatch(/80/);
+  it('保有株数・平均取得単価をテーブルに含む', () => {
+    const result = generateAssetReviewPrompt(singleAsset);
+    expect(result).toMatch(/100/);           // shares
+    expect(result).toMatch(/2,500|2500/);    // average_purchase_price
   });
 
-  it('dividendPerShareMap にない銘柄は「不明」と表示する', () => {
-    const result = generateAssetReviewPrompt(singleAsset, new Map());
-    expect(result).toMatch(/不明/);
+  it('テーブルヘッダーに現在値・取得額・評価額・評価損益額・損益率・推定1株配当を含まない', () => {
+    const result = generateAssetReviewPrompt(singleAsset);
+    const headerLine = result.split('\n').find((line) => line.startsWith('銘柄コード'));
+    expect(headerLine).toBeDefined();
+    expect(headerLine).not.toContain('現在値');
+    expect(headerLine).not.toContain('取得額');
+    expect(headerLine).not.toContain('評価額');
+    expect(headerLine).not.toContain('評価損益額');
+    expect(headerLine).not.toContain('損益率');
+    expect(headerLine).not.toContain('推定1株配当');
+  });
+
+  it('最新の公開情報を確認するよう外部AIへ指示する', () => {
+    const result = generateAssetReviewPrompt(singleAsset);
+    expect(result).toMatch(/公開情報/);
+    expect(result).toMatch(/最新/);
+    expect(result).toMatch(/株価|配当|業績|ニュース/);
+  });
+
+  it('投資目的・期間・リスク許容度等の不足情報を追加質問として列挙するよう指示する', () => {
+    const result = generateAssetReviewPrompt(singleAsset);
+    expect(result).toMatch(/投資目的/);
+    expect(result).toMatch(/リスク許容度/);
+    expect(result).toMatch(/追加質問/);
   });
 
   it('データが空の場合でもエラーを出さず空プロンプトを返す', () => {
-    expect(() => generateAssetReviewPrompt([], new Map())).not.toThrow();
-    const result = generateAssetReviewPrompt([], new Map());
+    expect(() => generateAssetReviewPrompt([])).not.toThrow();
+    const result = generateAssetReviewPrompt([]);
     expect(typeof result).toBe('string');
   });
 
   it('個人識別情報（メール・ユーザーID）を含まない', () => {
-    const result = generateAssetReviewPrompt(multiAssets, new Map());
+    const result = generateAssetReviewPrompt(multiAssets);
     expect(result).not.toMatch(/@/);
     expect(result).not.toMatch(/user_id|userId/);
   });
 
-  it('保有株数・平均取得単価・現在値・取得額・評価額・損益率を含む', () => {
-    const result = generateAssetReviewPrompt(singleAsset, new Map());
-    expect(result).toMatch(/100/);   // shares
-    expect(result).toMatch(/2,500|2500/); // average_purchase_price
-    expect(result).toMatch(/2,600|2600/); // current_price
-    expect(result).toMatch(/250,000|250000/); // total_purchase_amount
-    expect(result).toMatch(/260,000|260000/); // market_value
-    expect(result).toMatch(/4\.0|4\.00/);  // profit_loss_rate
-  });
-
-  it('各銘柄の評価損益額（market_value - total_purchase_amount）を含む', () => {
-    // トヨタ: 260,000 - 250,000 = 10,000
-    const result = generateAssetReviewPrompt(singleAsset, new Map());
-    expect(result).toMatch(/10,000|10000/);
-  });
-
   it('外部AIへ不足情報の質問を促す文言を含む', () => {
-    const result = generateAssetReviewPrompt(singleAsset, new Map());
+    const result = generateAssetReviewPrompt(singleAsset);
     expect(result).toMatch(/質問|不足|情報/);
   });
 });

--- a/frontend/src/features/assetBalance/utils/assetReviewPrompt.ts
+++ b/frontend/src/features/assetBalance/utils/assetReviewPrompt.ts
@@ -4,83 +4,40 @@ function fmt(value: number): string {
   return value.toLocaleString('ja-JP');
 }
 
-function fmtRate(value: number): string {
-  return `${value.toFixed(2)}%`;
-}
+export function generateAssetReviewPrompt(assets: AssetBalanceData[]): string {
+  const header = ['銘柄コード', '銘柄名', '保有株数', '平均取得単価'].join(' | ');
 
-export function generateAssetReviewPrompt(
-  assets: AssetBalanceData[],
-  dividendPerShareMap: Map<string, number>
-): string {
-  const totalPurchase = assets.reduce((sum, a) => sum + a.total_purchase_amount, 0);
-  const totalMarketValue = assets.reduce((sum, a) => sum + a.market_value, 0);
-  const totalProfitLoss = totalMarketValue - totalPurchase;
-  const totalProfitLossRate =
-    totalPurchase > 0 ? (totalProfitLoss / totalPurchase) * 100 : 0;
-
-  const summaryLines = [
-    `- 保有銘柄数: ${assets.length}銘柄`,
-    `- 合計取得金額: ¥${fmt(totalPurchase)}`,
-    `- 合計評価額: ¥${fmt(totalMarketValue)}`,
-    `- 評価損益額: ¥${fmt(totalProfitLoss)}`,
-    `- 評価損益率: ${fmtRate(totalProfitLossRate)}`,
-  ].join('\n');
-
-  const header = [
-    '銘柄コード',
-    '銘柄名',
-    '保有株数',
-    '平均取得単価',
-    '現在値',
-    '取得額',
-    '評価額',
-    '評価損益額',
-    '損益率',
-    '推定1株配当',
-  ].join(' | ');
-
-  const rows = assets.map((a) => {
-    const profitLossAmount = a.market_value - a.total_purchase_amount;
-    const div = dividendPerShareMap.has(a.security_code)
-      ? `¥${dividendPerShareMap.get(a.security_code)}`
-      : '不明';
-    return [
+  const rows = assets.map((a) =>
+    [
       a.security_code,
       a.security_name,
       fmt(a.shares),
       `¥${fmt(a.average_purchase_price)}`,
-      `¥${fmt(a.current_price)}`,
-      `¥${fmt(a.total_purchase_amount)}`,
-      `¥${fmt(a.market_value)}`,
-      `¥${fmt(profitLossAmount)}`,
-      fmtRate(a.profit_loss_rate),
-      div,
-    ].join(' | ');
-  });
+    ].join(' | ')
+  );
 
-  return `あなたは日本株ポートフォリオをレビューする投資分析アシスタントです。
-以下の保有銘柄データをもとに、ポートフォリオ全体の総評をしてください。
+  return `あなたは日本株の公開情報調査を支援するリサーチアシスタントです。
+証券アナリストの観点で、事実確認・論点整理・リスク整理を行ってください。
+なお、このプロンプトによる回答は金融商品取引業者・投資顧問としての助言ではなく、売買指示・目標株価・断定的推奨を行うものではありません。
 
-【重要な注意事項】
-このプロンプトで求めるのは投資助言・売買推奨ではありません。
-判断材料の整理・リスク観点・確認事項として回答してください。
-確定的な予測や断定的な表現は避け、検討観点と質問リストを提示してください。
+以下の保有銘柄データをもとに、ポートフォリオ全体の論点を整理してください。
 
-【お願いしたい分析項目】
-1. ポートフォリオ全体の総評
+【重要】
+- 株価・配当・業績・ニュース・決算・各種指標は、最新の公開情報を確認してから扱ってください
+- このアプリから渡す保有データだけで含み損益や時価評価を判断しないでください
+- 確認できない情報は推測せず「不明」または「要確認」と明記してください
+- 銘柄コードが曖昧な場合は、市場・上場銘柄の確認から始めてください
+- 売買指示・目標株価・断定的推奨は避け、論点整理・リスク・確認すべき質問・追加調査項目に限定してください
+- 投資目的、投資期間、リスク許容度、流動性需要、税務状況、他の資産状況が不足しているため、個別判断が必要な場合は追加質問として列挙してください
+
+【お願いしたい項目】
+1. ポートフォリオ全体の論点整理
 2. 集中リスク・業種偏り・銘柄偏りの読み取り
-3. 損益状況の読み取り（含み益/損の分布）
-4. 配当観点のコメント（推定配当が不明な銘柄は不明として扱う）
-5. 追加で確認すべきIR・決算・ニュース・指標
-6. 売買指示ではなく、検討すべき観点と質問リスト
+3. 最新の株価・配当・業績・ニュース・指標を公開情報で確認し、論点を整理
+4. 追加で確認すべきIR・決算・ニュース・指標
+5. 個別判断に必要な追加質問リスト
 
 【保有銘柄データ】
-集計:
-${summaryLines}
-
-各銘柄:
 ${header}
-${rows.join('\n')}
-
-不足している情報があれば、分析に必要な情報として質問してください。`;
+${rows.join('\n')}`;
 }


### PR DESCRIPTION
## 概要
- AI総評プロンプトの入力情報を「銘柄コード・銘柄名・保有株数・平均取得単価」のみに縮小
- 最新性を保証できない評価系・価格系・配当推定情報を削除
- コピー成功/失敗表示をボタン文言へ集約し、空の status 領域を削除

## 削除した情報
- 合計評価額 / 評価損益額 / 評価損益率
- 現在値 / 取得額 / 評価額 / 損益率
- 推定1株配当
- 保有銘柄数などの集計セクション

## 設計理由
アプリ内の価格・評価・配当推定は、外部AIへ貼る時点で最新・正確とは限らないため、プロンプトへ事実として渡さない。AIには最新の公開情報確認と論点整理を依頼する。

## 検証
- cd frontend && npm test -- --run src/features/assetBalance
- cd frontend && npm test -- --run src/pages/__tests__/AssetBalance.test.tsx
- cd frontend && npm run lint
- cd frontend && npm run build
- cd frontend && npx playwright test --config playwright.ci.config.ts e2e/assetbalance-flow.spec.ts