### PR TITLE
fix: SecurityCodeLink のクラス結合を修正

### DIFF
--- a/frontend/src/components/atoms/SecurityCodeLink.tsx
+++ b/frontend/src/components/atoms/SecurityCodeLink.tsx
@@ -1,3 +1,4 @@
+import { cn } from '@/lib/utils/classNames';
 import { normalizeSecurityCode, SECURITY_CODE_REGEX } from '@/lib/utils/formatters';
 
 interface SecurityCodeLinkProps {
@@ -5,7 +6,8 @@ interface SecurityCodeLinkProps {
   className?: string;
 }
 
-const FONT_WEIGHT_CLASS_REGEX = /\bfont-(?:thin|extralight|light|normal|medium|semibold|bold|extrabold|black)\b/;
+// hover:font-bold や sm:font-semibold 等の responsive/state prefix を含む font-weight クラスを検出する
+const FONT_WEIGHT_CLASS_REGEX = /(?:^|\s)(?:[a-z-]+:)*font-(?:thin|extralight|light|normal|medium|semibold|bold|extrabold|black)\b/;
 
 /**
  * 銘柄コードをリンクとして表示するコンポーネント
@@ -24,14 +26,16 @@ export const SecurityCodeLink: React.FC<SecurityCodeLinkProps> = ({ value, class
     return <span>{code}</span>;
   }
 
-  const baseClassName = 'security-code-link text-blue-700 underline-offset-2 hover:text-blue-900 hover:underline focus-visible:rounded-sm focus-visible:outline-2 focus-visible:outline-blue-500';
-  const fontWeightClassName = className && FONT_WEIGHT_CLASS_REGEX.test(className) ? '' : 'font-bold';
-  const combinedClassName = [className, fontWeightClassName, baseClassName].filter(Boolean).join(' ');
+  const hasFontWeight = !!className && FONT_WEIGHT_CLASS_REGEX.test(className);
 
   return (
     <a
       href={`/search?code=${encodeURIComponent(code)}`}
-      className={combinedClassName}
+      className={cn(
+        'security-code-link text-blue-700 underline-offset-2 hover:text-blue-900 hover:underline focus-visible:rounded-sm focus-visible:outline-2 focus-visible:outline-blue-500',
+        !hasFontWeight && 'font-bold',
+        className
+      )}
       data-search={code}
     >
       {code}

--- a/frontend/src/components/atoms/__tests__/SecurityCodeLink.test.tsx
+++ b/frontend/src/components/atoms/__tests__/SecurityCodeLink.test.tsx
@@ -57,4 +57,16 @@ describe('SecurityCodeLink', () => {
     expect(link).not.toHaveClass('font-bold');
     expect(link).toHaveClass('text-blue-700');
   });
+
+  it('prefix 付き font weight を指定した場合はデフォルトの font-bold と競合しない', () => {
+    render(
+      <MemoryRouter>
+        <SecurityCodeLink value="7203" className="hover:font-semibold" />
+      </MemoryRouter>
+    );
+
+    const link = screen.getByRole('link', { name: '7203' });
+    expect(link).toHaveClass('hover:font-semibold');
+    expect(link).not.toHaveClass('font-bold');
+  });
 });


### PR DESCRIPTION
## 概要
SecurityCodeLink のクラス結合を cn() に統一し、prefix 付き font-weight クラスで font-bold が重複しないように修正しました。

## テスト
- npm test: 896 passed
- vp lint: pass