### PR TITLE
銘柄名の右クリックコピーを追加

### DIFF
--- a/frontend/src/components/atoms/SecurityCodeLink.tsx
+++ b/frontend/src/components/atoms/SecurityCodeLink.tsx
@@ -39,6 +39,44 @@ export const SecurityCodeLink: React.FC<SecurityCodeLinkProps> = ({ value, class
   );
 };
 
+interface CopyableInstrumentNameProps {
+  name: unknown;
+  code?: unknown;
+  className?: string;
+}
+
+const toDisplayText = (value: unknown): string => {
+  if (value === null || value === undefined) return "-";
+  const text = String(value).trim();
+  return text || "-";
+};
+
+const createInstrumentCopyText = (name: unknown, code?: unknown): string => {
+  const displayName = toDisplayText(name);
+  const normalizedCode = normalizeSecurityCode(code);
+  return normalizedCode ? displayName + "(" + normalizedCode + ")" : displayName;
+};
+
+export const CopyableInstrumentName: React.FC<CopyableInstrumentNameProps> = ({ name, code, className }) => {
+  const displayName = toDisplayText(name);
+  const copyText = createInstrumentCopyText(name, code);
+
+  const handleContextMenu = (event: React.MouseEvent<HTMLSpanElement>) => {
+    event.preventDefault();
+    if (copyText && navigator.clipboard?.writeText) {
+      void navigator.clipboard.writeText(copyText);
+    }
+  };
+
+  const combinedClassName = className ? className + " cursor-copy" : "cursor-copy";
+
+  return (
+    <span className={combinedClassName} title={copyText} onContextMenu={handleContextMenu}>
+      {displayName}
+    </span>
+  );
+};
+
 /**
  * カラムのformat用レンダラー（ReactNodeを返す）
  */

--- a/frontend/src/components/organisms/ReceiptTable/ReceiptTable.tsx
+++ b/frontend/src/components/organisms/ReceiptTable/ReceiptTable.tsx
@@ -45,8 +45,16 @@ const isNegativeValue = (value: unknown): boolean => {
     return Number(normalized) < 0;
 };
 
