### PR TITLE
fix: 銘柄検索を未ログインで利用可能に戻す

### DIFF
--- a/backend/src/handlers/stock/tests.rs
+++ b/backend/src/handlers/stock/tests.rs
@@ -111,36 +111,6 @@ async fn call(
     app.oneshot(request.body(body).unwrap()).await.unwrap()
 }
 
-async fn make_session(pool: &Pool<Postgres>) -> String {
-    let (user_id,): (uuid::Uuid,) = sqlx::query_as(
-        "INSERT INTO users (google_id, email) VALUES ('test-google-id', 'test@example.com') RETURNING id",
-    )
-    .fetch_one(pool)
-    .await
-    .unwrap();
-    crate::services::auth::create_session(pool, user_id)
-        .await
-        .unwrap()
-}
-
-async fn call_with_session(
-    app: Router,
-    method: &str,
-    uri: &str,
-    session_cookie: &str,
-) -> axum::response::Response {
-    app.oneshot(
-        Request::builder()
-            .method(method)
-            .uri(uri)
-            .header("cookie", session_cookie)
-            .body(Body::empty())
-            .unwrap(),
-    )
-    .await
-    .unwrap()
-}
-
 async fn read_json(response: axum::response::Response) -> Value {
     serde_json::from_slice(
         &axum::body::to_bytes(response.into_body(), BODY_LIMIT)
@@ -169,12 +139,9 @@ fn stock_payload(code: &str, name: &str) -> Value {
 #[ignore = "requires Docker to run Postgres container"]
 async fn test_search_stock() {
     let (pool, _node) = setup_test_db().await;
-    let session_token = make_session(&pool).await;
-    let cookie = format!("session_token={}", session_token);
     let app = setup_test_app(pool);
 
-    let response =
-        call_with_session(app.clone(), "GET", "/api/v1/stocks?query=1234", &cookie).await;
+    let response = call(app.clone(), "GET", "/api/v1/stocks?query=1234", None).await;
     assert_eq!(response.status(), StatusCode::OK);
 
     let stock = read_json(response).await;
@@ -188,9 +155,7 @@ async fn test_search_stock() {
         ("/api/v1/stocks?query=9999", StatusCode::NOT_FOUND),
     ] {
         assert_eq!(
-            call_with_session(app.clone(), "GET", uri, &cookie)
-                .await
-                .status(),
+            call(app.clone(), "GET", uri, None).await.status(),
             expected_status
         );
     }
@@ -247,12 +212,12 @@ async fn test_create_stock_unauthorized() {
 }
 
 #[tokio::test]
-async fn test_search_stock_unauthorized() {
+async fn test_search_stock_allows_anonymous() {
     let pool = crate::db::connect_pool_lazy("postgresql://postgres:postgres@localhost/postgres", 1)
         .unwrap();
     let app = setup_test_app(pool);
 
-    assert_eq!(
+    assert_ne!(
         call(app, "GET", "/api/v1/stocks?query=7203", None)
             .await
             .status(),

--- a/backend/src/handlers/v1.rs
+++ b/backend/src/handlers/v1.rs
@@ -213,10 +213,10 @@ mod tests {
     #[tokio::test]
     async fn test_v1_stocks_search_allows_anonymous() {
         let router = data_routes().with_state(make_test_state());
-        assert_ne!(
-            check_status(router, Method::GET, "/api/v1/stocks?query=7203").await,
-            StatusCode::UNAUTHORIZED
-        );
+        let status = check_status(router, Method::GET, "/api/v1/stocks?query=7203").await;
+        assert_ne!(status, StatusCode::UNAUTHORIZED);
+        assert_ne!(status, StatusCode::NOT_FOUND);
+        assert_ne!(status, StatusCode::METHOD_NOT_ALLOWED);
     }
 
     /// 認証必須 collection v1 route が未認証で 401 を返す

--- a/backend/src/handlers/v1.rs
+++ b/backend/src/handlers/v1.rs
@@ -209,11 +209,11 @@ mod tests {
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 
-    /// GET /api/v1/stocks?query=... は未認証で 401 を返す
+    /// GET /api/v1/stocks?query=... は未認証でも認証エラーにしない
     #[tokio::test]
-    async fn test_v1_stocks_search_requires_auth() {
+    async fn test_v1_stocks_search_allows_anonymous() {
         let router = data_routes().with_state(make_test_state());
-        assert_eq!(
+        assert_ne!(
             check_status(router, Method::GET, "/api/v1/stocks?query=7203").await,
             StatusCode::UNAUTHORIZED
         );
@@ -223,11 +223,6 @@ mod tests {
     #[tokio::test]
     async fn test_v1_collection_routes_return_401_without_auth() {
         for (router, method, uri) in [
-            (
-                data_routes().with_state(make_test_state()),
-                Method::GET,
-                "/api/v1/stocks?query=7203",
-            ),
             (
                 data_routes().with_state(make_test_state()),
                 Method::GET,

--- a/backend/src/handlers/v1/stocks.rs
+++ b/backend/src/handlers/v1/stocks.rs
@@ -33,14 +33,11 @@ pub struct StockSearchQuery {
     ),
     responses(
         (status = 200, body = Stock),
-        (status = 401, body = ErrorResponse),
         (status = 404, body = ErrorResponse),
-    ),
-    security(("cookieAuth" = []))
+    )
 )]
 pub async fn search(
     State(state): State<AppState>,
-    _auth_user: AuthenticatedUser,
     Query(params): Query<StockSearchQuery>,
 ) -> Result<impl IntoResponse, ApiError> {
     let stock = stock_service::search(&state.pool, &params.query).await?;

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -249,11 +249,6 @@ mod tests {
     async fn test_all_endpoints_require_auth() {
         for (router, method, uri) in [
             (
-                handlers::v1::data_routes(),
-                Method::GET,
-                "/api/v1/stocks?query=7203",
-            ),
-            (
                 handlers::v1::jquants_routes(),
                 Method::GET,
                 "/api/v1/financial-statements?code=7203",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1213,16 +1213,6 @@
               }
             }
           },
-          "401": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
           "404": {
             "description": "",
             "content": {
@@ -1233,12 +1223,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "cookieAuth": []
-          }
-        ]
+        }
       },
       "post": {
         "tags": [

--- a/frontend/src/generated/api.ts
+++ b/frontend/src/generated/api.ts
@@ -1688,14 +1688,6 @@ export interface operations {
                     "application/json": components["schemas"]["Stock"];
                 };
             };
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
             404: {
                 headers: {
                     [name: string]: unknown;


### PR DESCRIPTION
## Summary

- GET `/api/v1/stocks` の認証要件を外し、未ログインでも銘柄検索できる仕様に戻しました
- OpenAPI と frontend generated API から GET 銘柄検索の 401/cookieAuth を削除しました
- POST `/api/v1/stocks` の認証必須は維持しています

## Root Cause

PR #605 の変更で `GET /api/v1/stocks` に `AuthenticatedUser` と `cookieAuth` が追加され、銘柄検索がログイン必須になっていました。仕様では銘柄検索は未ログインでも利用可能なため、GET 側だけ認証を外しています。

## Tests

- `cargo test handlers::v1::tests::test_v1_stocks_search_allows_anonymous`
- `cargo test handlers::stock::tests::test_search_stock_allows_anonymous`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cd frontend && npm ci`
- `cd frontend && npm run typecheck`
- pre-push OpenAPI/generated API check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 在庫検索機能が、ログイン不要で利用できるようになりました。
* **Bug Fixes**
  * 在庫検索のアクセス制御を見直し、未認証時に不要な認証エラーが返らないようになりました。
* **Documentation**
  * API仕様書を更新し、在庫検索のエラーレスポンス定義を整理しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->