### PR TITLE
refactor: 認証サービス層のHTTP責務を分離

### DIFF
--- a/backend/src/extractors/auth.rs
+++ b/backend/src/extractors/auth.rs
@@ -35,9 +35,14 @@ where
             .await
             .map_err(|_| ApiError::Unauthorized("Cookieの取得に失敗しました".to_string()))?;
 
-        // セッショントークンを取得
-        let session_id = auth_service::get_session_id_from_jar(&jar)?;
-
+        // セッショントークンを取得してセッションIDにパース
+        let session_token = jar
+            .get(auth_service::SESSION_COOKIE_NAME)
+            .map(|c| c.value().to_string())
+            .ok_or_else(|| ApiError::Unauthorized("ログインが必要です".to_string()))?;
+        let session_id: uuid::Uuid = session_token
+            .parse()
+            .map_err(|_| ApiError::Unauthorized("無効なセッショントークンです".to_string()))?;
         // セッションテーブルからユーザーを取得（期限切れでないセッションのみ）
         let user = auth_service::select_user_by_session(&app_state.pool, session_id)
             .await

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -1,17 +1,19 @@
 use crate::config;
 use crate::errors::ApiError;
-use crate::models::user::{GoogleUserInfo, UserResponse};
+use crate::models::user::UserResponse;
 use crate::services::auth::{self as auth_service, create_oauth_client};
 use crate::state::AppState;
 use axum::{
     extract::{Query, State},
     response::{IntoResponse, Json, Redirect, Response},
 };
-use axum_extra::extract::CookieJar;
-use oauth2::{AuthorizationCode, CsrfToken, Scope, TokenResponse};
+use axum_extra::extract::{
+    cookie::{Cookie, SameSite},
+    CookieJar,
+};
+use oauth2::{CsrfToken, Scope};
 use serde::Deserialize;
 
