### PR TITLE
期間検索のレビュー指摘を反映

### DIFF
--- a/frontend/src/components/organisms/SearchCard/SearchCard.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchCard.tsx
@@ -240,18 +240,22 @@ interface DatePeriodBlockProps {
 const DatePeriodBlock: React.FC<DatePeriodBlockProps> = ({
     dateSegment, years, yearValue, monthValue, dateValue, rangeStart, rangeEnd, isYearPickerOpen,
     onSegmentChange, onToggleYearPicker, onYearOptionSelect, onMonthChange, onDateValueChange, onRangeStartChange, onRangeEndChange,
-}) => (
+}) => {
+    const availableSegments = years.length > 0 ? DATE_SEGMENTS : DATE_SEGMENTS.filter(seg => seg !== '年');
+    const visibleDateSegment = years.length === 0 && dateSegment === '年' ? '月' : dateSegment;
+
+    return (
     <div className="space-y-2">
         <div className="text-sm font-bold text-slate-800">期間</div>
         <div className="flex gap-1">
-            {DATE_SEGMENTS.map(seg => (
+            {availableSegments.map(seg => (
                 <button
                     key={seg}
                     type="button"
-                    aria-pressed={dateSegment === seg}
+                    aria-pressed={visibleDateSegment === seg}
                     onClick={() => onSegmentChange(seg)}
                     className={`flex-1 rounded px-2 py-1 text-xs font-semibold transition-colors ${
-                        dateSegment === seg
+                        visibleDateSegment === seg
                             ? 'bg-slate-950 text-white'
                             : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
                     }`}
@@ -260,7 +264,7 @@ const DatePeriodBlock: React.FC<DatePeriodBlockProps> = ({
                 </button>
             ))}
         </div>
-        {dateSegment === '年' && (
+        {visibleDateSegment === '年' && (
             <div className="relative">
                 <button
                     type="button"
@@ -318,7 +322,7 @@ const DatePeriodBlock: React.FC<DatePeriodBlockProps> = ({
                 )}
             </div>
         )}
-        {dateSegment === '月' && (
+        {visibleDateSegment === '月' && (
             <CalendarDateButton
                 label="月を選択"
                 value={monthValue}
@@ -326,14 +330,14 @@ const DatePeriodBlock: React.FC<DatePeriodBlockProps> = ({
                 onChange={onMonthChange}
             />
         )}
-        {dateSegment === '日' && (
+        {visibleDateSegment === '日' && (
             <CalendarDateButton
                 label="日を選択"
                 value={dateValue}
                 onChange={onDateValueChange}
             />
         )}
-        {dateSegment === '範囲' && (
+        {visibleDateSegment === '範囲' && (
             <div className="flex flex-col gap-2">
                 <CalendarDateButton
                     label="開始日"
@@ -348,7 +352,8 @@ const DatePeriodBlock: React.FC<DatePeriodBlockProps> = ({
             </div>
         )}
     </div>
-);
+    );
+};
 
 interface SearchCardProps {
     onSearch: (query: string) => void;
@@ -403,7 +408,8 @@ export const SearchCard: React.FC<SearchCardProps> = ({
         hasData(categories.securities) ||
         hasData(categories.products) ||
         hasData(categories.accounts) ||
-        hasData(categories.years)
+        hasData(categories.years) ||
+        Boolean(categories.dates)
     );
 
     // 展開状態の切り替え処理
@@ -413,8 +419,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
         onExpandToggle?.(newExpandedState);
     };
 
-    // キーボードイベントハンドラ
-    const handleKeyDown = (e: React.KeyboardEvent) => {
+    const handleToggleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
         if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
             handleToggleExpanded();
@@ -499,7 +504,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
         return null;
     }
 
-    const datePeriodBlock = Boolean(categories?.dates) && hasData(categories?.years) ? (
+    const datePeriodBlock = categories?.dates ? (
         <div className="mb-3.5">
             <DatePeriodBlock
                 dateSegment={dateSegment}
@@ -525,17 +530,18 @@ export const SearchCard: React.FC<SearchCardProps> = ({
         return (
             <section className="px-4 py-4" data-testid="search-card-compact">
                 <div
-                    className="flex cursor-pointer items-center justify-between gap-2 select-none"
-                    onClick={handleToggleExpanded}
-                    onKeyDown={handleKeyDown}
-                    role="button"
-                    tabIndex={0}
-                    aria-expanded={isExpanded}
-                    aria-controls="search-options-body"
-                    aria-label={`検索オプション ${isExpanded ? '閉じる' : '開く'}`}
-                    data-testid="search-card-header"
+                    className="flex items-center justify-between gap-2"
                 >
-                    <div className="flex min-w-0 items-center gap-2.5">
+                    <button
+                        type="button"
+                        className="flex min-w-0 items-center gap-2.5 text-left select-none"
+                        onClick={handleToggleExpanded}
+                        onKeyDown={handleToggleKeyDown}
+                        aria-expanded={isExpanded}
+                        aria-controls="search-options-body"
+                        aria-label={`検索オプション ${isExpanded ? '閉じる' : '開く'}`}
+                        data-testid="search-card-header"
+                    >
                         <span className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-slate-950 text-white">
                             <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
@@ -550,7 +556,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                                 </span>
                             )}
                         </div>
-                    </div>
+                    </button>
                     <div className="flex shrink-0 items-center gap-1.5">
                         <Button
                             type="button"
@@ -606,21 +612,22 @@ export const SearchCard: React.FC<SearchCardProps> = ({
         <Card className="mt-1 overflow-hidden">
             <CardHeader
                 variant="secondary"
-                className={`flex cursor-pointer items-center justify-between select-none transition-colors focus-within:ring-2 focus-within:ring-white/50 focus-within:ring-inset ${
+                className={`flex items-center justify-between transition-colors focus-within:ring-2 focus-within:ring-white/50 focus-within:ring-inset ${
                     isExpanded
                         ? 'bg-slate-950 hover:bg-slate-900 border-b border-amber-500'
                         : 'bg-slate-800 hover:bg-slate-900'
                 }`}
-                onClick={handleToggleExpanded}
-                onKeyDown={handleKeyDown}
-                role="button"
-                tabIndex={0}
-                aria-expanded={isExpanded}
-                aria-controls="search-options-body"
-                aria-label={`検索オプション ${isExpanded ? '閉じる' : '開く'}`}
-                data-testid="search-card-header"
             >
-                <div className="flex items-center gap-2">
+                <button
+                    type="button"
+                    className="flex items-center gap-2 text-left select-none"
+                    onClick={handleToggleExpanded}
+                    onKeyDown={handleToggleKeyDown}
+                    aria-expanded={isExpanded}
+                    aria-controls="search-options-body"
+                    aria-label={`検索オプション ${isExpanded ? '閉じる' : '開く'}`}
+                    data-testid="search-card-header"
+                >
                     <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
                     </svg>
@@ -630,7 +637,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                             フィルタ適用中
                         </span>
                     )}
-                </div>
+                </button>
                 <div className="flex items-center gap-6">
                     {/* 条件クリアボタン（ヘッダー内・常にレンダリングし高さを固定） */}
                     <Button

--- a/frontend/src/components/organisms/SearchCard/__tests__/SearchCard.test.tsx
+++ b/frontend/src/components/organisms/SearchCard/__tests__/SearchCard.test.tsx
@@ -171,7 +171,7 @@ describe('SearchCard', () => {
     expect(container.firstChild).toBeNull();
   });
 
-  test('dates: true でも years が空の場合は SearchCard が非表示になる', () => {
+  test('dates: true で years が空の場合も日付検索用に SearchCard を表示する', () => {
     const { container } = render(
       <SearchCard
         onSearch={mockOnSearch}
@@ -185,7 +185,9 @@ describe('SearchCard', () => {
       />
     );
 
-    expect(container.firstChild).toBeNull();
+    expect(container.firstChild).not.toBeNull();
+    expect(screen.getByText('期間')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '月', pressed: true })).toBeInTheDocument();
   });
 
   test('年度のみのデータがある場合のレイアウト', () => {
@@ -429,6 +431,24 @@ describe('SearchCard', () => {
     test('datesカテゴリがある場合、期間ブロックが表示される', () => {
       render(<SearchCard onSearch={mockOnSearch} categories={dateCategories} />);
       expect(screen.getByText('期間')).toBeInTheDocument();
+    });
+
+    test('datesカテゴリがあり years が空でも月・日・範囲検索を表示する', () => {
+      const categoriesWithoutYears = {
+        ...defaultCategories,
+        years: [],
+        dates: true as const,
+      };
+
+      render(<SearchCard onSearch={mockOnSearch} categories={categoriesWithoutYears} />);
+
+      expect(screen.getByText('期間')).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: '年' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: '年を選択' })).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '月', pressed: true })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '月を選択' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '日' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '範囲' })).toBeInTheDocument();
     });
 
     test('dates: true の場合、「期間」が「銘柄」より前に表示される', () => {

--- a/frontend/src/lib/utils/__tests__/searchUtils.test.ts
+++ b/frontend/src/lib/utils/__tests__/searchUtils.test.ts
@@ -149,6 +149,16 @@ describe('filterByConfig', () => {
             const result = filterByConfig(testData, 'invalid..range', rangeConfig);
             expect(result).toHaveLength(0);
         });
+
+        it('非実在日付を含む範囲は一致しない', () => {
+            const result = filterByConfig(testData, '..2023-99-99', rangeConfig);
+            expect(result).toHaveLength(0);
+        });
+
+        it('開始日が終了日より後の範囲は一致しない', () => {
+            const result = filterByConfig(testData, '2023-02-01..2023-01-01', rangeConfig);
+            expect(result).toHaveLength(0);
+        });
     });
 
     describe('amountFields（金額検索）', () => {

--- a/frontend/src/lib/utils/searchUtils.ts
+++ b/frontend/src/lib/utils/searchUtils.ts
@@ -59,15 +59,23 @@ function matchesDate(date: Date, query: string): boolean {
  * 日付範囲検索マッチャー
  * クエリ形式: "YYYY-MM-DD..YYYY-MM-DD" / "YYYY-MM-DD.." / "..YYYY-MM-DD"
  */
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function isValidIsoDate(value: string): boolean {
+  if (!ISO_DATE_RE.test(value)) return false;
+  const date = new Date(value + 'T00:00:00.000Z');
+  return !Number.isNaN(date.getTime()) && date.toISOString().slice(0, 10) === value;
+}
+
 function matchesDateRange(date: Date, query: string): boolean {
   const sepIdx = query.indexOf('..');
   if (sepIdx === -1) return false;
   const start = query.slice(0, sepIdx);
   const end = query.slice(sepIdx + 2);
-  const datePattern = /^\d{4}-\d{2}-\d{2}$/;
-  if (start && !datePattern.test(start)) return false;
-  if (end && !datePattern.test(end)) return false;
+  if (start && !isValidIsoDate(start)) return false;
+  if (end && !isValidIsoDate(end)) return false;
   if (!start && !end) return false;
+  if (start && end && start > end) return false;
   const dateStr = date.toISOString().split('T')[0];
   if (start && end) return dateStr >= start && dateStr <= end;
   if (start) return dateStr >= start;


### PR DESCRIPTION
## 概要\n- #583 のレビュー指摘追従\n- dates: true かつ years 空でも月/日/範囲検索を表示\n- 日付範囲検索で非実在日付と逆順レンジを拒否\n\n## 対応した指摘\n- #583: years 空で日付検索UIが消える指摘\n- #583: matchesDateRange が非実在日付・逆順範囲を受理する指摘\n- #583: 不正日付・逆順範囲のテスト不足指摘\n\n## Validation\n- npm test -- src/components/organisms/SearchCard/__tests__/SearchCard.test.tsx src/lib/utils/__tests__/searchUtils.test.ts\n- npm run lint\n- npx tsc --noEmit