### PR TITLE
銘柄名コピーをホバーアイコンに変更

### DIFF
--- a/frontend/src/components/atoms/SecurityCodeLink.tsx
+++ b/frontend/src/components/atoms/SecurityCodeLink.tsx
@@ -65,18 +65,20 @@ export const CopyableInstrumentName: React.FC<CopyableInstrumentNameProps> = ({ 
   const displayName = toDisplayText(name);
   const copyText = createInstrumentCopyText(name, code);
 
-  const handleContextMenu = (event: React.MouseEvent<HTMLSpanElement>) => {
-    event.preventDefault();
-    if (copyText && navigator.clipboard?.writeText) {
-      void navigator.clipboard.writeText(copyText);
-    }
-  };
-
-  const combinedClassName = className ? className + " cursor-copy" : "cursor-copy";
-
   return (
-    <span className={combinedClassName} title={copyText} onContextMenu={handleContextMenu}>
-      {displayName}
+    <span className={cn('group inline-flex items-center gap-0.5', className)}>
+      <span>{displayName}</span>
+      <button
+        type="button"
+        aria-label={`${copyText} をコピー`}
+        onClick={() => { void navigator.clipboard?.writeText(copyText); }}
+        className="opacity-0 group-hover:opacity-100 focus:opacity-100 rounded p-0.5 text-gray-400 hover:text-gray-600 focus-visible:outline-2 focus-visible:outline-blue-500"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+        </svg>
+      </button>
     </span>
   );
 };

--- a/frontend/src/components/atoms/__tests__/SecurityCodeLink.test.tsx
+++ b/frontend/src/components/atoms/__tests__/SecurityCodeLink.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
-import { SecurityCodeLink } from '../SecurityCodeLink';
+import { SecurityCodeLink, CopyableInstrumentName } from '../SecurityCodeLink';
 
 describe('SecurityCodeLink', () => {
   it('有効な 4 桁コードをリンクとして表示する', () => {
@@ -68,5 +69,55 @@ describe('SecurityCodeLink', () => {
     const link = screen.getByRole('link', { name: '7203' });
     expect(link).toHaveClass('hover:font-semibold');
     expect(link).not.toHaveClass('font-bold');
+  });
+});
+
+describe('CopyableInstrumentName', () => {
+  it('銘柄名を表示する', () => {
+    render(<CopyableInstrumentName name="テスト株式" code="9433" />);
+    expect(screen.getByText('テスト株式')).toBeInTheDocument();
+  });
+
+  it('コピーボタンが accessible name を持つ（銘柄名+コード）', () => {
+    render(<CopyableInstrumentName name="ＫＤＤＩ" code="9433" />);
+    expect(screen.getByRole('button', { name: 'ＫＤＤＩ(9433) をコピー' })).toBeInTheDocument();
+  });
+
+  it('コードなしの場合はファンド名のみの accessible name を持つ', () => {
+    render(<CopyableInstrumentName name="テストファンドA" />);
+    expect(screen.getByRole('button', { name: 'テストファンドA をコピー' })).toBeInTheDocument();
+  });
+
+  it('右クリックしてもコピーされない', () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+    render(<CopyableInstrumentName name="ＫＤＤＩ" code="9433" />);
+    fireEvent.contextMenu(screen.getByText('ＫＤＤＩ'));
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it('コピーボタンをクリックすると clipboard.writeText が呼ばれる', () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+    render(<CopyableInstrumentName name="ＫＤＤＩ" code="9433" />);
+    fireEvent.click(screen.getByRole('button', { name: 'ＫＤＤＩ(9433) をコピー' }));
+    expect(writeText).toHaveBeenCalledWith('ＫＤＤＩ(9433)');
+  });
+
+  it('navigator.clipboard がない環境でもエラーにならない', () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: undefined,
+      configurable: true,
+    });
+    render(<CopyableInstrumentName name="ＫＤＤＩ" code="9433" />);
+    expect(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'ＫＤＤＩ(9433) をコピー' }));
+    }).not.toThrow();
   });
 });

--- a/frontend/src/pages/Receipt/__tests__/Dividend.test.tsx
+++ b/frontend/src/pages/Receipt/__tests__/Dividend.test.tsx
@@ -122,7 +122,7 @@ describe('Dividend', () => {
         expect(screen.getByText('テスト株式2')).toBeInTheDocument();
     });
 
