### PR TITLE
chore: Dockerfile の Rust バージョンを 1.96 に更新

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # ビルドステージ
-FROM rust:1.88-bookworm AS builder
+FROM rust:1.96-bookworm AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## 概要

- sqlx 0.9.0 が rustc 1.94.0 以上を要求するため、Dockerfile のビルドイメージを更新
- `rust:1.88-bookworm` → `rust:1.96-bookworm`（最新 stable、2026-05-25 リリース）

## 変更内容

| 変更前 | 変更後 |
|--------|--------|
| `rust:1.88-bookworm` | `rust:1.96-bookworm` |

## テスト結果

Fly.io デプロイが `sqlx-core@0.9.0 requires rustc 1.94.0` エラーで失敗していたため修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * ビルド環境の基盤を更新し、今後のビルドで新しいツールチェーンが使われるようになりました。
  * これにより、ビルドの安定性や互換性が向上する可能性があります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->