### PR TITLE
fix: 資産管理の保有内訳を3列表示に戻す

### DIFF
--- a/frontend/src/components/molecules/PortfolioPieChart/PortfolioPieChart.tsx
+++ b/frontend/src/components/molecules/PortfolioPieChart/PortfolioPieChart.tsx
@@ -234,7 +234,7 @@ export const PortfolioPieChart: React.FC<PortfolioPieChartProps> = ({
   return (
     <div className={className} data-testid="portfolio-pie-chart">
       {/* 横棒グラフリスト（2-3列グリッド） */}
-      <div className={gridClassName}>
+      <div className={gridClassName} data-testid="portfolio-items-grid">
         {displayData.map((item, index) => (
           <PortfolioItemCard
             key={item.securityCode}

--- a/frontend/src/components/molecules/PortfolioPieChart/__tests__/PortfolioPieChart.test.tsx
+++ b/frontend/src/components/molecules/PortfolioPieChart/__tests__/PortfolioPieChart.test.tsx
@@ -88,6 +88,13 @@ describe('PortfolioPieChart', () => {
     expect(container.firstChild).toBeNull();
   });
 
+  it('3件以上のデータでは保有内訳カードを xl:grid-cols-3 で表示する', () => {
+    const { container } = render(<PortfolioPieChart data={mockData} />);
+    const grid = container.querySelector('[data-testid="portfolio-items-grid"]');
+    expect(grid).toHaveClass('xl:grid-cols-3');
+    expect(grid).not.toHaveClass('xl:grid-cols-4');
+  });
+
   it('カスタムクラス名が適用される', () => {
     render(<PortfolioPieChart data={mockData} className="custom-chart" />);
 

--- a/frontend/src/components/organisms/AssetPortfolioSummary/AssetPortfolioSummary.tsx
+++ b/frontend/src/components/organisms/AssetPortfolioSummary/AssetPortfolioSummary.tsx
@@ -131,7 +131,7 @@ export const AssetPortfolioSummary: React.FC<AssetPortfolioSummaryProps> = ({
             </div>
           ) : null}
         </div>
-        <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3" data-testid="portfolio-kpi-grid">
           <div className="rounded-lg border border-slate-950/10 bg-white px-4 py-4 shadow-sm">
             <p className="mb-1 text-xs font-medium text-slate-600">合計取得総額</p>
             <p className="text-3xl font-bold text-primary tabular-nums" data-negative={totalPurchaseAmount < 0 ? 'true' : undefined}>

--- a/frontend/src/components/organisms/AssetPortfolioSummary/__tests__/AssetPortfolioSummary.test.tsx
+++ b/frontend/src/components/organisms/AssetPortfolioSummary/__tests__/AssetPortfolioSummary.test.tsx
@@ -197,6 +197,15 @@ describe('AssetPortfolioSummary', () => {
     expect(screen.getByTestId('asset-portfolio-summary')).toBeInTheDocument();
   });
 
+  it('KPI strip のグリッドは xl:grid-cols-3 で3列ベースを使用し xl:grid-cols-4 は使用しない', () => {
+    const mockData = createMockData();
+    const { container } = render(<AssetPortfolioSummary assetBalanceData={mockData} />);
+    const kpiGrid = container.querySelector('[data-testid="portfolio-kpi-grid"]');
+    expect(kpiGrid).toBeInTheDocument();
+    expect(kpiGrid).toHaveClass('xl:grid-cols-3');
+    expect(kpiGrid).not.toHaveClass('xl:grid-cols-4');
+  });
+
   describe('配当金額・配当利回り', () => {
     it('ポートフォリオ全体の年間配当金額と配当利回りが正しく表示される', () => {
       const mockData = createMockData();


### PR DESCRIPTION
## 概要
フロントエンド主要画面デザイン再構築のレビュー指摘に対応し、資産管理の KPI strip と保有内訳カードを3列ベースに戻しました。

## テスト
- npm test: 897 passed
- vp lint: pass
- vp build: pass
- ./scripts/run-ui-e2e.sh --skip-csv: 13 passed