-    it('銘柄名を右クリックすると銘柄名と銘柄コードをコピーする', () => {
+    it('銘柄名を右クリックしてもコピーされない', () => {
         const writeText = vi.fn().mockResolvedValue(undefined);
         Object.defineProperty(navigator, 'clipboard', {
             value: { writeText },
@@ -136,6 +136,24 @@ describe('Dividend', () => {
         }]} />);
 
         fireEvent.contextMenu(screen.getByText('ＫＤＤＩ'));
+
+        expect(writeText).not.toHaveBeenCalled();
+    });
+
+    it('コピーアイコンを押すと銘柄名と銘柄コードをコピーする', () => {
+        const writeText = vi.fn().mockResolvedValue(undefined);
+        Object.defineProperty(navigator, 'clipboard', {
+            value: { writeText },
+            configurable: true,
+        });
+
+        render(<Dividend data={[{
+            ...mockData[0],
+            security_code: '9433',
+            security_name: 'ＫＤＤＩ',
+        }]} />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'ＫＤＤＩ(9433) をコピー' }));
 
         expect(writeText).toHaveBeenCalledWith('ＫＤＤＩ(9433)');
     });

--- a/frontend/src/pages/Receipt/__tests__/DomesticStock.test.tsx
+++ b/frontend/src/pages/Receipt/__tests__/DomesticStock.test.tsx
@@ -99,7 +99,7 @@ describe('DomesticStock', () => {
         expect(screen.getByText('テスト株式2')).toBeInTheDocument();
     });
 
-    it('銘柄名を右クリックすると銘柄名と銘柄コードをコピーする', () => {
+    it('銘柄名を右クリックしてもコピーされない', () => {
         const writeText = vi.fn().mockResolvedValue(undefined);
         Object.defineProperty(navigator, 'clipboard', {
             value: { writeText },
@@ -113,6 +113,24 @@ describe('DomesticStock', () => {
         }]} />);
 
         fireEvent.contextMenu(screen.getByText('ＫＤＤＩ'));
+
+        expect(writeText).not.toHaveBeenCalled();
+    });
+
+    it('コピーアイコンを押すと銘柄名と銘柄コードをコピーする', () => {
+        const writeText = vi.fn().mockResolvedValue(undefined);
+        Object.defineProperty(navigator, 'clipboard', {
+            value: { writeText },
+            configurable: true,
+        });
+
+        render(<DomesticStock data={[{
+            ...mockData[0],
+            security_code: '9433',
+            security_name: 'ＫＤＤＩ',
+        }]} />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'ＫＤＤＩ(9433) をコピー' }));
 
         expect(writeText).toHaveBeenCalledWith('ＫＤＤＩ(9433)');
     });

--- a/frontend/src/pages/Receipt/__tests__/Mutualfund.test.tsx
+++ b/frontend/src/pages/Receipt/__tests__/Mutualfund.test.tsx
@@ -94,7 +94,7 @@ describe('Mutualfund', () => {
         expect(screen.getByText('ファンド名')).toBeInTheDocument();
     });
 
-    it('ファンド名を右クリックするとファンド名をコピーする', () => {
+    it('ファンド名を右クリックしてもコピーされない', () => {
         const writeText = vi.fn().mockResolvedValue(undefined);
         Object.defineProperty(navigator, 'clipboard', {
             value: { writeText },
@@ -103,7 +103,21 @@ describe('Mutualfund', () => {
 
         render(<Mutualfund data={mockData} />);
 
-        fireEvent.contextMenu(screen.getByText('テストファンドA'));
+        fireEvent.contextMenu(screen.getAllByText('テストファンドA')[0]);
+
+        expect(writeText).not.toHaveBeenCalled();
+    });
+
+    it('コピーアイコンを押すとファンド名をコピーする', () => {
+        const writeText = vi.fn().mockResolvedValue(undefined);
+        Object.defineProperty(navigator, 'clipboard', {
+            value: { writeText },
+            configurable: true,
+        });
+
+        render(<Mutualfund data={mockData} />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'テストファンドA をコピー' }));
 
         expect(writeText).toHaveBeenCalledWith('テストファンドA');
     });


### PR DESCRIPTION
## 概要
- 右クリックで標準コンテキストメニューを奪うコピー挙動を廃止
- 銘柄名/ファンド名の横にコピーアイコンボタンを追加
- コピーアイコン押下で `銘柄名(銘柄コード)` またはファンド名をコピー
- 右クリックではコピーされないことをテストで保証

## テスト
- `npm test -- --run src/pages/Receipt/__tests__/Dividend.test.tsx src/pages/Receipt/__tests__/DomesticStock.test.tsx src/pages/Receipt/__tests__/Mutualfund.test.tsx src/components/atoms/__tests__/SecurityCodeLink.test.tsx src/components/organisms/ReceiptTable/__tests__/ReceiptTable.test.tsx`
- `vp lint`
- `npx tsc --noEmit`
- `vp build`

## 実装
- Claude 実装
- Codex レビュー済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 銘柄名などのコピー専用ボタン（アイコン）を追加。ホバー時に表示され、クリックでクリップボードにコピーできます。

* **Bug Fixes**
  * 右クリックメニュー経由のコピー機能を削除しました。

* **Tests**
  * コピー機能に関するテストケースを追加・更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->