### PR TITLE
fix: Card と Layout の背景処理を調整

### DIFF
--- a/frontend/src/components/atoms/Card.tsx
+++ b/frontend/src/components/atoms/Card.tsx
@@ -20,7 +20,7 @@ export function Card({ children, className, ...rest }: CardProps) {
   return (
     <div
       className={cn(
-        'rounded-xl border border-slate-950/10 bg-white/90 shadow-[0_14px_38px_-32px_rgba(15,23,42,0.85)] backdrop-blur-sm print:border-black print:shadow-none',
+        'rounded-xl border border-slate-950/10 bg-white/90 shadow-[0_14px_38px_-32px_rgba(15,23,42,0.85)] print:border-black print:shadow-none',
         className
       )}
       {...rest}

--- a/frontend/src/components/atoms/__tests__/Card.test.tsx
+++ b/frontend/src/components/atoms/__tests__/Card.test.tsx
@@ -7,6 +7,12 @@ describe('Card', () => {
 
     expect(screen.getByText('カード本文')).toBeInTheDocument();
   });
+
+  it('backdrop blur を適用しない', () => {
+    render(<Card>カード本文</Card>);
+
+    expect(screen.getByText('カード本文')).not.toHaveClass('backdrop-blur-sm');
+  });
 });
 
 describe('CardHeader', () => {

--- a/frontend/src/components/templates/Layout.tsx
+++ b/frontend/src/components/templates/Layout.tsx
@@ -9,7 +9,7 @@ interface LayoutProps {
 
 export function Layout({ children }: LayoutProps) {
   return (
-    <div className="min-h-screen flex flex-col bg-transparent text-slate-950">
+    <div className="min-h-screen flex flex-col bg-slate-50 text-slate-950">
       <a
         href="#main-content"
         className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:rounded-md focus:bg-white focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:shadow-lg focus:outline-2 focus:outline-primary"

--- a/frontend/src/components/templates/__tests__/Layout.test.tsx
+++ b/frontend/src/components/templates/__tests__/Layout.test.tsx
@@ -30,4 +30,10 @@ describe('Layout', () => {
     expect(screen.getByTestId('header')).toBeInTheDocument();
     expect(screen.getByTestId('footer')).toBeInTheDocument();
   });
+
+  it('明示的な背景色を持つ', () => {
+    render(<Layout><div>コンテンツ</div></Layout>);
+
+    expect(screen.getByText('コンテンツ').closest('.min-h-screen')).toHaveClass('bg-slate-50');
+  });
 });

--- a/frontend/src/features/receipt/components/ReceiptsTabNav.tsx
+++ b/frontend/src/features/receipt/components/ReceiptsTabNav.tsx
@@ -37,10 +37,10 @@ export function ReceiptsTabNav({
             <button
               key={tab}
               id={`tab-${tab}`}
-              className={`inline-flex items-center gap-2 rounded-lg border px-4 py-2.5 text-sm font-bold transition-[color,background-color,border-color,box-shadow] ${
+              className={`inline-flex items-center gap-2 rounded-lg border px-4 py-2.5 text-sm font-bold ${
                 isActive
                   ? 'border-slate-950 bg-slate-950 text-white shadow-[inset_0_-2px_0_#f59e0b]'
-                  : 'border-transparent text-slate-500 hover:bg-white hover:text-slate-900'
+                  : 'border-slate-300 bg-white text-slate-800 hover:border-slate-400 hover:bg-white hover:text-slate-950'
               }`}
               onClick={() => onTabChange(tab)}
               onKeyDown={onKeyDown}
@@ -56,7 +56,7 @@ export function ReceiptsTabNav({
                 className={`inline-flex min-w-6 items-center justify-center rounded-full px-2 py-0.5 text-xs font-semibold ${
                   isActive
                     ? 'border border-white/20 bg-white text-slate-950'
-                    : 'bg-slate-100 text-slate-500'
+                    : 'border border-slate-200 bg-white text-slate-700'
                 }`}
               >
                 {counts[tab]}

--- a/frontend/src/features/receipt/components/__tests__/ReceiptsTabNav.test.tsx
+++ b/frontend/src/features/receipt/components/__tests__/ReceiptsTabNav.test.tsx
@@ -47,6 +47,23 @@ describe('ReceiptsTabNav', () => {
     expect(screen.getByTestId('tab-count-mutualfund')).toHaveTextContent('2');
   });
 
+  it('非選択タブと件数バッジは淡い背景でも十分なコントラストの文字色を使う', () => {
+    render(
+      <ReceiptsTabNav
+        receiptsType="domesticstock"
+        tablistRef={createRef<HTMLDivElement>()}
+        onTabChange={vi.fn()}
+        onKeyDown={vi.fn()}
+        counts={counts}
+      />
+    );
+
+    const inactiveTab = screen.getByRole('tab', { name: /配当金/ });
+
+    expect(inactiveTab).toHaveClass('text-slate-800');
+    expect(screen.getByTestId('tab-count-dividend')).toHaveClass('text-slate-700');
+  });
+
   it('タブクリックで onTabChange コールバックが呼ばれる', () => {
     const onTabChange = vi.fn();
 


### PR DESCRIPTION
## 概要
Card から backdrop-blur-sm を除去し、Layout に明示的な bg-slate-50 を設定しました。

## テスト
- npm test: 897 passed
- vp lint: pass
- ./scripts/run-ui-e2e.sh --skip-csv: 13 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **スタイル変更**
  * Card コンポーネントの背景ぼかし効果を削除しました
  * Layout コンポーネントの背景色を更新しました
  * 受領書タブの見た目（非アクティブ時の枠・背景・ホバーなど）と件数バッジのスタイルを更新しました
* **テスト**
  * Card の「ぼかしなし」表示を確認するテストを追加しました
  * Layout の背景色クラス適用を確認するテストを追加しました
  * 受領書タブナビの非アクティブ状態の見た目（コントラスト）を確認するテストを追加しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->