### PR TITLE
銘柄検索候補に最新名称を表示

### DIFF
--- a/frontend/src/lib/utils/__tests__/dataTransformer.test.ts
+++ b/frontend/src/lib/utils/__tests__/dataTransformer.test.ts
@@ -6,6 +6,12 @@ interface TestItemWithCode {
     value?: number;
 }
 
+interface TestItemWithCodeAndDate {
+    code: string;
+    name: string;
+    date: Date | string;
+}
+
 interface TestItemWithDate {
     date: Date;
     category: string;
@@ -52,10 +58,79 @@ describe('createSearchOptions', () => {
         ];
 
         const result = createSearchOptions(testData, 'code', 'name', true);
-        
+
         expect(result).toEqual([
             { value: '1234', label: '1234: テスト1' },
             { value: '5678', label: '5678: テスト2' }
+        ]);
+    });
+
+    it('dateFieldを指定すると同一valueで最新日付のlabelを採用する（古い名称が先）', () => {
+        const testData: TestItemWithCodeAndDate[] = [
+            { code: '9432', name: '日本電信電話', date: new Date('2024-06-21') },
+            { code: '9432', name: 'ＮＴＴ', date: new Date('2026-06-01') },
+            { code: '1234', name: 'テスト', date: new Date('2023-01-01') },
+        ];
+
+        const result = createSearchOptions(testData, 'code', 'name', true, 'date');
+
+        expect(result).toEqual([
+            { value: '1234', label: '1234: テスト' },
+            { value: '9432', label: '9432: ＮＴＴ' },
+        ]);
+    });
+
+    it('dateFieldを指定すると同一valueで最新日付のlabelを採用する（新しい名称が先）', () => {
+        const testData: TestItemWithCodeAndDate[] = [
+            { code: '9432', name: 'ＮＴＴ', date: new Date('2026-06-01') },
+            { code: '9432', name: '日本電信電話', date: new Date('2024-06-21') },
+            { code: '1234', name: 'テスト', date: new Date('2023-01-01') },
+        ];
+
+        const result = createSearchOptions(testData, 'code', 'name', true, 'date');
+
+        expect(result).toEqual([
+            { value: '1234', label: '1234: テスト' },
+            { value: '9432', label: '9432: ＮＴＴ' },
+        ]);
+    });
+
+    it('dateFieldを日付文字列で指定しても最新日付のlabelを採用する', () => {
+        const testData: TestItemWithCodeAndDate[] = [
+            { code: '9432', name: '日本電信電話', date: '2024-06-21' },
+            { code: '9432', name: 'ＮＴＴ', date: '2026-06-01' },
+        ];
+
+        const result = createSearchOptions(testData, 'code', 'name', true, 'date');
+
+        expect(result).toEqual([
+            { value: '9432', label: '9432: ＮＴＴ' },
+        ]);
+    });
+
+    it('dateFieldを指定しない場合は最初に出たlabelを保持する（後方互換）', () => {
+        const testData: TestItemWithCodeAndDate[] = [
+            { code: '9432', name: '日本電信電話', date: new Date('2024-06-21') },
+            { code: '9432', name: 'ＮＴＴ', date: new Date('2026-06-01') },
+        ];
+
+        const result = createSearchOptions(testData, 'code', 'name', true);
+
+        expect(result).toEqual([
+            { value: '9432', label: '9432: 日本電信電話' },
+        ]);
+    });
+
+    it('先頭itemの日付が不正文字列でも後続の有効な日付のlabelを採用する', () => {
+        const testData: TestItemWithCodeAndDate[] = [
+            { code: '9432', name: '日本電信電話', date: 'not-a-date' },
+            { code: '9432', name: 'ＮＴＴ', date: '2026-06-01' },
+        ];
+
+        const result = createSearchOptions(testData, 'code', 'name', true, 'date');
+
+        expect(result).toEqual([
+            { value: '9432', label: '9432: ＮＴＴ' },
         ]);
     });
 });

