### PR TITLE
取引明細の期間検索を柔軟化

### DIFF
--- a/frontend/src/components/organisms/SearchCard/SearchCard.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchCard.tsx
@@ -1,13 +1,23 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { SearchCategories } from '@/types/common';
 import { Button } from '@/components/atoms/Button';
 import { Card, CardBody, CardHeader } from '@/components/atoms/Card';
+
+type ActiveSearchType = 'securities' | 'years' | 'products' | 'accounts' | 'date' | null;
+type DateSegment = '年' | '月' | '日' | '範囲';
+
+const DATE_SEGMENTS: DateSegment[] = ['年', '月', '日', '範囲'];
+
+function buildRangeQuery(start: string, end: string): string {
+    if (!start && !end) return '';
+    return `${start}..${end}`;
+}
 
 interface QuickSearchDropdownProps {
     items: { value: string; label: string }[];
     id: string;
     searchType: 'securities' | 'years';
-    activeSearchType: 'securities' | 'years' | 'products' | 'accounts' | null;
+    activeSearchType: ActiveSearchType;
     searchQuery: string;
     onSearch: (value: string, searchType: 'securities' | 'years') => void;
 }
@@ -50,7 +60,7 @@ const QuickSearchDropdown: React.FC<QuickSearchDropdownProps> = ({
 interface QuickSearchButtonsProps {
     items: string[];
     searchType: 'products' | 'accounts';
-    activeSearchType: 'securities' | 'years' | 'products' | 'accounts' | null;
+    activeSearchType: ActiveSearchType;
     searchQuery: string;
     onSearch: (value: string, searchType: 'products' | 'accounts') => void;
 }
@@ -109,7 +119,7 @@ const BUTTONS_CONFIGS: Array<{ key: ButtonsSearchType; label: string }> = [
 interface SearchFieldsGridProps {
     categories: SearchCategories;
     gridClassName: string;
-    activeSearchType: 'securities' | 'years' | 'products' | 'accounts' | null;
+    activeSearchType: ActiveSearchType;
     searchQuery: string;
     onSearch: (value: string, searchType: 'securities' | 'years' | 'products' | 'accounts') => void;
     hasData: (data: unknown[] | undefined) => boolean;
@@ -120,7 +130,8 @@ const SearchFieldsGrid: React.FC<SearchFieldsGridProps> = ({
 }) => (
     <div className={`grid ${gridClassName}`}>
         {DROPDOWN_CONFIGS.map(({ key, label }) =>
-            hasData(categories[key]) && (
+            // yearsはdatesブロックが有効な場合は期間ブロック側で表示するため除外
+            hasData(categories[key]) && !(key === 'years' && Boolean(categories.dates)) && (
                 <div key={key} className="space-y-1">
                     <label htmlFor={`${key}-search`} className="text-sm font-bold text-slate-800">{label}</label>
                     <QuickSearchDropdown
@@ -153,6 +164,192 @@ const SearchFieldsGrid: React.FC<SearchFieldsGridProps> = ({
     </div>
 );
 
+const formatDateLabel = (value: string): string => value.replace(/-/g, "/");
+
+interface CalendarDateButtonProps {
+    label: string;
+    value: string;
+    inputType?: 'date' | 'month';
+    onChange: (value: string) => void;
+}
+
+const CalendarDateButton: React.FC<CalendarDateButtonProps> = ({ label, value, inputType = 'date', onChange }) => {
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    const handleButtonClick = () => {
+        const input = inputRef.current;
+        if (!input) return;
+        try {
+            const pickerInput = input as HTMLInputElement & { showPicker?: () => void };
+            if (typeof pickerInput.showPicker === 'function') {
+                pickerInput.showPicker();
+                return;
+            }
+        } catch {
+            // fall through to the click fallback
+        }
+        input.focus();
+        input.click();
+    };
+
+    return (
+        <div className="relative">
+            <button
+                type="button"
+                onClick={handleButtonClick}
+                className={"w-full flex items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors focus:outline-none focus:ring-2 focus:border-amber-600 focus:ring-amber-500/25 " + (value ? "border-amber-500 bg-amber-50 text-amber-900 font-semibold" : "border-slate-300 bg-white text-slate-500 hover:border-slate-400")}
+            >
+                <svg className="w-3.5 h-3.5 shrink-0 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                </svg>
+                <span className="flex-1 text-left">
+                    {value ? formatDateLabel(value) : label}
+                </span>
+            </button>
+            <input
+                ref={inputRef}
+                type={inputType}
+                value={value}
+                onChange={e => onChange(e.target.value)}
+                aria-hidden="true"
+                tabIndex={-1}
+                className="absolute opacity-0 pointer-events-none w-px h-px overflow-hidden"
+            />
+        </div>
+    );
+};
+
+interface DatePeriodBlockProps {
+    dateSegment: DateSegment;
+    years: { value: string; label: string }[];
+    yearValue: string;
+    monthValue: string;
+    dateValue: string;
+    rangeStart: string;
+    rangeEnd: string;
+    isYearPickerOpen: boolean;
+    onSegmentChange: (segment: DateSegment) => void;
+    onToggleYearPicker: () => void;
+    onYearOptionSelect: (value: string) => void;
+    onMonthChange: (value: string) => void;
+    onDateValueChange: (value: string) => void;
+    onRangeStartChange: (value: string) => void;
+    onRangeEndChange: (value: string) => void;
+}
+
+const DatePeriodBlock: React.FC<DatePeriodBlockProps> = ({
+    dateSegment, years, yearValue, monthValue, dateValue, rangeStart, rangeEnd, isYearPickerOpen,
+    onSegmentChange, onToggleYearPicker, onYearOptionSelect, onMonthChange, onDateValueChange, onRangeStartChange, onRangeEndChange,
+}) => (
+    <div className="space-y-2">
+        <div className="text-sm font-bold text-slate-800">期間</div>
+        <div className="flex gap-1">
+            {DATE_SEGMENTS.map(seg => (
+                <button
+                    key={seg}
+                    type="button"
+                    aria-pressed={dateSegment === seg}
+                    onClick={() => onSegmentChange(seg)}
+                    className={`flex-1 rounded px-2 py-1 text-xs font-semibold transition-colors ${
+                        dateSegment === seg
+                            ? 'bg-slate-950 text-white'
+                            : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
+                    }`}
+                >
+                    {seg}
+                </button>
+            ))}
+        </div>
+        {dateSegment === '年' && (
+            <div className="relative">
+                <button
+                    type="button"
+                    aria-label="年を選択"
+                    aria-haspopup="listbox"
+                    aria-expanded={isYearPickerOpen}
+                    onClick={onToggleYearPicker}
+                    className={`w-full flex items-center gap-2 border px-3 py-2 text-sm transition-colors focus:outline-none focus:ring-2 focus:border-amber-600 focus:ring-amber-500/25 ${
+                        isYearPickerOpen ? 'rounded-t-md rounded-b-none' : 'rounded-md'
+                    } ${
+                        yearValue
+                            ? 'border-amber-500 bg-amber-50 text-amber-900 font-semibold'
+                            : 'border-slate-300 bg-white text-slate-500 hover:border-slate-400'
+                    }`}
+                >
+                    <svg className="w-3.5 h-3.5 shrink-0 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                    </svg>
+                    <span className="flex-1 text-left">
+                        {yearValue ? (years.find(y => y.value === yearValue)?.label ?? yearValue) : '年を選択'}
+                    </span>
+                    <svg
+                        className={`w-4 h-4 shrink-0 text-slate-400 transition-transform duration-150 ${isYearPickerOpen ? 'rotate-180' : ''}`}
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                        aria-hidden="true"
+                    >
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                    </svg>
+                </button>
+                {isYearPickerOpen && (
+                    <div
+                        role="listbox"
+                        aria-label="年候補"
+                        className="absolute z-10 w-full grid grid-cols-3 gap-1 rounded-b-md border border-t-0 border-slate-300 bg-white px-2 pb-2 pt-1.5"
+                    >
+                        {years.map(year => (
+                            <button
+                                key={year.value}
+                                type="button"
+                                role="option"
+                                aria-selected={yearValue === year.value}
+                                onClick={() => onYearOptionSelect(year.value)}
+                                className={
+                                    yearValue === year.value
+                                        ? 'rounded px-1 py-1.5 text-sm font-semibold text-center whitespace-nowrap bg-amber-50 text-amber-900 ring-1 ring-inset ring-amber-400 transition-colors'
+                                        : 'rounded px-1 py-1.5 text-sm text-center whitespace-nowrap text-slate-600 hover:bg-slate-100 hover:text-slate-900 transition-colors'
+                                }
+                            >
+                                {year.label}
+                            </button>
+                        ))}
+                    </div>
+                )}
+            </div>
+        )}
+        {dateSegment === '月' && (
+            <CalendarDateButton
+                label="月を選択"
+                value={monthValue}
+                inputType="month"
+                onChange={onMonthChange}
+            />
+        )}
+        {dateSegment === '日' && (
+            <CalendarDateButton
+                label="日を選択"
+                value={dateValue}
+                onChange={onDateValueChange}
+            />
+        )}
+        {dateSegment === '範囲' && (
+            <div className="flex flex-col gap-2">
+                <CalendarDateButton
+                    label="開始日"
+                    value={rangeStart}
+                    onChange={onRangeStartChange}
+                />
+                <CalendarDateButton
+                    label="終了日"
+                    value={rangeEnd}
+                    onChange={onRangeEndChange}
+                />
+            </div>
+        )}
+    </div>
+);
+
 interface SearchCardProps {
     onSearch: (query: string) => void;
     categories?: SearchCategories;
@@ -177,15 +374,23 @@ export const SearchCard: React.FC<SearchCardProps> = ({
 
     const [isExpanded, setIsExpanded] = useState(initialExpanded);
     // layout 切り替えなどで initialExpanded が変化したときに展開状態を同期する
-    // useEffect ではなくレンダー中に調整することで余分な再レンダーを防ぐ
     const [prevInitialExpanded, setPrevInitialExpanded] = useState(initialExpanded);
     if (prevInitialExpanded !== initialExpanded) {
         setPrevInitialExpanded(initialExpanded);
         setIsExpanded(initialExpanded);
     }
     const [searchQuery, setSearchQuery] = useState('');
-    // アクティブな検索タイプを追跡（ドロップダウンの表示制御用）
-    const [activeSearchType, setActiveSearchType] = useState<'securities' | 'years' | 'products' | 'accounts' | null>(null);
+    const [activeSearchType, setActiveSearchType] = useState<ActiveSearchType>(null);
+
+    // 日付検索用ステート
+    const [dateSegment, setDateSegment] = useState<DateSegment>('年');
+    const [yearValue, setYearValue] = useState('');
+    const [monthValue, setMonthValue] = useState('');
+    const [dateValue, setDateValue] = useState('');
+    const [rangeStart, setRangeStart] = useState('');
+    const [rangeEnd, setRangeEnd] = useState('');
+    const [isYearPickerOpen, setIsYearPickerOpen] = useState(false);
+
     const effectiveSearchQuery = value ?? searchQuery;
     const effectiveActiveSearchType = value === '' ? null : activeSearchType;
 
@@ -216,10 +421,65 @@ export const SearchCard: React.FC<SearchCardProps> = ({
         }
     };
 
+    const resetDateInputs = () => {
+        setYearValue('');
+        setMonthValue('');
+        setDateValue('');
+        setRangeStart('');
+        setRangeEnd('');
+        setIsYearPickerOpen(false);
+    };
+
     const handleQuickSearch = (value: string, searchType: 'securities' | 'years' | 'products' | 'accounts') => {
         setSearchQuery(value);
         setActiveSearchType(value ? searchType : null);
+        resetDateInputs();
         onSearch(value);
+    };
+
+    const handleDateSearch = (val: string) => {
+        setSearchQuery(val);
+        setActiveSearchType(val ? 'date' : null);
+        onSearch(val);
+    };
+
+    const handleSegmentChange = (segment: DateSegment) => {
+        if (segment === dateSegment) return;
+        setDateSegment(segment);
+        if (activeSearchType !== null) {
+            setSearchQuery('');
+            setActiveSearchType(null);
+            onSearch('');
+        }
+        resetDateInputs();
+    };
+
+    const handleYearOptionSelect = (val: string) => {
+        setYearValue(val);
+        setIsYearPickerOpen(false);
+        handleDateSearch(val);
+    };
+
+    const handleMonthChange = (val: string) => {
+        setMonthValue(val);
+        handleDateSearch(val);
+    };
+
+    const handleDateValueChange = (val: string) => {
+        setDateValue(val);
+        handleDateSearch(val);
+    };
+
+    const handleRangeStartChange = (val: string) => {
+        setRangeStart(val);
+        const query = buildRangeQuery(val, rangeEnd);
+        handleDateSearch(query);
+    };
+
+    const handleRangeEndChange = (val: string) => {
+        setRangeEnd(val);
+        const query = buildRangeQuery(rangeStart, val);
+        handleDateSearch(query);
     };
 
     // 検索条件が初期状態かどうか
@@ -229,6 +489,8 @@ export const SearchCard: React.FC<SearchCardProps> = ({
     const handleClearSearch = () => {
         setSearchQuery('');
         setActiveSearchType(null);
+        setDateSegment('年');
+        resetDateInputs();
         onSearch('');
     };
 
@@ -236,6 +498,28 @@ export const SearchCard: React.FC<SearchCardProps> = ({
     if (!hasAnyCategories) {
         return null;
     }
+
+    const datePeriodBlock = Boolean(categories?.dates) && hasData(categories?.years) ? (
+        <div className="mb-3.5">
+            <DatePeriodBlock
+                dateSegment={dateSegment}
+                years={categories?.years ?? []}
+                yearValue={yearValue}
+                monthValue={monthValue}
+                dateValue={dateValue}
+                rangeStart={rangeStart}
+                rangeEnd={rangeEnd}
+                isYearPickerOpen={isYearPickerOpen}
+                onSegmentChange={handleSegmentChange}
+                onToggleYearPicker={() => setIsYearPickerOpen(open => !open)}
+                onYearOptionSelect={handleYearOptionSelect}
+                onMonthChange={handleMonthChange}
+                onDateValueChange={handleDateValueChange}
+                onRangeStartChange={handleRangeStartChange}
+                onRangeEndChange={handleRangeEndChange}
+            />
+        </div>
+    ) : null;
 
     if (compact) {
         return (
@@ -303,6 +587,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                 </div>
                 {isExpanded && categories && (
                     <div id="search-options-body" className="pt-4">
+                        {datePeriodBlock}
                         <SearchFieldsGrid
                             categories={categories}
                             gridClassName="grid-cols-1 gap-3.5"
@@ -397,6 +682,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
             </CardHeader>
             {isExpanded && categories && (
                 <CardBody id="search-options-body" className="p-3">
+                    {datePeriodBlock}
                     <SearchFieldsGrid
                         categories={categories}
                         gridClassName="grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4"

--- a/frontend/src/components/organisms/SearchCard/__tests__/SearchCard.test.tsx
+++ b/frontend/src/components/organisms/SearchCard/__tests__/SearchCard.test.tsx
@@ -455,7 +455,6 @@ describe('SearchCard', () => {
     test('年セグメントに text/number input が存在しない', () => {
       render(<SearchCard onSearch={mockOnSearch} categories={dateCategories} />);
       expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
-      // eslint-disable-next-line testing-library/no-node-access
       expect(document.querySelector('input[type="number"]')).not.toBeInTheDocument();
     });
 
@@ -517,19 +516,16 @@ describe('SearchCard', () => {
         <SearchCard onSearch={mockOnSearch} categories={dateCategories} />
       );
       fireEvent.click(screen.getByRole('button', { name: '月' }));
-      // eslint-disable-next-line testing-library/no-node-access
       let ariaHiddenInputs = Array.from(container.querySelectorAll("input[aria-hidden]"));
       expect(ariaHiddenInputs).toHaveLength(1);
       expect(ariaHiddenInputs[0]).toHaveAttribute('type', 'month');
       expect(ariaHiddenInputs[0]).toHaveAttribute('aria-hidden', 'true');
       fireEvent.click(screen.getByRole('button', { name: '日' }));
-      // eslint-disable-next-line testing-library/no-node-access
       ariaHiddenInputs = Array.from(container.querySelectorAll("input[aria-hidden]"));
       expect(ariaHiddenInputs).toHaveLength(1);
       expect(ariaHiddenInputs[0]).toHaveAttribute('type', 'date');
       expect(ariaHiddenInputs[0]).toHaveAttribute('aria-hidden', 'true');
       fireEvent.click(screen.getByRole('button', { name: '範囲' }));
-      // eslint-disable-next-line testing-library/no-node-access
       ariaHiddenInputs = Array.from(container.querySelectorAll("input[aria-hidden]"));
       expect(ariaHiddenInputs).toHaveLength(2);
       ariaHiddenInputs.forEach(input => expect(input).toHaveAttribute('aria-hidden', 'true'));
@@ -541,7 +537,6 @@ describe('SearchCard', () => {
       );
       fireEvent.click(screen.getByRole('button', { name: '月' }));
       expect(screen.getByRole('button', { name: '月を選択' })).toBeInTheDocument();
-      // eslint-disable-next-line testing-library/no-node-access
       const monthInput = container.querySelector("input[aria-hidden]") as HTMLInputElement;
       expect(monthInput).toHaveAttribute('type', 'month');
       fireEvent.change(monthInput, { target: { value: '2024-03' } });
@@ -554,7 +549,6 @@ describe('SearchCard', () => {
         <SearchCard onSearch={mockOnSearch} categories={dateCategories} />
       );
       fireEvent.click(screen.getByRole('button', { name: '日' }));
-      // eslint-disable-next-line testing-library/no-node-access
       const dateInput = container.querySelector("input[aria-hidden]") as HTMLInputElement;
       fireEvent.change(dateInput, { target: { value: '2024-03-15' } });
       expect(mockOnSearch).toHaveBeenCalledWith('2024-03-15');
@@ -566,7 +560,6 @@ describe('SearchCard', () => {
         <SearchCard onSearch={mockOnSearch} categories={dateCategories} />
       );
       fireEvent.click(screen.getByRole('button', { name: '範囲' }));
-      // eslint-disable-next-line testing-library/no-node-access
       const inputs = Array.from(container.querySelectorAll("input[aria-hidden]")) as HTMLInputElement[];
       fireEvent.change(inputs[0], { target: { value: '2024-03-01' } });
       fireEvent.change(inputs[1], { target: { value: '2024-03-31' } });

--- a/frontend/src/components/organisms/SearchCard/__tests__/SearchCard.test.tsx
+++ b/frontend/src/components/organisms/SearchCard/__tests__/SearchCard.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { vi, describe, test, expect, beforeEach } from 'vitest';
 import '@testing-library/jest-dom';
 import { SearchCard } from '../SearchCard';
@@ -168,6 +168,23 @@ describe('SearchCard', () => {
     );
 
     // SearchCardがレンダーされないことを確認
+    expect(container.firstChild).toBeNull();
+  });
+
+  test('dates: true でも years が空の場合は SearchCard が非表示になる', () => {
+    const { container } = render(
+      <SearchCard
+        onSearch={mockOnSearch}
+        categories={{
+          securities: [],
+          products: [],
+          accounts: [],
+          years: [],
+          dates: true,
+        }}
+      />
+    );
+
     expect(container.firstChild).toBeNull();
   });
 
@@ -401,6 +418,192 @@ describe('SearchCard', () => {
     fireEvent.keyDown(clearBtn2, { key: 'Enter' });
     fireEvent.keyDown(clearBtn2, { key: ' ' });
     expect(clearBtn2).toBeInTheDocument();
+  });
+
+  describe('期間ブロック', () => {
+    const dateCategories = {
+      ...defaultCategories,
+      dates: true as const,
+    };
+
+    test('datesカテゴリがある場合、期間ブロックが表示される', () => {
+      render(<SearchCard onSearch={mockOnSearch} categories={dateCategories} />);
+      expect(screen.getByText('期間')).toBeInTheDocument();
+    });
+
+    test('dates: true の場合、「期間」が「銘柄」より前に表示される', () => {
+      const { container } = render(
+        <SearchCard onSearch={mockOnSearch} categories={dateCategories} />
+      );
+      const text = container.textContent ?? '';
+      expect(text.indexOf('期間')).toBeLessThan(text.indexOf('銘柄'));
+    });
+
+    test('compact モードでも「期間」が「銘柄」より前に表示される', () => {
+      const { container } = render(
+        <SearchCard onSearch={mockOnSearch} categories={dateCategories} compact />
+      );
+      const text = container.textContent ?? '';
+      expect(text.indexOf('期間')).toBeLessThan(text.indexOf('銘柄'));
+    });
+
+    test('datesカテゴリがない場合、期間ブロックが表示されない', () => {
+      render(<SearchCard onSearch={mockOnSearch} categories={defaultCategories} />);
+      expect(screen.queryByText('期間')).not.toBeInTheDocument();
+    });
+
+    test('年セグメントに text/number input が存在しない', () => {
+      render(<SearchCard onSearch={mockOnSearch} categories={dateCategories} />);
+      expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+      // eslint-disable-next-line testing-library/no-node-access
+      expect(document.querySelector('input[type="number"]')).not.toBeInTheDocument();
+    });
+
+    test('年モードでは「年を選択」ボタンが表示される', () => {
+      render(<SearchCard onSearch={mockOnSearch} categories={dateCategories} />);
+      expect(screen.getByRole('button', { name: '年を選択' })).toBeInTheDocument();
+    });
+
+    test("「年を選択」ボタンをクリックすると年候補だけが表示される", () => {
+      render(<SearchCard onSearch={mockOnSearch} categories={dateCategories} />);
+      fireEvent.click(screen.getByLabelText("年を選択"));
+      const picker = screen.getByRole("listbox", { name: "年候補" });
+      expect(within(picker).getByText("2023年")).toBeInTheDocument();
+      expect(within(picker).getByText("2024年")).toBeInTheDocument();
+      expect(within(picker).queryByText(/1月|2月|月曜日|（|）/)).not.toBeInTheDocument();
+    });
+
+    test("年候補を選択すると年検索が実行され、パネルが閉じ、field が更新される", () => {
+      render(<SearchCard onSearch={mockOnSearch} categories={dateCategories} />);
+      fireEvent.click(screen.getByLabelText("年を選択"));
+      fireEvent.click(screen.getByRole("option", { name: "2024年" }));
+      expect(mockOnSearch).toHaveBeenCalledWith("2024");
+      expect(screen.queryByRole("listbox", { name: "年候補" })).not.toBeInTheDocument();
+      expect(screen.getByLabelText("年を選択")).toHaveTextContent("2024年");
+    });
+
+    test("月セグメントへ切り替えると年候補が閉じる", () => {
+      render(<SearchCard onSearch={mockOnSearch} categories={dateCategories} />);
+      fireEvent.click(screen.getByLabelText("年を選択"));
+      expect(screen.getByRole("listbox", { name: "年候補" })).toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: "月" }));
+      expect(screen.queryByRole("listbox", { name: "年候補" })).not.toBeInTheDocument();
+    });
+
+    test('期間ブロックのどのセグメントにも曜日・括弧が表示されない（native date input 由来の括弧も含む）', () => {
+      const FORBIDDEN = /月曜日|火曜日|水曜日|木曜日|金曜日|土曜日|日曜日|（|）|\(|\)/;
+      const { container } = render(
+        <SearchCard onSearch={mockOnSearch} categories={dateCategories} />
+      );
+      // 年モード（初期）
+      expect(container.textContent).not.toMatch(FORBIDDEN);
+      // 年候補パネルを開いた状態でも同様
+      fireEvent.click(screen.getByLabelText('年を選択'));
+      expect(container.textContent).not.toMatch(FORBIDDEN);
+      // 月モード
+      fireEvent.click(screen.getByRole('button', { name: '月' }));
+      expect(container.textContent).not.toMatch(FORBIDDEN);
+      // 日モード（hidden input が括弧を混入しないことを確認）
+      fireEvent.click(screen.getByRole('button', { name: '日' }));
+      expect(container.textContent).not.toMatch(FORBIDDEN);
+      // 範囲モード（hidden input 2つとも括弧を混入しないことを確認）
+      fireEvent.click(screen.getByRole('button', { name: '範囲' }));
+      expect(container.textContent).not.toMatch(FORBIDDEN);
+    });
+
+
+    test('月・日・範囲セグメントの native input は aria-hidden で画面上の表示から除外される（括弧・曜日の混入防止）', () => {
+      const { container } = render(
+        <SearchCard onSearch={mockOnSearch} categories={dateCategories} />
+      );
+      fireEvent.click(screen.getByRole('button', { name: '月' }));
+      // eslint-disable-next-line testing-library/no-node-access
+      let ariaHiddenInputs = Array.from(container.querySelectorAll("input[aria-hidden]"));
+      expect(ariaHiddenInputs).toHaveLength(1);
+      expect(ariaHiddenInputs[0]).toHaveAttribute('type', 'month');
+      expect(ariaHiddenInputs[0]).toHaveAttribute('aria-hidden', 'true');
+      fireEvent.click(screen.getByRole('button', { name: '日' }));
+      // eslint-disable-next-line testing-library/no-node-access
+      ariaHiddenInputs = Array.from(container.querySelectorAll("input[aria-hidden]"));
+      expect(ariaHiddenInputs).toHaveLength(1);
+      expect(ariaHiddenInputs[0]).toHaveAttribute('type', 'date');
+      expect(ariaHiddenInputs[0]).toHaveAttribute('aria-hidden', 'true');
+      fireEvent.click(screen.getByRole('button', { name: '範囲' }));
+      // eslint-disable-next-line testing-library/no-node-access
+      ariaHiddenInputs = Array.from(container.querySelectorAll("input[aria-hidden]"));
+      expect(ariaHiddenInputs).toHaveLength(2);
+      ariaHiddenInputs.forEach(input => expect(input).toHaveAttribute('aria-hidden', 'true'));
+    });
+
+    test('月モードで hidden month input に change を発火すると onSearch が呼ばれ button 表示が更新される', () => {
+      const { container } = render(
+        <SearchCard onSearch={mockOnSearch} categories={dateCategories} />
+      );
+      fireEvent.click(screen.getByRole('button', { name: '月' }));
+      expect(screen.getByRole('button', { name: '月を選択' })).toBeInTheDocument();
+      // eslint-disable-next-line testing-library/no-node-access
+      const monthInput = container.querySelector("input[aria-hidden]") as HTMLInputElement;
+      expect(monthInput).toHaveAttribute('type', 'month');
+      fireEvent.change(monthInput, { target: { value: '2024-03' } });
+      expect(mockOnSearch).toHaveBeenCalledWith('2024-03');
+      expect(screen.getByRole('button', { name: '2024/03' })).toBeInTheDocument();
+    });
+
+    test('日モードで hidden date input に change を発火すると onSearch が呼ばれ button 表示が更新される', () => {
+      const { container } = render(
+        <SearchCard onSearch={mockOnSearch} categories={dateCategories} />
+      );
+      fireEvent.click(screen.getByRole('button', { name: '日' }));
+      // eslint-disable-next-line testing-library/no-node-access
+      const dateInput = container.querySelector("input[aria-hidden]") as HTMLInputElement;
+      fireEvent.change(dateInput, { target: { value: '2024-03-15' } });
+      expect(mockOnSearch).toHaveBeenCalledWith('2024-03-15');
+      expect(screen.getByRole('button', { name: '2024/03/15' })).toBeInTheDocument();
+    });
+
+    test('範囲モードで hidden date inputs に change を発火すると button 表示が更新され YYYY-MM-DD..YYYY-MM-DD 形式で onSearch が呼ばれる', () => {
+      const { container } = render(
+        <SearchCard onSearch={mockOnSearch} categories={dateCategories} />
+      );
+      fireEvent.click(screen.getByRole('button', { name: '範囲' }));
+      // eslint-disable-next-line testing-library/no-node-access
+      const inputs = Array.from(container.querySelectorAll("input[aria-hidden]")) as HTMLInputElement[];
+      fireEvent.change(inputs[0], { target: { value: '2024-03-01' } });
+      fireEvent.change(inputs[1], { target: { value: '2024-03-31' } });
+      expect(mockOnSearch).toHaveBeenLastCalledWith('2024-03-01..2024-03-31');
+      expect(screen.getByRole('button', { name: '2024/03/01' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '2024/03/31' })).toBeInTheDocument();
+    });
+
+    test('銘柄検索後に月セグメントへ切り替えると既存検索が解除される', () => {
+      const { container } = render(
+        <SearchCard onSearch={mockOnSearch} categories={dateCategories} />
+      );
+      // 銘柄を選択
+      const secSelect = container.querySelector('#securities-search') as HTMLSelectElement;
+      fireEvent.change(secSelect, { target: { value: 'AAPL' } });
+      expect(mockOnSearch).toHaveBeenCalledWith('AAPL');
+      expect(secSelect.value).toBe('AAPL');
+      // 月セグメントへ切り替え → 既存検索が解除される
+      fireEvent.click(screen.getByRole('button', { name: '月' }));
+      expect(mockOnSearch).toHaveBeenLastCalledWith('');
+      // 銘柄ドロップダウンの選択表示が外れる
+      expect(secSelect.value).toBe('');
+    });
+
+    test('クリアで期間入力状態がリセットされる', () => {
+      render(<SearchCard onSearch={mockOnSearch} categories={dateCategories} />);
+      // 年ピッカーで2024を選択
+      fireEvent.click(screen.getByLabelText('年を選択'));
+      fireEvent.click(screen.getByRole('option', { name: '2024年' }));
+      expect(mockOnSearch).toHaveBeenCalledWith('2024');
+      // クリアで検索もUIも初期化される
+      fireEvent.click(screen.getByTestId('search-clear-button'));
+      expect(mockOnSearch).toHaveBeenLastCalledWith('');
+      // セグメントが年モードに戻り、年ピッカーが「年を選択」を表示する
+      expect(screen.getByRole('button', { name: '年', pressed: true })).toBeInTheDocument();
+      expect(screen.getByLabelText('年を選択')).toHaveTextContent('年を選択');
+    });
   });
 
   test('compactモードでは検索グリッドが1列表示になる', () => {

--- a/frontend/src/lib/utils/__tests__/searchUtils.test.ts
+++ b/frontend/src/lib/utils/__tests__/searchUtils.test.ts
@@ -123,6 +123,34 @@ describe('filterByConfig', () => {
         });
     });
 
+    describe('dateRangeSearch（日付範囲検索）', () => {
+        const rangeConfig: FilterConfig<TestItem> = {
+            dateField: item => item.date,
+            dateRangeSearch: true,
+        };
+
+        it('閉区間 2023-01-01..2023-01-31 に一致する', () => {
+            const result = filterByConfig(testData, '2023-01-01..2023-01-31', rangeConfig);
+            expect(result).toHaveLength(1);
+            expect(result[0].code).toBe('1234'); // 2023-01-15
+        });
+
+        it('開始日のみ 2023-02-01.. に一致する', () => {
+            const result = filterByConfig(testData, '2023-02-01..', rangeConfig);
+            expect(result).toHaveLength(2); // 2023-02-20, 2024-01-10
+        });
+
+        it('終了日のみ ..2023-01-31 に一致する', () => {
+            const result = filterByConfig(testData, '..2023-01-31', rangeConfig);
+            expect(result).toHaveLength(1); // 2023-01-15
+        });
+
+        it('無効な範囲文字列は既存検索に影響しない（0件）', () => {
+            const result = filterByConfig(testData, 'invalid..range', rangeConfig);
+            expect(result).toHaveLength(0);
+        });
+    });
+
     describe('amountFields（金額検索）', () => {
         it('金額の部分一致で検索できる', () => {
             const config: FilterConfig<TestItem> = {

--- a/frontend/src/lib/utils/searchUtils.ts
+++ b/frontend/src/lib/utils/searchUtils.ts
@@ -55,6 +55,25 @@ function matchesDate(date: Date, query: string): boolean {
   return dateStr === query;
 }
 
+/**
+ * 日付範囲検索マッチャー
+ * クエリ形式: "YYYY-MM-DD..YYYY-MM-DD" / "YYYY-MM-DD.." / "..YYYY-MM-DD"
+ */
+function matchesDateRange(date: Date, query: string): boolean {
+  const sepIdx = query.indexOf('..');
+  if (sepIdx === -1) return false;
+  const start = query.slice(0, sepIdx);
+  const end = query.slice(sepIdx + 2);
+  const datePattern = /^\d{4}-\d{2}-\d{2}$/;
+  if (start && !datePattern.test(start)) return false;
+  if (end && !datePattern.test(end)) return false;
+  if (!start && !end) return false;
+  const dateStr = date.toISOString().split('T')[0];
+  if (start && end) return dateStr >= start && dateStr <= end;
+  if (start) return dateStr >= start;
+  return dateStr <= end;
+}
+
 // ==================== 汎用フィルタ設定 ====================
 
 /**
@@ -73,6 +92,8 @@ export interface FilterConfig<T> {
   yearMonthSearch?: boolean;
   /** 日付検索を有効にするか */
   dateSearch?: boolean;
+  /** 日付範囲検索を有効にするか（YYYY-MM-DD..YYYY-MM-DD 形式） */
+  dateRangeSearch?: boolean;
   /** 金額フィールド（部分一致検索用） */
   amountFields?: ((item: T) => number)[];
 }
@@ -128,6 +149,11 @@ export function filterByConfig<T>(
 
       // 日付検索
       if (config.dateSearch && matchesDate(date, normalizedQuery)) {
+        return true;
+      }
+
+      // 日付範囲検索
+      if (config.dateRangeSearch && matchesDateRange(date, normalizedQuery)) {
         return true;
       }
     }

--- a/frontend/src/pages/Receipt/Dividend.tsx
+++ b/frontend/src/pages/Receipt/Dividend.tsx
@@ -45,6 +45,7 @@ const FILTER_CONFIG: FilterConfig<DividendData> = {
     yearSearch: true,
     yearMonthSearch: true,
     dateSearch: true,
+    dateRangeSearch: true,
     amountFields: [
         item => item.unit_price,
         item => item.shares,
@@ -72,7 +73,8 @@ export const Dividend: React.FC<DividendProps> = ({ data, previewData, utilityRa
         securities: createSearchOptions(dividendData, 'security_code', 'security_name', true),
         products: getUniqueValues(dividendData, item => item.product),
         accounts: getUniqueValues(dividendData, item => item.account),
-        years: createYearOptions(dividendData, item => item.settlement_date)
+        years: createYearOptions(dividendData, item => item.settlement_date),
+        dates: true,
     };
 
     // 表示用の集計（検索前後で同一ロジック: フィルタ後データから計算）

--- a/frontend/src/pages/Receipt/DomesticStock.tsx
+++ b/frontend/src/pages/Receipt/DomesticStock.tsx
@@ -35,6 +35,9 @@ const FILTER_CONFIG: FilterConfig<DomesticStockData> = {
     ],
     dateField: item => item.trade_date,
     yearSearch: true,
+    yearMonthSearch: true,
+    dateSearch: true,
+    dateRangeSearch: true,
     amountFields: [
         item => item.shares,
         item => item.asked_price,
@@ -61,7 +64,8 @@ export const DomesticStock: React.FC<DomesticStockProps> = ({ data, previewData,
     const searchCategories = {
         securities: createSearchOptions(domesticStockData, 'security_code', 'security_name', true),
         accounts: getUniqueValues(domesticStockData, item => item.account),
-        years: createYearOptions(domesticStockData, item => item.trade_date)
+        years: createYearOptions(domesticStockData, item => item.trade_date),
+        dates: true,
     };
 
     // 日次集計（searchQuery がある場合はフィルタ後データ、ない場合は全データを使用）

--- a/frontend/src/pages/Receipt/Mutualfund.tsx
+++ b/frontend/src/pages/Receipt/Mutualfund.tsx
@@ -29,6 +29,9 @@ const FILTER_CONFIG: FilterConfig<MutualfundData> = {
     ],
     dateField: item => item.trade_date,
     yearSearch: true,
+    yearMonthSearch: true,
+    dateSearch: true,
+    dateRangeSearch: true,
 };
 
 interface MutualfundProps {
@@ -47,7 +50,8 @@ export const Mutualfund: React.FC<MutualfundProps> = ({ data, previewData, utili
     // 検索オプションの生成
     const searchCategories = {
         securities: createSearchOptions(mutualfundData, '', 'fund_name', true),
-        years: createYearOptions(mutualfundData, item => item.trade_date)
+        years: createYearOptions(mutualfundData, item => item.trade_date),
+        dates: true,
     };
 
     // 表示用の集計（検索前後で同一ロジック: フィルタ後データから計算）

--- a/frontend/src/pages/Receipt/__tests__/Dividend.test.tsx
+++ b/frontend/src/pages/Receipt/__tests__/Dividend.test.tsx
@@ -355,16 +355,12 @@ describe('Dividend', () => {
 
     it('年で検索すると年月単位のグループが維持される', async () => {
         const user = userEvent.setup();
-        const { container } = render(<Dividend data={mockData} />);
+        render(<Dividend data={mockData} />);
 
         const searchCardHeader = screen.getByTestId('search-card-header');
         fireEvent.click(searchCardHeader);
-        await waitFor(() => {
-            expect(container.querySelector('#years-search')).toBeInTheDocument();
-        });
-
-        const yearSelect = container.querySelector('#years-search') as HTMLSelectElement;
-        await user.selectOptions(yearSelect, '2023');
+        await user.click(await screen.findByRole('button', { name: '年を選択' }));
+        await user.click(await screen.findByRole('option', { name: '2023年' }));
 
         await waitFor(() => {
             expect(screen.getByText('2023年1月')).toBeInTheDocument();

--- a/frontend/src/pages/Receipt/__tests__/Mutualfund.test.tsx
+++ b/frontend/src/pages/Receipt/__tests__/Mutualfund.test.tsx
@@ -145,16 +145,11 @@ describe('Mutualfund', () => {
 
     it('年検索でフィルタリングされる', async () => {
         const user = userEvent.setup();
-        const { container } = render(<Mutualfund data={mockData} />);
+        render(<Mutualfund data={mockData} />);
 
         fireEvent.click(screen.getByTestId('search-card-header'));
-
-        await waitFor(() => {
-            expect(container.querySelector('#years-search')).toBeInTheDocument();
-        }, waitOpts);
-
-        const yearSelect = container.querySelector('#years-search') as HTMLSelectElement;
-        await user.selectOptions(yearSelect, '2023');
+        await user.click(await screen.findByRole('button', { name: '年を選択' }));
+        await user.click(await screen.findByRole('option', { name: '2023年' }));
 
         const table = screen.getByRole('table');
         await waitFor(() => {

--- a/frontend/src/types/common.ts
+++ b/frontend/src/types/common.ts
@@ -20,4 +20,5 @@ export interface SearchCategories {
   products?: string[];
   accounts?: string[];
   years?: { value: string, label: string }[];
+  dates?: boolean; // true の場合、日付検索UIを表示
 }


### PR DESCRIPTION
## 概要
配当金、国内株式、投資信託の検索オプションに、年・月・日・範囲の期間検索を追加しました。

## 主な変更内容
- 検索オプションの最上部に期間検索ブロックを追加
- 年は候補ピッカー、月/日/範囲は統一されたボタン型カレンダーUIに変更
- 月/日/範囲の表示は YYYY/MM または YYYY/MM/DD に統一し、環境依存の曜日・括弧表示を回避
- `YYYY-MM-DD..YYYY-MM-DD` 形式の日付範囲検索に対応
- 配当金、国内株式、投資信託の検索設定とテストを更新

## Codex review
LGTM。PR前にフロント全体テストで旧UI前提のReceiptテスト失敗を検出し、新しい年ピッカー操作に更新済みです。

## テスト
- [x] `npm test`（99 files / 938 tests）
- [x] `npx tsc --noEmit`
- [x] `vp lint`
- [x] `vp build`
- [x] `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 日付範囲検索機能を追加しました。配当金、国内株式、投資信託のページで、特定の期間内の取引を検索できるようになりました。年、月、日、および開始日～終了日の期間指定に対応しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->