### PR TITLE
フロントエンドフックの状態管理を整理

### DIFF
--- a/frontend/src/features/assetBalance/hooks/useAssetBalance.ts
+++ b/frontend/src/features/assetBalance/hooks/useAssetBalance.ts
@@ -1,5 +1,5 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 import type { AssetBalanceData } from '@/types/api';
 import { assetBalanceApi } from '@/features/assetBalance/api/assetBalanceApi';
 import { useAuth } from '@/features/auth/hooks/useAuth';
@@ -40,29 +40,23 @@ export function useAssetBalance(options: UseAssetBalanceOptions = {}): UseAssetB
   }, [onLogout, queryClient]);
 
   // 未認証時はキャッシュに残存データがあっても空を返す
-  const assetBalanceData = useMemo(
-    () => (isAuthenticated ? (query.data ?? []) : []),
-    [isAuthenticated, query.data]
-  );
+  const assetBalanceData = isAuthenticated ? (query.data ?? []) : [];
 
-  const getAssetBalanceByCode = useCallback(
-    (code: string): AssetBalanceData | undefined => {
-      const normalizedCode = normalizeSecurityCode(code);
-      if (!normalizedCode) return undefined;
-      return assetBalanceData.find(balance =>
-        balance && normalizeSecurityCode(balance.security_code) === normalizedCode
-      );
-    },
-    [assetBalanceData]
-  );
+  const getAssetBalanceByCode = (code: string): AssetBalanceData | undefined => {
+    const normalizedCode = normalizeSecurityCode(code);
+    if (!normalizedCode) return undefined;
+    return assetBalanceData.find(balance =>
+      balance && normalizeSecurityCode(balance.security_code) === normalizedCode
+    );
+  };
 
-  const getTotalMarketValue = useCallback((): number => {
+  const getTotalMarketValue = (): number => {
     return assetBalanceData.reduce((total, balance) => total + (balance?.market_value || 0), 0);
-  }, [assetBalanceData]);
+  };
 
-  const refetch = useCallback(async () => {
+  const refetch = async () => {
     await queryClient.invalidateQueries({ queryKey: assetBalanceQueryKeys.all(userId) });
-  }, [queryClient, userId]);
+  };
 
   return {
     assetBalanceData,

--- a/frontend/src/features/jquants/hooks/useDividendBatch.ts
+++ b/frontend/src/features/jquants/hooks/useDividendBatch.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useMemo } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { fetchDividendPerShareBatch, DividendStatus } from '../api/dividendPerShareApi';
 
 const BASE_RETRIES = 3;