-const GOOGLE_USERINFO_URL: &str = "https://www.googleapis.com/oauth2/v3/userinfo";
 /// コールバック時のクエリパラメータ
 #[derive(Debug, Deserialize)]
 pub struct AuthCallbackQuery {
@@ -19,12 +21,85 @@ pub struct AuthCallbackQuery {
     pub state: String,
 }
 
+fn same_site(secure: bool) -> SameSite {
+    if secure {
+        SameSite::None
+    } else {
+        SameSite::Lax
+    }
+}
+
+pub fn build_state_cookie(state: &str, secure: bool) -> Cookie<'static> {
+    Cookie::build((auth_service::OAUTH_STATE_COOKIE_NAME, state.to_string()))
+        .path("/")
+        .http_only(true)
+        .secure(secure)
+        .same_site(same_site(secure))
+        .max_age(time::Duration::minutes(10))
+        .build()
+}
+
+pub fn clear_state_cookie(secure: bool) -> Cookie<'static> {
+    Cookie::build((auth_service::OAUTH_STATE_COOKIE_NAME, ""))
+        .path("/")
+        .http_only(true)
+        .secure(secure)
+        .same_site(same_site(secure))
+        .max_age(time::Duration::seconds(0))
+        .build()
+}
+
+pub fn build_session_cookie(token: &str, secure: bool) -> Cookie<'static> {
+    Cookie::build((auth_service::SESSION_COOKIE_NAME, token.to_string()))
+        .path("/")
+        .http_only(true)
+        .secure(secure)
+        .same_site(same_site(secure))
+        .max_age(time::Duration::days(7))
+        .build()
+}
+
+pub fn clear_session_cookie(secure: bool) -> Cookie<'static> {
+    Cookie::build((auth_service::SESSION_COOKIE_NAME, ""))
+        .path("/")
+        .http_only(true)
+        .secure(secure)
+        .same_site(same_site(secure))
+        .max_age(time::Duration::seconds(0))
+        .build()
+}
+
+pub fn get_session_id_from_jar(jar: &CookieJar) -> Result<uuid::Uuid, ApiError> {
+    let session_token = jar
+        .get(auth_service::SESSION_COOKIE_NAME)
+        .map(|c| c.value().to_string())
+        .ok_or_else(|| ApiError::Unauthorized("ログインが必要です".to_string()))?;
+
+    let session_id: uuid::Uuid = session_token
+        .parse()
+        .map_err(|_| ApiError::Unauthorized("無効なセッショントークンです".to_string()))?;
+
+    Ok(session_id)
+}
+
 /// Google OAuth認証を開始（直接リダイレクト）
 pub async fn google_auth(
     State(state): State<AppState>,
     jar: CookieJar,
 ) -> Result<(CookieJar, Redirect), ApiError> {
-    let client = create_oauth_client(&state)?;
+    let client_id =
+        state.secrets.google_client_id.as_deref().ok_or_else(|| {
+            ApiError::ApiError("GOOGLE_CLIENT_ID が設定されていません".to_string())
+        })?;
+    let client_secret = state
+        .secrets
+        .google_client_secret
+        .as_deref()
+        .ok_or_else(|| {
+            ApiError::ApiError("GOOGLE_CLIENT_SECRET が設定されていません".to_string())
+        })?;
+
+    let client = create_oauth_client(client_id, client_secret)?;
 
     let (auth_url, csrf_token) = client
         .authorize_url(CsrfToken::new_random)
@@ -35,7 +110,7 @@ pub async fn google_auth(
 
     // CSRF トークンを Cookie に保存（10分間有効）
     let is_secure = config::is_secure_cookie();
-    let state_cookie = auth_service::build_state_cookie(csrf_token.secret(), is_secure);
+    let state_cookie = build_state_cookie(csrf_token.secret(), is_secure);
 
     let jar = jar.add(state_cookie);
 
@@ -62,47 +137,34 @@ pub async fn google_callback(
 
     // state Cookie を削除
     let is_secure = config::is_secure_cookie();
-    let jar = jar.remove(auth_service::clear_state_cookie(is_secure));
+    let jar = jar.remove(clear_state_cookie(is_secure));
 
-    let client = create_oauth_client(&state)?;
-
-    // 認証コードをトークンに交換（oauth2 5.0.0 の新しい HTTP クライアント API）
-    let http_client = oauth2::reqwest::Client::new();
-    let token_result = client
-        .exchange_code(AuthorizationCode::new(query.code))
-        .request_async(&http_client)
-        .await
-        .map_err(|e| {
-            tracing::error!("OAuth token exchange error: {}", e);
-            ApiError::OAuthError(e.to_string())
+    let client_id =
+        state.secrets.google_client_id.as_deref().ok_or_else(|| {
+            ApiError::ApiError("GOOGLE_CLIENT_ID が設定されていません".to_string())
+        })?;
+    let client_secret = state
+        .secrets
+        .google_client_secret
+        .as_deref()
+        .ok_or_else(|| {
+            ApiError::ApiError("GOOGLE_CLIENT_SECRET が設定されていません".to_string())
         })?;
 
-    let access_token = token_result.access_token().secret();
+    let client = create_oauth_client(client_id, client_secret)?;
 
-    // Googleユーザー情報を取得
-    let user_info: GoogleUserInfo = state
-        .client
-        .get(GOOGLE_USERINFO_URL)
-        .bearer_auth(access_token)
-        .send()
-        .await
-        .map_err(|e| ApiError::NetworkError(format!("ユーザー情報取得エラー: {}", e)))?
-        .json()
-        .await
-        .map_err(|e| ApiError::NetworkError(format!("ユーザー情報解析エラー: {}", e)))?;
-
-    // ユーザーをデータベースに登録または更新
-    let user = auth_service::upsert_user(&state.pool, &user_info).await?;
-
-    // ランダムなセッショントークンを生成してデータベースに保存
-    let session_token = auth_service::create_session(&state.pool, user.id).await?;
+    let session_token = auth_service::authenticate_with_google_code(
+        &state.pool,
+        &state.client,
+        &client,
+        query.code,
+    )
+    .await?;
 
     // Cookieを設定
     // クロスオリジン（フロントエンド: GitHub Pages, バックエンド: Fly.io）で
     // Cookieを送受信するには SameSite=None + Secure が必要
-    let is_secure = config::is_secure_cookie();
-    let cookie = auth_service::build_session_cookie(&session_token, is_secure);
-
+    let cookie = build_session_cookie(&session_token, is_secure);
     let jar = jar.add(cookie);
 
     // フロントエンドにリダイレクト
@@ -117,7 +179,7 @@ pub async fn get_current_user(
     State(state): State<AppState>,
     jar: CookieJar,
 ) -> Result<Json<UserResponse>, ApiError> {
-    let session_id = auth_service::get_session_id_from_jar(&jar)?;
+    let session_id = get_session_id_from_jar(&jar)?;
 
     // セッションテーブルからユーザーを取得（期限切れでないセッションのみ）
     let user = auth_service::select_user_by_session(&state.pool, session_id)
@@ -140,7 +202,7 @@ pub async fn logout(State(state): State<AppState>, jar: CookieJar) -> impl IntoR
     }
 
     let is_secure = config::is_secure_cookie();
-    let cookie = auth_service::clear_session_cookie(is_secure);
+    let cookie = clear_session_cookie(is_secure);
 
     let jar = jar.remove(cookie);
 
@@ -151,6 +213,7 @@ pub async fn logout(State(state): State<AppState>, jar: CookieJar) -> impl IntoR
 }
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::{
         db::connect_pool_lazy,
         errors::ErrorResponse,
@@ -161,6 +224,10 @@ mod tests {
         body::{to_bytes, Body},
         http::{Method, Request, StatusCode},
         Router,
+    };
+    use axum_extra::extract::{
+        cookie::{Cookie, SameSite},
+        CookieJar,
     };
     use {reqwest::Client, serde::de::DeserializeOwned, std::sync::Arc, tower::ServiceExt};
     const BODY_LIMIT: usize = 1024 * 1024;
@@ -218,6 +285,66 @@ mod tests {
         assert_eq!(
             (status, message.message.as_str()),
             (StatusCode::OK, "ログアウトしました")
+        );
+    }
+    #[test]
+    fn test_cookie_helpers() {
+        use crate::services::auth::{OAUTH_STATE_COOKIE_NAME, SESSION_COOKIE_NAME};
+        for (secure, expected_secure) in [(true, true), (false, false)] {
+            for (cookie, expected_name, expected_value) in [
+                (
+                    build_state_cookie("test_state", secure),
+                    OAUTH_STATE_COOKIE_NAME,
+                    "test_state",
+                ),
+                (
+                    build_session_cookie("test_token", secure),
+                    SESSION_COOKIE_NAME,
+                    "test_token",
+                ),
+            ] {
+                assert_eq!(
+                    (
+                        cookie.name(),
+                        cookie.value(),
+                        cookie.secure(),
+                        cookie.http_only()
+                    ),
+                    (
+                        expected_name,
+                        expected_value,
+                        Some(expected_secure),
+                        Some(true)
+                    )
+                );
+            }
+        }
+        for (cookie, expected_name) in [
+            (clear_state_cookie(true), OAUTH_STATE_COOKIE_NAME),
+            (clear_session_cookie(true), SESSION_COOKIE_NAME),
+        ] {
+            assert_eq!((cookie.name(), cookie.value()), (expected_name, ""));
+        }
+        assert_eq!(
+            (same_site(true), same_site(false)),
+            (SameSite::None, SameSite::Lax)
+        );
+    }
+    #[test]
+    fn test_jar_helpers() {
+        use crate::services::auth::SESSION_COOKIE_NAME;
+        assert!(get_session_id_from_jar(&CookieJar::new()).is_err());
+        assert!(get_session_id_from_jar(
+            &CookieJar::new().add(Cookie::new(SESSION_COOKIE_NAME, "invalid-uuid"))
+        )
+        .is_err());
+        let uuid = uuid::Uuid::new_v4();
+        assert_eq!(
+            get_session_id_from_jar(
+                &CookieJar::new().add(Cookie::new(SESSION_COOKIE_NAME, uuid.to_string()))
+            )
+            .unwrap(),
+            uuid
         );
     }
 }

--- a/backend/src/handlers/csv_import.rs
+++ b/backend/src/handlers/csv_import.rs
@@ -1,4 +1,5 @@
 use crate::errors::ApiError;
+use crate::models::csv_import::CsvUploadResponse;
 use crate::services::csv_domain::CsvDomain;
 use crate::state::AppState;
 use axum::{extract::Multipart, http::StatusCode, response::IntoResponse, Json, Router};
@@ -46,14 +47,15 @@ pub async fn handle_preview_csv<D: CsvDomain>(
 /// ドメイン共通のアップロード処理
 ///
 /// ハンドラーから `handle_upload_csv::<DividendDomain>(&state.pool, auth_user.id(), multipart).await` のように呼ぶ。
+/// HTTP ステータスコードは呼び出し元ハンドラーが決める。
 pub async fn handle_upload_csv<D: CsvDomain>(
     pool: &sqlx::PgPool,
     user_id: Uuid,
     multipart: Multipart,
-) -> Result<impl IntoResponse, ApiError> {
+) -> Result<Json<CsvUploadResponse>, ApiError> {
     let bytes = read_csv_file_bytes(multipart).await?;
     let response = D::upload_csv(pool, user_id, &bytes).await?;
-    Ok((StatusCode::CREATED, Json(response)))
+    Ok(Json(response))
 }
 #[cfg(test)]
 mod tests {
@@ -182,7 +184,8 @@ mod tests {
         State(pool): State<sqlx::PgPool>,
         multipart: Multipart,
     ) -> Result<impl IntoResponse, ApiError> {
-        handle_upload_csv::<UploadDomain>(&pool, Uuid::nil(), multipart).await
+        let json = handle_upload_csv::<UploadDomain>(&pool, Uuid::nil(), multipart).await?;
+        Ok((StatusCode::CREATED, json))
     }
 
     #[tokio::test]

--- a/backend/src/handlers/dividend_per_share.rs
+++ b/backend/src/handlers/dividend_per_share.rs
@@ -1,5 +1,5 @@
 use crate::{
-    errors::{ApiError, ErrorResponse},
+    errors::ApiError,
     extractors::auth::AuthenticatedUser,
     extractors::validated_json::ValidatedJson,
     models::dividend_cache::{DividendPerShareBatchRequest, DividendPerShareBatchResponse},
@@ -8,19 +8,6 @@ use crate::{
 };
 use axum::{extract::State, response::IntoResponse, Json};
 
-/// 配当利回り一括取得
-#[utoipa::path(
-    post,
-    path = "/dividends/per-share/batch",
-    operation_id = "dividend_per_share_batch",
-    request_body = DividendPerShareBatchRequest,
-    responses(
-        (status = 200, body = DividendPerShareBatchResponse),
-        (status = 400, body = ErrorResponse),
-        (status = 401, body = ErrorResponse),
-    ),
-    security(("cookieAuth" = []))
-)]
 pub async fn batch(
     State(state): State<AppState>,
     _auth_user: AuthenticatedUser,

--- a/backend/src/handlers/v1/asset_balances.rs
+++ b/backend/src/handlers/v1/asset_balances.rs
@@ -122,12 +122,13 @@ pub async fn import(
     auth_user: AuthenticatedUser,
     multipart: Multipart,
 ) -> Result<impl IntoResponse, ApiError> {
-    crate::handlers::csv_import::handle_upload_csv::<AssetBalanceDomain>(
+    let json = crate::handlers::csv_import::handle_upload_csv::<AssetBalanceDomain>(
         &state.pool,
         auth_user.id(),
         multipart,
     )
-    .await
+    .await?;
+    Ok((StatusCode::CREATED, json))
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/src/handlers/v1/auth.rs
+++ b/backend/src/handlers/v1/auth.rs
@@ -101,7 +101,7 @@ pub async fn delete_account(
     State(state): State<AppState>,
     jar: CookieJar,
 ) -> Result<impl IntoResponse, ApiError> {
-    let session_id = auth_service::get_session_id_from_jar(&jar)?;
+    let session_id = crate::handlers::auth::get_session_id_from_jar(&jar)?;
 
     let confirmation = jar
         .get(ACCOUNT_DELETE_CONFIRMATION_COOKIE_NAME)
@@ -119,7 +119,7 @@ pub async fn delete_account(
 
     let is_secure = config::is_secure_cookie();
     let jar = jar
-        .remove(auth_service::clear_session_cookie(is_secure))
+        .remove(crate::handlers::auth::clear_session_cookie(is_secure))
         .remove(clear_account_delete_confirmation_cookie(is_secure));
 
     Ok((

--- a/backend/src/handlers/v1/dividends.rs
+++ b/backend/src/handlers/v1/dividends.rs
@@ -100,12 +100,13 @@ pub async fn import(
     auth_user: AuthenticatedUser,
     multipart: Multipart,
 ) -> Result<impl IntoResponse, ApiError> {
-    crate::handlers::csv_import::handle_upload_csv::<DividendDomain>(
+    let json = crate::handlers::csv_import::handle_upload_csv::<DividendDomain>(
         &state.pool,
         auth_user.id(),
         multipart,
     )
-    .await
+    .await?;
+    Ok((StatusCode::CREATED, json))
 }
 
 /// 配当利回りを一括取得（v1）

--- a/backend/src/handlers/v1/domestic_stocks.rs
+++ b/backend/src/handlers/v1/domestic_stocks.rs
@@ -99,12 +99,13 @@ pub async fn import(
     auth_user: AuthenticatedUser,
     multipart: Multipart,
 ) -> Result<impl IntoResponse, ApiError> {
-    crate::handlers::csv_import::handle_upload_csv::<DomesticStockDomain>(
+    let json = crate::handlers::csv_import::handle_upload_csv::<DomesticStockDomain>(
         &state.pool,
         auth_user.id(),
         multipart,
     )
-    .await
+    .await?;
+    Ok((StatusCode::CREATED, json))
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/src/handlers/v1/mutual_funds.rs
+++ b/backend/src/handlers/v1/mutual_funds.rs
@@ -99,12 +99,13 @@ pub async fn import(
     auth_user: AuthenticatedUser,
     multipart: Multipart,
 ) -> Result<impl IntoResponse, ApiError> {
-    crate::handlers::csv_import::handle_upload_csv::<MutualfundDomain>(
+    let json = crate::handlers::csv_import::handle_upload_csv::<MutualfundDomain>(
         &state.pool,
         auth_user.id(),
         multipart,
     )
-    .await
+    .await?;
+    Ok((StatusCode::CREATED, json))
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/src/services/auth.rs
+++ b/backend/src/services/auth.rs
@@ -1,23 +1,19 @@
-use axum_extra::extract::{
-    cookie::{Cookie, SameSite},
-    CookieJar,
-};
 use oauth2::{
-    basic::BasicClient, AuthUrl, ClientId, ClientSecret, EndpointNotSet, EndpointSet, RedirectUrl,
-    TokenUrl,
+    basic::BasicClient, AuthUrl, AuthorizationCode, ClientId, ClientSecret, EndpointNotSet,
+    EndpointSet, RedirectUrl, TokenResponse, TokenUrl,
 };
 use sqlx::PgPool;
 
 use crate::config;
 use crate::errors::ApiError;
 use crate::models::user::{GoogleUserInfo, User};
-use crate::state::AppState;
 
 pub const SESSION_COOKIE_NAME: &str = "session_token";
 pub const OAUTH_STATE_COOKIE_NAME: &str = "oauth_state";
 
 const GOOGLE_AUTH_URL: &str = "https://accounts.google.com/o/oauth2/v2/auth";
 const GOOGLE_TOKEN_URL: &str = "https://oauth2.googleapis.com/token";
+const GOOGLE_USERINFO_URL: &str = "https://www.googleapis.com/oauth2/v3/userinfo";
 
 type GoogleOAuthClient = oauth2::Client<
     oauth2::basic::BasicErrorResponse,
@@ -32,25 +28,14 @@ type GoogleOAuthClient = oauth2::Client<
     EndpointSet,
 >;
 
-pub fn create_oauth_client(state: &AppState) -> Result<GoogleOAuthClient, ApiError> {
-    let client_id = state
-        .secrets
-        .google_client_id
-        .as_deref()
-        .ok_or_else(|| ApiError::ApiError("GOOGLE_CLIENT_ID が設定されていません".to_string()))?
-        .to_string();
-
-    let client_secret = state
-        .secrets
-        .google_client_secret
-        .as_deref()
-        .ok_or_else(|| ApiError::ApiError("GOOGLE_CLIENT_SECRET が設定されていません".to_string()))?
-        .to_string();
-
+pub fn create_oauth_client(
+    client_id: &str,
+    client_secret: &str,
+) -> Result<GoogleOAuthClient, ApiError> {
     let redirect_url = format!("{}/api/v1/oauth/google/callback", config::backend_url());
 
-    let client = BasicClient::new(ClientId::new(client_id))
-        .set_client_secret(ClientSecret::new(client_secret))
+    let client = BasicClient::new(ClientId::new(client_id.to_string()))
+        .set_client_secret(ClientSecret::new(client_secret.to_string()))
         .set_auth_uri(
             AuthUrl::new(GOOGLE_AUTH_URL.to_string())
                 .map_err(|e| ApiError::ApiError(format!("認証URL解析エラー: {}", e)))?,
@@ -67,65 +52,43 @@ pub fn create_oauth_client(state: &AppState) -> Result<GoogleOAuthClient, ApiErr
     Ok(client)
 }
 
-fn same_site(secure: bool) -> SameSite {
-    if secure {
-        SameSite::None
-    } else {
-        SameSite::Lax
-    }
-}
-
-pub fn get_session_id_from_jar(jar: &CookieJar) -> Result<uuid::Uuid, ApiError> {
-    let session_token = jar
-        .get(SESSION_COOKIE_NAME)
-        .map(|c| c.value().to_string())
-        .ok_or_else(|| ApiError::Unauthorized("ログインが必要です".to_string()))?;
-
-    let session_id: uuid::Uuid = session_token
-        .parse()
-        .map_err(|_| ApiError::Unauthorized("無効なセッショントークンです".to_string()))?;
-
-    Ok(session_id)
-}
-
-pub fn build_state_cookie(state: &str, secure: bool) -> Cookie<'static> {
-    Cookie::build((OAUTH_STATE_COOKIE_NAME, state.to_string()))
-        .path("/")
-        .http_only(true)
-        .secure(secure)
-        .same_site(same_site(secure))
-        .max_age(time::Duration::minutes(10))
+/// Google OAuth コードをトークンに交換し、ユーザーを upsert してセッショントークンを返す
+pub async fn authenticate_with_google_code(
+    pool: &PgPool,
+    http_client: &reqwest::Client,
+    oauth_client: &GoogleOAuthClient,
+    code: String,
+) -> Result<String, ApiError> {
+    let oauth_http_client = oauth2::reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .redirect(oauth2::reqwest::redirect::Policy::limited(3))
         .build()
-}
+        .map_err(|e| ApiError::OAuthError(format!("OAuth HTTPクライアント構築エラー: {}", e)))?;
+    let token_result = oauth_client
+        .exchange_code(AuthorizationCode::new(code))
+        .request_async(&oauth_http_client)
+        .await
+        .map_err(|e| {
+            tracing::error!("OAuth token exchange error: {}", e);
+            ApiError::OAuthError(e.to_string())
+        })?;
 
-pub fn clear_state_cookie(secure: bool) -> Cookie<'static> {
-    Cookie::build((OAUTH_STATE_COOKIE_NAME, ""))
-        .path("/")
-        .http_only(true)
-        .secure(secure)
-        .same_site(same_site(secure))
-        .max_age(time::Duration::seconds(0))
-        .build()
-}
+    let access_token = token_result.access_token().secret().to_string();
 
-pub fn build_session_cookie(token: &str, secure: bool) -> Cookie<'static> {
-    Cookie::build((SESSION_COOKIE_NAME, token.to_string()))
-        .path("/")
-        .http_only(true)
-        .secure(secure)
-        .same_site(same_site(secure))
-        .max_age(time::Duration::days(7))
-        .build()
-}
+    let user_info: GoogleUserInfo = http_client
+        .get(GOOGLE_USERINFO_URL)
+        .bearer_auth(&access_token)
+        .send()
+        .await
+        .map_err(|e| ApiError::NetworkError(format!("ユーザー情報取得エラー: {}", e)))?
+        .json()
+        .await
+        .map_err(|e| ApiError::NetworkError(format!("ユーザー情報解析エラー: {}", e)))?;
 
-pub fn clear_session_cookie(secure: bool) -> Cookie<'static> {
-    Cookie::build((SESSION_COOKIE_NAME, ""))
-        .path("/")
-        .http_only(true)
-        .secure(secure)
-        .same_site(same_site(secure))
-        .max_age(time::Duration::seconds(0))
-        .build()
+    let user = upsert_user(pool, &user_info).await?;
+    let session_token = create_session(pool, user.id).await?;
+
+    Ok(session_token)
 }
 
 pub async fn select_user_by_session(
@@ -229,102 +192,19 @@ pub async fn delete_account(pool: &PgPool, user_id: uuid::Uuid) -> Result<(), sq
 mod tests {
     use {
         super::*,
-        crate::{
-            state::Secrets,
-            test_env::{EnvGuard, ENV_MUTEX},
-        },
-        std::sync::Arc,
+        crate::test_env::{EnvGuard, ENV_MUTEX},
     };
-    fn test_state() -> AppState {
-        AppState {
-            pool: crate::db::connect_pool_lazy("postgresql://user:password@localhost/test_db", 1)
-                .expect("pool"),
-            secrets: Arc::new(Secrets {
-                database_url: "postgresql://user:password@localhost/test_db".to_string(),
-                jquants_api_key: None,
-                google_client_id: Some("client-id".to_string()),
-                google_client_secret: Some("client-secret".to_string()),
-                frontend_url: "http://localhost:8080".to_string(),
-            }),
-            client: reqwest::Client::new(),
-            dividend_cache: crate::state::DividendCacheState::default(),
-        }
-    }
+
     #[test]
-    fn test_auth_helpers() {
-        for (secure, expected_secure) in [(true, true), (false, false)] {
-            for (cookie, expected_name, expected_value) in [
-                (
-                    build_state_cookie("test_state", secure),
-                    OAUTH_STATE_COOKIE_NAME,
-                    "test_state",
-                ),
-                (
-                    build_session_cookie("test_token", secure),
-                    SESSION_COOKIE_NAME,
-                    "test_token",
-                ),
-            ] {
-                assert_eq!(
-                    (
-                        cookie.name(),
-                        cookie.value(),
-                        cookie.secure(),
-                        cookie.http_only()
-                    ),
-                    (
-                        expected_name,
-                        expected_value,
-                        Some(expected_secure),
-                        Some(true)
-                    )
-                );
-            }
-        }
-        assert!(get_session_id_from_jar(&CookieJar::new()).is_err());
-        assert!(get_session_id_from_jar(
-            &CookieJar::new().add(Cookie::new(SESSION_COOKIE_NAME, "invalid-uuid"))
-        )
-        .is_err());
-        let uuid = uuid::Uuid::new_v4();
-        assert_eq!(
-            get_session_id_from_jar(
-                &CookieJar::new().add(Cookie::new(SESSION_COOKIE_NAME, uuid.to_string()))
-            )
-            .unwrap(),
-            uuid
-        );
-        for (cookie, expected_name) in [
-            (clear_state_cookie(true), OAUTH_STATE_COOKIE_NAME),
-            (clear_session_cookie(true), SESSION_COOKIE_NAME),
-        ] {
-            assert_eq!((cookie.name(), cookie.value()), (expected_name, ""));
-        }
-        assert_eq!(
-            (
-                same_site(true),
-                same_site(false),
-                SESSION_COOKIE_NAME,
-                OAUTH_STATE_COOKIE_NAME
-            ),
-            (
-                SameSite::None,
-                SameSite::Lax,
-                "session_token",
-                "oauth_state"
-            )
-        );
-    }
-    #[tokio::test]
-    async fn test_create_oauth_client() {
-        assert!(create_oauth_client(&test_state()).is_ok());
+    fn test_create_oauth_client() {
+        assert!(create_oauth_client("client-id", "client-secret").is_ok());
     }
 
     #[tokio::test]
     async fn test_oauth_redirect_uri_is_v1_path() {
         let _lock = ENV_MUTEX.lock().await;
         let _env = EnvGuard::set("BACKEND_URL", Some("https://shoken-backend.fly.dev"));
-        let client = create_oauth_client(&test_state()).unwrap();
+        let client = create_oauth_client("client-id", "client-secret").unwrap();
         let (auth_url, _csrf) = client.authorize_url(oauth2::CsrfToken::new_random).url();
         let url_str = auth_url.to_string();
         assert!(


### PR DESCRIPTION
## 概要
- OAuth の token exchange / userinfo 取得 / user upsert / session 作成を service 関数へ集約
- Cookie 構築と CookieJar 解析を HTTP 層へ移動し、services/auth.rs から axum_extra 依存を削除
- CSV import 共通処理から StatusCode 固定を外し、各 handler 側で 201 Created を返すよう整理
- stale な dividend_per_share の utoipa path annotation を削除

## 検証
- [x] cd backend && cargo fmt --check
- [x] cd backend && cargo clippy --all-targets -- -D warnings
- [x] cd backend && cargo test
- [x] pre-push hook による OpenAPI / api.ts 同期確認

## レビュー
- [x] Codex review 実施
- [x] レビュー指摘 1 件を Claude が修正済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Googleログインの認証フローを改善し、サインイン処理がより安定しました。
  * CSVインポート後の結果が一貫して201 Createdで返るようになり、アップロード成功が明確になりました。

* **Bug Fixes**
  * セッショントークンの判定を強化し、未ログイン時や無効なトークン時に適切なエラーを返すようになりました。
  * ログアウトやアカウント削除時のセッション処理を整理し、認証状態の不整合を減らしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->