### PR TITLE
fix: 資産サマリーのKPIグリッドを4列横並びに変更

### DIFF
--- a/frontend/src/components/organisms/AssetPortfolioSummary/AssetPortfolioSummary.tsx
+++ b/frontend/src/components/organisms/AssetPortfolioSummary/AssetPortfolioSummary.tsx
@@ -131,7 +131,7 @@ export const AssetPortfolioSummary: React.FC<AssetPortfolioSummaryProps> = ({
             </div>
           ) : null}
         </div>
-        <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3" data-testid="portfolio-kpi-grid">
+        <div className="mt-4 grid grid-cols-2 gap-3 lg:grid-cols-4" data-testid="portfolio-kpi-grid">
           <div className="rounded-lg border border-slate-950/10 bg-white px-4 py-4 shadow-sm">
             <p className="mb-1 text-xs font-medium text-slate-600">合計取得総額</p>
             <p className="text-3xl font-bold text-primary tabular-nums" data-negative={totalPurchaseAmount < 0 ? 'true' : undefined}>

--- a/frontend/src/components/organisms/AssetPortfolioSummary/__tests__/AssetPortfolioSummary.test.tsx
+++ b/frontend/src/components/organisms/AssetPortfolioSummary/__tests__/AssetPortfolioSummary.test.tsx
@@ -197,13 +197,13 @@ describe('AssetPortfolioSummary', () => {
     expect(screen.getByTestId('asset-portfolio-summary')).toBeInTheDocument();
   });
 
-  it('KPI strip のグリッドは xl:grid-cols-3 で3列ベースを使用し xl:grid-cols-4 は使用しない', () => {
+  it('KPI strip のグリッドは lg:grid-cols-4 で4列表示を使用する', () => {
     const mockData = createMockData();
     const { container } = render(<AssetPortfolioSummary assetBalanceData={mockData} />);
     const kpiGrid = container.querySelector('[data-testid="portfolio-kpi-grid"]');
     expect(kpiGrid).toBeInTheDocument();
-    expect(kpiGrid).toHaveClass('xl:grid-cols-3');
-    expect(kpiGrid).not.toHaveClass('xl:grid-cols-4');
+    expect(kpiGrid).toHaveClass('lg:grid-cols-4');
+    expect(kpiGrid).not.toHaveClass('xl:grid-cols-3');
   });
 
   describe('配当金額・配当利回り', () => {


### PR DESCRIPTION
## 概要

資産サマリーの4枚のKPIカード（合計取得総額・年間配当金額・配当利回り・保有銘柄数）をlg以上で1行4列に横並び表示する。

## 主な変更内容

- `grid-cols-2 gap-3 lg:grid-cols-4` に変更（従来: `grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3`）
- モバイルは2列、lg（1024px）以上で4列
- テストのグリッドクラスアサーションを更新

## テスト

- [x] `npm test` 全16件 pass