### PR TITLE
検索オプションを複数AND条件に対応

### DIFF
--- a/frontend/src/components/organisms/SearchCard/SearchCard.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchCard.tsx
@@ -3,14 +3,40 @@ import { SearchCategories } from '@/types/common';
 import { Button } from '@/components/atoms/Button';
 import { Card, CardBody, CardHeader } from '@/components/atoms/Card';
 
-type ActiveSearchType = 'securities' | 'years' | 'products' | 'accounts' | 'date' | null;
+type SearchKey = 'securities' | 'years' | 'products' | 'accounts' | 'date';
+type ActiveSearchType = SearchKey | null;
 type DateSegment = '年' | '月' | '日' | '範囲';
 
 const DATE_SEGMENTS: DateSegment[] = ['年', '月', '日', '範囲'];
+const SEARCH_ORDER: SearchKey[] = ['date', 'securities', 'years', 'products', 'accounts'];
+
+function createEmptySelectedQueries(): Record<SearchKey, string> {
+    return {
+        securities: '',
+        years: '',
+        products: '',
+        accounts: '',
+        date: '',
+    };
+}
 
 function buildRangeQuery(start: string, end: string): string {
     if (!start && !end) return '';
     return `${start}..${end}`;
+}
+
+function formatQueryToken(value: string): string {
+    const trimmed = value.trim();
+    if (!/\s/.test(trimmed)) return trimmed;
+    return `"${trimmed.replace(/"/g, '\\"')}"`;
+}
+
+function buildCombinedQuery(queries: Record<SearchKey, string>): string {
+    return SEARCH_ORDER
+        .map(key => queries[key].trim())
+        .filter(Boolean)
+        .map(formatQueryToken)
+        .join(' ');
 }
 
 interface QuickSearchDropdownProps {
@@ -119,14 +145,13 @@ const BUTTONS_CONFIGS: Array<{ key: ButtonsSearchType; label: string }> = [
 interface SearchFieldsGridProps {
     categories: SearchCategories;
     gridClassName: string;
-    activeSearchType: ActiveSearchType;
-    searchQuery: string;
+    selectedQueries: Record<SearchKey, string>;
     onSearch: (value: string, searchType: 'securities' | 'years' | 'products' | 'accounts') => void;
     hasData: (data: unknown[] | undefined) => boolean;
 }
 
 const SearchFieldsGrid: React.FC<SearchFieldsGridProps> = ({
-    categories, gridClassName, activeSearchType, searchQuery, onSearch, hasData,
+    categories, gridClassName, selectedQueries, onSearch, hasData,
 }) => (
     <div className={`grid ${gridClassName}`}>
         {DROPDOWN_CONFIGS.map(({ key, label }) =>
@@ -138,8 +163,8 @@ const SearchFieldsGrid: React.FC<SearchFieldsGridProps> = ({
                         items={categories[key]!}
                         id={`${key}-search`}
                         searchType={key}
-                        activeSearchType={activeSearchType}
-                        searchQuery={searchQuery}
+                        activeSearchType={selectedQueries[key] ? key : null}
+                        searchQuery={selectedQueries[key]}
                         onSearch={onSearch}
                     />
                 </div>
@@ -153,8 +178,8 @@ const SearchFieldsGrid: React.FC<SearchFieldsGridProps> = ({
                         <QuickSearchButtons
                             items={categories[key]!}
                             searchType={key}
-                            activeSearchType={activeSearchType}
-                            searchQuery={searchQuery}
+                            activeSearchType={selectedQueries[key] ? key : null}
+                            searchQuery={selectedQueries[key]}
                             onSearch={onSearch}
                         />
                     </div>
@@ -384,8 +409,9 @@ export const SearchCard: React.FC<SearchCardProps> = ({
         setPrevInitialExpanded(initialExpanded);
         setIsExpanded(initialExpanded);
     }
-    const [searchQuery, setSearchQuery] = useState('');
-    const [activeSearchType, setActiveSearchType] = useState<ActiveSearchType>(null);
+    const [selectedQueries, setSelectedQueries] = useState<Record<SearchKey, string>>(
+        createEmptySelectedQueries()
+    );
 
     // 日付検索用ステート
     const [dateSegment, setDateSegment] = useState<DateSegment>('年');
@@ -396,8 +422,8 @@ export const SearchCard: React.FC<SearchCardProps> = ({
     const [rangeEnd, setRangeEnd] = useState('');
     const [isYearPickerOpen, setIsYearPickerOpen] = useState(false);
 
-    const effectiveSearchQuery = value ?? searchQuery;
-    const effectiveActiveSearchType = value === '' ? null : activeSearchType;
+    const effectiveSelectedQueries = value === '' ? createEmptySelectedQueries() : selectedQueries;
+    const hasActiveSearch = Object.values(effectiveSelectedQueries).some(Boolean);
 
     // データが存在するかチェック
     const hasData = (data: unknown[] | undefined): boolean =>
@@ -435,26 +461,36 @@ export const SearchCard: React.FC<SearchCardProps> = ({
         setIsYearPickerOpen(false);
     };
 
+    const applySelectedQueries = (nextQueries: Record<SearchKey, string>) => {
+        setSelectedQueries(nextQueries);
+        onSearch(buildCombinedQuery(nextQueries));
+    };
+
     const handleQuickSearch = (value: string, searchType: 'securities' | 'years' | 'products' | 'accounts') => {
-        setSearchQuery(value);
-        setActiveSearchType(value ? searchType : null);
-        resetDateInputs();
-        onSearch(value);
+        const shouldToggleOff =
+            (searchType === 'products' || searchType === 'accounts') &&
+            effectiveSelectedQueries[searchType] === value;
+        applySelectedQueries({
+            ...effectiveSelectedQueries,
+            [searchType]: value === '' || shouldToggleOff ? '' : value,
+        });
     };
 
     const handleDateSearch = (val: string) => {
-        setSearchQuery(val);
-        setActiveSearchType(val ? 'date' : null);
-        onSearch(val);
+        applySelectedQueries({
+            ...effectiveSelectedQueries,
+            date: val,
+        });
     };
 
     const handleSegmentChange = (segment: DateSegment) => {
         if (segment === dateSegment) return;
         setDateSegment(segment);
-        if (activeSearchType !== null) {
-            setSearchQuery('');
-            setActiveSearchType(null);
-            onSearch('');
+        if (effectiveSelectedQueries.date) {
+            applySelectedQueries({
+                ...effectiveSelectedQueries,
+                date: '',
+            });
         }
         resetDateInputs();
     };
@@ -488,12 +524,11 @@ export const SearchCard: React.FC<SearchCardProps> = ({
     };
 
     // 検索条件が初期状態かどうか
-    const isDefaultState = effectiveSearchQuery === '' && effectiveActiveSearchType === null;
+    const isDefaultState = !hasActiveSearch;
 
     // 検索条件をクリア
     const handleClearSearch = () => {
-        setSearchQuery('');
-        setActiveSearchType(null);
+        setSelectedQueries(createEmptySelectedQueries());
         setDateSegment('年');
         resetDateInputs();
         onSearch('');
@@ -550,7 +585,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                         <div className="min-w-0">
                             <p className="text-[10px] font-black uppercase tracking-[0.18em] text-slate-500">Filter</p>
                             <h5 className="whitespace-nowrap text-sm font-black text-slate-950">検索オプション</h5>
-                            {!isExpanded && effectiveActiveSearchType && (
+                            {!isExpanded && hasActiveSearch && (
                                 <span className="mt-1 inline-flex whitespace-nowrap rounded-md border border-amber-200 bg-amber-50 px-2 py-0.5 text-[11px] font-bold text-amber-800">
                                     適用中
                                 </span>
@@ -597,8 +632,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                         <SearchFieldsGrid
                             categories={categories}
                             gridClassName="grid-cols-1 gap-3.5"
-                            activeSearchType={effectiveActiveSearchType}
-                            searchQuery={effectiveSearchQuery}
+                            selectedQueries={effectiveSelectedQueries}
                             onSearch={handleQuickSearch}
                             hasData={hasData}
                         />
@@ -632,7 +666,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
                     </svg>
                     <h5 className="text-sm font-semibold">検索オプション</h5>
-                    {!isExpanded && effectiveActiveSearchType && (
+                    {!isExpanded && hasActiveSearch && (
                         <span className="text-xs px-2 py-0.5 rounded bg-white/20">
                             フィルタ適用中
                         </span>
@@ -693,8 +727,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                     <SearchFieldsGrid
                         categories={categories}
                         gridClassName="grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4"
-                        activeSearchType={effectiveActiveSearchType}
-                        searchQuery={effectiveSearchQuery}
+                        selectedQueries={effectiveSelectedQueries}
                         onSearch={handleQuickSearch}
                         hasData={hasData}
                     />

--- a/frontend/src/components/organisms/SearchCard/__tests__/SearchCard.test.tsx
+++ b/frontend/src/components/organisms/SearchCard/__tests__/SearchCard.test.tsx
@@ -588,7 +588,7 @@ describe('SearchCard', () => {
       expect(screen.getByRole('button', { name: '2024/03/31' })).toBeInTheDocument();
     });
 
-    test('銘柄検索後に月セグメントへ切り替えると既存検索が解除される', () => {
+    test('銘柄検索後に月セグメントへ切り替えても銘柄条件は維持される', () => {
       const { container } = render(
         <SearchCard onSearch={mockOnSearch} categories={dateCategories} />
       );
@@ -597,11 +597,10 @@ describe('SearchCard', () => {
       fireEvent.change(secSelect, { target: { value: 'AAPL' } });
       expect(mockOnSearch).toHaveBeenCalledWith('AAPL');
       expect(secSelect.value).toBe('AAPL');
-      // 月セグメントへ切り替え → 既存検索が解除される
+      // 月セグメントへ切り替えても、日付条件だけが初期化され銘柄条件は維持される
       fireEvent.click(screen.getByRole('button', { name: '月' }));
-      expect(mockOnSearch).toHaveBeenLastCalledWith('');
-      // 銘柄ドロップダウンの選択表示が外れる
-      expect(secSelect.value).toBe('');
+      expect(mockOnSearch).toHaveBeenLastCalledWith('AAPL');
+      expect(secSelect.value).toBe('AAPL');
     });
 
     test('クリアで期間入力状態がリセットされる', () => {
@@ -632,5 +631,125 @@ describe('SearchCard', () => {
     expect(grid).toHaveClass('grid-cols-1');
     expect(grid).not.toHaveClass('sm:grid-cols-2');
     expect(grid).not.toHaveClass('lg:grid-cols-4');
+  });
+
+  describe('value prop による外部クリア後の挙動', () => {
+    test('親が value を空文字にリセットした後の操作で古い商品条件が復活しない', () => {
+      const { rerender } = render(
+        <SearchCard
+          onSearch={mockOnSearch}
+          categories={defaultCategories}
+        />
+      );
+
+      // 「株式」を選択
+      fireEvent.click(screen.getByText('株式'));
+      expect(mockOnSearch).toHaveBeenCalledWith('株式');
+
+      // 親が value='' でリセット
+      rerender(
+        <SearchCard
+          onSearch={mockOnSearch}
+          categories={defaultCategories}
+          value=""
+        />
+      );
+
+      // 「一般口座」をクリック → '株式' が復活しないこと
+      fireEvent.click(screen.getByText('一般口座'));
+      expect(mockOnSearch).toHaveBeenLastCalledWith('一般口座');
+    });
+
+    test('親が value を空文字にリセットした後のセグメント切り替えで古い日付条件が復活しない', () => {
+      const dateCategories = { ...defaultCategories, dates: true as const };
+      const { rerender } = render(
+        <SearchCard onSearch={mockOnSearch} categories={dateCategories} />
+      );
+
+      // 年ピッカーで 2024 を選択
+      fireEvent.click(screen.getByLabelText('年を選択'));
+      fireEvent.click(screen.getByRole('option', { name: '2024年' }));
+      expect(mockOnSearch).toHaveBeenCalledWith('2024');
+
+      // 親が value='' でリセット
+      rerender(
+        <SearchCard onSearch={mockOnSearch} categories={dateCategories} value="" />
+      );
+
+      // 月セグメントへ切り替え → 旧日付条件 '2024' が onSearch に再渡しされないこと
+      fireEvent.click(screen.getByRole('button', { name: '月' }));
+      // handleSegmentChange は effectiveSelectedQueries.date === '' なので applySelectedQueries を呼ばない
+      expect(mockOnSearch).toHaveBeenLastCalledWith('2024');
+    });
+
+    test('親が value を空文字にリセットした後の銘柄選択で古い銘柄条件が復活しない', () => {
+      const { container, rerender } = render(
+        <SearchCard onSearch={mockOnSearch} categories={defaultCategories} />
+      );
+
+      // 銘柄 AAPL を選択
+      const select = container.querySelector('#securities-search') as HTMLSelectElement;
+      fireEvent.change(select, { target: { value: 'AAPL' } });
+      expect(mockOnSearch).toHaveBeenCalledWith('AAPL');
+
+      // 親が value='' でリセット
+      rerender(
+        <SearchCard onSearch={mockOnSearch} categories={defaultCategories} value="" />
+      );
+
+      // 別の銘柄 GOOGL を選択 → 'AAPL' が復活しないこと
+      fireEvent.change(select, { target: { value: 'GOOGL' } });
+      expect(mockOnSearch).toHaveBeenLastCalledWith('GOOGL');
+    });
+  });
+
+  describe('複数条件の組み合わせ', () => {
+    test('商品「株式」選択後に口座「一般口座」を選択すると、最後のonSearchがスペース区切りの両条件クエリになること', () => {
+      render(
+        <SearchCard
+          onSearch={mockOnSearch}
+          categories={defaultCategories}
+        />
+      );
+
+      fireEvent.click(screen.getByText('株式'));
+      fireEvent.click(screen.getByText('一般口座'));
+
+      expect(mockOnSearch).toHaveBeenLastCalledWith('株式 一般口座');
+    });
+
+    test('商品「株式」選択後に同じ「株式」を再クリックすると条件が解除されて最後のonSearchが空文字になること', () => {
+      render(
+        <SearchCard
+          onSearch={mockOnSearch}
+          categories={defaultCategories}
+        />
+      );
+
+      fireEvent.click(screen.getByText('株式'));
+      fireEvent.click(screen.getByText('株式'));
+
+      expect(mockOnSearch).toHaveBeenLastCalledWith('');
+    });
+
+    test('年ピッカーで2024年を選択後に銘柄AAPLを選択すると、最後のonSearchが「2024 AAPL」になること', () => {
+      const { container } = render(
+        <SearchCard
+          onSearch={mockOnSearch}
+          categories={{
+            ...defaultCategories,
+            dates: true as const,
+          }}
+        />
+      );
+
+      fireEvent.click(screen.getByLabelText('年を選択'));
+      fireEvent.click(screen.getByRole('option', { name: '2024年' }));
+
+      const select = container.querySelector('#securities-search') as HTMLSelectElement;
+      fireEvent.change(select, { target: { value: 'AAPL' } });
+
+      expect(mockOnSearch).toHaveBeenLastCalledWith('2024 AAPL');
+    });
   });
 });

--- a/frontend/src/lib/utils/__tests__/searchUtils.test.ts
+++ b/frontend/src/lib/utils/__tests__/searchUtils.test.ts
@@ -72,6 +72,40 @@ describe('filterByConfig', () => {
         });
     });
 
+    describe('AND検索（複数条件）', () => {
+        it('スペース区切りの複数トークンをAND条件として絞り込む', () => {
+            // クエリ形式: スペース区切りのトークンをAND結合
+            // 例: 'A 2023' → トークン1='A'（category完全一致）かつトークン2='2023'（年度一致）
+            const query = 'A 2023';
+            const config: FilterConfig<TestItem> = {
+                stringFields: [item => item.category],
+                dateField: item => item.date,
+                yearSearch: true,
+            };
+            const result = filterByConfig(testData, query, config);
+            // testData のうち category='A' かつ year=2023 → code='1234' のみ
+            expect(result).toHaveLength(1);
+            expect(result[0].code).toBe('1234');
+        });
+
+
+        it('引用符で囲まれた空白入りトークンを1条件として扱う', () => {
+            const data = [
+                { code: '1', name: 'Alpha Fund A', category: 'A', date: new Date('2023-01-15'), amount: 100 },
+                { code: '2', name: 'Alpha Fund B', category: 'A', date: new Date('2023-01-15'), amount: 100 },
+                { code: '3', name: 'Alpha Fund A', category: 'A', date: new Date('2024-01-15'), amount: 100 },
+            ];
+            const config: FilterConfig<TestItem> = {
+                stringFields: [item => item.name],
+                dateField: item => item.date,
+                yearSearch: true,
+            };
+            const result = filterByConfig(data, '"Alpha Fund A" 2023', config);
+            expect(result).toHaveLength(1);
+            expect(result[0].code).toBe('1');
+        });
+    });
+
     describe('複合条件', () => {
         it('stringFieldsとpartialStringFieldsを組み合わせられる', () => {
             const config: FilterConfig<TestItem> = {

--- a/frontend/src/lib/utils/searchUtils.ts
+++ b/frontend/src/lib/utils/searchUtils.ts
@@ -106,8 +106,50 @@ export interface FilterConfig<T> {
   amountFields?: ((item: T) => number)[];
 }
 
+function parseSearchTokens(query: string): string[] {
+  const tokens: string[] = [];
+  const tokenPattern = /"((?:\\.|[^"\\])*)"|(\S+)/g;
+  for (const match of query.matchAll(tokenPattern)) {
+    const rawToken = match[1] ?? match[2] ?? '';
+    const token = rawToken.replace(/\\"/g, '"').trim().toLowerCase();
+    if (token) tokens.push(token);
+  }
+  return tokens;
+}
+
+function matchesToken<T>(item: T, token: string, config: FilterConfig<T>): boolean {
+  if (config.stringFields) {
+    for (const getter of config.stringFields) {
+      if (getter(item).toLowerCase() === token) return true;
+    }
+  }
+
+  if (config.partialStringFields) {
+    for (const getter of config.partialStringFields) {
+      if (getter(item).toLowerCase().includes(token)) return true;
+    }
+  }
+
+  if (config.dateField) {
+    const date = config.dateField(item);
+    if (config.yearSearch && matchesYear(date, token)) return true;
+    if (config.yearMonthSearch && matchesYearMonth(date, token)) return true;
+    if (config.dateSearch && matchesDate(date, token)) return true;
+    if (config.dateRangeSearch && matchesDateRange(date, token)) return true;
+  }
+
+  if (config.amountFields) {
+    for (const getter of config.amountFields) {
+      if (getter(item).toString().includes(token)) return true;
+    }
+  }
+
+  return false;
+}
+
 /**
  * 設定ベースの汎用フィルタ関数
+ * スペース区切りの複数トークンはAND条件として扱う（日付範囲 ".." はトークン分割しない）
  * @param data フィルタ対象データ
  * @param query 検索クエリ
  * @param config フィルタ設定
@@ -118,63 +160,11 @@ export function filterByConfig<T>(
   query: string,
   config: FilterConfig<T>
 ): T[] {
-  if (!query) return data;
+  const trimmed = query.trim();
+  if (!trimmed) return data;
 
-  const normalizedQuery = query.toLowerCase();
+  const tokens = parseSearchTokens(trimmed);
+  if (tokens.length === 0) return data;
 
-  return data.filter(item => {
-    // 文字列フィールドの完全一致検索
-    if (config.stringFields) {
-      for (const getter of config.stringFields) {
-        if (getter(item).toLowerCase() === normalizedQuery) {
-          return true;
-        }
-      }
-    }
-
-    // 文字列フィールドの部分一致検索
-    if (config.partialStringFields) {
-      for (const getter of config.partialStringFields) {
-        if (getter(item).toLowerCase().includes(normalizedQuery)) {
-          return true;
-        }
-      }
-    }
-
-    // 日付関連の検索
-    if (config.dateField) {
-      const date = config.dateField(item);
-
-      // 年度検索
-      if (config.yearSearch && matchesYear(date, normalizedQuery)) {
-        return true;
-      }
-
-      // 年月検索
-      if (config.yearMonthSearch && matchesYearMonth(date, normalizedQuery)) {
-        return true;
-      }
-
-      // 日付検索
-      if (config.dateSearch && matchesDate(date, normalizedQuery)) {
-        return true;
-      }
-
-      // 日付範囲検索
-      if (config.dateRangeSearch && matchesDateRange(date, normalizedQuery)) {
-        return true;
-      }
-    }
-
-    // 金額の部分一致検索
-    if (config.amountFields) {
-      for (const getter of config.amountFields) {
-        if (getter(item).toString().includes(normalizedQuery)) {
-          return true;
-        }
-      }
-    }
-
-    return false;
-  });
+  return data.filter(item => tokens.every(token => matchesToken(item, token, config)));
 }


### PR DESCRIPTION
## 概要
検索オプションで複数条件を同時に指定できるようにし、条件同士をANDで絞り込むようにしました。

## 主な変更
- SearchCardの検索状態を種別ごとの選択状態に変更
- 商品/口座ボタンの再クリックで該当条件だけ解除
- 期間条件と銘柄/商品/口座条件の併用に対応
- 複数トークン検索をAND条件として扱うfilterByConfigへ変更
- 空白を含むファンド名などを壊さないよう引用符付きトークンをサポート

## テスト
- npm test -- src/components/organisms/SearchCard/__tests__/SearchCard.test.tsx src/lib/utils/__tests__/searchUtils.test.ts src/hooks/receipt/__tests__/useReceiptPageState.test.ts
- npm test -- src/pages/Receipt/__tests__/Dividend.test.tsx src/pages/Receipt/__tests__/DomesticStock.test.tsx src/pages/Receipt/__tests__/Mutualfund.test.tsx
- npm run lint
- npx tsc --noEmit
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 変更内容

* **New Features**
  * 複数の検索条件を同時に組み合わせたAND検索に対応しました
  * スペース区切りで複数キーワードを指定できるようになりました
  * 検索タイプを切り替えた場合でも前の検索条件が保持されるように改善されました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->