@@ -18,15 +18,14 @@ export const useDividendBatch = (
   const [loading, setLoading] = useState<boolean>(false);
   const [fetchedCount, setFetchedCount] = useState(0);
   const [totalCount, setTotalCount] = useState(0);
-  const [retryCount, setRetryCount] = useState(0);
+  const [retryTick, setRetryTick] = useState(0);
   const retryCountRef = useRef(0);
   const prevCodesRef = useRef<string>('');
+  // 直前フェッチ開始時の codesKey を保持し、銘柄集合の実変更を判定する
+  const lastCodesKeyRef = useRef<string>('');
 
   // 重複排除・ソートした安定キー（配列参照の変化に影響されない）
-  const codesKey = useMemo(
-    () => [...new Set(securityCodes)].sort().join(','),
-    [securityCodes]
-  );
+  const codesKey = [...new Set(securityCodes)].sort().join(',');
 
   useEffect(() => {
     if (!enabled || codesKey === '') {
@@ -36,14 +35,18 @@ export const useDividendBatch = (
       setTotalCount(0);
       prevCodesRef.current = '';
       retryCountRef.current = 0;
+      lastCodesKeyRef.current = '';
       return;
     }
 
-    if (codesKey === prevCodesRef.current && retryCount === 0) return;
+    // 前回フェッチ済みの codesKey なら再フェッチしない
+    if (codesKey === prevCodesRef.current) return;
 
-    // コードセットが変わった場合はリトライカウントをリセット
-    if (codesKey !== prevCodesRef.current && retryCount === 0) {
+    // 実際の銘柄集合が変わった場合のみリトライカウントをリセット
+    // （リトライ時は prevCodesRef が '' になるが lastCodesKeyRef は変わらないため区別できる）
+    if (codesKey !== lastCodesKeyRef.current) {
       retryCountRef.current = 0;
+      lastCodesKeyRef.current = codesKey;
     }
 
     // バックエンドが12秒/銘柄で処理するため、銘柄数に応じて最大リトライ数を動的に計算
@@ -61,7 +64,7 @@ export const useDividendBatch = (
         retryTimer = setTimeout(() => {
           if (isActive) {
             prevCodesRef.current = '';
-            setRetryCount(c => c + 1);
+            setRetryTick(c => c + 1);
           }
         }, RETRY_DELAY_MS);
       } else {
@@ -117,7 +120,7 @@ export const useDividendBatch = (
       isActive = false;
       if (retryTimer !== null) clearTimeout(retryTimer);
     };
-  }, [codesKey, enabled, retryCount]);
+  }, [codesKey, enabled, retryTick]);
 
   return { dividendPerShareMap, dividendStatusMap, loading, fetchedCount, totalCount };
 };

--- a/frontend/src/features/receipt/hooks/__tests__/useReceiptsData.test.ts
+++ b/frontend/src/features/receipt/hooks/__tests__/useReceiptsData.test.ts
@@ -426,41 +426,6 @@ describe('useReceiptsData: 認証境界・キャッシュ境界', () => {
     });
   });
 
-  it('clearCache 実行で receipts キャッシュが消える', async () => {
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
-    });
-
-    vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({ isAuthenticated: true }));
-    vi.mocked(receiptApiModule.dividendApi.list).mockResolvedValue([
-      { id: '1', payment_date: '2023-01-01' } as never,
-    ]);
-    vi.mocked(receiptApiModule.domesticStockApi.list).mockResolvedValue([
-      { id: '2', trade_date: '2023-01-02' } as never,
-    ]);
-    vi.mocked(receiptApiModule.mutualfundApi.list).mockResolvedValue([
-      { id: '3', settlement_date: '2023-01-03' } as never,
-    ]);
-
-    const { result } = renderHook(() => useReceiptsData(), { wrapper: makeWrapper(qc) });
-
-    await waitFor(() => {
-      expect(qc.getQueryData(receiptQueryKeys.dividend('user-1'))).toBeDefined();
-      expect(qc.getQueryData(receiptQueryKeys.domesticstock('user-1'))).toBeDefined();
-      expect(qc.getQueryData(receiptQueryKeys.mutualfund('user-1'))).toBeDefined();
-    });
-
-    act(() => {
-      result.current.clearCache();
-    });
-
-    await waitFor(() => {
-      expect(qc.getQueryData(receiptQueryKeys.dividend('user-1'))).toBeUndefined();
-      expect(qc.getQueryData(receiptQueryKeys.domesticstock('user-1'))).toBeUndefined();
-      expect(qc.getQueryData(receiptQueryKeys.mutualfund('user-1'))).toBeUndefined();
-    });
-  });
-
   it('uploadCsv mutation エラー時: dbError に反映される', async () => {
     const qc = new QueryClient({
       defaultOptions: { queries: { retry: false, staleTime: Infinity } },

--- a/frontend/src/features/receipt/hooks/__tests__/useReceiptsState.test.ts
+++ b/frontend/src/features/receipt/hooks/__tests__/useReceiptsState.test.ts
@@ -48,7 +48,6 @@ function setupMocks(isAuthenticated = true) {
     uploadCsv: mockUploadCsv,
     previewCsv: mockPreviewCsv,
     deleteAll: mockDeleteAll,
-    clearCache: vi.fn(),
   });
 }
 

--- a/frontend/src/features/receipt/hooks/useReceiptsData.ts
+++ b/frontend/src/features/receipt/hooks/useReceiptsData.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useCallback, useEffect } from 'react';
+import { useEffect } from 'react';
 import { dividendApi, domesticStockApi, mutualfundApi } from '../api/receiptApi';
 import {
   transformDBDividend,
@@ -31,7 +31,6 @@ interface UseReceiptsDataResult {
   uploadCsv: (args: UploadCsvArgs) => void;
   previewCsv: (args: PreviewCsvArgs) => void;
   deleteAll: (type: ReceiptsType, options?: { onSuccess?: () => void }) => void;
-  clearCache: () => void;
 }
 
 interface UploadCsvArgs {
@@ -148,10 +147,6 @@ export function useReceiptsData(): UseReceiptsDataResult {
     },
   });
 
-  const clearCache = useCallback(() => {
-    clearReceiptsCache(queryClient);
-  }, [queryClient]);
-
   const queryError = dividendQuery.error ?? domesticstockQuery.error ?? mutualfundQuery.error;
   const mutationError = uploadCsvMutation.error ?? deleteAllMutation.error;
 
@@ -174,6 +169,5 @@ export function useReceiptsData(): UseReceiptsDataResult {
     uploadCsv: uploadCsvMutation.mutate,
     previewCsv: previewCsvMutation.mutate,
     deleteAll: (type, options) => deleteAllMutation.mutate(type, { onSuccess: options?.onSuccess }),
-    clearCache,
   };
 }

