### PR TITLE
className 結合を cn に統一

### DIFF
--- a/frontend/src/components/molecules/CSVFileInput.tsx
+++ b/frontend/src/components/molecules/CSVFileInput.tsx
@@ -1,4 +1,5 @@
 import { useId, useRef } from 'react';
+import { cn } from '@/lib/utils/classNames';
 
 interface CSVFileInputProps {
   onFileSelect: (file: File) => void;
@@ -29,9 +30,10 @@ export function CSVFileInput({ onFileSelect, selectedFileName = '', disabled = f
     <div className="space-y-2.5">
       <label
         data-testid="csv-file-trigger"
-        className={`flex min-h-20 cursor-pointer items-center justify-between gap-3 rounded-[1.35rem] border border-dashed border-slate-300 bg-slate-50 px-4 py-3 transition-colors ${
+        className={cn(
+          'flex min-h-20 cursor-pointer items-center justify-between gap-3 rounded-[1.35rem] border border-dashed border-slate-300 bg-slate-50 px-4 py-3 transition-colors',
           disabled ? 'pointer-events-none opacity-65' : 'hover:border-slate-400 hover:bg-slate-100'
-        }`}
+        )}
         htmlFor={inputId}
       >
         <div className="flex min-w-0 items-center gap-3">

--- a/frontend/src/components/molecules/ErrorBoundary.tsx
+++ b/frontend/src/components/molecules/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { Component, ReactNode, ErrorInfo } from 'react';
+import { cn } from '@/lib/utils/classNames';
 
 interface ErrorBoundaryProps {
   fallback?: ReactNode | ((error: Error, errorInfo: ErrorInfo) => ReactNode);
@@ -137,7 +138,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
       // デフォルトフォールバック
       return (
-        <div className={`p-4 ${isolate ? 'isolated' : ''}`}>
+        <div className={cn('p-4', isolate && 'isolated')}>
           <div className="bg-danger/10 border-l-4 border-danger text-danger rounded-lg p-4" role="alert">
             <h4 className="font-bold text-lg mb-2">エラーが発生しました</h4>
             <p>申し訳ございません。予期しないエラーが発生しました。</p>

--- a/frontend/src/components/molecules/PortfolioPieChart/PortfolioPieChart.tsx
+++ b/frontend/src/components/molecules/PortfolioPieChart/PortfolioPieChart.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { SecurityCodeLink } from '@/components/atoms/SecurityCodeLink';
 import { formatCurrency, formatNumber, formatPercentageValue } from '@/lib/utils/formatters';
 import { DividendStatus } from '@/features/jquants/api/dividendPerShareApi';
+import { cn } from '@/lib/utils/classNames';
 
 // 横棒グラフ用の配色（視認性を考慮した10色）
 const COLORS = [
@@ -158,7 +159,7 @@ function PortfolioItemCard({ item, index, dividendPerShareMap, dividendStatusMap
         <div className="min-w-0 px-2 py-2 text-xs text-slate-600">
           <p className="truncate text-[10px] font-medium text-slate-500">1株配当</p>
           <p
-            className={`mt-0.5 truncate text-[12px] font-semibold ${divInfo?.perShare !== null && divInfo?.perShare !== undefined ? 'text-emerald-600' : 'text-slate-500'}`}
+            className={cn('mt-0.5 truncate text-[12px] font-semibold', divInfo?.perShare !== null && divInfo?.perShare !== undefined ? 'text-emerald-600' : 'text-slate-500')}
             title={formatPerShare(divInfo)}
           >
             {formatPerShare(divInfo)}

--- a/frontend/src/components/organisms/Header.tsx
+++ b/frontend/src/components/organisms/Header.tsx
@@ -81,7 +81,7 @@ export function Header() {
   return (
     <>
       <header className="sticky top-0 z-40 border-b border-slate-950/10 bg-[#111827]/95 text-white shadow-[0_18px_44px_-34px_rgba(15,23,42,0.95)] backdrop-blur no-print">
-        <div className={`${APP_SHELL_CONTAINER} py-3`}>
+        <div className={cn(APP_SHELL_CONTAINER, 'py-3')}>
           <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
             <div className="flex items-center justify-between gap-4">
               <Link className="group inline-flex items-center gap-3 text-white transition-colors hover:text-amber-100" to="/">

--- a/frontend/src/components/organisms/SearchCard/SearchCard.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchCard.tsx
@@ -58,11 +58,12 @@ const QuickSearchDropdown: React.FC<QuickSearchDropdownProps> = ({
         <div className="relative">
             <select
                 id={id}
-                className={`w-full rounded-md border px-3 py-2 text-sm transition-colors focus:outline-none focus:ring-2 ${
+                className={cn(
+                    'w-full rounded-md border px-3 py-2 text-sm transition-colors focus:outline-none focus:ring-2',
                     isSelected
                         ? 'border-amber-500 bg-amber-50 text-amber-900 font-bold ring-2 ring-amber-500/30'
                         : 'border-slate-300 bg-white text-dark hover:border-slate-500 focus:border-amber-600 focus:ring-amber-500/25'
-                }`}
+                )}
                 value={displayValue}
                 onChange={(e) => onSearch(e.target.value, searchType)}
             >

--- a/frontend/src/features/receipt/components/ReceiptsTabNav.tsx
+++ b/frontend/src/features/receipt/components/ReceiptsTabNav.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { ReceiptsType } from '../reducer';
+import { cn } from '@/lib/utils/classNames';
 
 const TAB_LABEL: Record<ReceiptsType, string> = {
   dividend: '配当金',
@@ -37,11 +38,12 @@ export function ReceiptsTabNav({
             <button
               key={tab}
               id={`tab-${tab}`}
-              className={`inline-flex items-center gap-2 rounded-lg border px-4 py-2.5 text-sm font-bold ${
+              className={cn(
+                'inline-flex items-center gap-2 rounded-lg border px-4 py-2.5 text-sm font-bold',
                 isActive
                   ? 'border-slate-950 bg-slate-950 text-white shadow-[inset_0_-2px_0_#f59e0b]'
                   : 'border-slate-300 bg-white text-slate-800 hover:border-slate-400 hover:bg-white hover:text-slate-950'
-              }`}
+              )}
               onClick={() => onTabChange(tab)}
               onKeyDown={onKeyDown}
               type="button"


### PR DESCRIPTION
## Summary
- 対象6ファイルの条件付き className 結合を cn ユーティリティに統一
- 既存挙動を変えずにテンプレートリテラルの対象箇所を整理

## Verification
- npm run typecheck
- npm test
- npm run lint
- git diff --check

## Notes
- 実装: Claude
- レビュー: Codex