### PR TITLE
フロントエンド主要画面のデザインを再構築

### DIFF
--- a/frontend/src/components/atoms/Alert.tsx
+++ b/frontend/src/components/atoms/Alert.tsx
@@ -9,16 +9,16 @@ interface AlertProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 const variantClasses: Record<AlertVariant, string> = {
-  info: 'bg-info/10 text-info border-info/30',
-  warning: 'bg-warning/15 text-warning border-warning/40',
-  danger: 'bg-danger/10 text-danger border-danger/30',
-  success: 'bg-success/10 text-success border-success/30',
+  info: 'border-blue-200 bg-blue-50 text-blue-800',
+  warning: 'border-amber-200 bg-amber-50 text-amber-900',
+  danger: 'border-red-200 bg-red-50 text-red-700',
+  success: 'border-teal-200 bg-teal-50 text-teal-800',
 };
 
 export function Alert({ children, variant = 'info', className, ...rest }: AlertProps) {
   return (
     <div
-      className={cn('rounded-md border px-4 py-3 text-sm', variantClasses[variant], className)}
+      className={cn('rounded-lg border px-4 py-3 text-sm font-medium shadow-sm', variantClasses[variant], className)}
       role="alert"
       {...rest}
     >

--- a/frontend/src/components/atoms/Button.tsx
+++ b/frontend/src/components/atoms/Button.tsx
@@ -18,31 +18,29 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   iconPosition?: 'left' | 'right';
 }
 
-// バリアント別のスタイル定義
 const variantStyles: Record<ButtonVariant, string> = {
-  primary: 'bg-primary text-white hover:bg-primary-hover active:bg-primary-dark',
-  secondary: 'bg-secondary text-white hover:bg-secondary-hover',
-  success: 'bg-success text-white hover:bg-success-hover',
-  danger: 'bg-danger text-white hover:bg-danger-hover',
-  warning: 'bg-warning text-dark hover:bg-warning-hover',
-  info: 'bg-info text-dark hover:bg-info-hover',
-  light: 'bg-light text-dark hover:bg-gray-200',
-  dark: 'bg-dark text-white hover:bg-gray-800',
-  'outline-primary': 'border border-primary text-primary hover:bg-primary hover:text-white',
-  'outline-secondary': 'border border-secondary text-secondary hover:bg-secondary hover:text-white',
-  'outline-success': 'border border-success text-success hover:bg-success hover:text-white',
+  primary: 'border border-slate-950 bg-slate-950 text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.12)] hover:bg-slate-800 active:bg-slate-950',
+  secondary: 'border border-slate-300 bg-white text-slate-800 hover:border-slate-500 hover:bg-slate-50',
+  success: 'border border-teal-700 bg-teal-700 text-white hover:bg-teal-800',
+  danger: 'border border-danger bg-danger text-white hover:bg-danger-hover',
+  warning: 'border border-amber-500 bg-amber-500 text-slate-950 hover:bg-amber-600',
+  info: 'border border-blue-600 bg-blue-600 text-white hover:bg-blue-700',
+  light: 'border border-slate-200 bg-white text-slate-900 hover:bg-slate-100',
+  dark: 'border border-slate-950 bg-slate-950 text-white hover:bg-slate-800',
+  'outline-primary': 'border border-slate-950 text-slate-950 hover:bg-slate-950 hover:text-white',
+  'outline-secondary': 'border border-slate-300 text-slate-700 hover:border-slate-500 hover:bg-slate-50',
+  'outline-success': 'border border-teal-700 text-teal-700 hover:bg-teal-700 hover:text-white',
   'outline-danger': 'border border-danger text-danger hover:bg-danger hover:text-white',
-  'outline-warning': 'border border-amber-600 text-amber-700 hover:bg-warning hover:text-dark',
-  'outline-info': 'border border-info text-info hover:bg-info hover:text-dark',
-  'outline-light': 'border border-light text-light hover:bg-light hover:text-dark',
-  'outline-dark': 'border border-dark text-dark hover:bg-dark hover:text-white',
+  'outline-warning': 'border border-amber-600 text-amber-700 hover:bg-amber-500 hover:text-slate-950',
+  'outline-info': 'border border-blue-600 text-blue-700 hover:bg-blue-600 hover:text-white',
+  'outline-light': 'border border-white/70 text-white hover:bg-white hover:text-slate-950',
+  'outline-dark': 'border border-slate-950 text-slate-950 hover:bg-slate-950 hover:text-white',
 };
 
-// サイズ別のスタイル定義
 const sizeStyles: Record<ButtonSize, string> = {
-  sm: 'px-2 py-1 text-sm',
-  md: 'px-3 py-1.5 text-base',
-  lg: 'px-4 py-2 text-lg',
+  sm: 'px-3 py-1.5 text-sm',
+  md: 'px-4 py-2 text-sm',
+  lg: 'px-5 py-2.5 text-base',
 };
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(
@@ -61,7 +59,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     },
     ref
   ) => {
-    const baseClasses = 'inline-flex items-center justify-center font-medium rounded transition-colors focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-primary/50 disabled:opacity-65 disabled:cursor-not-allowed no-print';
+    const baseClasses = 'inline-flex items-center justify-center rounded-md font-bold transition-[background-color,border-color,color,box-shadow,transform] focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 no-print';
     const variantClass = variantStyles[variant];
     const sizeClass = sizeStyles[size];
     const widthClass = fullWidth ? 'w-full' : '';

--- a/frontend/src/components/atoms/Card.tsx
+++ b/frontend/src/components/atoms/Card.tsx
@@ -16,12 +16,11 @@ interface CardBodyProps extends HTMLAttributes<HTMLDivElement> {
   children: ReactNode;
 }
 
-
 export function Card({ children, className, ...rest }: CardProps) {
   return (
     <div
       className={cn(
-        'rounded-lg border border-border bg-white shadow-sm print:border-black print:shadow-none',
+        'rounded-xl border border-slate-950/10 bg-white/90 shadow-[0_14px_38px_-32px_rgba(15,23,42,0.85)] backdrop-blur-sm print:border-black print:shadow-none',
         className
       )}
       {...rest}
@@ -33,14 +32,14 @@ export function Card({ children, className, ...rest }: CardProps) {
 
 export function CardHeader({ children, variant = 'default', className, ...rest }: CardHeaderProps) {
   const variantClasses: Record<CardVariant, string> = {
-    primary: 'bg-slate-700 text-white',
-    secondary: 'bg-slate-500 text-white',
-    default: 'border-b border-border bg-white text-dark',
+    primary: 'border-b border-slate-950/10 bg-slate-950 text-white',
+    secondary: 'border-b border-slate-950/10 bg-slate-900 text-white',
+    default: 'border-b border-slate-950/10 bg-white/80 text-dark',
   };
 
   return (
     <div
-      className={cn('px-4 py-2', variantClasses[variant], className)}
+      className={cn('px-4 py-3', variantClasses[variant], className)}
       {...rest}
     >
       {children}
@@ -55,4 +54,3 @@ export function CardBody({ children, className, ...rest }: CardBodyProps) {
     </div>
   );
 }
-

--- a/frontend/src/components/atoms/EmptyState.tsx
+++ b/frontend/src/components/atoms/EmptyState.tsx
@@ -9,20 +9,15 @@ interface EmptyStateProps {
   description?: string;
   action?: ReactNode;
   className?: string;
-  /** 見出しレベル（デフォルト: h3） */
   headingLevel?: HeadingLevel;
 }
 
 const headingStyles: Record<HeadingLevel, string> = {
-  h1: 'text-2xl font-bold text-slate-900',
-  h2: 'text-xl font-bold text-slate-900',
-  h3: 'text-base font-semibold text-slate-900',
+  h1: 'text-2xl font-black text-slate-950',
+  h2: 'text-xl font-black text-slate-950',
+  h3: 'text-base font-black text-slate-950',
 };
 
-/**
- * 空状態を表示するコンポーネント
- * データがない場合やエラー時に使用
- */
 export function EmptyState({
   icon,
   title,
@@ -36,7 +31,7 @@ export function EmptyState({
   return (
     <div
       className={cn(
-        'flex flex-col items-center justify-center py-8 px-4 text-center',
+        'flex flex-col items-center justify-center rounded-xl border border-dashed border-slate-300 bg-slate-50/70 px-4 py-8 text-center',
         className
       )}
     >
@@ -47,7 +42,7 @@ export function EmptyState({
       )}
       <Heading className={headingStyles[headingLevel]}>{title}</Heading>
       {description && (
-        <p className="mt-1.5 max-w-md text-sm text-slate-600">{description}</p>
+        <p className="mt-1.5 max-w-md text-sm font-medium text-slate-600">{description}</p>
       )}
       {action ? <div className="mt-4">{action}</div> : null}
     </div>

--- a/frontend/src/components/atoms/InputField.tsx
+++ b/frontend/src/components/atoms/InputField.tsx
@@ -28,17 +28,14 @@ const InputField = forwardRef<HTMLInputElement, InputFieldProps>(
     const generatedId = useId();
     const inputId = id || generatedId;
 
-    // ベーススタイル
-    const baseInputClasses = 'block px-3 py-1.5 text-base text-dark bg-white border rounded transition-colors focus:outline-none focus:ring-2 focus:ring-primary/25';
+    const baseInputClasses = 'block px-3 py-2 text-sm font-medium text-slate-950 bg-white border rounded-md transition-[border-color,box-shadow,background-color] placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-amber-500/25';
 
-    // バリアント別スタイル
     const variantClasses = {
-      outlined: 'border-gray-300 focus:border-primary',
-      filled: 'border-gray-300 bg-gray-100 focus:border-primary focus:bg-white',
-      standard: 'border-0 border-b border-gray-300 rounded-none focus:border-primary',
+      outlined: 'border-slate-300 focus:border-amber-600',
+      filled: 'border-slate-200 bg-slate-50 focus:border-amber-600 focus:bg-white',
+      standard: 'border-0 border-b border-slate-300 rounded-none focus:border-amber-600',
     };
 
-    // エラー時のスタイル
     const errorClasses = error
       ? 'border-danger focus:border-danger focus:ring-danger/25'
       : '';
@@ -54,7 +51,7 @@ const InputField = forwardRef<HTMLInputElement, InputFieldProps>(
     ].filter(Boolean).join(' ');
 
     const labelElement = label && (
-      <label htmlFor={inputId} className="block mb-1 text-sm font-medium text-dark">
+      <label htmlFor={inputId} className="mb-1 block text-sm font-bold text-slate-800">
         {label}
         {required ? <span className="text-danger ml-1">*</span> : null}
       </label>

--- a/frontend/src/components/atoms/PageHeader.tsx
+++ b/frontend/src/components/atoms/PageHeader.tsx
@@ -8,18 +8,15 @@ interface PageHeaderProps {
   className?: string;
 }
 
-/**
- * ページタイトル用の見出しコンポーネント
- * H1レベルの見出しとして使用
- */
 export function PageHeader({ title, description, actions, className }: PageHeaderProps) {
   return (
-    <div className={cn('mb-4', className)}>
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+    <div className={cn('mb-5', className)}>
+      <div className="flex flex-col gap-3 border-l-4 border-amber-500 pl-4 sm:flex-row sm:items-end sm:justify-between">
         <div>
-          <h1 className="text-xl font-bold text-slate-900">{title}</h1>
+          <p className="mb-1 text-[11px] font-bold uppercase tracking-[0.22em] text-slate-500">Workspace</p>
+          <h1 className="text-2xl font-black leading-tight tracking-normal text-slate-950">{title}</h1>
           {description ? (
-            <p className="mt-0.5 text-sm text-slate-600">{description}</p>
+            <p className="mt-1 text-sm font-medium text-slate-600">{description}</p>
           ) : null}
         </div>
         {actions ? <div className="flex items-center gap-2">{actions}</div> : null}

--- a/frontend/src/components/atoms/SecurityCodeLink.tsx
+++ b/frontend/src/components/atoms/SecurityCodeLink.tsx
@@ -22,8 +22,8 @@ export const SecurityCodeLink: React.FC<SecurityCodeLinkProps> = ({ value, class
     return <span>{code}</span>;
   }
 
-  const baseClassName = 'security-code-link text-primary font-semibold hover:underline';
-  const combinedClassName = className ? `${baseClassName} ${className}` : baseClassName;
+  const baseClassName = 'security-code-link font-bold text-blue-700 underline-offset-2 hover:text-blue-900 hover:underline focus-visible:rounded-sm focus-visible:outline-2 focus-visible:outline-blue-500';
+  const combinedClassName = className ? `${className} ${baseClassName}` : baseClassName;
 
   return (
     <a

--- a/frontend/src/components/atoms/SecurityCodeLink.tsx
+++ b/frontend/src/components/atoms/SecurityCodeLink.tsx
@@ -5,6 +5,8 @@ interface SecurityCodeLinkProps {
   className?: string;
 }
 
+const FONT_WEIGHT_CLASS_REGEX = /\bfont-(?:thin|extralight|light|normal|medium|semibold|bold|extrabold|black)\b/;
+
 /**
  * 銘柄コードをリンクとして表示するコンポーネント
  * - 銘柄コードを正規化してパラメータ検証
@@ -22,8 +24,9 @@ export const SecurityCodeLink: React.FC<SecurityCodeLinkProps> = ({ value, class
     return <span>{code}</span>;
   }
 
-  const baseClassName = 'security-code-link font-bold text-blue-700 underline-offset-2 hover:text-blue-900 hover:underline focus-visible:rounded-sm focus-visible:outline-2 focus-visible:outline-blue-500';
-  const combinedClassName = className ? `${className} ${baseClassName}` : baseClassName;
+  const baseClassName = 'security-code-link text-blue-700 underline-offset-2 hover:text-blue-900 hover:underline focus-visible:rounded-sm focus-visible:outline-2 focus-visible:outline-blue-500';
+  const fontWeightClassName = className && FONT_WEIGHT_CLASS_REGEX.test(className) ? '' : 'font-bold';
+  const combinedClassName = [className, fontWeightClassName, baseClassName].filter(Boolean).join(' ');
 
   return (
     <a

--- a/frontend/src/components/atoms/Table.tsx
+++ b/frontend/src/components/atoms/Table.tsx
@@ -37,14 +37,13 @@ interface TableCellProps extends HTMLAttributes<HTMLTableCellElement> {
   colSpan?: number;
 }
 
-// バリアント別の背景色
 const variantBgColors: Record<string, string> = {
-  primary: 'bg-primary/10',
+  primary: 'bg-slate-950/10',
   secondary: 'bg-secondary/10',
-  success: 'bg-success/10',
+  success: 'bg-teal-50',
   danger: 'bg-danger/10',
-  warning: 'bg-warning/10',
-  info: 'bg-info/10',
+  warning: 'bg-amber-50',
+  info: 'bg-blue-50',
   light: 'bg-light',
   dark: 'bg-dark text-white',
 };
@@ -77,18 +76,18 @@ const Table = forwardRef<HTMLTableElement, TableProps>(
       forceResize,
     });
 
-    // CSSクラスの構築（モバイル対応: パディング縮小、フォント調整）
     const tableClasses = cn(
-      'w-full table-fixed text-left border-collapse',
-      small ? 'text-[12px] leading-5 sm:text-[13px]' : 'text-sm sm:text-[15px]',
+      'w-full table-fixed border-collapse text-left',
+      small ? 'text-[12px] leading-5 sm:text-[13px]' : 'text-sm sm:text-[14px]',
       bordered && '[&_th]:border [&_th]:border-slate-200 [&_td]:border [&_td]:border-slate-200 print:[&_th]:border-black print:[&_td]:border-black',
       small
         ? '[&_th]:py-1.5 [&_th]:px-2 [&_td]:py-1.5 [&_td]:px-2 sm:[&_th]:py-2 sm:[&_th]:px-2.5 sm:[&_td]:py-2 sm:[&_td]:px-2.5'
         : '[&_th]:py-2 [&_th]:px-2.5 [&_td]:py-2 [&_td]:px-2.5 sm:[&_th]:py-2.5 sm:[&_th]:px-3 sm:[&_td]:py-2.5 sm:[&_td]:px-3',
       '[&_th]:whitespace-nowrap [&_td]:whitespace-nowrap [&_th]:overflow-hidden [&_td]:overflow-hidden [&_th]:text-ellipsis [&_td]:text-ellipsis',
+      '[&_tbody_td]:border-b [&_tbody_td]:border-slate-100 [&_tbody_th]:border-b [&_tbody_th]:border-slate-100',
       variant && variantBgColors[variant],
-      striped && '[&_tbody_tr:nth-child(even)]:bg-slate-50',
-      hover && '[&_tbody_tr:hover]:bg-slate-100',
+      striped && '[&_tbody_tr:nth-child(even)]:bg-slate-50/80',
+      hover && '[&_tbody_tr:hover]:bg-amber-50/60',
       className
     );
 
@@ -98,7 +97,6 @@ const Table = forwardRef<HTMLTableElement, TableProps>(
       </table>
     );
 
-    // レスポンシブまたは自動高さが有効な場合はラッパーで包む
     if (responsive || autoHeight) {
       const containerStyle = autoHeight
         ? {
@@ -112,7 +110,7 @@ const Table = forwardRef<HTMLTableElement, TableProps>(
         <div
           ref={containerRef}
           className={cn(
-            'relative w-full overflow-x-hidden rounded-md',
+            'relative w-full overflow-x-hidden rounded-lg border border-slate-950/10 bg-white',
             '[&::-webkit-scrollbar]:h-2.5 [&::-webkit-scrollbar-track]:bg-slate-100 [&::-webkit-scrollbar-thumb]:bg-slate-400 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:hover:bg-slate-500'
           )}
           style={containerStyle}
@@ -131,9 +129,9 @@ Table.displayName = 'Table';
 const TableHeader = forwardRef<HTMLTableSectionElement, TableHeaderProps>(
   ({ children, variant, stickyTop = true, className, ...rest }, ref) => {
     const headerClasses = cn(
-      'bg-slate-50',
+      'bg-slate-100 text-slate-800',
       variant === 'light' && 'bg-slate-100',
-      variant === 'dark' && 'bg-slate-800 text-white',
+      variant === 'dark' && 'bg-slate-950 text-white',
       stickyTop && 'sticky top-0 z-10',
       className
     );
@@ -164,7 +162,7 @@ const TableRow = forwardRef<HTMLTableRowElement, TableRowProps>(
   ({ children, active = false, variant, className, ...rest }, ref) => {
     const rowClasses = cn(
       '[&_th]:align-middle [&_td]:align-middle',
-      active && 'bg-primary/10',
+      active && 'bg-amber-50',
       variant && variantBgColors[variant],
       className
     );
@@ -193,7 +191,7 @@ const TableCell = forwardRef<HTMLTableCellElement, TableCellProps>(
   ) => {
     const Cell = as;
     const scopeAttr = as === 'th' ? { scope } : {};
-    const cellClasses = cn(as === 'th' && 'font-semibold text-slate-700', className);
+    const cellClasses = cn(as === 'th' && 'font-black text-slate-800', className);
 
     return (
       <Cell ref={ref} className={cellClasses} {...scopeAttr} {...rest} colSpan={colSpan}>

--- a/frontend/src/components/atoms/__tests__/Alert.test.tsx
+++ b/frontend/src/components/atoms/__tests__/Alert.test.tsx
@@ -7,24 +7,24 @@ describe('Alert', () => {
 
     const alert = screen.getByRole('alert');
     expect(alert).toHaveTextContent('お知らせ');
-    expect(alert).toHaveClass('bg-info/10');
+    expect(alert).toHaveClass('bg-blue-50');
   });
 
   it('warning variant のクラスを適用する', () => {
     render(<Alert variant="warning">警告</Alert>);
 
-    expect(screen.getByRole('alert')).toHaveClass('bg-warning/15');
+    expect(screen.getByRole('alert')).toHaveClass('bg-amber-50');
   });
 
   it('danger variant のクラスを適用する', () => {
     render(<Alert variant="danger">危険</Alert>);
 
-    expect(screen.getByRole('alert')).toHaveClass('bg-danger/10');
+    expect(screen.getByRole('alert')).toHaveClass('bg-red-50');
   });
 
   it('success variant のクラスを適用する', () => {
     render(<Alert variant="success">成功</Alert>);
 
-    expect(screen.getByRole('alert')).toHaveClass('bg-success/10');
+    expect(screen.getByRole('alert')).toHaveClass('bg-teal-50');
   });
 });

--- a/frontend/src/components/atoms/__tests__/Button.test.tsx
+++ b/frontend/src/components/atoms/__tests__/Button.test.tsx
@@ -12,14 +12,14 @@ describe('Button', () => {
     
     const button = screen.getByRole('button', { name: 'テストボタン' });
     expect(button).toBeInTheDocument();
-    expect(button).toHaveClass('bg-primary');
+    expect(button).toHaveClass('bg-slate-950');
   });
 
   it('指定されたvariantのクラスが適用される', () => {
     render(<Button {...defaultProps} variant="success" />);
     
     const button = screen.getByRole('button');
-    expect(button).toHaveClass('bg-success');
+    expect(button).toHaveClass('bg-teal-700');
   });
 
   it('outline variantが正しく適用される', () => {
@@ -33,14 +33,14 @@ describe('Button', () => {
     render(<Button {...defaultProps} size="lg" />);
     
     const button = screen.getByRole('button');
-    expect(button).toHaveClass('text-lg');
+    expect(button).toHaveClass('text-base');
   });
 
-  it('デフォルトサイズ(md)の場合はサイズクラスが追加されない', () => {
+  it('デフォルトサイズ(md)の場合は標準サイズのクラスが追加される', () => {
     render(<Button {...defaultProps} size="md" />);
     
     const button = screen.getByRole('button');
-    expect(button).toHaveClass('text-base');
+    expect(button).toHaveClass('text-sm');
   });
 
   it('fullWidthプロパティが動作する', () => {

--- a/frontend/src/components/atoms/__tests__/Card.test.tsx
+++ b/frontend/src/components/atoms/__tests__/Card.test.tsx
@@ -15,7 +15,7 @@ describe('CardHeader', () => {
 
     const header = screen.getByText('ヘッダー');
     expect(header).toBeInTheDocument();
-    expect(header).toHaveClass('bg-slate-700');
+    expect(header).toHaveClass('bg-slate-950');
   });
 });
 

--- a/frontend/src/components/atoms/__tests__/InputField.test.tsx
+++ b/frontend/src/components/atoms/__tests__/InputField.test.tsx
@@ -84,7 +84,7 @@ describe('InputField', () => {
     render(<InputField label="テスト項目" variant="filled" />);
 
     const input = screen.getByLabelText('テスト項目');
-    expect(input).toHaveClass('bg-gray-100');
+    expect(input).toHaveClass('bg-slate-50');
   });
 
   it('variant=standardのスタイルが適用される', () => {

--- a/frontend/src/components/atoms/__tests__/SecurityCodeLink.test.tsx
+++ b/frontend/src/components/atoms/__tests__/SecurityCodeLink.test.tsx
@@ -44,4 +44,17 @@ describe('SecurityCodeLink', () => {
 
     expect(screen.getByRole('link', { name: '7203' })).toHaveClass('custom-class');
   });
+
+  it('font weight を指定した場合はデフォルトの font-bold と競合しない', () => {
+    render(
+      <MemoryRouter>
+        <SecurityCodeLink value="7203" className="text-[11px] font-semibold" />
+      </MemoryRouter>
+    );
+
+    const link = screen.getByRole('link', { name: '7203' });
+    expect(link).toHaveClass('font-semibold');
+    expect(link).not.toHaveClass('font-bold');
+    expect(link).toHaveClass('text-blue-700');
+  });
 });

--- a/frontend/src/components/atoms/__tests__/Table.test.tsx
+++ b/frontend/src/components/atoms/__tests__/Table.test.tsx
@@ -66,7 +66,7 @@ describe('Table', () => {
     );
 
     const table = screen.getByRole('table');
-    expect(table).toHaveClass('[&_tbody_tr:nth-child(even)]:bg-slate-50');
+    expect(table).toHaveClass('[&_tbody_tr:nth-child(even)]:bg-slate-50/80');
   });
 
   test('borderedプロパティが正しく適用される', () => {
@@ -96,7 +96,7 @@ describe('Table', () => {
     );
 
     const table = screen.getByRole('table');
-    expect(table).toHaveClass('[&_tbody_tr:hover]:bg-slate-100');
+    expect(table).toHaveClass('[&_tbody_tr:hover]:bg-amber-50/60');
   });
 
   test('smallプロパティが正しく適用される', () => {
@@ -158,7 +158,7 @@ describe('Table', () => {
     );
 
     const table = screen.getByRole('table');
-    expect(table).toHaveClass('bg-primary/10');
+    expect(table).toHaveClass('bg-slate-950/10');
   });
 
   test('forceResizeプロパティが変更されたとき再計算がトリガーされる', async () => {
@@ -245,7 +245,7 @@ describe('Table', () => {
     );
 
     const row = screen.getByRole('row');
-    expect(row).toHaveClass('bg-primary/10');
+    expect(row).toHaveClass('bg-amber-50');
   });
 
   test('TableRowのvariantプロパティが正しく適用される', () => {
@@ -260,7 +260,7 @@ describe('Table', () => {
     );
 
     const row = screen.getByRole('row');
-    expect(row).toHaveClass('bg-success/10');
+    expect(row).toHaveClass('bg-teal-50');
   });
 
   test('TableHeaderのstickyTopプロパティが正しく適用される', () => {
@@ -290,7 +290,7 @@ describe('Table', () => {
     );
 
     const thead = screen.getByRole('rowgroup');
-    expect(thead).toHaveClass('bg-slate-800', 'text-white');
+    expect(thead).toHaveClass('bg-slate-950', 'text-white');
   });
 
   test('TableCellのscopeプロパティがthの場合に正しく適用される', () => {

--- a/frontend/src/components/molecules/PortfolioPieChart/PortfolioPieChart.tsx
+++ b/frontend/src/components/molecules/PortfolioPieChart/PortfolioPieChart.tsx
@@ -106,17 +106,17 @@ function PortfolioItemCard({ item, index, dividendPerShareMap, dividendStatusMap
   const color = COLORS[index % COLORS.length];
 
   return (
-    <div className="rounded-lg border border-slate-200 bg-white px-3.5 py-3 shadow-sm">
+    <div className="rounded-lg border border-slate-950/10 bg-white px-3.5 py-3 shadow-sm">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2.5 min-w-0">
             <span className="h-3 w-3 shrink-0 rounded-sm" style={{ backgroundColor: color }} />
             <div className="flex min-w-0 items-center gap-2" data-testid="portfolio-card-identity">
               <span
-                className="inline-flex shrink-0 items-center rounded-full bg-slate-100 px-2 py-0.5"
+                className="inline-flex shrink-0 items-center rounded-full bg-blue-50 px-2 py-0.5"
                 data-testid="portfolio-card-code"
               >
-                <SecurityCodeLink value={item.securityCode} className="text-[11px] font-semibold tracking-[0.16em] text-slate-500 no-underline hover:underline" />
+                <SecurityCodeLink value={item.securityCode} className="text-[11px] font-semibold tracking-[0.16em] no-underline hover:underline" />
               </span>
               <p className="truncate text-[15px] font-semibold text-slate-800" title={item.name}>
                 {item.name}
@@ -140,36 +140,45 @@ function PortfolioItemCard({ item, index, dividendPerShareMap, dividendStatusMap
         className="mt-2.5 grid grid-cols-3 overflow-hidden rounded-md bg-slate-50"
         data-testid="portfolio-card-acquisition-stats"
       >
-        <div className="min-w-0 px-3 py-2">
+        <div className="min-w-0 px-2 py-2">
           <p className="truncate text-[10px] font-medium text-slate-500">取得総額</p>
-          <p className="mt-0.5 truncate text-sm font-semibold text-slate-800">{formatCurrency(item.value)}</p>
+          <p className="mt-0.5 truncate text-[12px] font-semibold text-slate-800" title={formatCurrency(item.value)}>{formatCurrency(item.value)}</p>
         </div>
-        <div className="min-w-0 border-l border-slate-200/80 px-3 py-2">
+        <div className="min-w-0 border-l border-slate-200/80 px-2 py-2">
           <p className="truncate text-[10px] font-medium text-slate-500">取得単価</p>
-          <p className="mt-0.5 truncate text-sm font-semibold text-slate-800">{formatCurrency(item.averagePrice)}</p>
+          <p className="mt-0.5 truncate text-[12px] font-semibold text-slate-800" title={formatCurrency(item.averagePrice)}>{formatCurrency(item.averagePrice)}</p>
         </div>
-        <div className="min-w-0 border-l border-slate-200/80 px-3 py-2">
+        <div className="min-w-0 border-l border-slate-200/80 px-2 py-2">
           <p className="truncate text-[10px] font-medium text-slate-500">数量</p>
-          <p className="mt-0.5 truncate text-sm font-semibold text-slate-800">{`${formatNumber(item.shares)}株`}</p>
+          <p className="mt-0.5 truncate text-[12px] font-semibold text-slate-800" title={`${formatNumber(item.shares)}株`}>{`${formatNumber(item.shares)}株`}</p>
         </div>
       </div>
 
       <div className="mt-2.5 grid grid-cols-3 overflow-hidden rounded-md bg-emerald-50/55">
-        <div className="min-w-0 px-3 py-2 text-xs text-slate-600">
+        <div className="min-w-0 px-2 py-2 text-xs text-slate-600">
           <p className="truncate text-[10px] font-medium text-slate-500">1株配当</p>
-          <p className={`mt-0.5 truncate text-sm font-semibold ${divInfo?.perShare !== null && divInfo?.perShare !== undefined ? 'text-emerald-600' : 'text-slate-500'}`}>
+          <p
+            className={`mt-0.5 truncate text-[12px] font-semibold ${divInfo?.perShare !== null && divInfo?.perShare !== undefined ? 'text-emerald-600' : 'text-slate-500'}`}
+            title={formatPerShare(divInfo)}
+          >
             {formatPerShare(divInfo)}
           </p>
         </div>
-        <div className="min-w-0 border-l border-emerald-100/80 px-3 py-2 text-xs text-slate-600">
+        <div className="min-w-0 border-l border-emerald-100/80 px-2 py-2 text-xs text-slate-600">
           <p className="truncate text-[10px] font-medium text-slate-500">年間配当</p>
-          <p className={`mt-0.5 truncate text-sm font-semibold ${divInfo?.annual !== null && divInfo?.annual !== undefined ? 'text-emerald-600' : 'text-slate-500'}`}>
+          <p
+            className={`mt-0.5 truncate text-[12px] font-semibold ${divInfo?.annual !== null && divInfo?.annual !== undefined ? 'text-emerald-600' : 'text-slate-500'}`}
+            title={formatAnnual(divInfo)}
+          >
             {formatAnnual(divInfo)}
           </p>
         </div>
-        <div className="min-w-0 border-l border-emerald-100/80 px-3 py-2 text-xs text-slate-600">
+        <div className="min-w-0 border-l border-emerald-100/80 px-2 py-2 text-xs text-slate-600">
           <p className="truncate text-[10px] font-medium text-slate-500">配当利回り</p>
-          <p className={`mt-0.5 truncate text-sm font-semibold ${divInfo?.yieldValue !== null && divInfo?.yieldValue !== undefined ? 'text-emerald-600' : 'text-slate-500'}`}>
+          <p
+            className={`mt-0.5 truncate text-[12px] font-semibold ${divInfo?.yieldValue !== null && divInfo?.yieldValue !== undefined ? 'text-emerald-600' : 'text-slate-500'}`}
+            title={formatYield(divInfo)}
+          >
             {formatYield(divInfo)}
           </p>
         </div>

--- a/frontend/src/components/molecules/ReceiptHeader/ReceiptHeader.tsx
+++ b/frontend/src/components/molecules/ReceiptHeader/ReceiptHeader.tsx
@@ -13,14 +13,14 @@ interface ReceiptHeaderProps {
 // コンポーネント外に定義（毎レンダーで新参照が生成されるのを防ぐ）
 // AssetPortfolioSummary の KPI カード（border-{color}-100 bg-{color}-50 / border-slate-200 bg-white）と統一
 const KPI_CARD_BG: Record<KpiTone, string> = {
-    emerald: 'border-emerald-100 bg-emerald-50',
+    emerald: 'border-teal-200 bg-teal-50',
     red:     'border-rose-100 bg-rose-50',
     blue:    'border-blue-100 bg-blue-50',
     slate:   'border-slate-200 bg-white',
 };
 
 const TONE_VALUE_COLOR: Record<KpiTone, string> = {
-    emerald: 'text-emerald-600',
+    emerald: 'text-teal-700',
     red:     'text-red-500',
     blue:    'text-blue-600',
     slate:   'text-slate-800',
@@ -107,7 +107,7 @@ export const ReceiptHeader: React.FC<ReceiptHeaderProps> = ({
     };
 
     const chevron = collapsible && (
-        <span className="flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-2.5 py-1 text-slate-700" aria-hidden="true">
+        <span className="flex items-center gap-1.5 rounded-md border border-slate-300 bg-white px-2.5 py-1 text-slate-700" aria-hidden="true">
             <span className="text-xs font-semibold">{effectiveExpanded ? '閉じる' : '開く'}</span>
             <svg
                 className={cn('w-4 h-4 text-slate-500 transition-transform duration-200', effectiveExpanded && 'rotate-180')}
@@ -122,40 +122,40 @@ export const ReceiptHeader: React.FC<ReceiptHeaderProps> = ({
 
     return (
         <section
-            className="rounded-xl border border-slate-200 bg-white px-5 py-5 shadow-sm"
+            className="rounded-xl border border-slate-950/10 bg-white/95 px-4 py-3 shadow-[0_12px_34px_-30px_rgba(15,23,42,0.85)]"
             data-testid="receipt-summary-strip"
         >
             {collapsible ? (
                 <button
                     type="button"
-                    className="flex w-full items-start justify-between gap-3 border-b border-slate-200/80 pb-4 text-left"
+                    className="flex w-full items-start justify-between gap-3 border-b border-slate-950/10 pb-2.5 text-left"
                     onClick={handleToggleExpanded}
                     aria-expanded={effectiveExpanded}
                     aria-controls={bodyId}
                     data-testid="receipt-header"
                 >
-                    <div><h2 className="text-sm font-semibold text-slate-800">{title}</h2></div>
+                    <div><h2 className="text-sm font-black text-slate-950">{title}</h2></div>
                     {chevron}
                 </button>
             ) : (
                 <div
-                    className="flex items-start justify-between gap-3 border-b border-slate-200/80 pb-4"
+                    className="flex items-start justify-between gap-3 border-b border-slate-950/10 pb-2.5"
                     data-testid="receipt-header"
                 >
-                    <div><h2 className="text-sm font-semibold text-slate-800">{title}</h2></div>
+                    <div><h2 className="text-sm font-black text-slate-950">{title}</h2></div>
                 </div>
             )}
-            <div id={bodyId} hidden={collapsible && !effectiveExpanded} className="pt-4">
+            <div id={bodyId} hidden={collapsible && !effectiveExpanded} className="pt-3">
                 <KpiGrid
                     items={items}
-                    gridClassName="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3"
+                    gridClassName="grid grid-cols-1 gap-2.5 sm:grid-cols-2 xl:grid-cols-3"
                     cardBg={KPI_CARD_BG}
-                    cardBaseClassName="rounded-lg border px-4 py-4"
-                    valueSizeClassName="text-3xl"
+                    cardBaseClassName="rounded-lg border px-3.5 py-3"
+                    valueSizeClassName="text-2xl"
                 />
                 <ChildrenSection
                     hasItems={items.length > 0}
-                    dividerClassName="mt-4 border-t border-slate-200 pt-4"
+                    dividerClassName="mt-3 border-t border-slate-950/10 pt-3"
                 >
                     {children}
                 </ChildrenSection>

--- a/frontend/src/components/molecules/ReceiptHeader/__tests__/ReceiptHeader.test.tsx
+++ b/frontend/src/components/molecules/ReceiptHeader/__tests__/ReceiptHeader.test.tsx
@@ -168,7 +168,7 @@ describe('ReceiptHeader', () => {
     render(<ReceiptHeader items={defaultItems} />);
 
     const strip = screen.getByTestId('receipt-summary-strip');
-    expect(strip).toHaveClass('rounded-xl', 'border-slate-200', 'bg-white', 'shadow-sm');
+    expect(strip).toHaveClass('rounded-xl', 'border-slate-950/10', 'bg-white/95');
   });
 
   it('KPIカードの角丸・背景がAssetPortfolioSummaryのKPIカードと一致する', () => {

--- a/frontend/src/components/organisms/AssetPortfolioSummary/AssetPortfolioSummary.tsx
+++ b/frontend/src/components/organisms/AssetPortfolioSummary/AssetPortfolioSummary.tsx
@@ -74,7 +74,7 @@ export const AssetPortfolioSummary: React.FC<AssetPortfolioSummaryProps> = ({
   // データがない場合
   if (assetBalanceData.length === 0) {
     return (
-      <Card className="mb-3">
+      <Card className="mb-3 overflow-hidden">
         <CardBody>
           <EmptyState
             title={isFiltered ? "該当する銘柄がありません" : "資産管理データがありません"}
@@ -107,16 +107,16 @@ export const AssetPortfolioSummary: React.FC<AssetPortfolioSummaryProps> = ({
   return (
     <div className="mb-3 space-y-4" data-testid="asset-portfolio-summary">
       <section
-        className="rounded-xl border border-slate-200 bg-white px-5 py-5 shadow-sm"
+        className="rounded-xl border border-slate-950/10 bg-white/95 px-5 py-5 shadow-[0_16px_44px_-38px_rgba(15,23,42,0.9)]"
         data-testid="portfolio-kpi-strip"
       >
-        <div className="flex flex-col gap-3 border-b border-slate-200/80 pb-4 sm:flex-row sm:items-end sm:justify-between">
+        <div className="flex flex-col gap-3 border-b border-slate-950/10 pb-4 sm:flex-row sm:items-end sm:justify-between">
           <div>
-            <h2 className="text-sm font-semibold text-slate-800">資産サマリー</h2>
+            <h2 className="text-sm font-black text-slate-950">資産サマリー</h2>
           </div>
           {isFiltered ? (
             <div className="flex flex-wrap items-center gap-2">
-              <span className="inline-flex items-center rounded-full bg-blue-50 px-3 py-1 text-sm font-semibold text-blue-700">
+              <span className="inline-flex items-center rounded-md border border-blue-200 bg-blue-50 px-3 py-1 text-sm font-bold text-blue-700">
                 絞り込み中: {displayCount}/{actualTotalCount}件
               </span>
               {onClearFilter ? (
@@ -132,25 +132,25 @@ export const AssetPortfolioSummary: React.FC<AssetPortfolioSummaryProps> = ({
           ) : null}
         </div>
         <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
-          <div className="rounded-lg border border-slate-200 bg-white px-4 py-4">
+          <div className="rounded-lg border border-slate-950/10 bg-white px-4 py-4 shadow-sm">
             <p className="mb-1 text-xs font-medium text-slate-600">合計取得総額</p>
             <p className="text-3xl font-bold text-primary tabular-nums" data-negative={totalPurchaseAmount < 0 ? 'true' : undefined}>
               {formatCurrency(totalPurchaseAmount)}
             </p>
           </div>
-          <div className="rounded-lg border border-emerald-100 bg-emerald-50 px-4 py-4">
+          <div className="rounded-lg border border-teal-200 bg-teal-50 px-4 py-4 shadow-sm">
             <p className="mb-1 text-xs font-medium text-slate-600">年間配当金額</p>
-            <p className="text-3xl font-bold text-emerald-600 tabular-nums" data-testid="portfolio-annual-dividends">
+            <p className="text-3xl font-bold text-teal-700 tabular-nums" data-testid="portfolio-annual-dividends">
               {totalAnnualDividends !== null ? formatCurrency(totalAnnualDividends) : '---'}
             </p>
           </div>
-          <div className="rounded-lg border border-emerald-100 bg-emerald-50 px-4 py-4">
+          <div className="rounded-lg border border-teal-200 bg-teal-50 px-4 py-4 shadow-sm">
             <p className="mb-1 text-xs font-medium text-slate-600">配当利回り</p>
-            <p className="text-3xl font-bold text-emerald-600 tabular-nums" data-testid="portfolio-dividend-yield">
+            <p className="text-3xl font-bold text-teal-700 tabular-nums" data-testid="portfolio-dividend-yield">
               {portfolioDividendYield !== null ? formatPercentageValue(portfolioDividendYield) : '---'}
             </p>
           </div>
-          <div className="rounded-lg border border-slate-200 bg-white px-4 py-4">
+          <div className="rounded-lg border border-slate-950/10 bg-white px-4 py-4 shadow-sm">
             <p className="mb-1 text-xs font-medium text-slate-600">保有銘柄数</p>
             <p className="text-3xl font-bold text-slate-700 tabular-nums">
               {isFiltered
@@ -163,11 +163,11 @@ export const AssetPortfolioSummary: React.FC<AssetPortfolioSummaryProps> = ({
         </div>
       </section>
 
-      <Card className="overflow-hidden rounded-xl border-slate-200 bg-white shadow-sm">
+      <Card className="overflow-hidden border-slate-950/10 bg-white/95">
         <CardBody className="p-0">
-          <div className="flex flex-col gap-3 border-b border-slate-200 px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-col gap-3 border-b border-slate-950/10 bg-slate-50/80 px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
             <div>
-              <h3 className="text-sm font-semibold text-slate-700">保有内訳</h3>
+              <h3 className="text-sm font-black text-slate-900">保有内訳</h3>
             </div>
           </div>
           <div className="p-4">

--- a/frontend/src/components/organisms/DataActionRail/DataActionRail.tsx
+++ b/frontend/src/components/organisms/DataActionRail/DataActionRail.tsx
@@ -46,7 +46,7 @@ export function DataActionRail({
   saveModeLabel,
 }: DataActionRailProps) {
   return (
-    <section className="space-y-3 px-5 py-5" role="group" aria-label="データ操作">
+    <section className="space-y-3 bg-slate-50/60 px-5 py-5" role="group" aria-label="データ操作">
       <div className="space-y-3">
         <CSVFileInput
           onFileSelect={onFileSelect}
@@ -57,7 +57,7 @@ export function DataActionRail({
           <Button
             variant="primary"
             size="sm"
-            className="h-11 w-full rounded-xl text-sm font-semibold"
+            className="h-11 w-full rounded-md text-sm font-bold"
             onClick={onSave}
             disabled={saveDisabled}
             aria-disabled={saveDisabled}
@@ -69,7 +69,7 @@ export function DataActionRail({
           <Button
             variant="outline-danger"
             size="sm"
-            className="h-11 w-full rounded-xl text-sm font-semibold"
+            className="h-11 w-full rounded-md text-sm font-bold"
             onClick={onDeleteRequest}
             disabled={deleteDisabled}
             aria-disabled={deleteDisabled}

--- a/frontend/src/components/organisms/Header.tsx
+++ b/frontend/src/components/organisms/Header.tsx
@@ -5,14 +5,12 @@ import { useAuth } from '../../features/auth/hooks/useAuth';
 import { cn } from '../../lib/utils/classNames';
 import { APP_SHELL_CONTAINER } from '@/lib/layout';
 
-// ナビゲーションリンクの設定
 const NAV_LINKS = [
   { to: '/search', label: '銘柄検索' },
   { to: '/assetbalance', label: '資産管理' },
   { to: '/receipts', label: '取引明細' },
 ] as const;
 
-// ユーザー名からイニシャルを取得
 const getInitials = (name: string | null | undefined, email: string | null | undefined): string => {
   if (name) {
     const parts = name.trim().split(/\s+/);
@@ -35,7 +33,6 @@ export function Header() {
   const dropdownRef = useRef<HTMLDivElement>(null);
   const location = useLocation();
 
-  // ドロップダウン外クリックで閉じる
   useEffect(() => {
     if (!showDropdown) return;
 
@@ -49,7 +46,6 @@ export function Header() {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [showDropdown]);
 
-  // キーボード操作対応（Escapeで閉じる）
   useEffect(() => {
     if (!showDropdown) return;
 
@@ -84,14 +80,22 @@ export function Header() {
 
   return (
     <>
-      <header className="bg-slate-800 text-white no-print">
+      <header className="sticky top-0 z-40 border-b border-slate-950/10 bg-[#111827]/95 text-white shadow-[0_18px_44px_-34px_rgba(15,23,42,0.95)] backdrop-blur no-print">
         <div className={`${APP_SHELL_CONTAINER} py-3`}>
-          <div className="flex flex-col gap-2 md:flex-row md:items-center">
-            <div className="flex items-center justify-between">
-              <Link className="text-2xl font-bold tracking-wide text-white hover:text-slate-200 transition-colors" to="/">証券Web</Link>
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
+            <div className="flex items-center justify-between gap-4">
+              <Link className="group inline-flex items-center gap-3 text-white transition-colors hover:text-amber-100" to="/">
+                <span className="flex h-10 w-10 items-center justify-center rounded-md border border-white/15 bg-white text-sm font-black text-slate-950 shadow-[inset_0_-3px_0_rgba(192,132,3,0.35)]">
+                  証
+                </span>
+                <span>
+                  <span className="block text-[11px] font-bold uppercase tracking-[0.28em] text-amber-300/90">Portfolio Desk</span>
+                  <span className="block text-xl font-black leading-tight tracking-normal">証券Web</span>
+                </span>
+              </Link>
             </div>
 
-            <nav className="flex flex-wrap items-center gap-1" aria-label="主要ナビゲーション">
+            <nav className="flex flex-wrap items-center gap-1 rounded-md border border-white/10 bg-white/5 p-1" aria-label="主要ナビゲーション">
               {NAV_LINKS.map(({ to, label }) => {
                 const isActive = location.pathname === to || location.pathname.startsWith(to + '/');
                 return (
@@ -99,10 +103,10 @@ export function Header() {
                     key={to}
                     to={to}
                     className={cn(
-                      'px-4 py-2 text-base font-medium transition-colors border-b-2',
+                      'rounded px-3.5 py-2 text-sm font-bold transition-[background-color,color,box-shadow]',
                       isActive
-                        ? 'border-white text-white font-semibold'
-                        : 'border-transparent text-slate-300 hover:text-white hover:border-slate-500'
+                        ? 'bg-white text-slate-950 shadow-[inset_0_-2px_0_#f59e0b]'
+                        : 'text-slate-300 hover:bg-white/10 hover:text-white'
                     )}
                     aria-current={isActive ? 'page' : undefined}
                   >
@@ -112,28 +116,27 @@ export function Header() {
               })}
             </nav>
 
-            <div className="flex items-center gap-3 md:ml-auto">
+            <div className="flex items-center gap-3 lg:ml-auto">
               {isLoading ? (
-                <span className="text-white/80 text-base">読み込み中...</span>
+                <span className="text-sm font-semibold text-white/70">読み込み中...</span>
               ) : isAuthenticated && user ? (
-                <div className="flex items-center gap-3">
-                  {/* ユーザーアバター（フォールバック付き） */}
+                <div className="flex flex-wrap items-center gap-3">
                   {user.picture_url && !imageError ? (
                     <img
                       src={user.picture_url}
                       alt={user.name || 'ユーザー'}
-                      className="h-8 w-8 rounded-full object-cover bg-slate-600"
+                      className="h-9 w-9 rounded-md border border-white/20 bg-slate-700 object-cover"
                       onError={() => setImageError(true)}
                     />
                   ) : (
                     <div
-                      className="h-8 w-8 rounded-full bg-slate-600 flex items-center justify-center text-white text-sm font-medium"
+                      className="flex h-9 w-9 items-center justify-center rounded-md border border-white/20 bg-slate-700 text-sm font-black text-white"
                       aria-label={user.name || 'ユーザー'}
                     >
                       {getInitials(user.name, user.email)}
                     </div>
                   )}
-                  <span className="text-base text-white/90">{user.name || user.email}</span>
+                  <span className="max-w-[16rem] truncate text-sm font-semibold text-white/85">{user.name || user.email}</span>
                   <div className="relative" ref={dropdownRef}>
                     <Button
                       variant="outline-light"
@@ -148,26 +151,26 @@ export function Header() {
                     {showDropdown && (
                       <ul
                         id="user-menu"
-                        className="absolute right-0 mt-2 w-56 rounded-md border border-border bg-white text-dark shadow-lg"
+                        className="absolute right-0 mt-2 w-56 overflow-hidden rounded-lg border border-slate-950/10 bg-white text-dark shadow-2xl"
                         role="menu"
                         aria-label="ユーザーメニュー"
                       >
                         <li role="none">
                           <button
-                            className="w-full px-3 py-2 text-left text-base hover:bg-gray-100"
+                            className="w-full px-3 py-2 text-left text-sm font-semibold hover:bg-slate-100"
                             onClick={handleLogout}
                             role="menuitem"
                           >
                             ログアウト
                           </button>
                         </li>
-                        <li role="none"><hr className="my-1 border-border" /></li>
-                        <li role="none" className="px-3 py-1 text-xs text-secondary">
+                        <li role="none"><hr className="border-border" /></li>
+                        <li role="none" className="px-3 py-2 text-xs font-bold uppercase tracking-[0.16em] text-secondary">
                           危険な操作
                         </li>
                         <li role="none">
                           <button
-                            className="w-full px-3 py-2 text-left text-base text-danger hover:bg-danger/10"
+                            className="w-full px-3 py-2 text-left text-sm font-bold text-danger hover:bg-danger/10"
                             onClick={() => setShowDeleteConfirm(true)}
                             role="menuitem"
                             aria-describedby="delete-warning"
@@ -192,10 +195,9 @@ export function Header() {
         </div>
       </header>
 
-      {/* アカウント削除確認モーダル */}
       {showDeleteConfirm && (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/60 p-4 backdrop-blur-sm"
           onClick={() => setShowDeleteConfirm(false)}
           onKeyDown={(e) => { if (e.key === 'Escape') setShowDeleteConfirm(false); }}
           role="dialog"
@@ -210,21 +212,21 @@ export function Header() {
             onClick={(e) => e.stopPropagation()}
             onKeyDown={(e) => { if (e.key === 'Escape') setShowDeleteConfirm(false); else e.stopPropagation(); }}
           >
-            <div className="rounded-lg bg-white shadow-lg">
+            <div className="overflow-hidden rounded-xl bg-white shadow-2xl">
               <div className="flex items-center justify-between border-b border-border px-4 py-3">
-                <h5 id="delete-modal-title" className="text-danger font-semibold">
+                <h5 id="delete-modal-title" className="font-bold text-danger">
                   アカウント削除の確認
                 </h5>
                 <button
                   type="button"
-                  className="text-gray-500 hover:text-gray-700"
+                  className="rounded px-2 py-1 text-slate-500 hover:bg-slate-100 hover:text-slate-800"
                   onClick={() => setShowDeleteConfirm(false)}
                   aria-label="閉じる"
                 >
                   <span aria-hidden="true">✕</span>
                 </button>
               </div>
-              <div id="delete-modal-description" className="px-4 py-4 text-base text-dark">
+              <div id="delete-modal-description" className="px-4 py-4 text-sm text-dark">
                 <p>本当にアカウントを削除しますか？</p>
                 <p className="mt-2 text-danger">
                   <strong>警告:</strong> この操作は取り消せません。

--- a/frontend/src/components/organisms/SearchCard/SearchCard.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchCard.tsx
@@ -23,8 +23,8 @@ const QuickSearchDropdown: React.FC<QuickSearchDropdownProps> = ({
                 id={id}
                 className={`w-full rounded-md border px-3 py-2 text-sm transition-colors focus:outline-none focus:ring-2 ${
                     isSelected
-                        ? 'border-primary bg-primary/20 text-blue-800 font-bold ring-2 ring-primary/50'
-                        : 'border-gray-300 bg-white text-dark hover:border-slate-400 focus:border-primary focus:ring-primary/25'
+                        ? 'border-amber-500 bg-amber-50 text-amber-900 font-bold ring-2 ring-amber-500/30'
+                        : 'border-slate-300 bg-white text-dark hover:border-slate-500 focus:border-amber-600 focus:ring-amber-500/25'
                 }`}
                 value={displayValue}
                 onChange={(e) => onSearch(e.target.value, searchType)}
@@ -37,7 +37,7 @@ const QuickSearchDropdown: React.FC<QuickSearchDropdownProps> = ({
                 ))}
             </select>
             {isSelected && (
-                <span className="absolute right-8 top-1/2 -translate-y-1/2 text-blue-700 pointer-events-none">
+                <span className="absolute right-8 top-1/2 -translate-y-1/2 text-amber-700 pointer-events-none">
                     <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
                         <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
                     </svg>
@@ -72,8 +72,8 @@ const QuickSearchButtons: React.FC<QuickSearchButtonsProps> = ({
                             size="sm"
                             onClick={() => onSearch(item, searchType)}
                             className={isSelected
-                                ? 'ring-2 ring-primary ring-offset-1 font-bold shadow-md'
-                                : `${hasSelection ? 'opacity-50' : 'opacity-80'} hover:opacity-100 hover:bg-slate-100 hover:ring-1 hover:ring-slate-300 focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:outline-none`
+                                ? 'ring-2 ring-amber-500 ring-offset-1 font-bold shadow-md'
+                                : `${hasSelection ? 'opacity-50' : 'opacity-80'} hover:opacity-100 hover:bg-slate-100 hover:ring-1 hover:ring-slate-300 focus-visible:ring-2 focus-visible:ring-amber-500/50 focus-visible:outline-none`
                             }
                             aria-pressed={isSelected}
                             aria-label={isSelected ? `${item}（選択中）` : item}
@@ -122,7 +122,7 @@ const SearchFieldsGrid: React.FC<SearchFieldsGridProps> = ({
         {DROPDOWN_CONFIGS.map(({ key, label }) =>
             hasData(categories[key]) && (
                 <div key={key} className="space-y-1">
-                    <label htmlFor={`${key}-search`} className="text-sm font-medium text-dark">{label}</label>
+                    <label htmlFor={`${key}-search`} className="text-sm font-bold text-slate-800">{label}</label>
                     <QuickSearchDropdown
                         items={categories[key]!}
                         id={`${key}-search`}
@@ -137,7 +137,7 @@ const SearchFieldsGrid: React.FC<SearchFieldsGridProps> = ({
         {BUTTONS_CONFIGS.map(({ key, label }) =>
             hasData(categories[key]) && (
                 <div key={key} className="space-y-1">
-                    <div className="text-sm font-medium text-dark">{label}</div>
+                    <div className="text-sm font-bold text-slate-800">{label}</div>
                     <div className="flex flex-wrap gap-1">
                         <QuickSearchButtons
                             items={categories[key]!}
@@ -239,9 +239,9 @@ export const SearchCard: React.FC<SearchCardProps> = ({
 
     if (compact) {
         return (
-            <section className="px-5 py-5" data-testid="search-card-compact">
+            <section className="px-4 py-4" data-testid="search-card-compact">
                 <div
-                    className="flex cursor-pointer items-start justify-between gap-3 select-none"
+                    className="flex cursor-pointer items-center justify-between gap-2 select-none"
                     onClick={handleToggleExpanded}
                     onKeyDown={handleKeyDown}
                     role="button"
@@ -251,50 +251,45 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                     aria-label={`検索オプション ${isExpanded ? '閉じる' : '開く'}`}
                     data-testid="search-card-header"
                 >
-                    <div className="flex min-w-0 items-start gap-3">
-                        <span className="mt-0.5 inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-2xl bg-slate-100 text-slate-600">
+                    <div className="flex min-w-0 items-center gap-2.5">
+                        <span className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-slate-950 text-white">
                             <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
                             </svg>
                         </span>
                         <div className="min-w-0">
-                            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">Filter</p>
-                            <h5 className="mt-1 text-sm font-semibold text-slate-800">検索オプション</h5>
+                            <p className="text-[10px] font-black uppercase tracking-[0.18em] text-slate-500">Filter</p>
+                            <h5 className="whitespace-nowrap text-sm font-black text-slate-950">検索オプション</h5>
                             {!isExpanded && effectiveActiveSearchType && (
-                                <span className="mt-2 inline-flex rounded-full border border-blue-100 bg-blue-50 px-2.5 py-1 text-xs font-semibold text-blue-700">
-                                    フィルタ適用中
+                                <span className="mt-1 inline-flex whitespace-nowrap rounded-md border border-amber-200 bg-amber-50 px-2 py-0.5 text-[11px] font-bold text-amber-800">
+                                    適用中
                                 </span>
                             )}
                         </div>
                     </div>
-                    <div className="flex shrink-0 items-center gap-2">
-                        <Button
-                            type="button"
-                            variant="outline-secondary"
-                            size="sm"
-                            onClick={(e: React.MouseEvent) => {
-                                e.stopPropagation();
-                                handleClearSearch();
-                            }}
-                            onKeyDown={(e: React.KeyboardEvent) => {
-                                if (e.key === 'Enter' || e.key === ' ') {
+                    <div className="flex shrink-0 items-center gap-1.5">
+                        {!isDefaultState && (
+                            <Button
+                                type="button"
+                                variant="outline-secondary"
+                                size="sm"
+                                onClick={(e: React.MouseEvent) => {
                                     e.stopPropagation();
-                                }
-                            }}
-                            className={`rounded-full px-3 py-1 text-xs transition-opacity ${
-                                isDefaultState
-                                    ? 'pointer-events-none opacity-0'
-                                    : 'opacity-100 border-slate-300 bg-white text-slate-700 hover:bg-slate-50'
-                            }`}
-                            aria-label="検索条件をクリア"
-                            aria-hidden={isDefaultState}
-                            tabIndex={isDefaultState ? -1 : 0}
-                            data-testid="search-clear-button"
-                        >
-                            リセット
-                        </Button>
-                        <span className="flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-2.5 py-1 text-slate-700" aria-hidden="true">
-                            <span className="text-xs font-semibold">{isExpanded ? '閉じる' : '開く'}</span>
+                                    handleClearSearch();
+                                }}
+                                onKeyDown={(e: React.KeyboardEvent) => {
+                                    if (e.key === 'Enter' || e.key === ' ') {
+                                        e.stopPropagation();
+                                    }
+                                }}
+                                className="whitespace-nowrap rounded-md border-slate-300 bg-white px-2 py-1 text-xs text-slate-700 hover:bg-slate-50"
+                                aria-label="検索条件をクリア"
+                                data-testid="search-clear-button"
+                            >
+                                解除
+                            </Button>
+                        )}
+                        <span className="flex h-8 w-8 items-center justify-center rounded-md border border-slate-300 bg-white text-slate-700" aria-hidden="true">
                             <svg
                                 className={`h-4 w-4 text-slate-500 transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`}
                                 fill="none"
@@ -323,13 +318,13 @@ export const SearchCard: React.FC<SearchCardProps> = ({
     }
 
     return (
-        <Card className="mt-1">
+        <Card className="mt-1 overflow-hidden">
             <CardHeader
                 variant="secondary"
                 className={`flex cursor-pointer items-center justify-between select-none transition-colors focus-within:ring-2 focus-within:ring-white/50 focus-within:ring-inset ${
                     isExpanded
-                        ? 'bg-slate-600 hover:bg-slate-700 border-b-2 border-slate-700'
-                        : 'bg-slate-400 hover:bg-slate-500'
+                        ? 'bg-slate-950 hover:bg-slate-900 border-b border-amber-500'
+                        : 'bg-slate-800 hover:bg-slate-900'
                 }`}
                 onClick={handleToggleExpanded}
                 onKeyDown={handleKeyDown}
@@ -383,7 +378,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                     </Button>
                     {/* シェブロンアイコン: 回転で開閉状態を表現 */}
                     <span
-                        className="flex items-center gap-1.5 rounded border border-white/30 bg-white/10 px-2 py-0.5"
+                        className="flex items-center gap-1.5 rounded-md border border-white/25 bg-white/10 px-2 py-0.5"
                         aria-hidden="true"
                     >
                         <span className="text-xs font-semibold whitespace-nowrap text-white">

--- a/frontend/src/components/organisms/SearchForm.tsx
+++ b/frontend/src/components/organisms/SearchForm.tsx
@@ -28,14 +28,14 @@ export const SearchForm: React.FC<SearchFormProps> = ({
   };
 
   return (
-    <Card className="mb-4">
-      <CardBody className="p-4">
+    <Card className="mb-5 overflow-hidden border-slate-950/10">
+      <CardBody className="p-4 sm:p-5">
         <form onSubmit={handleSubmit}>
-          <div className="flex w-full items-stretch">
+          <div className="flex w-full items-stretch rounded-lg border border-slate-300 bg-white p-1 shadow-inner shadow-slate-200/80 focus-within:border-amber-600 focus-within:ring-2 focus-within:ring-amber-500/20">
             <div className="flex-1 min-w-0">
               <InputField
                 type="text"
-                className="rounded-r-none border-r-0"
+                className="h-11 rounded-r-none border-0 bg-transparent text-base shadow-none focus:ring-0"
                 placeholder="銘柄コードまたは銘柄名"
                 value={stockCode}
                 onChange={handleInputChange}
@@ -51,7 +51,7 @@ export const SearchForm: React.FC<SearchFormProps> = ({
               disabled={isLoading || !stockCode}
               loading={isLoading}
               aria-label={isLoading ? '検索中' : '銘柄を検索'}
-              className="rounded-l-none shrink-0 whitespace-nowrap"
+              className="h-11 shrink-0 whitespace-nowrap rounded-md px-5"
             >
               {isLoading ? '検索中...' : '検索'}
             </Button>

--- a/frontend/src/components/organisms/StockInfo.tsx
+++ b/frontend/src/components/organisms/StockInfo.tsx
@@ -1,6 +1,6 @@
 import { StockData } from '../../features/stock/types';
 import { StockInfoLinks } from '../molecules/StockInfoLinks';
-import { Card, CardHeader, CardBody } from '../atoms/Card';
+import { Card, CardBody } from '../atoms/Card';
 
 interface StockInfoProps {
   stockData: StockData;
@@ -29,25 +29,28 @@ export function StockInfo({ stockData }: StockInfoProps) {
 
   return (
     <div>
-      <Card className="mb-4">
-        <CardHeader variant="primary" className="rounded-t-lg">
-          <div className="flex items-center gap-3 flex-wrap">
-            <span className="text-base font-semibold leading-tight">{name}</span>
-            <span className="inline-block rounded bg-slate-500 px-2 py-0.5 font-mono text-sm tracking-wider">
+      <Card className="mb-4 overflow-hidden">
+        <div className="border-b border-slate-950/10 bg-slate-950 px-5 py-4 text-white">
+          <div className="flex flex-wrap items-end justify-between gap-3">
+            <div>
+              <p className="text-[11px] font-black uppercase tracking-[0.22em] text-amber-300">Security</p>
+              <h2 className="mt-1 text-xl font-black leading-tight">{name}</h2>
+            </div>
+            <span className="inline-flex rounded-md border border-white/20 bg-white px-3 py-1 font-mono text-sm font-black tracking-wider text-slate-950">
               {code}
             </span>
           </div>
-        </CardHeader>
+        </div>
         <CardBody>
-          <dl className="grid grid-cols-2 gap-px bg-gray-200 border-b border-gray-200 text-sm">
+          <dl className="grid grid-cols-1 gap-px bg-slate-200 text-sm sm:grid-cols-2 lg:grid-cols-4">
             {metaItems.map(item => (
-              <div key={item.label} className="bg-white px-3 py-2">
-                <dt className="text-xs font-medium text-slate-500">{item.label}</dt>
-                <dd className="mt-0.5 text-dark">{item.value || '-'}</dd>
+              <div key={item.label} className="bg-white px-4 py-3">
+                <dt className="text-[11px] font-black uppercase tracking-[0.16em] text-slate-500">{item.label}</dt>
+                <dd className="mt-1 font-bold text-dark">{item.value || '-'}</dd>
               </div>
             ))}
           </dl>
-          <div className="px-3 py-3">
+          <div className="px-4 py-4">
             <StockInfoLinks code={code} />
           </div>
         </CardBody>

--- a/frontend/src/components/templates/Layout.tsx
+++ b/frontend/src/components/templates/Layout.tsx
@@ -9,18 +9,17 @@ interface LayoutProps {
 
 export function Layout({ children }: LayoutProps) {
   return (
-    <div className="min-h-screen flex flex-col bg-slate-50">
-      {/* スキップリンク: キーボード・スクリーンリーダー利用者向け */}
+    <div className="min-h-screen flex flex-col bg-transparent text-slate-950">
       <a
         href="#main-content"
-        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:rounded focus:bg-white focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:shadow-lg focus:outline-2 focus:outline-primary"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:rounded-md focus:bg-white focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:shadow-lg focus:outline-2 focus:outline-primary"
       >
         メインコンテンツへスキップ
       </a>
 
       <Header />
 
-      <main id="main-content" className={`${APP_SHELL_CONTAINER} flex flex-1 flex-col py-4`}>
+      <main id="main-content" className={`${APP_SHELL_CONTAINER} flex flex-1 flex-col py-5`}>
         {children}
       </main>
 

--- a/frontend/src/components/templates/ReceiptTemplate.tsx
+++ b/frontend/src/components/templates/ReceiptTemplate.tsx
@@ -51,7 +51,7 @@ const ReceiptTemplateContent: React.FC<ReceiptTemplateProps> = ({
   ) : null;
 
   const mainCard = (
-    <Card className="mt-1 overflow-hidden rounded-xl border-slate-200/90 bg-white/95 shadow-[0_4px_12px_-4px_rgba(15,23,42,0.12)]" data-testid="receipt-card">
+    <Card className="overflow-hidden border-slate-950/10 bg-white/95 shadow-[0_16px_44px_-36px_rgba(15,23,42,0.9)]" data-testid="receipt-card">
       <CardBody className="p-0" data-testid="receipt-card-body">
         {children}
       </CardBody>
@@ -60,10 +60,10 @@ const ReceiptTemplateContent: React.FC<ReceiptTemplateProps> = ({
 
   if (layout === 'workspace') {
     return (
-      <div className="space-y-2" data-testid="receipt-container">
+      <div className="space-y-1.5" data-testid="receipt-container">
         <WorkspaceShell
           testIdPrefix="receipt"
-          mainClassName="space-y-4"
+          mainClassName="space-y-2"
           main={<>{header}{mainCard}</>}
           rail={<>{utilityRail}{searchCard}</>}
         />
@@ -73,9 +73,9 @@ const ReceiptTemplateContent: React.FC<ReceiptTemplateProps> = ({
   }
 
   return (
-    <div className="space-y-2" data-testid="receipt-container">
+    <div className="space-y-1.5" data-testid="receipt-container">
       {searchCard}
-      {header ? <div className="mt-1">{header}</div> : null}
+      {header ? <div>{header}</div> : null}
       {mainCard}
       {footer ? <div>{footer}</div> : null}
     </div >

--- a/frontend/src/components/templates/WorkspaceShell.tsx
+++ b/frontend/src/components/templates/WorkspaceShell.tsx
@@ -8,22 +8,18 @@ interface WorkspaceShellProps {
   testIdPrefix?: string;
 }
 
-/**
- * 2カラム workspace レイアウト（main stage + utility rail）の共通テンプレート。
- * ReceiptTemplate および AssetBalance の grid / rail スタイルを一元管理する。
- */
 export function WorkspaceShell({ main, rail, mainClassName, testIdPrefix = '' }: WorkspaceShellProps) {
   const prefix = testIdPrefix ? `${testIdPrefix}-` : '';
   return (
     <div
-      className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_22rem] lg:items-start xl:gap-6 xl:grid-cols-[minmax(0,1fr)_24rem]"
+      className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_19rem] lg:items-start xl:gap-5 xl:grid-cols-[minmax(0,1fr)_20rem]"
       data-testid={`${prefix}workspace`}
     >
       <div className={cn('min-w-0', mainClassName)} data-testid={`${prefix}main-stage`}>
         {main}
       </div>
       <aside data-testid={`${prefix}utility-rail`}>
-        <div className="overflow-hidden rounded-[2rem] border border-slate-200/90 bg-white/80 shadow-[0_20px_48px_-34px_rgba(15,23,42,0.45)] backdrop-blur-sm divide-y divide-slate-200/80">
+        <div className="overflow-hidden rounded-xl border border-slate-950/10 bg-white/90 shadow-[0_18px_58px_-42px_rgba(15,23,42,0.9)] backdrop-blur-sm divide-y divide-slate-950/10">
           {rail}
         </div>
       </aside>

--- a/frontend/src/components/templates/__tests__/ReceiptTemplate.test.tsx
+++ b/frontend/src/components/templates/__tests__/ReceiptTemplate.test.tsx
@@ -272,8 +272,8 @@ describe('ReceiptTemplate', () => {
 
     expect(screen.getByTestId('receipt-workspace')).toBeInTheDocument();
     expect(screen.getByTestId('receipt-utility-rail')).toBeInTheDocument();
-    expect(screen.getByTestId('receipt-workspace').className).toContain('lg:grid-cols-[minmax(0,1fr)_22rem]');
-    expect(screen.getByTestId('receipt-workspace').className).toContain('xl:grid-cols-[minmax(0,1fr)_24rem]');
+    expect(screen.getByTestId('receipt-workspace').className).toContain('lg:grid-cols-[minmax(0,1fr)_19rem]');
+    expect(screen.getByTestId('receipt-workspace').className).toContain('xl:grid-cols-[minmax(0,1fr)_20rem]');
 
     const utilityRail = screen.getByTestId('receipt-utility-rail');
     expect(utilityRail).toContainElement(screen.getByTestId('workspace-tools'));

--- a/frontend/src/features/receipt/components/ReceiptsTabNav.tsx
+++ b/frontend/src/features/receipt/components/ReceiptsTabNav.tsx
@@ -25,9 +25,9 @@ export function ReceiptsTabNav({
   counts,
 }: ReceiptsTabNavProps) {
   return (
-    <nav className="mb-5 no-print" aria-label="取引明細タブ">
+    <nav className="mb-2 no-print" aria-label="取引明細タブ">
       <div
-        className="flex flex-wrap gap-1.5 border-b border-slate-200/90"
+        className="flex flex-wrap gap-1.5 rounded-xl border border-slate-950/10 bg-white/70 p-1 shadow-sm"
         role="tablist"
         ref={tablistRef}
       >
@@ -37,10 +37,10 @@ export function ReceiptsTabNav({
             <button
               key={tab}
               id={`tab-${tab}`}
-              className={`-mb-px inline-flex items-center gap-2 rounded-t-lg border border-transparent border-b-0 px-4 py-3 text-sm font-medium transition-[color,background-color,border-color,box-shadow] ${
+              className={`inline-flex items-center gap-2 rounded-lg border px-4 py-2.5 text-sm font-bold transition-[color,background-color,border-color,box-shadow] ${
                 isActive
-                  ? 'border-slate-200 bg-white text-slate-900 shadow-[0_-1px_0_0_rgba(255,255,255,1),0_4px_8px_-6px_rgba(15,23,42,0.35)]'
-                  : 'text-slate-500 hover:bg-white/80 hover:text-slate-800'
+                  ? 'border-slate-950 bg-slate-950 text-white shadow-[inset_0_-2px_0_#f59e0b]'
+                  : 'border-transparent text-slate-500 hover:bg-white hover:text-slate-900'
               }`}
               onClick={() => onTabChange(tab)}
               onKeyDown={onKeyDown}
@@ -55,7 +55,7 @@ export function ReceiptsTabNav({
                 data-testid={`tab-count-${tab}`}
                 className={`inline-flex min-w-6 items-center justify-center rounded-full px-2 py-0.5 text-xs font-semibold ${
                   isActive
-                    ? 'border border-slate-200 bg-slate-100 text-slate-700'
+                    ? 'border border-white/20 bg-white text-slate-950'
                     : 'bg-slate-100 text-slate-500'
                 }`}
               >

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -8,8 +8,8 @@ const STATUS_ITEMS = [
     sub: '検索',
     to: '/search' as string | null,
     icon: (
-      <svg className="h-5 w-5 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true" focusable="false">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+      <svg className="h-5 w-5 text-slate-950" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true" focusable="false">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
       </svg>
     ),
   },
@@ -18,8 +18,8 @@ const STATUS_ITEMS = [
     sub: '一覧確認',
     to: '/assetbalance' as string | null,
     icon: (
-      <svg className="h-5 w-5 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true" focusable="false">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+      <svg className="h-5 w-5 text-slate-950" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true" focusable="false">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
       </svg>
     ),
   },
@@ -28,8 +28,8 @@ const STATUS_ITEMS = [
     sub: '明細確認',
     to: '/receipts' as string | null,
     icon: (
-      <svg className="h-5 w-5 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true" focusable="false">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+      <svg className="h-5 w-5 text-slate-950" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true" focusable="false">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
       </svg>
     ),
   },
@@ -39,7 +39,7 @@ const STATUS_ITEMS = [
     to: null as string | null,
     icon: (
       <svg className="h-5 w-5 text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true" focusable="false">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
       </svg>
     ),
   },
@@ -52,9 +52,9 @@ const NEXT_ACTIONS = [
 ] as const;
 
 const FLOW_STEPS = [
-  { step: '1', text: '証券会社からCSVをダウンロード' },
-  { step: '2', text: '各ページのCSV取込から反映' },
-  { step: '3', text: '資産・配当金・取引明細を確認' },
+  { step: '01', text: 'CSV取得' },
+  { step: '02', text: '各ページで取込' },
+  { step: '03', text: '資産と明細を確認' },
 ] as const;
 
 export function HomePage() {
@@ -62,21 +62,40 @@ export function HomePage() {
 
   return (
     <Layout>
-      <div className="page-surface space-y-6">
-        {/* ダッシュボードヘッダー */}
-        <div>
-          <h1 className="text-xl font-bold text-slate-900">証券Web</h1>
-          <p className="mt-0.5 text-sm text-slate-500">日々の資産・取引を確認する</p>
+      <div className="page-surface space-y-7">
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1.25fr)_minmax(20rem,0.75fr)] lg:items-end">
+          <div>
+            <p className="mb-2 text-[11px] font-black uppercase tracking-[0.28em] text-amber-700">Portfolio Desk</p>
+            <h1 className="text-3xl font-black leading-tight tracking-normal text-slate-950 sm:text-4xl">証券Web</h1>
+            <p className="mt-2 max-w-2xl text-sm font-medium text-slate-600">資産、配当、取引明細をひとつの作業面で確認します。</p>
+          </div>
+          <div className="rounded-xl border border-slate-950/10 bg-slate-950 p-4 text-white shadow-[0_18px_44px_-34px_rgba(15,23,42,0.95)]">
+            <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-amber-300">Current Focus</p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {NEXT_ACTIONS.map(({ label, to }) => (
+                <Link
+                  key={to}
+                  to={to}
+                  className="rounded-md border border-white/15 bg-white/10 px-3 py-2 text-sm font-bold text-white transition-colors hover:bg-white hover:text-slate-950"
+                >
+                  {label}
+                </Link>
+              ))}
+            </div>
+          </div>
         </div>
 
-        {/* ステータス／アクションストリップ */}
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
           {STATUS_ITEMS.map(({ label, sub, to, icon }) => {
             const inner = (
               <>
-                <div className="mb-2">{icon}</div>
-                <p className="text-sm font-semibold text-slate-800">{label}</p>
-                <p className="text-xs text-slate-500 mt-0.5">{sub}</p>
+                <div className="flex items-start justify-between gap-3">
+                  <span className="inline-flex h-10 w-10 items-center justify-center rounded-md border border-slate-950/10 bg-white shadow-sm">
+                    {icon}
+                  </span>
+                  <span className="text-[11px] font-black uppercase tracking-[0.18em] text-slate-400">{sub}</span>
+                </div>
+                <p className="mt-4 text-base font-black text-slate-950">{label}</p>
               </>
             );
 
@@ -85,7 +104,7 @@ export function HomePage() {
                 <Link
                   key={label}
                   to={to}
-                  className="rounded-lg border border-slate-200 bg-white px-4 py-3 hover:border-primary hover:shadow-sm transition-all group"
+                  className="group rounded-xl border border-slate-950/10 bg-white/80 px-4 py-4 shadow-sm transition-[border-color,box-shadow,transform] hover:-translate-y-0.5 hover:border-amber-500 hover:shadow-[0_18px_40px_-32px_rgba(15,23,42,0.85)]"
                 >
                   {inner}
                 </Link>
@@ -95,49 +114,41 @@ export function HomePage() {
             return (
               <div
                 key={label}
-                className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3"
+                className="rounded-xl border border-dashed border-slate-300 bg-slate-100/70 px-4 py-4"
               >
                 {inner}
-                <p className="text-xs text-slate-600 mt-1">各ページから取込可能</p>
+                <p className="mt-2 text-xs font-medium text-slate-500">各ページから取込可能</p>
               </div>
             );
           })}
         </div>
 
-        {/* 次に行う操作 */}
-        <div className="pt-4 border-t border-slate-200">
-          <h2 className="text-sm font-medium text-slate-500 mb-3">次に行う操作</h2>
-          <div className="flex flex-wrap gap-2">
-            {NEXT_ACTIONS.map(({ label, to }) => (
-              <Link
-                key={to}
-                to={to}
-                className="inline-flex items-center px-3 py-1.5 text-sm bg-slate-100 hover:bg-slate-200 text-slate-700 rounded-full transition-colors"
-              >
-                {label}
-              </Link>
-            ))}
-          </div>
-        </div>
-
-        {/* データ確認フロー */}
-        <div className="pt-4 border-t border-slate-200">
-          <h2 className="text-sm font-medium text-slate-500 mb-3">データ確認フロー</h2>
-          <div className="flex flex-wrap gap-2 items-center">
-            {FLOW_STEPS.map(({ step, text }, i) => (
-              <div key={step} className="flex items-center gap-2">
-                <div className="flex items-center gap-1.5">
-                  <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
-                    {step}
-                  </span>
-                  <span className="text-sm text-slate-700">{text}</span>
+        <div className="grid gap-4 border-t border-slate-950/10 pt-5 lg:grid-cols-[minmax(0,1fr)_minmax(18rem,0.55fr)]">
+          <section>
+            <h2 className="text-sm font-black text-slate-950">データ確認フロー</h2>
+            <div className="mt-3 grid gap-2 sm:grid-cols-3">
+              {FLOW_STEPS.map(({ step, text }) => (
+                <div key={step} className="rounded-lg border border-slate-950/10 bg-white/75 px-3 py-3">
+                  <span className="text-[11px] font-black uppercase tracking-[0.18em] text-amber-700">{step}</span>
+                  <p className="mt-1 text-sm font-bold text-slate-800">{text}</p>
                 </div>
-                {i < FLOW_STEPS.length - 1 && (
-                  <span className="text-slate-300 text-sm" aria-hidden="true">→</span>
-                )}
-              </div>
-            ))}
-          </div>
+              ))}
+            </div>
+          </section>
+          <section className="rounded-lg border border-slate-950/10 bg-white/70 px-4 py-3">
+            <h2 className="text-sm font-black text-slate-950">操作ショートカット</h2>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {NEXT_ACTIONS.map(({ label, to }) => (
+                <Link
+                  key={to}
+                  to={to}
+                  className="inline-flex items-center rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm font-bold text-slate-700 transition-colors hover:border-slate-950 hover:text-slate-950"
+                >
+                  {label}
+                </Link>
+              ))}
+            </div>
+          </section>
         </div>
       </div>
     </Layout>

--- a/frontend/src/pages/Receipt/Mutualfund.tsx
+++ b/frontend/src/pages/Receipt/Mutualfund.tsx
@@ -98,16 +98,16 @@ export const Mutualfund: React.FC<MutualfundProps> = ({ data, previewData, utili
 
     // テーブルカラムの定義（列幅を明示的に設定して右端切れを防止）
     const columns: TableColumnConfig[] = [
-        { key: 'trade_date', header: '約定日', width: '84px', format: formatJPDate },
-        { key: 'fund_name', header: 'ファンド名', width: '180px' },
+        { key: 'trade_date', header: '約定日', width: '112px', format: formatJPDate },
+        { key: 'fund_name', header: 'ファンド名', width: '300px' },
         { key: 'account', header: '口座', width: '60px' },
-        { key: 'shares', header: '数量', width: '64px', textAlign: 'right', format: formatNumber },
-        { key: 'cancellation_unit_price_yen', header: '解約単価', width: '82px', textAlign: 'right', format: formatCurrency },
-        { key: 'cancellation_amount_yen', header: '解約額', width: '82px', textAlign: 'right', format: formatCurrency },
-        { key: 'average_acquisition_price_yen', header: '取得価額', width: '82px', textAlign: 'right', format: formatCurrency },
-        { key: 'realized_profit_and_loss', header: '実現損益', width: '82px', textAlign: 'right', format: formatCurrency },
-        { key: 'taxes', header: '税額', width: '64px', textAlign: 'right', format: formatCurrency },
-        { key: 'realized_profit_and_loss_after_tax', header: '税引損益', width: '84px', textAlign: 'right', format: formatCurrency },
+        { key: 'shares', header: '数量', width: '112px', textAlign: 'right', format: formatNumber },
+        { key: 'cancellation_unit_price_yen', header: '解約単価', width: '98px', textAlign: 'right', format: formatCurrency },
+        { key: 'cancellation_amount_yen', header: '解約額', width: '128px', textAlign: 'right', format: formatCurrency },
+        { key: 'average_acquisition_price_yen', header: '取得価額', width: '116px', textAlign: 'right', format: formatCurrency },
+        { key: 'realized_profit_and_loss', header: '実現損益', width: '112px', textAlign: 'right', format: formatCurrency },
+        { key: 'taxes', header: '税額', width: '106px', textAlign: 'right', format: formatCurrency },
+        { key: 'realized_profit_and_loss_after_tax', header: '税引損益', width: '118px', textAlign: 'right', format: formatCurrency },
     ];
 
     // サマリーカラムの定義（ヘッダーと同じ項目: 実現損益、税額、税引後）

--- a/frontend/src/pages/Receipts.tsx
+++ b/frontend/src/pages/Receipts.tsx
@@ -71,7 +71,7 @@ export function ReceiptsPage() {
         onKeyDown={handleTabKeyDown}
         counts={counts}
       />
-      <div className="mt-2" aria-busy={workspaceBusy}>
+      <div className="mt-0" aria-busy={workspaceBusy}>
         <div data-testid="receipts-workspace">
           {!initialLoading &&
             panels.map((panel) => (

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -86,9 +86,9 @@ export function SearchPage() {
               description="銘柄コード（例：7203）または銘柄名を入力して検索してください。"
               className="py-10"
             />
-            <div className="mt-6 rounded-lg border border-slate-200 bg-slate-50 p-4">
-              <h3 className="text-sm font-semibold text-slate-600 mb-2">検索のヒント</h3>
-              <ul className="space-y-1 text-sm text-slate-500">
+            <div className="mt-6 rounded-xl border border-slate-950/10 bg-slate-50/80 p-4">
+              <h3 className="mb-2 text-sm font-black text-slate-800">検索のヒント</h3>
+              <ul className="space-y-1 text-sm font-medium text-slate-600">
                 <li>4桁の銘柄コードで検索できます（例：7203, 9984）</li>
                 <li>会社名の一部でも検索できます（例：トヨタ）</li>
                 <li>検索結果から各種証券サイトへのリンクを確認できます</li>

--- a/frontend/src/pages/__tests__/AssetBalancePage.test.tsx
+++ b/frontend/src/pages/__tests__/AssetBalancePage.test.tsx
@@ -266,7 +266,7 @@ describe('AssetBalancePage 認証境界・キャッシュ境界', () => {
     });
   });
 
-  it('認証済み時: workspace は広めの right rail レイアウトで表示される', async () => {
+  it('認証済み時: workspace はメイン幅を優先した right rail レイアウトで表示される', async () => {
     vi.mocked(authHook.useAuth).mockReturnValue(
       makeAuthMock({ isAuthenticated: true, userId: 'user-1' })
     );
@@ -278,8 +278,8 @@ describe('AssetBalancePage 認証境界・キャッシュ境界', () => {
       expect(screen.getByTestId('assetbalance-workspace')).toBeInTheDocument();
     });
 
-    expect(screen.getByTestId('assetbalance-workspace').className).toContain('lg:grid-cols-[minmax(0,1fr)_22rem]');
-    expect(screen.getByTestId('assetbalance-workspace').className).toContain('xl:grid-cols-[minmax(0,1fr)_24rem]');
+    expect(screen.getByTestId('assetbalance-workspace').className).toContain('lg:grid-cols-[minmax(0,1fr)_19rem]');
+    expect(screen.getByTestId('assetbalance-workspace').className).toContain('xl:grid-cols-[minmax(0,1fr)_20rem]');
   });
 
   it('保存後: right rail に軽い confirmation strip が表示される', async () => {

--- a/frontend/src/pages/__tests__/Home.test.tsx
+++ b/frontend/src/pages/__tests__/Home.test.tsx
@@ -27,7 +27,7 @@ describe('HomePage', () => {
     );
 
     expect(screen.getByRole('heading', { level: 1, name: '証券Web' })).toBeInTheDocument();
-    expect(screen.getByText('日々の資産・取引を確認する')).toBeInTheDocument();
+    expect(screen.getByText('資産、配当、取引明細をひとつの作業面で確認します。')).toBeInTheDocument();
   });
 
   it('ステータスストリップに4件のタイルを表示する', () => {
@@ -94,7 +94,7 @@ describe('HomePage', () => {
     );
 
     const nextSection = screen
-      .getByRole('heading', { name: '次に行う操作' })
+      .getByRole('heading', { name: '操作ショートカット' })
       .parentElement;
 
     expect(nextSection).not.toBeNull();
@@ -121,8 +121,8 @@ describe('HomePage', () => {
 
     const scoped = within(flowSection as HTMLElement);
 
-    expect(scoped.getByText('証券会社からCSVをダウンロード')).toBeInTheDocument();
-    expect(scoped.getByText('各ページのCSV取込から反映')).toBeInTheDocument();
-    expect(scoped.getByText('資産・配当金・取引明細を確認')).toBeInTheDocument();
+    expect(scoped.getByText('CSV取得')).toBeInTheDocument();
+    expect(scoped.getByText('各ページで取込')).toBeInTheDocument();
+    expect(scoped.getByText('資産と明細を確認')).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/__tests__/Receipts.test.tsx
+++ b/frontend/src/pages/__tests__/Receipts.test.tsx
@@ -804,7 +804,7 @@ describe('ReceiptsPage', () => {
       expect(screen.getByTestId('tab-count-mutualfund')).toHaveTextContent('0');
     }, waitOpts);
 
-    expect(screen.getByRole('tablist').className).toContain('border-b');
-    expect(screen.getByRole('tab', { name: /^配当金/ }).className).toContain('rounded-t-lg');
+    expect(screen.getByRole('tablist').className).toContain('rounded-xl');
+    expect(screen.getByRole('tab', { name: /^配当金/ }).className).toContain('rounded-lg');
   });
 });

--- a/frontend/src/pages/__tests__/ReceiptsAlerts.test.tsx
+++ b/frontend/src/pages/__tests__/ReceiptsAlerts.test.tsx
@@ -27,7 +27,7 @@ describe('ReceiptsAlerts', () => {
     );
 
     expect(screen.getByText('2行目: 金額が不正です')).toBeInTheDocument();
-    expect(screen.getByRole('alert')).toHaveClass('bg-warning/15');
+    expect(screen.getByRole('alert')).toHaveClass('bg-amber-50');
   });
 
   it('csvPreview.errors が空なら warning バリアントを使わない', () => {
@@ -41,8 +41,8 @@ describe('ReceiptsAlerts', () => {
     );
 
     const alert = screen.getByRole('alert');
-    expect(alert).toHaveClass('bg-info/10');
-    expect(alert).not.toHaveClass('bg-warning/15');
+    expect(alert).toHaveClass('bg-blue-50');
+    expect(alert).not.toHaveClass('bg-amber-50');
   });
 
   it('dbError があるとエラーメッセージを表示する', () => {

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -30,6 +30,7 @@
 
   --container-wide: 1600px;
 
+  /* stylelint-disable-next-line value-keyword-case -- Meiryo is the official Windows font family name. */
   --font-sans: 'BIZ UDPGothic', 'Yu Gothic', 'Hiragino Kaku Gothic ProN', 'Hiragino Sans', Meiryo, sans-serif;
 }
 

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -1,58 +1,65 @@
 @import 'tailwindcss';
 
-/* カスタムテーマ設定 */
 @theme {
-  /* カラーパレット（既存テーマ互換 + 拡張） */
-  --color-primary: #0d6efd;
-  --color-primary-hover: #0b5ed7;
-  --color-primary-dark: #0a58ca;
-  --color-secondary: #6c757d;
-  --color-secondary-hover: #5c636a;
-  --color-success: #198754;
-  --color-success-hover: #157347;
-  --color-info: #0dcaf0;
-  --color-info-hover: #31d2f2;
-  --color-warning: #ffc107;
-  --color-warning-hover: #ffca2c;
+  --color-primary: #111827;
+  --color-primary-hover: #1f2937;
+  --color-primary-dark: #030712;
+  --color-secondary: #64748b;
+  --color-secondary-hover: #475569;
+  --color-success: #0f766e;
+  --color-success-hover: #115e59;
+  --color-info: #2563eb;
+  --color-info-hover: #1d4ed8;
+  --color-warning: #d97706;
+  --color-warning-hover: #b45309;
   --color-danger: #dc3545;
   --color-danger-hover: #bb2d3b;
-  --color-light: #f8f9fa;
-  --color-dark: #212529;
+  --color-light: #f8fafc;
+  --color-dark: #111827;
   --color-negative: #dc3545;
   --color-negative-dark: #ff6b6b;
+  --color-accent: #c08403;
+  --color-accent-soft: #fff7ed;
 
-  /* 背景色 */
-  --color-bg-body: #f5f5f5;
-  --color-bg-dark: #121212;
+  --color-bg-body: #f6f7f4;
+  --color-bg-dark: #111827;
   --color-bg-card-dark: #1e1e1e;
 
-  /* ボーダー色 */
-  --color-border: rgba(0, 0, 0, 0.125);
+  --color-border: rgba(15, 23, 42, 0.12);
   --color-border-dark: #333;
 
-  /* コンテナ幅 */
   --container-wide: 1600px;
 
-  /* フォントファミリー */
-  --font-sans: 'Helvetica Neue', Arial, 'Hiragino Kaku Gothic ProN', 'Hiragino Sans', Meiryo, sans-serif;
+  --font-sans: 'BIZ UDPGothic', 'Yu Gothic', 'Hiragino Kaku Gothic ProN', 'Hiragino Sans', Meiryo, sans-serif;
 }
 
-/* ベーススタイル */
 @layer base {
+  html {
+    background: var(--color-bg-body);
+  }
+
   body {
     font-family: var(--font-sans);
     line-height: 1.6;
     color: var(--color-dark);
     background-color: var(--color-bg-body);
+    background-image:
+      linear-gradient(rgba(17, 24, 39, 0.035) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(17, 24, 39, 0.025) 1px, transparent 1px),
+      linear-gradient(180deg, #f9faf7 0%, #eef2f3 100%);
+    background-size: 44px 44px, 44px 44px, 100% 100%;
+    font-feature-settings: "palt" 1;
   }
 
-  /* ダークモード対応 */
   [data-theme="dark"] body {
     background-color: var(--color-bg-dark);
     color: #f5f5f5;
   }
 
-  /* 負の値を赤色で表示 */
+  ::selection {
+    background: rgba(192, 132, 3, 0.24);
+  }
+
   [data-negative="true"] {
     color: var(--color-negative) !important;
     font-weight: 500;
@@ -62,24 +69,23 @@
     color: var(--color-negative-dark) !important;
   }
 
-  /* スクロールバーのスタイリング */
   ::-webkit-scrollbar {
     width: 8px;
     height: 8px;
   }
 
   ::-webkit-scrollbar-track {
-    background: #f1f1f1;
+    background: #e5e7eb;
     border-radius: 4px;
   }
 
   ::-webkit-scrollbar-thumb {
-    background: #c1c1c1;
+    background: #94a3b8;
     border-radius: 4px;
   }
 
   ::-webkit-scrollbar-thumb:hover {
-    background: #888;
+    background: #64748b;
   }
 
   [data-theme="dark"] ::-webkit-scrollbar-track {
@@ -96,38 +102,36 @@
 }
 
 @layer components {
-  /* 単発ページのコンテンツ面（Home・Search など） */
   .page-surface {
-    @apply flex-1 rounded-lg border border-slate-200 bg-white p-6 shadow-sm;
+    @apply relative flex-1 overflow-hidden rounded-[1.25rem] border border-slate-950/10 bg-white/90 p-6 shadow-[0_18px_60px_-48px_rgba(15,23,42,0.85)] backdrop-blur-sm;
   }
 
-  /* フォーム入力コンテナ（CSV入力等） */
+  .page-surface::before {
+    content: "";
+    @apply pointer-events-none absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-slate-950 via-amber-500 to-teal-700;
+  }
+
   .form-input-container {
     @apply w-full max-w-[400px];
   }
 
-  /* 統計情報グリッド（3カラム） */
   .stat-grid {
     @apply grid grid-cols-1 gap-4 md:grid-cols-3;
   }
 
-  /* アクションツールバー */
   .action-toolbar {
-    @apply flex flex-wrap items-center gap-3 rounded-lg border border-slate-200 bg-white p-3 shadow-sm;
+    @apply flex flex-wrap items-center gap-3 rounded-xl border border-slate-950/10 bg-white/85 p-3 shadow-sm backdrop-blur;
   }
 
-  /* ボタングループ（カード装飾なし、横並びのみ） */
   .action-button-group {
     @apply flex flex-wrap items-center gap-3;
   }
 
-  /* ステータスメッセージ（ローディング・空状態） */
   .status-message {
     @apply my-4 flex flex-col items-center gap-2;
   }
 }
 
-/* 印刷対応 */
 @media print {
   .no-print {
     display: none !important;


### PR DESCRIPTION
## 概要
フロントエンド主要画面のデザインを再構築しました。
ホーム、検索、資産管理、取引明細の共通トーンを整理し、取引明細と資産管理の表示崩れを修正しています。

## 主な変更
- 共通テーマ、ヘッダー、カード、フォーム、テーブル、ページ見出しのスタイルを更新
- 資産管理の保有内訳は3列表示を維持し、銘柄コードリンクを青色で識別しやすく調整
- 右レールの検索オプション見出しが折り返されないよう調整
- 投資信託テーブルの列幅を見直し、数値・日付・ファンド名の省略表示を解消
- 取引明細タブと集計情報カードの余白を圧縮

## 検証
- [x] `cd frontend && vp lint`
- [x] `cd frontend && vp build`
- [x] `./scripts/run-ui-e2e.sh --skip-csv`（13 passed）
- [x] Playwright DOM計測で資産管理の保有内訳3列表示を確認
- [x] Playwright DOM計測で右レール検索オプション見出し1行表示を確認
- [x] Playwright DOM計測で投資信託テーブルの overflowCells が空であることを確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * UIコンポーネント全体のスタイルを刷新しました。色パレット、スペーシング、角丸、シャドウなどの表現を統一し、デザインの一貫性を向上させています。
  * ホームページレイアウトを再編成し、ダッシュボード構成に変更しました。
  * フォントサイズ、太さ、配色を全体的に調整し、視認性を改善しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->