### PR TITLE
fix: AND検索レビュー指摘に対応

### DIFF
--- a/frontend/src/components/atoms/SecurityCodeLink.tsx
+++ b/frontend/src/components/atoms/SecurityCodeLink.tsx
@@ -69,7 +69,13 @@ export const CopyableInstrumentName: React.FC<CopyableInstrumentNameProps> = ({ 
     <button
       type="button"
       aria-label={`${copyText} をコピー`}
-      onClick={() => { void navigator.clipboard?.writeText(copyText); }}
+      onClick={async () => {
+        try {
+          await navigator.clipboard?.writeText(copyText);
+        } catch (err) {
+          console.warn('クリップボードへのコピーに失敗しました', err);
+        }
+      }}
       className={cn(
         'group inline-flex cursor-pointer items-center gap-0.5 border-0 bg-transparent p-0 text-left text-inherit',
         'focus-visible:rounded-sm focus-visible:outline-2 focus-visible:outline-blue-500',

--- a/frontend/src/components/atoms/__tests__/SecurityCodeLink.test.tsx
+++ b/frontend/src/components/atoms/__tests__/SecurityCodeLink.test.tsx
@@ -132,6 +132,22 @@ describe('CopyableInstrumentName', () => {
     expect(writeText).toHaveBeenCalledWith('ＫＤＤＩ(9433)');
   });
 
+  it('clipboard.writeText が失敗した場合は console.warn を呼び例外を投げない', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('permission denied'));
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    render(<CopyableInstrumentName name="ＫＤＤＩ" code="9433" />);
+    fireEvent.click(screen.getByRole('button', { name: 'ＫＤＤＩ(9433) をコピー' }));
+    await vi.waitFor(() => expect(warnSpy).toHaveBeenCalledWith(
+      'クリップボードへのコピーに失敗しました',
+      expect.any(Error)
+    ));
+    warnSpy.mockRestore();
+  });
+
   it('SVGアイコンに group-focus-visible:opacity-100 が含まれ focus:opacity-100 が含まれない', () => {
     const { container } = render(<CopyableInstrumentName name="ＫＤＤＩ" code="9433" />);
     const svg = container.querySelector('svg');

--- a/frontend/src/components/organisms/SearchCard/SearchCard.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchCard.tsx
@@ -190,6 +190,12 @@ const SearchFieldsGrid: React.FC<SearchFieldsGridProps> = ({
     </div>
 );
 
+function getInitialDateSegment(cats: SearchCategories | undefined): DateSegment {
+    if ((cats?.years?.length ?? 0) > 0) return '年';
+    if (cats?.dates) return '月';
+    return '年';
+}
+
 const formatDateLabel = (value: string): string => value.replace(/-/g, "/");
 
 interface CalendarDateButtonProps {
@@ -490,8 +496,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
 
     // 日付検索用ステート
     const [dateSegment, setDateSegment] = useState<DateSegment>(() =>
-        (categories?.years?.length ?? 0) > 0 ? '年' :
-        categories?.dates ? '月' : '年'
+        getInitialDateSegment(categories)
     );
     const [yearValue, setYearValue] = useState('');
     const [monthValue, setMonthValue] = useState('');
@@ -513,10 +518,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
         setRangeStart('');
         setRangeEnd('');
         setIsYearPickerOpen(false);
-        setDateSegment(
-            (cats?.years?.length ?? 0) > 0 ? '年' :
-            cats?.dates ? '月' : '年'
-        );
+        setDateSegment(getInitialDateSegment(cats));
     }, [value]);
 
     const effectiveSelectedQueries = value === '' ? createEmptySelectedQueries() : selectedQueries;
@@ -626,10 +628,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
     // 検索条件をクリア
     const handleClearSearch = () => {
         setSelectedQueries(createEmptySelectedQueries());
-        setDateSegment(
-            (categories?.years?.length ?? 0) > 0 ? '年' :
-            categories?.dates ? '月' : '年'
-        );
+        setDateSegment(getInitialDateSegment(categories));
         resetDateInputs();
         onSearch('');
     };

--- a/frontend/src/components/organisms/SearchCard/SearchCard.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchCard.tsx
@@ -1,14 +1,15 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { SearchCategories } from '@/types/common';
 import { Button } from '@/components/atoms/Button';
 import { Card, CardBody, CardHeader } from '@/components/atoms/Card';
+import { cn } from '@/lib/utils/classNames';
 
 type SearchKey = 'securities' | 'years' | 'products' | 'accounts' | 'date';
 type ActiveSearchType = SearchKey | null;
 type DateSegment = '年' | '月' | '日' | '範囲';
 
 const DATE_SEGMENTS: DateSegment[] = ['年', '月', '日', '範囲'];
-const SEARCH_ORDER: SearchKey[] = ['date', 'securities', 'years', 'products', 'accounts'];
+const SEARCH_ORDER = ['date', 'securities', 'years', 'products', 'accounts'] as const satisfies readonly SearchKey[];
 
 function createEmptySelectedQueries(): Record<SearchKey, string> {
     return {
@@ -211,7 +212,7 @@ const CalendarDateButton: React.FC<CalendarDateButtonProps> = ({ label, value, i
                 return;
             }
         } catch {
-            // fall through to the click fallback
+            // showPicker が失敗した場合はクリックフォールバックへ
         }
         input.focus();
         input.click();
@@ -222,7 +223,12 @@ const CalendarDateButton: React.FC<CalendarDateButtonProps> = ({ label, value, i
             <button
                 type="button"
                 onClick={handleButtonClick}
-                className={"w-full flex items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors focus:outline-none focus:ring-2 focus:border-amber-600 focus:ring-amber-500/25 " + (value ? "border-amber-500 bg-amber-50 text-amber-900 font-semibold" : "border-slate-300 bg-white text-slate-500 hover:border-slate-400")}
+                className={cn(
+                    'w-full flex items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors focus:outline-none focus:ring-2 focus:border-amber-600 focus:ring-amber-500/25',
+                    value
+                        ? 'border-amber-500 bg-amber-50 text-amber-900 font-semibold'
+                        : 'border-slate-300 bg-white text-slate-500 hover:border-slate-400'
+                )}
             >
                 <svg className="w-3.5 h-3.5 shrink-0 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
@@ -260,14 +266,79 @@ interface DatePeriodBlockProps {
     onDateValueChange: (value: string) => void;
     onRangeStartChange: (value: string) => void;
     onRangeEndChange: (value: string) => void;
+    onClose?: () => void;
 }
 
 const DatePeriodBlock: React.FC<DatePeriodBlockProps> = ({
     dateSegment, years, yearValue, monthValue, dateValue, rangeStart, rangeEnd, isYearPickerOpen,
-    onSegmentChange, onToggleYearPicker, onYearOptionSelect, onMonthChange, onDateValueChange, onRangeStartChange, onRangeEndChange,
+    onSegmentChange, onToggleYearPicker, onYearOptionSelect, onMonthChange, onDateValueChange, onRangeStartChange, onRangeEndChange, onClose,
 }) => {
     const availableSegments = years.length > 0 ? DATE_SEGMENTS : DATE_SEGMENTS.filter(seg => seg !== '年');
     const visibleDateSegment = years.length === 0 && dateSegment === '年' ? '月' : dateSegment;
+
+    const triggerRef = useRef<HTMLButtonElement>(null);
+    const listboxRef = useRef<HTMLDivElement>(null);
+
+    const getListboxOptions = () => {
+        if (!listboxRef.current) return [];
+        return Array.from(listboxRef.current.querySelectorAll<HTMLButtonElement>('[role="option"]'));
+    };
+
+    const handleListboxKeyDown = (e: React.KeyboardEvent) => {
+        const options = getListboxOptions();
+        if (options.length === 0) return;
+        const currentIndex = options.indexOf(document.activeElement as HTMLButtonElement);
+        switch (e.key) {
+            case 'ArrowDown':
+            case 'ArrowRight': {
+                e.preventDefault();
+                const next = currentIndex >= 0 && currentIndex < options.length - 1 ? options[currentIndex + 1] : options[0];
+                next.focus();
+                break;
+            }
+            case 'ArrowUp':
+            case 'ArrowLeft': {
+                e.preventDefault();
+                const prev = currentIndex > 0 ? options[currentIndex - 1] : options[options.length - 1];
+                prev.focus();
+                break;
+            }
+            case 'Home':
+                e.preventDefault();
+                options[0].focus();
+                break;
+            case 'End':
+                e.preventDefault();
+                options[options.length - 1].focus();
+                break;
+            case 'Enter':
+            case ' ': {
+                e.preventDefault();
+                if (currentIndex >= 0) options[currentIndex].click();
+                break;
+            }
+            case 'Escape':
+                e.preventDefault();
+                onClose?.();
+                triggerRef.current?.focus();
+                break;
+        }
+    };
+
+    const handleTriggerKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+        if (!isYearPickerOpen) return;
+        const options = getListboxOptions();
+        if (e.key === 'ArrowDown' || e.key === 'ArrowRight') {
+            e.preventDefault();
+            options[0]?.focus();
+        } else if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') {
+            e.preventDefault();
+            options[options.length - 1]?.focus();
+        } else if (e.key === 'Escape') {
+            e.preventDefault();
+            onClose?.();
+        }
+    };
 
     return (
     <div className="space-y-2">
@@ -292,11 +363,13 @@ const DatePeriodBlock: React.FC<DatePeriodBlockProps> = ({
         {visibleDateSegment === '年' && (
             <div className="relative">
                 <button
+                    ref={triggerRef}
                     type="button"
                     aria-label="年を選択"
                     aria-haspopup="listbox"
                     aria-expanded={isYearPickerOpen}
                     onClick={onToggleYearPicker}
+                    onKeyDown={handleTriggerKeyDown}
                     className={`w-full flex items-center gap-2 border px-3 py-2 text-sm transition-colors focus:outline-none focus:ring-2 focus:border-amber-600 focus:ring-amber-500/25 ${
                         isYearPickerOpen ? 'rounded-t-md rounded-b-none' : 'rounded-md'
                     } ${
@@ -323,8 +396,10 @@ const DatePeriodBlock: React.FC<DatePeriodBlockProps> = ({
                 </button>
                 {isYearPickerOpen && (
                     <div
+                        ref={listboxRef}
                         role="listbox"
                         aria-label="年候補"
+                        onKeyDown={handleListboxKeyDown}
                         className="absolute z-10 w-full grid grid-cols-3 gap-1 rounded-b-md border border-t-0 border-slate-300 bg-white px-2 pb-2 pt-1.5"
                     >
                         {years.map(year => (
@@ -414,13 +489,35 @@ export const SearchCard: React.FC<SearchCardProps> = ({
     );
 
     // 日付検索用ステート
-    const [dateSegment, setDateSegment] = useState<DateSegment>('年');
+    const [dateSegment, setDateSegment] = useState<DateSegment>(() =>
+        (categories?.years?.length ?? 0) > 0 ? '年' :
+        categories?.dates ? '月' : '年'
+    );
     const [yearValue, setYearValue] = useState('');
     const [monthValue, setMonthValue] = useState('');
     const [dateValue, setDateValue] = useState('');
     const [rangeStart, setRangeStart] = useState('');
     const [rangeEnd, setRangeEnd] = useState('');
     const [isYearPickerOpen, setIsYearPickerOpen] = useState(false);
+
+    const categoriesRef = useRef(categories);
+    categoriesRef.current = categories;
+
+    useEffect(() => {
+        if (value !== '') return;
+        const cats = categoriesRef.current;
+        setSelectedQueries(createEmptySelectedQueries());
+        setYearValue('');
+        setMonthValue('');
+        setDateValue('');
+        setRangeStart('');
+        setRangeEnd('');
+        setIsYearPickerOpen(false);
+        setDateSegment(
+            (cats?.years?.length ?? 0) > 0 ? '年' :
+            cats?.dates ? '月' : '年'
+        );
+    }, [value]);
 
     const effectiveSelectedQueries = value === '' ? createEmptySelectedQueries() : selectedQueries;
     const hasActiveSearch = Object.values(effectiveSelectedQueries).some(Boolean);
@@ -529,7 +626,10 @@ export const SearchCard: React.FC<SearchCardProps> = ({
     // 検索条件をクリア
     const handleClearSearch = () => {
         setSelectedQueries(createEmptySelectedQueries());
-        setDateSegment('年');
+        setDateSegment(
+            (categories?.years?.length ?? 0) > 0 ? '年' :
+            categories?.dates ? '月' : '年'
+        );
         resetDateInputs();
         onSearch('');
     };
@@ -557,6 +657,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                 onDateValueChange={handleDateValueChange}
                 onRangeStartChange={handleRangeStartChange}
                 onRangeEndChange={handleRangeEndChange}
+                onClose={() => setIsYearPickerOpen(false)}
             />
         </div>
     ) : null;
@@ -569,7 +670,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                 >
                     <button
                         type="button"
-                        className="flex min-w-0 items-center gap-2.5 text-left select-none"
+                        className="flex min-w-0 items-center gap-2.5 text-left select-none cursor-pointer"
                         onClick={handleToggleExpanded}
                         onKeyDown={handleToggleKeyDown}
                         aria-expanded={isExpanded}
@@ -654,7 +755,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
             >
                 <button
                     type="button"
-                    className="flex items-center gap-2 text-left select-none"
+                    className="flex items-center gap-2 text-left select-none cursor-pointer"
                     onClick={handleToggleExpanded}
                     onKeyDown={handleToggleKeyDown}
                     aria-expanded={isExpanded}

--- a/frontend/src/lib/utils/searchUtils.ts
+++ b/frontend/src/lib/utils/searchUtils.ts
@@ -106,7 +106,7 @@ export interface FilterConfig<T> {
   amountFields?: ((item: T) => number)[];
 }
 
-function parseSearchTokens(query: string): string[] {
+export function parseSearchTokens(query: string): string[] {
   const tokens: string[] = [];
   const tokenPattern = /"((?:\\.|[^"\\])*)"|(\S+)/g;
   for (const match of query.matchAll(tokenPattern)) {

--- a/frontend/src/pages/Receipt/Dividend.tsx
+++ b/frontend/src/pages/Receipt/Dividend.tsx
@@ -24,8 +24,7 @@ import { useReceiptCalculations, useReceiptBaseData } from '@/hooks/receipt/useR
 import {
     createYearOptions,
     getUniqueValues,
-    matchesYear,
-    matchesYearMonth,
+    parseSearchTokens,
     FilterConfig
 } from '@/lib/utils/searchUtils';
 import { DividendInfo } from '@/components/molecules/DividendInfo/DividendInfo';
@@ -98,35 +97,28 @@ export const Dividend: React.FC<DividendProps> = ({ data, previewData, utilityRa
             return createYearMonthKey(item.settlement_date);
         }
 
-        const query = searchQuery.toLowerCase();
+        // AND クエリをトークンに分割し各トークンで判定
+        const tokens = parseSearchTokens(searchQuery);
 
-        // 銘柄での検索の場合（同一コードの旧名/新名を最新銘柄名で1グループにまとめる）
-        if (item.security_code.toLowerCase() === query ||
-            item.security_name.toLowerCase() === query) {
+        // いずれかのトークンが銘柄コード・銘柄名に一致 → 銘柄グループ化
+        if (tokens.some(t =>
+            item.security_code.toLowerCase() === t ||
+            item.security_name.toLowerCase() === t
+        )) {
             return latestSecurityNameByCode.get(item.security_code)?.name ?? item.security_name;
         }
 
-        // 商品での検索の場合
-        if (item.product.toLowerCase() === query) {
+        // いずれかのトークンが商品に一致
+        if (tokens.some(t => item.product.toLowerCase() === t)) {
             return item.product;
         }
 
-        // 口座での検索の場合
-        if (item.account.toLowerCase() === query) {
+        // いずれかのトークンが口座に一致
+        if (tokens.some(t => item.account.toLowerCase() === t)) {
             return item.account;
         }
 
-        // 年度での検索の場合も月単位でグループ化（検索なし時と同一ルール）
-        if (matchesYear(item.settlement_date, query)) {
-            return createYearMonthKey(item.settlement_date);
-        }
-
-        // 年月での検索の場合も月単位でグループ化（検索なし時と同一ルール）
-        if (matchesYearMonth(item.settlement_date, query)) {
-            return createYearMonthKey(item.settlement_date);
-        }
-
-        // デフォルトは年月でグループ化
+        // デフォルトは年月でグループ化（年度・年月検索を含む）
         return createYearMonthKey(item.settlement_date);
     };
 
@@ -140,14 +132,18 @@ export const Dividend: React.FC<DividendProps> = ({ data, previewData, utilityRa
     // 銘柄名検索時に銘柄コードを補完
     const searchSecurityCode = (() => {
         if (!searchQuery) return '';
-        const normalizedQuery = searchQuery.toLowerCase();
+        // コード付きラベル形式（先頭が "XXXX:" で始まる場合）は先頭コードを使用
         const labelMatch = searchQuery.match(/^\s*([0-9A-Za-z]+)\s*[:：]/);
         if (labelMatch) {
             return labelMatch[1];
         }
+        // AND トークンのうち銘柄コード・銘柄名に一致するものを探す
+        const tokens = parseSearchTokens(searchQuery);
         const matchedItem = filteredData.find(item =>
-            item.security_code.toLowerCase() === normalizedQuery ||
-            item.security_name.toLowerCase() === normalizedQuery
+            tokens.some(t =>
+                item.security_code.toLowerCase() === t ||
+                item.security_name.toLowerCase() === t
+            )
         );
         return matchedItem?.security_code || '';
     })();

--- a/frontend/src/pages/Receipt/Mutualfund.tsx
+++ b/frontend/src/pages/Receipt/Mutualfund.tsx
@@ -16,7 +16,7 @@ import {
     formatCurrency,
     formatNumber
 } from '@/lib/utils/formatters';
-import { createYearOptions, FilterConfig } from '@/lib/utils/searchUtils';
+import { createYearOptions, parseSearchTokens, FilterConfig } from '@/lib/utils/searchUtils';
 import { useReceiptCalculations, useReceiptBaseData } from '@/hooks/receipt/useReceiptData';
 import { sortMutualfundByTradeDate } from '@/features/receipt/parsers';
 import { calculateMutualfund } from '@/features/receipt/calculations';
@@ -61,9 +61,9 @@ export const Mutualfund: React.FC<MutualfundProps> = ({ data, previewData, utili
     // ファンド名検索時は元データの正式表記を使用
     const getGroupKey = (item: MutualfundData): string => {
         if (searchQuery) {
-            // ファンド名検索の場合は元データの表記を使用（小文字化しない）
-            const query = searchQuery.toLowerCase();
-            if (item.fund_name.toLowerCase().includes(query)) {
+            // AND クエリをトークンに分割し、いずれかがファンド名に部分一致する場合はファンド名でグループ化
+            const tokens = parseSearchTokens(searchQuery);
+            if (tokens.some(t => item.fund_name.toLowerCase().includes(t))) {
                 return item.fund_name;
             }
             // 年検索など他の場合は年月でグループ化

--- a/frontend/src/pages/Receipt/__tests__/Dividend.test.tsx
+++ b/frontend/src/pages/Receipt/__tests__/Dividend.test.tsx
@@ -461,6 +461,64 @@ describe('Dividend', () => {
         }
     });
 
+    it('銘柄コード+年のAND検索でも銘柄名でグループ化される', () => {
+        const useReceiptBaseDataSpy = vi.spyOn(receiptHooks, 'useReceiptBaseData').mockReturnValue({
+            sortedData: mockData,
+            searchQuery: '1234 2023',
+            setSearchQuery: vi.fn(),
+            filteredData: [mockData[0]],
+        } as ReturnType<typeof receiptHooks.useReceiptBaseData>);
+
+        try {
+            render(<Dividend data={mockData} />);
+
+            // グループヘッダーセルは銘柄名でグループ化される
+            const summaryCell = screen.getByRole('table').querySelector('tbody tr td');
+            expect(summaryCell).toHaveTextContent('テスト株式1');
+            expect(summaryCell).toHaveTextContent('1件');
+        } finally {
+            useReceiptBaseDataSpy.mockRestore();
+        }
+    });
+
+    it('銘柄コード+年のAND検索でisSecurityCodeSearchがtrueになる', () => {
+        const useReceiptBaseDataSpy = vi.spyOn(receiptHooks, 'useReceiptBaseData').mockReturnValue({
+            sortedData: mockData,
+            searchQuery: '1234 2023',
+            setSearchQuery: vi.fn(),
+            filteredData: [mockData[0]],
+        } as ReturnType<typeof receiptHooks.useReceiptBaseData>);
+
+        try {
+            render(<Dividend data={mockData} />);
+
+            // 銘柄詳細ヘッダーが表示される（isSecurityCodeSearch=true）
+            expect(screen.getByText('集計情報')).toBeInTheDocument();
+            expect(screen.getByText('平均取得価格')).toBeVisible();
+        } finally {
+            useReceiptBaseDataSpy.mockRestore();
+        }
+    });
+
+    it('銘柄名+年のAND検索でも銘柄名でグループ化される', () => {
+        const useReceiptBaseDataSpy = vi.spyOn(receiptHooks, 'useReceiptBaseData').mockReturnValue({
+            sortedData: mockData,
+            searchQuery: 'テスト株式1 2023',
+            setSearchQuery: vi.fn(),
+            filteredData: [mockData[0]],
+        } as ReturnType<typeof receiptHooks.useReceiptBaseData>);
+
+        try {
+            render(<Dividend data={mockData} />);
+
+            const summaryCell = screen.getByRole('table').querySelector('tbody tr td');
+            expect(summaryCell).toHaveTextContent('テスト株式1');
+            expect(summaryCell).not.toHaveTextContent('2023年');
+        } finally {
+            useReceiptBaseDataSpy.mockRestore();
+        }
+    });
+
     it('コード付きラベル形式の検索クエリでも銘柄詳細ヘッダーが表示される', async () => {
         const useReceiptBaseDataSpy = vi.spyOn(receiptHooks, 'useReceiptBaseData').mockReturnValue({
             sortedData: mockData,

--- a/frontend/src/pages/Receipt/__tests__/Mutualfund.test.tsx
+++ b/frontend/src/pages/Receipt/__tests__/Mutualfund.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
+import * as receiptHooks from '@/hooks/receipt/useReceiptData';
 import { Mutualfund } from '../Mutualfund';
 import { waitOpts } from '@/test/utils';
 
@@ -141,6 +142,27 @@ describe('Mutualfund', () => {
             expect(within(table).queryByText('テストファンドB')).not.toBeInTheDocument();
             expect(within(table).queryByText('2023年1月')).not.toBeInTheDocument();
         }, waitOpts);
+    });
+
+    it('ファンド名+年のAND検索でもファンド名でグループ化される', () => {
+        const useReceiptBaseDataSpy = vi.spyOn(receiptHooks, 'useReceiptBaseData').mockReturnValue({
+            sortedData: mockData,
+            searchQuery: 'テストファンドA 2023',
+            setSearchQuery: vi.fn(),
+            filteredData: [mockData[0]],
+        } as ReturnType<typeof receiptHooks.useReceiptBaseData>);
+
+        try {
+            render(<Mutualfund data={mockData} />);
+
+            // グループヘッダーセルはファンド名でグループ化される（年月にならない）
+            const summaryCell = screen.getByRole('table').querySelector('tbody tr td');
+            expect(summaryCell).toHaveTextContent('テストファンドA');
+            expect(summaryCell).toHaveTextContent('1件');
+            expect(summaryCell).not.toHaveTextContent('2023年');
+        } finally {
+            useReceiptBaseDataSpy.mockRestore();
+        }
     });
 
     it('年検索でフィルタリングされる', async () => {


### PR DESCRIPTION
## 概要
- 配当金・投資信託の AND 検索時にグループ判定が崩れる問題を修正
- 配当金の AND 検索でも銘柄コードを抽出して詳細ヘッダーを表示できるよう修正
- 検索オプションのリセット、日付タブ初期値、年ピッカーのキーボード操作、cursor 表示、className 結合を修正
- 銘柄名コピー失敗時の処理とテストを追加

## テスト
- npm test -- src/components/organisms/SearchCard/__tests__/SearchCard.test.tsx src/components/atoms/__tests__/SecurityCodeLink.test.tsx src/pages/Receipt/__tests__/Dividend.test.tsx src/pages/Receipt/__tests__/Mutualfund.test.tsx src/pages/Receipt/__tests__/DomesticStock.test.tsx
- npm test
- vp lint
- npx tsc --noEmit
- vp build

## レビュー
- Codex review: LGTM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 検索語を複数トークンで扱えるようになり、銘柄・商品・口座の絞り込みやグルーピングがより自然になりました。
  * 日付検索の入力をクリアした際に、関連する選択状態が正しくリセットされるようになりました。
  * 期間選択でキーボード操作が使いやすくなり、Escape で閉じられるようになりました。
  * コピー失敗時に警告を表示し、失敗を把握しやすくなりました。

* **Tests**
  * 上記の検索条件、グルーピング、コピー失敗時の挙動を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->