--- a/frontend/src/features/stock/hooks/useStockSearch.ts
+++ b/frontend/src/features/stock/hooks/useStockSearch.ts
@@ -1,11 +1,11 @@
-import { useCallback, useState } from 'react';
+import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { fetchStockData } from '../api';
 import { StockData } from '../types';
 
 export function useStockSearch(initialCode?: string) {
   const [stockCode, setStockCode] = useState(initialCode || '');
-  const [searchQuery, setSearchQuery] = useState(initialCode || '');
+  const [submittedCode, setSubmittedCode] = useState(initialCode || '');
 
   const {
     data: stockData,
@@ -13,26 +13,26 @@ export function useStockSearch(initialCode?: string) {
     isLoading,
     isError
   } = useQuery<StockData, Error>({
-    queryKey: ['stock', searchQuery],
-    queryFn: () => fetchStockData(searchQuery),
-    enabled: !!searchQuery,
+    queryKey: ['stock', submittedCode],
+    queryFn: () => fetchStockData(submittedCode),
+    enabled: !!submittedCode,
     refetchOnWindowFocus: false,
   });
 
-  const handleSearch = useCallback((e: React.FormEvent) => {
+  const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
-    setSearchQuery(stockCode);
-  }, [stockCode]);
+    setSubmittedCode(stockCode);
+  };
 
   // 検索を直接実行（URLパラメータからの自動検索用）
   const searchByCode = (code: string) => {
     setStockCode(code);
-    setSearchQuery(code);
+    setSubmittedCode(code);
   };
 
   const resetSearch = () => {
     setStockCode('');
-    setSearchQuery('');
+    setSubmittedCode('');
   };
 
   return {


### PR DESCRIPTION
## 概要
- `useAssetBalance` の不要な `useMemo` / `useCallback` を削除
- `useReceiptsData` の未使用 public API `clearCache` を削除
- `useDividendBatch` の retry 上限判定を ref に集約し、retry trigger state を明確化
- `useStockSearch` の送信済み検索値を `submittedCode` にリネームして入力値との役割を明確化

## 変更種別
- [ ] 新機能
- [ ] バグ修正
- [x] リファクタリング

## 検証
- [x] `npm run typecheck`
- [x] 対象テスト（6 files / 53 tests）
- [x] `npm test`（99 files / 959 tests）
- [x] `vp lint`
- [x] `vp build`（plugin timing warning のみ）
- [x] `git diff --check`

## レビュー観点
- React Compiler 前提の不要な手動メモ化削除
- 入力中コードと送信済みコードの検索タイミング維持
- CodeRabbit / GitHub review comment は全件確認し、対応または理由をコメントしてから merge します。