### PR TITLE
銘柄名クリックでもコピーできるようにする

### DIFF
--- a/frontend/src/components/atoms/SecurityCodeLink.tsx
+++ b/frontend/src/components/atoms/SecurityCodeLink.tsx
@@ -66,20 +66,34 @@ export const CopyableInstrumentName: React.FC<CopyableInstrumentNameProps> = ({ 
   const copyText = createInstrumentCopyText(name, code);
 
   return (
-    <span className={cn('group inline-flex items-center gap-0.5', className)}>
+    <button
+      type="button"
+      aria-label={`${copyText} をコピー`}
+      onClick={() => { void navigator.clipboard?.writeText(copyText); }}
+      className={cn(
+        'group inline-flex cursor-pointer items-center gap-0.5 border-0 bg-transparent p-0 text-left text-inherit',
+        'focus-visible:rounded-sm focus-visible:outline-2 focus-visible:outline-blue-500',
+        className
+      )}
+    >
       <span>{displayName}</span>
-      <button
-        type="button"
-        aria-label={`${copyText} をコピー`}
-        onClick={() => { void navigator.clipboard?.writeText(copyText); }}
-        className="opacity-0 group-hover:opacity-100 focus:opacity-100 rounded p-0.5 text-gray-400 hover:text-gray-600 focus-visible:outline-2 focus-visible:outline-blue-500"
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="12"
+        height="12"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+        className="rounded p-0.5 text-gray-400 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 hover:text-gray-600"
       >
-        <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-          <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
-          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-        </svg>
-      </button>
-    </span>
+        <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+        <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+      </svg>
+    </button>
   );
 };
 

--- a/frontend/src/components/atoms/SecurityCodeLink.tsx
+++ b/frontend/src/components/atoms/SecurityCodeLink.tsx
@@ -88,7 +88,7 @@ export const CopyableInstrumentName: React.FC<CopyableInstrumentNameProps> = ({ 
         strokeLinecap="round"
         strokeLinejoin="round"
         aria-hidden="true"
-        className="rounded p-0.5 text-gray-400 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 hover:text-gray-600"
+        className="rounded p-0.5 text-gray-400 opacity-0 group-hover:opacity-100 group-hover:text-gray-600 group-focus-visible:opacity-100"
       >
         <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
         <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />

--- a/frontend/src/components/atoms/__tests__/SecurityCodeLink.test.tsx
+++ b/frontend/src/components/atoms/__tests__/SecurityCodeLink.test.tsx
@@ -120,4 +120,21 @@ describe('CopyableInstrumentName', () => {
       fireEvent.click(screen.getByRole('button', { name: 'ＫＤＤＩ(9433) をコピー' }));
     }).not.toThrow();
   });
+
+  it('表示文字列をクリックすると clipboard.writeText が呼ばれる', () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+    render(<CopyableInstrumentName name="ＫＤＤＩ" code="9433" />);
+    fireEvent.click(screen.getByText('ＫＤＤＩ'));
+    expect(writeText).toHaveBeenCalledWith('ＫＤＤＩ(9433)');
+  });
+
+  it('focus:opacity-100 が使われておらず focus-visible 系クラスが使われている', () => {
+    const { container } = render(<CopyableInstrumentName name="ＫＤＤＩ" code="9433" />);
+    expect(container.innerHTML).not.toContain('focus:opacity-100');
+    expect(container.innerHTML).toMatch(/focus-visible/);
+  });
 });

--- a/frontend/src/components/atoms/__tests__/SecurityCodeLink.test.tsx
+++ b/frontend/src/components/atoms/__tests__/SecurityCodeLink.test.tsx
@@ -132,9 +132,10 @@ describe('CopyableInstrumentName', () => {
     expect(writeText).toHaveBeenCalledWith('ＫＤＤＩ(9433)');
   });
 
-  it('focus:opacity-100 が使われておらず focus-visible 系クラスが使われている', () => {
+  it('SVGアイコンに group-focus-visible:opacity-100 が含まれ focus:opacity-100 が含まれない', () => {
     const { container } = render(<CopyableInstrumentName name="ＫＤＤＩ" code="9433" />);
-    expect(container.innerHTML).not.toContain('focus:opacity-100');
-    expect(container.innerHTML).toMatch(/focus-visible/);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('class')).toContain('group-focus-visible:opacity-100');
+    expect(svg?.getAttribute('class')).not.toContain('focus:opacity-100');
   });
 });


### PR DESCRIPTION
## 概要
- 銘柄名/ファンド名全体をコピー用ボタンにして、文字列クリックでもコピー可能に変更
- コピーアイコンの表示条件から `focus:opacity-100` を削除し、`group-focus-visible` に変更
- マウスクリック後にコピーアイコンが残り続ける挙動を解消

## テスト
- `npm test -- --run src/components/atoms/__tests__/SecurityCodeLink.test.tsx src/pages/Receipt/__tests__/Dividend.test.tsx src/pages/Receipt/__tests__/DomesticStock.test.tsx src/pages/Receipt/__tests__/Mutualfund.test.tsx`
- `vp lint`
- `npx tsc --noEmit`
- `vp build`

## 実装
- Claude 実装
- Codex レビュー済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **アクセシビリティ改善**
  * キーボード操作時のフォーカス表示を改善

* **テスト**
  * クリップボード機能とアクセシビリティの検証テストを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->