### PR TITLE
CI 実行時間を短縮

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7 https://github.com/actions/checkout/releases/tag/v7
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Detect backend changes
         id: detect
@@ -61,10 +61,6 @@ jobs:
       - name: Run tests
         if: steps.detect.outputs.backend == 'true'
         run: cargo test
-
-      - name: Check release build
-        if: steps.detect.outputs.backend == 'true'
-        run: cargo check --release
 
       - name: Generate OpenAPI schema
         if: steps.detect.outputs.backend == 'true'

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -64,8 +64,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-playwright-
 
+      - name: Cache APT packages (Playwright deps)
+        uses: awalsh128/cache-apt-pkgs-action@681749ae568c81c2037cb9185e38b709b261bd2f # v1.6.1 https://github.com/awalsh128/cache-apt-pkgs-action/releases/tag/v1.6.1
+        with:
+          version: playwright-ubuntu24.04-chromium-${{ hashFiles('frontend/package-lock.json') }}
+          packages: xvfb fonts-noto-color-emoji fonts-unifont libfontconfig1 libfreetype6 xfonts-cyrillic xfonts-scalable fonts-liberation fonts-ipafont-gothic fonts-wqy-zenhei fonts-tlwg-loma-otf fonts-freefont-ttf libasound2t64 libatk-bridge2.0-0t64 libatk1.0-0t64 libatspi2.0-0t64 libcairo2 libcups2t64 libdbus-1-3 libdrm2 libgbm1 libglib2.0-0t64 libnspr4 libnss3 libpango-1.0-0 libx11-6 libxcb1 libxcomposite1 libxdamage1 libxext6 libxfixes3 libxkbcommon0 libxrandr2
+
       - name: Install Playwright browsers
-        run: npx playwright install chromium --with-deps
+        run: npx playwright install chromium
 
       - name: Run E2E tests (CI mode)
         run: npm run test:e2e:ci

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -14,16 +14,18 @@ jobs:
   cargo-audit:
     name: cargo audit (Rust)
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: backend
+    permissions:
+      contents: read
+      checks: write
+      issues: write
     steps:
       # SHA pin: actions/checkout@v7
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
-      - name: Install cargo-audit
-        run: cargo install cargo-audit --locked
       - name: Run cargo audit
-        run: cargo audit
+        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0 https://github.com/rustsec/audit-check/releases/tag/v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          working-directory: backend
 
   npm-audit:
     name: npm audit (Node.js)
@@ -40,7 +42,5 @@ jobs:
           node-version: "22"
           cache: "npm"
           cache-dependency-path: frontend/package-lock.json
-      - name: Install dependencies
-        run: npm ci
       - name: Run npm audit
         run: npm audit --audit-level=high


### PR DESCRIPTION
## Summary
- cargo-audit を cargo install から rustsec/audit-check action へ置換
- npm audit 前の npm ci を削除
- backend CI の cargo check --release を削除
- backend checkout を fetch-depth: 1 に変更
- Playwright E2E のAPT依存を cache-apt-pkgs-action でキャッシュし、browser install から --with-deps を削除

## Risk Assessment
- cargo check --release 削除により、release profile 固有のコンパイル差分をPR時に直接検出する力は弱くなります。
- 代替gateとして cargo clippy、cargo test、OpenAPI生成、frontend type validation、Security Audit、Fly.io remote build が残ります。
- Fly.io は main push の deploy で remote build を実行するため、リリースビルド不能な差分は本番反映前のdeploy段階で検出されます。

## Verification
- git diff --check
- command-based cargo audit / cargo install / cargo check --release / npm ci / --with-deps / fetch-depth: 0 の残存なし
- rustsec/audit-check / cache-apt-pkgs-action / fetch-depth: 1 / npm audit / playwright install を確認
- フローティング uses タグ検出なし

## Notes
- 実装: Claude
- レビュー: Codex予定