### PR TITLE
fix: 認証認可のセキュリティ問題を修正

### DIFF
--- a/backend/src/handlers/stock/tests.rs
+++ b/backend/src/handlers/stock/tests.rs
@@ -111,6 +111,36 @@ async fn call(
     app.oneshot(request.body(body).unwrap()).await.unwrap()
 }
 
+async fn make_session(pool: &Pool<Postgres>) -> String {
+    let (user_id,): (uuid::Uuid,) = sqlx::query_as(
+        "INSERT INTO users (google_id, email) VALUES ('test-google-id', 'test@example.com') RETURNING id",
+    )
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    crate::services::auth::create_session(pool, user_id)
+        .await
+        .unwrap()
+}
+
+async fn call_with_session(
+    app: Router,
+    method: &str,
+    uri: &str,
+    session_cookie: &str,
+) -> axum::response::Response {
+    app.oneshot(
+        Request::builder()
+            .method(method)
+            .uri(uri)
+            .header("cookie", session_cookie)
+            .body(Body::empty())
+            .unwrap(),
+    )
+    .await
+    .unwrap()
+}
+
 async fn read_json(response: axum::response::Response) -> Value {
     serde_json::from_slice(
         &axum::body::to_bytes(response.into_body(), BODY_LIMIT)
@@ -139,9 +169,12 @@ fn stock_payload(code: &str, name: &str) -> Value {
 #[ignore = "requires Docker to run Postgres container"]
 async fn test_search_stock() {
     let (pool, _node) = setup_test_db().await;
+    let session_token = make_session(&pool).await;
+    let cookie = format!("session_token={}", session_token);
     let app = setup_test_app(pool);
 
-    let response = call(app.clone(), "GET", "/api/v1/stocks?query=1234", None).await;
+    let response =
+        call_with_session(app.clone(), "GET", "/api/v1/stocks?query=1234", &cookie).await;
     assert_eq!(response.status(), StatusCode::OK);
 
     let stock = read_json(response).await;
@@ -155,7 +188,9 @@ async fn test_search_stock() {
         ("/api/v1/stocks?query=9999", StatusCode::NOT_FOUND),
     ] {
         assert_eq!(
-            call(app.clone(), "GET", uri, None).await.status(),
+            call_with_session(app.clone(), "GET", uri, &cookie)
+                .await
+                .status(),
             expected_status
         );
     }
@@ -207,6 +242,20 @@ async fn test_create_stock_unauthorized() {
         )
         .await
         .status(),
+        StatusCode::UNAUTHORIZED
+    );
+}
+
+#[tokio::test]
+async fn test_search_stock_unauthorized() {
+    let pool = crate::db::connect_pool_lazy("postgresql://postgres:postgres@localhost/postgres", 1)
+        .unwrap();
+    let app = setup_test_app(pool);
+
+    assert_eq!(
+        call(app, "GET", "/api/v1/stocks?query=7203", None)
+            .await
+            .status(),
         StatusCode::UNAUTHORIZED
     );
 }

--- a/backend/src/handlers/v1.rs
+++ b/backend/src/handlers/v1.rs
@@ -184,19 +184,50 @@ mod tests {
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 
-    /// GET /api/v1/stocks?query=... の route が登録されている（404 にならない）
+    /// DELETE /api/v1/account は確認 cookie の値が UUID でない場合 400 を返す
     #[tokio::test]
-    async fn test_v1_stocks_search_route_registered() {
+    async fn test_delete_account_rejects_invalid_confirmation_cookie_uuid() {
+        let router = auth_routes().with_state(make_test_state());
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .method(Method::DELETE)
+                    .uri("/api/v1/account")
+                    .header(
+                        "cookie",
+                        format!(
+                            "session_token={}; account_delete_confirmation=not-a-uuid",
+                            uuid::Uuid::new_v4()
+                        ),
+                    )
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    /// GET /api/v1/stocks?query=... は未認証で 401 を返す
+    #[tokio::test]
+    async fn test_v1_stocks_search_requires_auth() {
         let router = data_routes().with_state(make_test_state());
-        // route が登録されていれば DB 接続エラーか 404 以外が返る
-        let status = check_status(router, Method::GET, "/api/v1/stocks?query=7203").await;
-        assert_ne!(status, StatusCode::NOT_FOUND);
+        assert_eq!(
+            check_status(router, Method::GET, "/api/v1/stocks?query=7203").await,
+            StatusCode::UNAUTHORIZED
+        );
     }
 
     /// 認証必須 collection v1 route が未認証で 401 を返す
     #[tokio::test]
     async fn test_v1_collection_routes_return_401_without_auth() {
         for (router, method, uri) in [
+            (
+                data_routes().with_state(make_test_state()),
+                Method::GET,
+                "/api/v1/stocks?query=7203",
+            ),
             (
                 data_routes().with_state(make_test_state()),
                 Method::GET,

--- a/backend/src/handlers/v1/auth.rs
+++ b/backend/src/handlers/v1/auth.rs
@@ -103,11 +103,13 @@ pub async fn delete_account(
 ) -> Result<impl IntoResponse, ApiError> {
     let session_id = auth_service::get_session_id_from_jar(&jar)?;
 
-    if jar.get(ACCOUNT_DELETE_CONFIRMATION_COOKIE_NAME).is_none() {
-        return Err(ApiError::ApiError(
-            "アカウント削除確認が完了していません".to_string(),
-        ));
-    }
+    let confirmation = jar
+        .get(ACCOUNT_DELETE_CONFIRMATION_COOKIE_NAME)
+        .ok_or_else(|| ApiError::ApiError("アカウント削除確認が完了していません".to_string()))?;
+    confirmation
+        .value()
+        .parse::<uuid::Uuid>()
+        .map_err(|_| ApiError::ApiError("アカウント削除確認が無効です".to_string()))?;
 
     let user_id = auth_service::select_user_id_by_session(&state.pool, session_id)
         .await?

--- a/backend/src/handlers/v1/stocks.rs
+++ b/backend/src/handlers/v1/stocks.rs
@@ -33,11 +33,14 @@ pub struct StockSearchQuery {
     ),
     responses(
         (status = 200, body = Stock),
+        (status = 401, body = ErrorResponse),
         (status = 404, body = ErrorResponse),
     ),
+    security(("cookieAuth" = []))
 )]
 pub async fn search(
     State(state): State<AppState>,
+    _auth_user: AuthenticatedUser,
     Query(params): Query<StockSearchQuery>,
 ) -> Result<impl IntoResponse, ApiError> {
     let stock = stock_service::search(&state.pool, &params.query).await?;

--- a/backend/src/middleware/security.rs
+++ b/backend/src/middleware/security.rs
@@ -36,6 +36,23 @@ pub async fn add_security_headers(req: Request<Body>, next: Next) -> Response {
     response
 }
 
+/// Origin/Referer なし unsafe method を拒否すべき環境かどうかを判定する
+///
+/// - RUST_ENV / APP_ENV が明示設定済みで、ローカル開発用の exempt 値でない → true（拒否）
+/// - 未設定の場合は BACKEND_URL=https:// のみ拒否（ローカル開発は通過）
+fn is_strict_origin_check() -> bool {
+    const EXEMPT: &[&str] = &["local", "dev", "development", "test"];
+    if let Ok(v) = std::env::var("RUST_ENV") {
+        return !EXEMPT.contains(&v.as_str());
+    }
+    if let Ok(v) = std::env::var("APP_ENV") {
+        return !EXEMPT.contains(&v.as_str());
+    }
+    std::env::var("BACKEND_URL")
+        .map(|url| url.starts_with("https://"))
+        .unwrap_or(false)
+}
+
 /// URL 文字列からオリジン部分（scheme://host[:port]）を抽出する
 ///
 /// `starts_with` での前方一致では `https://example.com.evil/` のような
@@ -116,8 +133,8 @@ pub async fn validate_origin(
                 }
                 None => {
                     // Origin も Referer もなし
-                    // 本番環境では CSRF リスクがあるため拒否する
-                    if crate::config::is_production_env() {
+                    // 本番・staging 等の明示設定済み環境では CSRF リスクがあるため拒否する
+                    if is_strict_origin_check() {
                         csrf_error()
                     } else {
                         next.run(request).await
@@ -285,6 +302,50 @@ mod tests {
             assert_ne!(
                 oneshot_status(test_app(), Method::GET, &[]).await,
                 StatusCode::FORBIDDEN
+            );
+        }
+
+        // APP_ENV=staging のとき Origin/Referer なしは 403（非本番でも明示設定済みなら拒否）
+        {
+            let _app_env = EnvGuard::set("APP_ENV", Some("staging"));
+            let _rust_env = EnvGuard::set("RUST_ENV", None);
+            let _backend_url = EnvGuard::set("BACKEND_URL", None);
+            assert_eq!(
+                oneshot_status(test_app(), Method::POST, &[]).await,
+                StatusCode::FORBIDDEN
+            );
+        }
+
+        // APP_ENV=development のとき Origin/Referer なしは通過（exempt 値）
+        {
+            let _app_env = EnvGuard::set("APP_ENV", Some("development"));
+            let _rust_env = EnvGuard::set("RUST_ENV", None);
+            let _backend_url = EnvGuard::set("BACKEND_URL", None);
+            assert_eq!(
+                oneshot_status(test_app(), Method::POST, &[]).await,
+                StatusCode::OK
+            );
+        }
+
+        // RUST_ENV=staging のとき Origin/Referer なしは 403
+        {
+            let _app_env = EnvGuard::set("APP_ENV", None);
+            let _rust_env = EnvGuard::set("RUST_ENV", Some("staging"));
+            let _backend_url = EnvGuard::set("BACKEND_URL", None);
+            assert_eq!(
+                oneshot_status(test_app(), Method::POST, &[]).await,
+                StatusCode::FORBIDDEN
+            );
+        }
+
+        // RUST_ENV=test のとき Origin/Referer なしは通過（exempt 値）
+        {
+            let _app_env = EnvGuard::set("APP_ENV", None);
+            let _rust_env = EnvGuard::set("RUST_ENV", Some("test"));
+            let _backend_url = EnvGuard::set("BACKEND_URL", None);
+            assert_eq!(
+                oneshot_status(test_app(), Method::POST, &[]).await,
+                StatusCode::OK
             );
         }
     }

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -249,6 +249,11 @@ mod tests {
     async fn test_all_endpoints_require_auth() {
         for (router, method, uri) in [
             (
+                handlers::v1::data_routes(),
+                Method::GET,
+                "/api/v1/stocks?query=7203",
+            ),
+            (
                 handlers::v1::jquants_routes(),
                 Method::GET,
                 "/api/v1/financial-statements?code=7203",

--- a/backend/src/services/auth.rs
+++ b/backend/src/services/auth.rs
@@ -163,6 +163,13 @@ pub async fn select_user_id_by_session(
 }
 
 pub async fn create_session(pool: &PgPool, user_id: uuid::Uuid) -> Result<String, sqlx::Error> {
+    let mut tx = pool.begin().await?;
+
+    sqlx::query("DELETE FROM sessions WHERE user_id = $1")
+        .bind(user_id)
+        .execute(&mut *tx)
+        .await?;
+
     let session_id: (uuid::Uuid,) = sqlx::query_as(
         r#"
         INSERT INTO sessions (user_id)
@@ -171,8 +178,10 @@ pub async fn create_session(pool: &PgPool, user_id: uuid::Uuid) -> Result<String
         "#,
     )
     .bind(user_id)
-    .fetch_one(pool)
+    .fetch_one(&mut *tx)
     .await?;
+
+    tx.commit().await?;
 
     Ok(session_id.0.to_string())
 }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1213,6 +1213,16 @@
               }
             }
           },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "404": {
             "description": "",
             "content": {
@@ -1223,7 +1233,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "cookieAuth": []
+          }
+        ]
       },
       "post": {
         "tags": [

--- a/frontend/src/generated/api.ts
+++ b/frontend/src/generated/api.ts
@@ -1688,6 +1688,14 @@ export interface operations {
                     "application/json": components["schemas"]["Stock"];
                 };
             };
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
             404: {
                 headers: {
                     [name: string]: unknown;


### PR DESCRIPTION
## 概要
- 再ログイン時に同一ユーザーの既存セッションを transaction 内で削除してから新規セッションを作成
- `GET /api/v1/stocks` を認証必須化し、OpenAPI / generated API 型も更新
- アカウント削除確認 cookie の UUID 値検証を追加
- `APP_ENV` / `RUST_ENV` が staging 等で明示された環境では、Origin/Referer なし unsafe method を CSRF として拒否

## 検証
- cargo fmt --check
- cargo clippy -- -D warnings
- cargo test