-const renderCell = (value: unknown, column: ColumnConfig, key: string, style?: React.CSSProperties) => {
-    const formattedValue = column.format ? column.format(value) : value;
+const renderCell = (
+    value: unknown,
+    column: ColumnConfig,
+    key: string,
+    style?: React.CSSProperties,
+    row?: DataItem
+) => {
+    const formattedValue = 'render' in column && column.render && row
+        ? column.render(value, row)
+        : column.format ? column.format(value) : value;
     const isNegative = !React.isValidElement(formattedValue) && isNegativeValue(value);
     const displayText = React.isValidElement(formattedValue) ? undefined : String(toText(formattedValue));
 
@@ -86,7 +94,7 @@ function renderDataRows<T extends DataItem>(
     return items.map((item, itemIndex) => (
         <TableRow key={`${keyPrefix}-${itemIndex}`}>
             {columns.map((column, colIndex) =>
-                renderCell(item[column.key], column, `${keyPrefix}-${itemIndex}-${colIndex}`)
+                renderCell(item[column.key], column, `${keyPrefix}-${itemIndex}-${colIndex}`, undefined, item)
             )}
         </TableRow>
     ));
@@ -161,7 +169,7 @@ function renderGroupedRows<T extends DataItem, S extends SummaryItem>(
                 {groupItems.map((item, itemIndex) => (
                     <TableRow key={`item-${summaryIndex}-${itemIndex}`}>
                         {columns.map((column, colIndex) =>
-                            renderCell(item[column.key], column, `item-${summaryIndex}-${itemIndex}-${colIndex}`)
+                            renderCell(item[column.key], column, `item-${summaryIndex}-${itemIndex}-${colIndex}`, undefined, item)
                         )}
                     </TableRow>
                 ))}

--- a/frontend/src/features/receipt/types.ts
+++ b/frontend/src/features/receipt/types.ts
@@ -1,4 +1,5 @@
 import type { components } from '@/generated/api';
+import type React from 'react';
 import type { FormatFunction, TableColumnAlignment } from '@/types/common';
 
 export type DividendApiData = components['schemas']['Dividend'];
@@ -19,6 +20,7 @@ export interface TableColumnConfig {
   width?: string;
   textAlign?: TableColumnAlignment;
   format?: FormatFunction;
+  render?: (value: unknown, row: Record<string, unknown>) => React.ReactNode;
 }
 
 export interface SummaryColumnConfig {

--- a/frontend/src/pages/Receipt/Dividend.tsx
+++ b/frontend/src/pages/Receipt/Dividend.tsx
@@ -19,7 +19,7 @@ import {
     formatNumber,
     SECURITY_CODE_REGEX
 } from '@/lib/utils/formatters';
-import { renderSecurityCode } from '@/components/atoms/SecurityCodeLink';
+import { CopyableInstrumentName, renderSecurityCode } from '@/components/atoms/SecurityCodeLink';
 import { useReceiptCalculations, useReceiptBaseData } from '@/hooks/receipt/useReceiptData';
 import {
     createYearOptions,
@@ -172,7 +172,7 @@ export const Dividend: React.FC<DividendProps> = ({ data, previewData, utilityRa
         { key: 'product', header: '商品', width: '64px' },
         { key: 'account', header: '口座', width: '64px' },
         { key: 'security_code', header: '銘柄コード', width: '72px', textAlign: 'center', format: renderSecurityCode },
-        { key: 'security_name', header: '銘柄名', width: '160px' },
+        { key: 'security_name', header: '銘柄名', width: '160px', render: (value, row) => <CopyableInstrumentName name={value} code={row.security_code} /> },
         { key: 'unit_price', header: '単価', width: '72px', textAlign: 'right', format: formatCurrency },
         { key: 'shares', header: '数量', width: '56px', textAlign: 'right', format: formatNumber },
         { key: 'dividends_before_tax', header: '配当金', width: '84px', textAlign: 'right', format: formatCurrency },

--- a/frontend/src/pages/Receipt/DomesticStock.tsx
+++ b/frontend/src/pages/Receipt/DomesticStock.tsx
@@ -15,7 +15,7 @@ import {
     formatNumber,
     createISODateKey
 } from '@/lib/utils/formatters';
-import { renderSecurityCode } from '@/components/atoms/SecurityCodeLink';
+import { CopyableInstrumentName, renderSecurityCode } from '@/components/atoms/SecurityCodeLink';
 import { useReceiptCalculations, useReceiptBaseData } from '@/hooks/receipt/useReceiptData';
 import {
     createYearOptions,
@@ -100,7 +100,7 @@ export const DomesticStock: React.FC<DomesticStockProps> = ({ data, previewData,
     const baseColumns: TableColumnConfig[] = [
         { key: 'trade_date', header: '約定日', width: '84px', format: formatJPDate },
         { key: 'security_code', header: '銘柄コード', width: '72px', textAlign: 'center', format: renderSecurityCode },
-        { key: 'security_name', header: '銘柄名', width: '156px' },
+        { key: 'security_name', header: '銘柄名', width: '156px', render: (value, row) => <CopyableInstrumentName name={value} code={row.security_code} /> },
         { key: 'account', header: '口座', width: '60px' },
         { key: 'shares', header: '数量', width: '56px', textAlign: 'right', format: formatNumber },
         { key: 'asked_price', header: '売却単価', width: '76px', textAlign: 'right', format: formatCurrency },

--- a/frontend/src/pages/Receipt/Mutualfund.tsx
+++ b/frontend/src/pages/Receipt/Mutualfund.tsx
@@ -3,6 +3,7 @@ import { ReceiptHeader } from '@/components/molecules/ReceiptHeader/ReceiptHeade
 import { ReceiptTable } from '@/components/organisms/ReceiptTable/ReceiptTable';
 import { EmptyState } from '@/components/atoms/EmptyState';
 import React from 'react';
+import { CopyableInstrumentName } from '@/components/atoms/SecurityCodeLink';
 import type {
     MutualfundData,
     SummaryColumnConfig,
@@ -99,7 +100,7 @@ export const Mutualfund: React.FC<MutualfundProps> = ({ data, previewData, utili
     // テーブルカラムの定義（列幅を明示的に設定して右端切れを防止）
     const columns: TableColumnConfig[] = [
         { key: 'trade_date', header: '約定日', width: '112px', format: formatJPDate },
-        { key: 'fund_name', header: 'ファンド名', width: '300px' },
+        { key: 'fund_name', header: 'ファンド名', width: '300px', render: (value) => <CopyableInstrumentName name={value} /> },
         { key: 'account', header: '口座', width: '60px' },
         { key: 'shares', header: '数量', width: '112px', textAlign: 'right', format: formatNumber },
         { key: 'cancellation_unit_price_yen', header: '解約単価', width: '98px', textAlign: 'right', format: formatCurrency },

--- a/frontend/src/pages/Receipt/__tests__/Dividend.test.tsx
+++ b/frontend/src/pages/Receipt/__tests__/Dividend.test.tsx
@@ -122,6 +122,24 @@ describe('Dividend', () => {
         expect(screen.getByText('テスト株式2')).toBeInTheDocument();
     });
 
+    it('銘柄名を右クリックすると銘柄名と銘柄コードをコピーする', () => {
+        const writeText = vi.fn().mockResolvedValue(undefined);
+        Object.defineProperty(navigator, 'clipboard', {
+            value: { writeText },
+            configurable: true,
+        });
+
+        render(<Dividend data={[{
+            ...mockData[0],
+            security_code: '9433',
+            security_name: 'ＫＤＤＩ',
+        }]} />);
+
+        fireEvent.contextMenu(screen.getByText('ＫＤＤＩ'));
+
+        expect(writeText).toHaveBeenCalledWith('ＫＤＤＩ(9433)');
+    });
+
     it('検索オプションが正しく生成される', async () => {
         const { container } = render(<Dividend data={mockData} />);
 

--- a/frontend/src/pages/Receipt/__tests__/DomesticStock.test.tsx
+++ b/frontend/src/pages/Receipt/__tests__/DomesticStock.test.tsx
@@ -99,6 +99,24 @@ describe('DomesticStock', () => {
         expect(screen.getByText('テスト株式2')).toBeInTheDocument();
     });
 
+    it('銘柄名を右クリックすると銘柄名と銘柄コードをコピーする', () => {
+        const writeText = vi.fn().mockResolvedValue(undefined);
+        Object.defineProperty(navigator, 'clipboard', {
+            value: { writeText },
+            configurable: true,
+        });
+
+        render(<DomesticStock data={[{
+            ...mockData[0],
+            security_code: '9433',
+            security_name: 'ＫＤＤＩ',
+        }]} />);
+
+        fireEvent.contextMenu(screen.getByText('ＫＤＤＩ'));
+
+        expect(writeText).toHaveBeenCalledWith('ＫＤＤＩ(9433)');
+    });
+
     it('検索オプションが正しく生成される', async () => {
         const { container } = render(<DomesticStock data={mockData} />);
 

--- a/frontend/src/pages/Receipt/__tests__/Mutualfund.test.tsx
+++ b/frontend/src/pages/Receipt/__tests__/Mutualfund.test.tsx
@@ -94,6 +94,20 @@ describe('Mutualfund', () => {
         expect(screen.getByText('ファンド名')).toBeInTheDocument();
     });
 
+    it('ファンド名を右クリックするとファンド名をコピーする', () => {
+        const writeText = vi.fn().mockResolvedValue(undefined);
+        Object.defineProperty(navigator, 'clipboard', {
+            value: { writeText },
+            configurable: true,
+        });
+
+        render(<Mutualfund data={mockData} />);
+
+        fireEvent.contextMenu(screen.getByText('テストファンドA'));
+
+        expect(writeText).toHaveBeenCalledWith('テストファンドA');
+    });
+
     it('ファンド名検索でフィルタリングされる', async () => {
         const user = userEvent.setup();
         const { container } = render(<Mutualfund data={mockData} />);


### PR DESCRIPTION
## 概要
- 配当金・国内株式の銘柄名を右クリックした時に `銘柄名(銘柄コード)` をコピー
- 投資信託のファンド名を右クリックした時にファンド名をコピー
- ReceiptTable の列定義に行データ参照用の render を追加

## テスト
- `npm test -- --run src/pages/Receipt/__tests__/Dividend.test.tsx src/pages/Receipt/__tests__/DomesticStock.test.tsx src/pages/Receipt/__tests__/Mutualfund.test.tsx src/components/organisms/ReceiptTable/__tests__/ReceiptTable.test.tsx`
- `vp lint`