### PR TITLE
Fly deploy 失敗を明示化

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -122,79 +122,19 @@ jobs:
 
       - name: Deploy to Fly.io
         id: fly-deploy
-        run: flyctl deploy --remote-only
-        continue-on-error: true
+        run: flyctl deploy --remote-only --label "GH_SHA=${GITHUB_SHA}"
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
-      - name: Stopped machine recovery
-        if: steps.fly-deploy.outcome == 'failure'
+      - name: Deploy failure diagnostics
+        if: failure() && steps.fly-deploy.outcome == 'failure'
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-          GH_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-
-          echo "=== flyctl deploy 失敗: stopped machine recovery を試みます ==="
-
-          # 新しい GH_SHA の machine 情報を一括取得
-          MACHINE_LIST=$(flyctl machine list --json)
-          MACHINE_IDS=$(echo "$MACHINE_LIST" | jq -r --arg sha "$GH_SHA" \
-            '.[] | select(.image_ref.labels.GH_SHA == $sha) | .id')
-
-          if [ -z "$MACHINE_IDS" ]; then
-            echo "エラー: GH_SHA=$GH_SHA の machine が存在しません"
-            echo "=== 全 machine 一覧 ==="
-            echo "$MACHINE_LIST" | jq '.[] | {id, state, sha: .image_ref.labels.GH_SHA, checks}'
-            exit 1
-          fi
-
-          echo "対象 machine: $(echo "$MACHINE_IDS" | tr '\n' ' ')"
-
-          # stopped machine を start する
-          while IFS= read -r id; do
-            STATE=$(echo "$MACHINE_LIST" | jq -r --arg id "$id" '.[] | select(.id == $id) | .state')
-            if [ "$STATE" = "stopped" ]; then
-              echo "Machine $id を起動します..."
-              flyctl machine start "$id"
-            else
-              echo "Machine $id の現在の状態: $STATE (start スキップ)"
-            fi
-          done <<< "$MACHINE_IDS"
-
-          # started + health check passing になるまで待機
-          MAX_WAIT=180
-          INTERVAL=10
-          ELAPSED=0
-
-          until [ "$ELAPSED" -ge "$MAX_WAIT" ]; do
-            sleep "$INTERVAL"
-            ELAPSED=$((ELAPSED + INTERVAL))
-            echo "--- ${ELAPSED}s 経過 ---"
-
-            CURRENT_LIST=$(flyctl machine list --json)
-            ALL_HEALTHY=true
-
-            while IFS= read -r id; do
-              INFO=$(echo "$CURRENT_LIST" | jq --arg id "$id" '.[] | select(.id == $id)')
-              STATE=$(echo "$INFO" | jq -r '.state')
-              CHECK_COUNT=$(echo "$INFO" | jq '.checks | length')
-              FAILING=$(echo "$INFO" | jq '[.checks[]? | select(.status != "passing")] | length')
-              echo "Machine $id: state=$STATE checks=$CHECK_COUNT failing=$FAILING"
-
-              if [ "$STATE" != "started" ] || [ "$FAILING" -gt 0 ]; then
-                ALL_HEALTHY=false
-              fi
-            done <<< "$MACHINE_IDS"
-
-            if [ "$ALL_HEALTHY" = "true" ]; then
-              echo "=== Recovery 成功: GH_SHA=$GH_SHA の machine が started + passing になりました ==="
-              exit 0
-            fi
-          done
-
-          echo "=== Recovery 失敗: ${MAX_WAIT}s でタイムアウト ==="
-          echo "=== GH_SHA=$GH_SHA の machine 最終状態 ==="
-          flyctl machine list --json | jq --arg sha "$GH_SHA" \
-            '[.[] | select(.image_ref.labels.GH_SHA == $sha) | {id, state, checks}]'
+          echo "::error::flyctl deploy failed. Previous running deployment was not modified by this recovery step."
+          echo "=== releases ==="
+          flyctl releases --json | jq '.' || true
+          echo "=== machine list ==="
+          flyctl machine list --json | jq '.' || true
           exit 1

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -132,7 +132,7 @@ jobs:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: |
           set -euo pipefail
-          echo "::error::flyctl deploy failed. Previous running deployment was not modified by this recovery step."
+          echo "::error::flyctl deploy failed. Previous running deployment was not modified. See diagnostic output below."
           echo "=== releases ==="
           flyctl releases --json | jq '.' || true
           echo "=== machine list ==="


### PR DESCRIPTION
## Summary
- Fly deploy の continue-on-error を削除し、deploy失敗をジョブ失敗として扱うよう変更
- deploy時に GH_SHA label を明示付与
- GH_SHA空振りで長時間待つ stopped machine recovery を削除
- deploy失敗時は releases / machine list を出力する診断stepに置換

## Investigation
- 現在の flyctl では flyctl releases rollback は rollback サブコマンドとして提供されていませんでした。
- flyctl deploy は --label をサポートしているため、GH_SHA は deploy 時に明示付与します。
- concurrency は現状維持です。pull_request は cancel、main push は cancel-in-progress=false で queue/serialize されるため、ロールバック/診断中断リスクを増やしません。

## Verification
- git diff --check
- diagnostics run block: bash -n pass
- continue-on-error / Stopped machine recovery の削除確認

## Notes
- 実装: Claude
- レビュー: Codex予定
- Vercel/Fly 順序制御は task scope 外

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * デプロイ手順を更新し、失敗時の確認情報が表示されるようになりました。
  * デプロイ失敗時に、関連するリリース情報とマシン情報を出力するようになりました。
  * 失敗後の待機や自動復旧の挙動を見直しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->