### PR TITLE
CI/CD のセキュリティを強化

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7 https://github.com/actions/checkout/releases/tag/v7
         with:
           fetch-depth: 0
 
@@ -31,6 +31,7 @@ jobs:
         id: detect
         working-directory: ${{ github.workspace }}
         run: |
+          set -euo pipefail
           if [ "${{ github.event_name }}" = "push" ]; then
             echo "run_backend=true" >> "$GITHUB_OUTPUT"
             exit 0
@@ -52,11 +53,11 @@ jobs:
 
       - name: Setup Rust toolchain
         if: steps.detect.outputs.run_backend == 'true'
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1 https://github.com/actions-rust-lang/setup-rust-toolchain/releases/tag/v1
 
       - name: Cache Cargo registry & build
         if: steps.detect.outputs.run_backend == 'true'
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5 https://github.com/actions/cache/releases/tag/v5
         with:
           path: |
             ~/.cargo/registry
@@ -93,7 +94,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.detect.outputs.run_backend == 'true'
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6 https://github.com/actions/setup-node/releases/tag/v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -134,10 +135,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7 https://github.com/actions/checkout/releases/tag/v7
 
       - name: Setup Fly.io CLI
-        uses: superfly/flyctl-actions/setup-flyctl@v1
+        uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # v1 https://github.com/superfly/flyctl-actions/releases/tag/v1
 
       - name: Deploy to Fly.io
         id: fly-deploy

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7 https://github.com/actions/checkout/releases/tag/v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6 https://github.com/actions/setup-node/releases/tag/v6
         with:
           node-version: 22
           cache: 'npm'
@@ -61,10 +61,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7 https://github.com/actions/checkout/releases/tag/v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6 https://github.com/actions/setup-node/releases/tag/v6
         with:
           node-version: 22
           cache: 'npm'
@@ -74,7 +74,7 @@ jobs:
         run: npm ci
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5 https://github.com/actions/cache/releases/tag/v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('frontend/package-lock.json') }}
@@ -89,7 +89,7 @@ jobs:
 
       - name: Upload E2E artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7 https://github.com/actions/upload-artifact/releases/tag/v7
         with:
           name: playwright-report
           path: frontend/playwright-report/

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -5,6 +5,10 @@ on:
     # 毎週月曜 09:00 JST（UTC 00:00）
     - cron: "0 0 * * 1"
   workflow_dispatch:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
 
 jobs:
   cargo-audit:
@@ -14,7 +18,7 @@ jobs:
       run:
         working-directory: backend
     steps:
-      # SHA pin: actions/checkout@v4
+      # SHA pin: actions/checkout@v7
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked
@@ -28,12 +32,12 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      # SHA pin: actions/checkout@v4
+      # SHA pin: actions/checkout@v7
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
-      # SHA pin: actions/setup-node@v7.0.0
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+      # SHA pin: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
           cache-dependency-path: frontend/package-lock.json
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- security-audit を PR と main push でも実行するように変更
- npm audit の Node.js を 22 に更新
- deploy backend/frontend workflow の GitHub Actions を SHA ピン化
- backend detect スクリプトに set -euo pipefail を追加

## Verification
- git diff --check
- フローティング uses タグ検出なし: rg -n 'uses: .*@v[0-9]|uses: .*@(main|master|latest)(\s|$)' .github/workflows/deploy-backend.yml .github/workflows/deploy-frontend.yml .github/workflows/security-audit.yml
- Detect backend changes の run ブロック先頭が set -euo pipefail であることを確認

## Notes
- 実装: Claude
- レビュー: Codex予定
- branch protection / Dependabot / OIDC / Fly.io 設定変更はスコープ外