### PR TITLE
数値フォーマット処理を共通化

### DIFF
--- a/frontend/src/components/atoms/StatItem.tsx
+++ b/frontend/src/components/atoms/StatItem.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { cn } from '../../lib/utils/classNames';
+import { formatNumber, formatPercentageValue } from '../../lib/utils/formatters';
 
-const defaultValueFormat = (value: number): string => value.toLocaleString('ja-JP');
-const defaultRateFormat = (rate: number): string => `${rate.toFixed(2)}%`;
+const defaultValueFormat = (value: number): string => formatNumber(value);
+const defaultRateFormat = (rate: number): string => formatPercentageValue(rate, 2);
 
 interface StatItemProps {
   title: string;

--- a/frontend/src/components/molecules/DividendInfo/DividendInfo.tsx
+++ b/frontend/src/components/molecules/DividendInfo/DividendInfo.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { NumberInputField } from '@/components/atoms/NumberInputField';
 import { StatItem, StatItemWithRate } from '@/components/atoms/StatItem';
-import { formatCurrency, parseNumber, normalizeSecurityCode, SECURITY_CODE_REGEX } from '@/lib/utils/formatters';
+import { formatCurrency, formatNumber, formatPercentageValue, parseNumber, normalizeSecurityCode, SECURITY_CODE_REGEX } from '@/lib/utils/formatters';
 import { useDividendBatch } from '@/features/jquants/hooks/useDividendBatch';
 import { useAssetBalance } from '@/features/assetBalance/hooks/useAssetBalance';
 import { SummaryResult } from '@/lib/utils/dataTransformer';
@@ -180,7 +180,7 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({
               className="text-2xl font-bold tabular-nums text-primary"
               title={holdingQuantity === undefined ? ASSET_BALANCE_HINT : undefined}
             >
-              {holdingQuantity !== undefined ? holdingQuantity.toLocaleString('ja-JP') : '---'}
+              {holdingQuantity !== undefined ? formatNumber(holdingQuantity) : '---'}
             </p>
             {holdingQuantity === undefined && (
               <p className="mt-0.5 text-xs text-slate-400">{ASSET_BALANCE_HINT}</p>
@@ -207,7 +207,7 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({
               {formatCurrency(totalDividendsBeforeTax)}
               {grossDividendReturnRate > 0 && (
                 <span className="text-sm font-normal text-slate-500 ml-1">
-                  ({grossDividendReturnRate.toFixed(2)}%)
+                  ({formatPercentageValue(grossDividendReturnRate, 2)})
                 </span>
               )}
             </p>
@@ -224,7 +224,7 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({
               {formatCurrency(totalNetAmountReceived)}
               {dividendReturnRate > 0 && (
                 <span className="text-sm font-normal text-slate-500 ml-1">
-                  ({dividendReturnRate.toFixed(2)}%)
+                  ({formatPercentageValue(dividendReturnRate, 2)})
                 </span>
               )}
             </p>

--- a/frontend/src/components/molecules/PortfolioPieChart/PortfolioPieChart.tsx
+++ b/frontend/src/components/molecules/PortfolioPieChart/PortfolioPieChart.tsx
@@ -126,7 +126,7 @@ function PortfolioItemCard({ item, index, dividendPerShareMap, dividendStatusMap
           </div>
         </div>
         <div className="shrink-0 text-right">
-          <p className="text-xl font-bold text-slate-800">{item.percentage.toFixed(1)}%</p>
+          <p className="text-xl font-bold text-slate-800">{formatPercentageValue(item.percentage, 1)}</p>
         </div>
       </div>
 
@@ -254,7 +254,7 @@ export const PortfolioPieChart: React.FC<PortfolioPieChartProps> = ({
                 その他 {chartData.length - TOP_N}銘柄
               </span>
               <span className="text-lg font-bold text-slate-500">
-                {othersPercentage.toFixed(1)}%
+                {formatPercentageValue(othersPercentage, 1)}
               </span>
             </div>
             <div className="h-2.5 w-full rounded-full bg-slate-200">

--- a/frontend/src/features/assetBalance/utils/assetReviewPrompt.ts
+++ b/frontend/src/features/assetBalance/utils/assetReviewPrompt.ts
@@ -1,8 +1,5 @@
 import type { AssetBalanceData } from '@/types/api';
-
-function fmt(value: number): string {
-  return value.toLocaleString('ja-JP');
-}
+import { formatNumber } from '@/lib/utils/formatters';
 
 export function generateAssetReviewPrompt(assets: AssetBalanceData[]): string {
   const header = ['銘柄コード', '銘柄名', '保有株数', '平均取得単価'].join(' | ');
@@ -11,8 +8,8 @@ export function generateAssetReviewPrompt(assets: AssetBalanceData[]): string {
     [
       a.security_code,
       a.security_name,
-      fmt(a.shares),
-      `¥${fmt(a.average_purchase_price)}`,
+      formatNumber(a.shares),
+      `¥${formatNumber(a.average_purchase_price)}`,
     ].join(' | ')
   );
 


### PR DESCRIPTION
## 概要
- ローカルの数値フォーマット処理を `formatNumber` に統一
- パーセント表示を `formatPercentageValue` に統一
- asset review prompt / StatItem / DividendInfo / PortfolioPieChart の重複実装を削除

## 変更種別
- [ ] 新機能
- [ ] バグ修正
- [x] リファクタリング

## 検証
- [x] `npm run typecheck`
- [x] `npm test`（99 files / 960 tests）
- [x] `git diff --check`
- [x] 残存 grep 確認（formatter 本体とテストモックのみ）

## レビュー対応方針
- CodeRabbit / GitHub review comment は全件確認し、対応または理由をコメントしてから merge します。