### PR TITLE
Dockerfile の不要コメントを削除

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,11 +17,6 @@ COPY migrations ./migrations
 # 依存関係のビルドキャッシュを無効化しないために、全 Rust ソースのタイムスタンプを更新
 RUN find src -name "*.rs" -exec touch {} +
 
-# SQLxのオフラインモード用（.sqlxディレクトリがある場合）
-# 注意: .sqlxディレクトリが存在しない場合はこの行をコメントアウトするか、
-# cargo sqlx prepare を実行して作成してください
-# COPY .sqlx ./.sqlx
-
 # 本番ビルド（SQLX_OFFLINE=falseでビルド - マクロはランタイムでチェックされる）
 RUN cargo build --release
 


### PR DESCRIPTION
## 概要
- backend/Dockerfile からコメントアウト済みの .sqlx COPY と周辺説明コメントを削除
- SQLx オフラインモード方針やビルドロジックは変更なし

## 変更種別
- [ ] 新機能
- [ ] バグ修正
- [x] ビルド・設定変更

## テスト
- [x] cargo fmt --check
- [x] cargo check
- [x] make docker-build

## 備考
- Claude 実装後、Codex が差分レビューと検証を実施

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * ビルド手順を簡素化し、追加のオフライン用ファイルを扱わずにそのまま本番ビルドへ進むようになりました。
  * 依存関係キャッシュの更新後、より直接的にアプリケーションをビルドできる構成に変更されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->