### PR TITLE
refactor: バックエンドの不要な複雑さを整理

### DIFF
--- a/backend/src/errors.rs
+++ b/backend/src/errors.rs
@@ -75,18 +75,36 @@ fn into_http(err: ApiError) -> (StatusCode, ErrorDetails) {
             simple_error(StatusCode::BAD_REQUEST, "JSON_PARSE_ERROR", err.to_string())
         }
         ApiError::DatabaseError(ref e) => {
-            let (code, message) = match e {
-                sqlx::Error::RowNotFound => ("NOT_FOUND", "Resource not found"),
+            let (status, code, message): (StatusCode, &str, &str) = match e {
+                sqlx::Error::RowNotFound => {
+                    (StatusCode::NOT_FOUND, "NOT_FOUND", "Resource not found")
+                }
                 sqlx::Error::Database(db_err) => {
                     if db_err.is_unique_violation() {
-                        ("DUPLICATE_ENTRY", "Duplicate entry")
+                        (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            "DUPLICATE_ENTRY",
+                            "Duplicate entry",
+                        )
                     } else if db_err.is_foreign_key_violation() {
-                        ("FOREIGN_KEY_VIOLATION", "Foreign key constraint violation")
+                        (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            "FOREIGN_KEY_VIOLATION",
+                            "Foreign key constraint violation",
+                        )
                     } else {
-                        ("DATABASE_ERROR", "Database error occurred")
+                        (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            "DATABASE_ERROR",
+                            "Database error occurred",
+                        )
                     }
                 }
-                _ => ("DATABASE_ERROR", "Database error occurred"),
+                _ => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "DATABASE_ERROR",
+                    "Database error occurred",
+                ),
             };
             if is_production_env() {
                 tracing::error!("Database error [{}]", code);
@@ -94,11 +112,7 @@ fn into_http(err: ApiError) -> (StatusCode, ErrorDetails) {
                 tracing::error!("Database error [{}]: {}", code, e);
             }
             (
-                if code == "NOT_FOUND" {
-                    StatusCode::NOT_FOUND
-                } else {
-                    StatusCode::INTERNAL_SERVER_ERROR
-                },
+                status,
                 ErrorDetails {
                     code: code.to_string(),
                     message: message.to_string(),

--- a/backend/src/services/auth.rs
+++ b/backend/src/services/auth.rs
@@ -33,14 +33,19 @@ type GoogleOAuthClient = oauth2::Client<
 >;
 
 pub fn create_oauth_client(state: &AppState) -> Result<GoogleOAuthClient, ApiError> {
-    let client_id =
-        state.secrets.google_client_id.clone().ok_or_else(|| {
-            ApiError::ApiError("GOOGLE_CLIENT_ID が設定されていません".to_string())
-        })?;
+    let client_id = state
+        .secrets
+        .google_client_id
+        .as_deref()
+        .ok_or_else(|| ApiError::ApiError("GOOGLE_CLIENT_ID が設定されていません".to_string()))?
+        .to_string();
 
-    let client_secret = state.secrets.google_client_secret.clone().ok_or_else(|| {
-        ApiError::ApiError("GOOGLE_CLIENT_SECRET が設定されていません".to_string())
-    })?;
+    let client_secret = state
+        .secrets
+        .google_client_secret
+        .as_deref()
+        .ok_or_else(|| ApiError::ApiError("GOOGLE_CLIENT_SECRET が設定されていません".to_string()))?
+        .to_string();
 
     let redirect_url = format!("{}/api/v1/oauth/google/callback", config::backend_url());
 

--- a/backend/src/services/csv_pipeline.rs
+++ b/backend/src/services/csv_pipeline.rs
@@ -57,11 +57,15 @@ pub fn parse_csv_with_config(
 }
 
 fn strip_header_rows(content: &str, skip_header_rows: usize) -> String {
-    content
-        .lines()
-        .skip(skip_header_rows)
-        .collect::<Vec<_>>()
-        .join("\n")
+    let mut lines = content.lines().skip(skip_header_rows).peekable();
+    let mut result = String::new();
+    while let Some(line) = lines.next() {
+        result.push_str(line);
+        if lines.peek().is_some() {
+            result.push('\n');
+        }
+    }
+    result
 }
 
 fn is_all_empty_record(record: &csv::StringRecord) -> bool {

--- a/backend/src/services/dividend_cache.rs
+++ b/backend/src/services/dividend_cache.rs
@@ -82,30 +82,17 @@ fn build_batch_items<'a>(
     let mut items: Vec<DividendPerShareItem> = Vec::with_capacity(codes.len());
 
     for code in codes {
-        let item = if let Some(cached_item) = cache_map.get(code.as_str()) {
-            let is_stale = compute_is_stale(&cached_item.status, cached_item.stale_at, now);
-            if is_stale && refresh_seen.insert(code.as_str()) {
-                refresh_codes.push(code.clone());
-            }
-            DividendPerShareItem {
-                security_code: code.clone(),
-                dividend_per_share: cached_item.dividend_per_share,
-                status: cached_item.status.clone(),
-                fetched_at: cached_item.fetched_at,
-                is_stale,
-            }
-        } else {
-            // 未キャッシュ → pending としてキューに積む
-            if refresh_seen.insert(code.as_str()) {
-                refresh_codes.push(code.clone());
-            }
-            DividendPerShareItem {
-                security_code: code.clone(),
-                dividend_per_share: None,
-                status: "pending".to_string(),
-                fetched_at: None,
-                is_stale: false,
-            }
+        let cached_entry = cache_map.get(code.as_str());
+        let is_stale = cached_entry.is_none_or(|c| compute_is_stale(&c.status, c.stale_at, now));
+        if is_stale && refresh_seen.insert(code.as_str()) {
+            refresh_codes.push(code.clone());
+        }
+        let item = DividendPerShareItem {
+            security_code: code.clone(),
+            dividend_per_share: cached_entry.and_then(|c| c.dividend_per_share),
+            status: cached_entry.map_or_else(|| "pending".to_string(), |c| c.status.clone()),
+            fetched_at: cached_entry.and_then(|c| c.fetched_at),
+            is_stale: cached_entry.is_some() && is_stale,
         };
         items.push(item);
     }

--- a/backend/src/services/dividend_cache/background.rs
+++ b/backend/src/services/dividend_cache/background.rs
@@ -47,12 +47,9 @@ pub fn spawn_background_refresh(
 
         for code in &codes {
             // DBレート制御: 1分5回(12秒間隔)を全インスタンスで保証
-            match acquire_rate_slot(&pool).await {
-                Ok(()) => {}
-                Err(e) => {
-                    tracing::error!("レート制御スロット取得エラー: {}", e);
-                    break;
-                }
+            if let Err(e) = acquire_rate_slot(&pool).await {
+                tracing::error!("レート制御スロット取得エラー: {}", e);
+                break;
             }
 
             match fetch_and_cache(&pool, &jquants_client, code).await {

--- a/backend/src/services/dividend_cache/logic.rs
+++ b/backend/src/services/dividend_cache/logic.rs
@@ -12,27 +12,33 @@ pub fn compute_is_stale(status: &str, stale_at: Option<DateTime<Utc>>, now: Date
 /// 決算サマリーから1株配当を抽出する
 /// 優先順位: 来期予想(NxFDivAnn) > 今期予想(FDivAnn) > 実績(DivAnn)
 pub fn extract_dividend(data: &[FinSummaryData]) -> (Option<f64>, String) {
-    // 開示日で降順ソート（最新データを優先）
-    let mut sorted: Vec<&FinSummaryData> = data.iter().collect();
-    sorted.sort_by(|a, b| b.disclosed_date.cmp(&a.disclosed_date));
+    // 有効な配当値を持つ summary の中で開示日が最大のものを選ぶ
+    // 同じ開示日の場合は入力順先勝ち（元の sort_by + 線形走査と同挙動）
+    let best = data
+        .iter()
+        .filter_map(|summary| {
+            [
+                summary
+                    .next_year_forecast_dividend_per_share_annual
+                    .as_deref(),
+                summary.forecast_dividend_per_share_annual.as_deref(),
+                summary.result_dividend_per_share_annual.as_deref(),
+            ]
+            .into_iter()
+            .flatten()
+            .filter(|s| !s.is_empty())
+            .find_map(|s| s.parse::<f64>().ok())
+            .map(|v| (&summary.disclosed_date, v))
+        })
+        .fold(None, |acc: Option<(&String, f64)>, (date, val)| match acc {
+            None => Some((date, val)),
+            Some((best_date, _)) if date > best_date => Some((date, val)),
+            Some(prev) => Some(prev),
+        });
 
-    for summary in &sorted {
-        for raw in [
-            summary
-                .next_year_forecast_dividend_per_share_annual
-                .as_deref(),
-            summary.forecast_dividend_per_share_annual.as_deref(),
-            summary.result_dividend_per_share_annual.as_deref(),
-        ] {
-            let Some(val_str) = raw.filter(|s| !s.is_empty()) else {
-                continue;
-            };
-
-            if let Ok(val) = val_str.parse::<f64>() {
-                let status = if val > 0.0 { "ok" } else { "zero" };
-                return (Some(val), status.to_string());
-            }
-        }
+    if let Some((_, val)) = best {
+        let status = if val > 0.0 { "ok" } else { "zero" };
+        return (Some(val), status.to_string());
     }
 
     // 配当情報が見つからない → ゼロ配当として扱う
@@ -118,6 +124,19 @@ mod tests {
         ]);
 
         assert_eq!(value, Some(60.0));
+        assert_eq!(status, "ok");
+    }
+
+    #[test]
+    fn test_extract_dividend_same_date_uses_first_input_order() {
+        // 同じ disclosed_date を持つ複数 summary がある場合、入力順で最初に現れた
+        // valid dividend が採用される。この値が persistence.rs によって DB に書き込まれるため、
+        // 後続の summary の値に変わらないことを保証する回帰テスト。
+        let (value, status) = extract_dividend(&[
+            make_summary("2024-01-01", None, None, Some("30.0")),
+            make_summary("2024-01-01", None, None, Some("99.0")),
+        ]);
+        assert_eq!(value, Some(30.0));
         assert_eq!(status, "ok");
     }
 

--- a/backend/src/services/jquants.rs
+++ b/backend/src/services/jquants.rs
@@ -41,17 +41,11 @@ impl JQuantsClient {
         params: FinSummaryQuery,
     ) -> Result<FinSummaryResponse, ApiError> {
         let mut query_params: Vec<(&str, &str)> = vec![("code", &params.code)];
-        let from_str;
-        let to_str;
-
-        if let Some(ref from) = params.from {
-            from_str = from.clone();
-            query_params.push(("from", &from_str));
+        if let Some(from) = params.from.as_deref() {
+            query_params.push(("from", from));
         }
-
-        if let Some(ref to) = params.to {
-            to_str = to.clone();
-            query_params.push(("to", &to_str));
+        if let Some(to) = params.to.as_deref() {
+            query_params.push(("to", to));
         }
 
         tracing::info!("JQuants API V2 リクエスト: code={}", params.code);


### PR DESCRIPTION
## 概要
- J-Quants クエリ組み立て、OAuth 設定取得、DB エラー変換の不要な中間処理を整理
- dividend cache の refresh 判定と background refresh の空 match アームを簡潔化
- CSV ヘッダ除去と配当抽出を中間 Vec / sort なしの1パス処理へ変更

## 検証
- cargo fmt --check
- cargo clippy -- -D warnings
- cargo test
