### PR TITLE
fix: 配当銘柄検索の旧名称グループ分割を修正

### DIFF
--- a/frontend/src/pages/Receipt/Dividend.tsx
+++ b/frontend/src/pages/Receipt/Dividend.tsx
@@ -80,6 +80,18 @@ export const Dividend: React.FC<DividendProps> = ({ data, previewData, utilityRa
     // 表示用の集計（検索前後で同一ロジック: フィルタ後データから計算）
     const calculations = useReceiptCalculations(filteredData, calculateDividends);
 
+    const latestSecurityNameByCode = new Map<string, { name: string; settlementTime: number }>();
+    for (const item of dividendData) {
+        const current = latestSecurityNameByCode.get(item.security_code);
+        const settlementTime = item.settlement_date.getTime();
+        if (!current || settlementTime > current.settlementTime) {
+            latestSecurityNameByCode.set(item.security_code, {
+                name: item.security_name,
+                settlementTime,
+            });
+        }
+    }
+
     // グループキーの取得（検索タイプに応じて動的に変更）
     const getGroupKey = (item: DividendData): string => {
         if (!searchQuery) {
@@ -88,10 +100,10 @@ export const Dividend: React.FC<DividendProps> = ({ data, previewData, utilityRa
 
         const query = searchQuery.toLowerCase();
 
-        // 銘柄での検索の場合（銘柄名でグループ化、年と誤判定を防ぐ）
+        // 銘柄での検索の場合（同一コードの旧名/新名を最新銘柄名で1グループにまとめる）
         if (item.security_code.toLowerCase() === query ||
             item.security_name.toLowerCase() === query) {
-            return item.security_name;
+            return latestSecurityNameByCode.get(item.security_code)?.name ?? item.security_name;
         }
 
         // 商品での検索の場合

--- a/frontend/src/pages/Receipt/__tests__/Dividend.test.tsx
+++ b/frontend/src/pages/Receipt/__tests__/Dividend.test.tsx
@@ -386,6 +386,63 @@ describe('Dividend', () => {
         }
     });
 
+    it('同一銘柄コードで旧名/新名が混在しても銘柄検索時は最新銘柄名の1グループにまとめられる', () => {
+        const mixedData = [
+            {
+                settlement_date: new Date('2024-06-21'),
+                product: '株式',
+                account: '特定口座',
+                security_code: '9432',
+                security_name: '日本電信電話',
+                unit_price: 10,
+                shares: 100,
+                dividends_before_tax: 1000,
+                taxes: 200,
+                net_amount_received: 800,
+            },
+            {
+                settlement_date: new Date('2026-06-01'),
+                product: '株式',
+                account: '特定口座',
+                security_code: '9432',
+                security_name: 'NTT',
+                unit_price: 10,
+                shares: 100,
+                dividends_before_tax: 2000,
+                taxes: 400,
+                net_amount_received: 1600,
+            },
+        ];
+
+        const useReceiptBaseDataSpy = vi.spyOn(receiptHooks, 'useReceiptBaseData').mockReturnValue({
+            sortedData: mixedData,
+            searchQuery: '9432',
+            setSearchQuery: vi.fn(),
+            filteredData: mixedData,
+        } as ReturnType<typeof receiptHooks.useReceiptBaseData>);
+
+        try {
+            render(<Dividend data={mixedData} />);
+
+            // グループヘッダーセル（最初のtd）は「NTT」で「2件」を示す
+            const summaryCell = screen.getByRole('table').querySelector('tbody tr td');
+            expect(summaryCell).toHaveTextContent('NTT');
+            expect(summaryCell).toHaveTextContent('2件');
+
+            // グループヘッダーセルに「日本電信電話」は表示されない（データ行は除外）
+            expect(summaryCell).not.toHaveTextContent('日本電信電話');
+
+            // 「件」バッジを含むグループヘッダー行が1つだけ（グループは1つ）
+            const allFirstCells = Array.from(
+                screen.getByRole('table').querySelectorAll('tbody tr td:first-child')
+            );
+            const groupHeaderCells = allFirstCells.filter(cell => cell.textContent?.includes('件'));
+            expect(groupHeaderCells).toHaveLength(1);
+        } finally {
+            useReceiptBaseDataSpy.mockRestore();
+        }
+    });
+
     it('検索種別に一致しないクエリでも年月単位でグループ化される', () => {
         const useReceiptBaseDataSpy = vi.spyOn(receiptHooks, 'useReceiptBaseData').mockReturnValue({
             sortedData: mockData,


### PR DESCRIPTION
## 概要
- 配当金ページの銘柄検索で、同一銘柄コードの旧銘柄名/最新銘柄名が別グループに分かれる問題を修正
- グループ名は銘柄コードごとの最新入金日の銘柄名を使い、明細行の銘柄名は元データのまま表示
- 9432 の旧名/新名混在ケースをテスト追加

## テスト
- npm test -- src/pages/Receipt/__tests__/Dividend.test.tsx
- vp lint
- npx tsc --noEmit
- vp build