### PR TITLE
Rust バージョン管理を一元化

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -2,6 +2,7 @@
 name = "backend"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.96"
 
 [dependencies]
 axum = { version = "0.8.9", features = ["macros", "multipart"] }

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,7 +4,7 @@ FROM rust:1.96-bookworm AS builder
 WORKDIR /app
 
 # 依存関係のキャッシュ用にCargo.tomlとCargo.lockをコピー
-COPY Cargo.toml Cargo.lock ./
+COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
 
 # ダミーのsrc/main.rsを作成して依存関係をキャッシュ
 RUN mkdir src && echo "fn main() {}" > src/main.rs

--- a/backend/rust-toolchain.toml
+++ b/backend/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.96"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## 概要
- backend/rust-toolchain.toml を追加し、Rust 1.96 をローカル/CI向けの正本として明示
- backend/Cargo.toml に rust-version = "1.96" を追加
- Docker build の依存キャッシュ層にも rust-toolchain.toml をコピーし、Docker 内の cargo 実行でも指定ツールチェーンを認識させる

## 補足
- backend/Dockerfile の builder は rust:1.96-bookworm のまま維持
- chore-dockerfile-rust-version-pin の rust:bookworm 化は再現性を落とすため、この一元化タスクで supersede します

## 確認
- cargo fmt --check
- cargo check
- rustup show
- cargo clippy --all-targets -- -D warnings
- cargo test
- make docker-build