--- a/frontend/src/lib/utils/dataTransformer.ts
+++ b/frontend/src/lib/utils/dataTransformer.ts
@@ -1,22 +1,47 @@
+function toDate(d: Date | string | null | undefined): Date | null {
+    if (!d) return null;
+    const parsed = d instanceof Date ? d : new Date(d);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
 export function createSearchOptions<T>(
     data: T[],
     valueField: keyof T,
     labelField: keyof T,
-    prefix?: boolean
+    prefix?: boolean,
+    dateField?: keyof T | ((item: T) => Date | string | null | undefined)
 ): { value: string, label: string }[] {
-    const seen = new Map<string, { value: string; label: string }>();
+    const getDate = dateField
+        ? (typeof dateField === 'function'
+            ? dateField
+            : (item: T) => item[dateField] as Date | string | null | undefined)
+        : undefined;
+
+    const labels = new Map<string, string>();
+    const dates = new Map<string, Date | null>();
+
     for (const item of data) {
         const value = String(item[valueField] || item[labelField]);
-        if (!seen.has(value)) {
-            seen.set(value, {
-                value,
-                label: prefix
-                    ? `${item[valueField] ? `${String(item[valueField])}: ` : ''}${String(item[labelField])}`
-                    : String(item[labelField]),
-            });
+        const label = prefix
+            ? `${item[valueField] ? `${String(item[valueField])}: ` : ''}${String(item[labelField])}`
+            : String(item[labelField]);
+        const itemDate = getDate ? toDate(getDate(item)) : null;
+
+        if (!labels.has(value)) {
+            labels.set(value, label);
+            dates.set(value, itemDate);
+        } else if (itemDate) {
+            const existingDate = dates.get(value) ?? null;
+            if (!existingDate || itemDate > existingDate) {
+                labels.set(value, label);
+                dates.set(value, itemDate);
+            }
         }
     }
-    return [...seen.values()].sort((a, b) => a.value.localeCompare(b.value));
+
+    return [...labels.entries()]
+        .map(([value, label]) => ({ value, label }))
+        .sort((a, b) => a.value.localeCompare(b.value));
 }
 
 export type SummaryResult<K extends string | number | symbol> = {

--- a/frontend/src/pages/Receipt/Dividend.tsx
+++ b/frontend/src/pages/Receipt/Dividend.tsx
@@ -70,7 +70,7 @@ export const Dividend: React.FC<DividendProps> = ({ data, previewData, utilityRa
 
     // 検索カテゴリーの生成
     const searchCategories = {
-        securities: createSearchOptions(dividendData, 'security_code', 'security_name', true),
+        securities: createSearchOptions(dividendData, 'security_code', 'security_name', true, 'settlement_date'),
         products: getUniqueValues(dividendData, item => item.product),
         accounts: getUniqueValues(dividendData, item => item.account),
         years: createYearOptions(dividendData, item => item.settlement_date),

--- a/frontend/src/pages/Receipt/DomesticStock.tsx
+++ b/frontend/src/pages/Receipt/DomesticStock.tsx
@@ -62,7 +62,7 @@ export const DomesticStock: React.FC<DomesticStockProps> = ({ data, previewData,
 
     // 検索カテゴリーの生成
     const searchCategories = {
-        securities: createSearchOptions(domesticStockData, 'security_code', 'security_name', true),
+        securities: createSearchOptions(domesticStockData, 'security_code', 'security_name', true, 'trade_date'),
         accounts: getUniqueValues(domesticStockData, item => item.account),
         years: createYearOptions(domesticStockData, item => item.trade_date),
         dates: true,

--- a/frontend/src/pages/Receipt/Mutualfund.tsx
+++ b/frontend/src/pages/Receipt/Mutualfund.tsx
@@ -49,7 +49,7 @@ export const Mutualfund: React.FC<MutualfundProps> = ({ data, previewData, utili
 
     // 検索オプションの生成
     const searchCategories = {
-        securities: createSearchOptions(mutualfundData, '', 'fund_name', true),
+        securities: createSearchOptions(mutualfundData, '', 'fund_name', true, 'trade_date'),
         years: createYearOptions(mutualfundData, item => item.trade_date),
         dates: true,
     };


### PR DESCRIPTION
## 概要
同一銘柄コードの検索候補ラベルで、最新日付の銘柄名を採用するようにしました。

例: 9432 で 2024/06/21「日本電信電話」と 2026/06/01「ＮＴＴ」がある場合、候補表示は「9432: ＮＴＴ」になります。

## 変更内容
- createSearchOptions に任意の dateField を追加
- 同一 value では最新日付の item の label を採用
- 配当金は settlement_date、国内株式と投資信託は trade_date を指定
- 既存互換として dateField 未指定時は従来通り最初の label を保持
- 9432 の名称変更ケースを含む回帰テストを追加

## テスト
- npm test -- src/lib/utils/__tests__/dataTransformer.test.ts src/pages/Receipt/__tests__/Dividend.test.tsx src/pages/Receipt/__tests__/DomesticStock.test.tsx src/pages/Receipt/__tests__/Mutualfund.test.tsx
- npm run lint
- npx tsc --noEmit
- npm run build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 検索オプションの生成時に日付フィールドを考慮し、同一の検索値に対して最新の日付を持つラベルを優先的に選択するようになりました。これにより、配当金、国内株式、投資信託ページの検索機能がより正確な結果を提供します。

* **テスト**
  * 日付考慮ロジックの検証テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->