### PR TITLE
fix: PageHeader の eyebrow を prop 化

### DIFF
--- a/frontend/src/components/atoms/PageHeader.tsx
+++ b/frontend/src/components/atoms/PageHeader.tsx
@@ -3,17 +3,20 @@ import { cn } from '../../lib/utils/classNames';
 
 interface PageHeaderProps {
   title: string;
+  eyebrow?: string;
   description?: string;
   actions?: ReactNode;
   className?: string;
 }
 
-export function PageHeader({ title, description, actions, className }: PageHeaderProps) {
+export function PageHeader({ title, eyebrow, description, actions, className }: PageHeaderProps) {
   return (
     <div className={cn('mb-5', className)}>
       <div className="flex flex-col gap-3 border-l-4 border-amber-500 pl-4 sm:flex-row sm:items-end sm:justify-between">
         <div>
-          <p className="mb-1 text-[11px] font-bold uppercase tracking-[0.22em] text-slate-500">Workspace</p>
+          {eyebrow ? (
+            <p className="mb-1 text-[11px] font-bold uppercase tracking-[0.22em] text-slate-500">{eyebrow}</p>
+          ) : null}
           <h1 className="text-2xl font-black leading-tight tracking-normal text-slate-950">{title}</h1>
           {description ? (
             <p className="mt-1 text-sm font-medium text-slate-600">{description}</p>

--- a/frontend/src/components/atoms/__tests__/PageHeader.test.tsx
+++ b/frontend/src/components/atoms/__tests__/PageHeader.test.tsx
@@ -19,4 +19,15 @@ describe('PageHeader', () => {
 
     expect(screen.getByRole('button', { name: '追加' })).toBeInTheDocument();
   });
+
+  it('eyebrow を指定した場合だけ表示する', () => {
+    const { rerender } = render(<PageHeader title="資産管理" />);
+
+    expect(screen.queryByText('Portfolio')).not.toBeInTheDocument();
+    expect(screen.queryByText('Workspace')).not.toBeInTheDocument();
+
+    rerender(<PageHeader title="資産管理" eyebrow="Portfolio" />);
+
+    expect(screen.getByText('Portfolio')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/AssetBalance.tsx
+++ b/frontend/src/pages/AssetBalance.tsx
@@ -86,6 +86,7 @@ export function AssetBalancePage() {
     <Layout>
       <PageHeader
         title="資産管理"
+        eyebrow="Portfolio"
         description="保有している銘柄の一覧と評価額を確認できます。"
       />
       <div className="mt-2" aria-busy={workspaceBusy}>

--- a/frontend/src/pages/Receipts.tsx
+++ b/frontend/src/pages/Receipts.tsx
@@ -62,6 +62,7 @@ export function ReceiptsPage() {
     <Layout>
       <PageHeader
         title="取引明細"
+        eyebrow="Transactions"
         description="配当金・国内株式・投資信託の取引明細を管理します。"
       />
       <ReceiptsTabNav

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -46,6 +46,7 @@ export function SearchPage() {
       <div className="page-surface">
         <PageHeader
           title="銘柄検索"
+          eyebrow="Search"
           description="銘柄コードまたは銘柄名を入力して株式情報を検索できます。"
         />
         <SearchForm


### PR DESCRIPTION
## 概要
PageHeader に eyebrow prop を追加し、未指定時は eyebrow 要素を出力しないようにしました。主要ページから適切な eyebrow を渡しています。

## テスト
- npm test: 896 passed
- vp lint: pass
- vp build: pass