### PR TITLE
refactor: CSVハンドラとバルク処理の共通化

### DIFF
--- a/backend/src/handlers.rs
+++ b/backend/src/handlers.rs
@@ -1,4 +1,5 @@
 pub mod auth;
+pub mod common;
 pub mod csv_import;
 pub mod dividend_per_share;
 pub mod stock;

--- a/backend/src/handlers/common.rs
+++ b/backend/src/handlers/common.rs
@@ -1,0 +1,11 @@
+use crate::models::common::MessageResponse;
+use axum::{http::StatusCode, response::Json};
+
+pub fn ok_message(message: &str) -> (StatusCode, Json<MessageResponse>) {
+    (
+        StatusCode::OK,
+        Json(MessageResponse {
+            message: message.to_string(),
+        }),
+    )
+}

--- a/backend/src/handlers/v1/asset_balances.rs
+++ b/backend/src/handlers/v1/asset_balances.rs
@@ -1,6 +1,7 @@
 use crate::{
     errors::{ApiError, ErrorResponse},
     extractors::{auth::AuthenticatedUser, validated_json::ValidatedJson},
+    handlers::common::ok_message,
     models::{
         asset_balance::{AssetBalance, BulkCreateAssetBalanceRequest},
         common::{BulkCreateResponse, MessageResponse},
@@ -76,12 +77,7 @@ pub async fn delete_all(
     auth_user: AuthenticatedUser,
 ) -> Result<impl IntoResponse, ApiError> {
     asset_balance_service::delete_all(&state.pool, auth_user.id()).await?;
-    Ok((
-        StatusCode::OK,
-        Json(MessageResponse {
-            message: "全ての保有銘柄データを削除しました".to_string(),
-        }),
-    ))
+    Ok(ok_message("全ての保有銘柄データを削除しました"))
 }
 
 /// 保有銘柄 CSV をバリデーション（v1）

--- a/backend/src/handlers/v1/dividends.rs
+++ b/backend/src/handlers/v1/dividends.rs
@@ -1,6 +1,7 @@
 use crate::{
     errors::{ApiError, ErrorResponse},
     extractors::{auth::AuthenticatedUser, validated_json::ValidatedJson},
+    handlers::common::ok_message,
     models::{
         common::MessageResponse,
         csv_import::{CsvPreviewResponse, CsvUploadForm, CsvUploadResponse},
@@ -54,12 +55,7 @@ pub async fn delete_all(
     auth_user: AuthenticatedUser,
 ) -> Result<impl IntoResponse, ApiError> {
     dividend_service::delete_all(&state.pool, auth_user.id()).await?;
-    Ok((
-        StatusCode::OK,
-        Json(MessageResponse {
-            message: "全ての配当金データを削除しました".to_string(),
-        }),
-    ))
+    Ok(ok_message("全ての配当金データを削除しました"))
 }
 
 /// 配当金 CSV をバリデーション（DB 書き込みなし）（v1）

--- a/backend/src/handlers/v1/domestic_stocks.rs
+++ b/backend/src/handlers/v1/domestic_stocks.rs
@@ -1,6 +1,7 @@
 use crate::{
     errors::{ApiError, ErrorResponse},
     extractors::auth::AuthenticatedUser,
+    handlers::common::ok_message,
     models::{
         common::MessageResponse,
         csv_import::{CsvPreviewResponse, CsvUploadForm, CsvUploadResponse},
@@ -53,12 +54,7 @@ pub async fn delete_transactions(
     auth_user: AuthenticatedUser,
 ) -> Result<impl IntoResponse, ApiError> {
     domestic_stock_service::delete_all(&state.pool, auth_user.id()).await?;
-    Ok((
-        StatusCode::OK,
-        Json(MessageResponse {
-            message: "全ての国内株式取引データを削除しました".to_string(),
-        }),
-    ))
+    Ok(ok_message("全ての国内株式取引データを削除しました"))
 }
 
 /// 国内株式取引 CSV をバリデーション（v1）

--- a/backend/src/handlers/v1/mutual_funds.rs
+++ b/backend/src/handlers/v1/mutual_funds.rs
@@ -1,6 +1,7 @@
 use crate::{
     errors::{ApiError, ErrorResponse},
     extractors::auth::AuthenticatedUser,
+    handlers::common::ok_message,
     models::{
         common::MessageResponse,
         csv_import::{CsvPreviewResponse, CsvUploadForm, CsvUploadResponse},
@@ -53,12 +54,7 @@ pub async fn delete_transactions(
     auth_user: AuthenticatedUser,
 ) -> Result<impl IntoResponse, ApiError> {
     mutualfund_service::delete_all(&state.pool, auth_user.id()).await?;
-    Ok((
-        StatusCode::OK,
-        Json(MessageResponse {
-            message: "全ての投資信託データを削除しました".to_string(),
-        }),
-    ))
+    Ok(ok_message("全ての投資信託データを削除しました"))
 }
 
 /// 投資信託 CSV をバリデーション（v1）

--- a/backend/src/services/dividend.rs
+++ b/backend/src/services/dividend.rs
@@ -108,7 +108,7 @@ pub async fn bulk_create(
     .execute(pool)
     .await?;
 
-    Ok(timer.finish_from_result(result))
+    timer.finish_from_result(result)
 }
 
 /// CSV バイト列から配当金をパースしてプレビュー情報を返す（DB 書き込みなし）

--- a/backend/src/services/dividend.rs
+++ b/backend/src/services/dividend.rs
@@ -59,15 +59,13 @@ pub async fn bulk_create(
     user_id: Uuid,
     items: &[CreateDividendRequest],
 ) -> Result<BulkCreateResponse, ApiError> {
-    let total = items.len();
-    let timer = BulkTimer::new("dividend", total);
-
-    if items.is_empty() {
-        return Ok(timer.finish(0));
-    }
+    let timer = match BulkTimer::new_with_guard("dividend", items) {
+        Ok(t) => t,
+        Err(empty) => return Ok(empty),
+    };
 
     // 各フィールドを配列に変換
-    let user_ids = user_ids_for_bulk_insert(user_id, total);
+    let user_ids = user_ids_for_bulk_insert(user_id, items.len());
     let settlement_dates: Vec<chrono::NaiveDate> =
         items.iter().map(|i| i.settlement_date).collect();
     let products: Vec<&str> = items.iter().map(|i| i.product.as_str()).collect();
@@ -110,8 +108,7 @@ pub async fn bulk_create(
     .execute(pool)
     .await?;
 
-    let inserted = result.rows_affected() as usize;
-    Ok(timer.finish(inserted))
+    Ok(timer.finish_from_result(result))
 }
 
 /// CSV バイト列から配当金をパースしてプレビュー情報を返す（DB 書き込みなし）

--- a/backend/src/services/domestic_stock.rs
+++ b/backend/src/services/domestic_stock.rs
@@ -172,7 +172,7 @@ pub async fn bulk_create(
     .execute(pool)
     .await?;
 
-    Ok(timer.finish_from_result(result))
+    timer.finish_from_result(result)
 }
 
 /// CSV バイト列から国内株式取引をパースしてプレビュー情報を返す（DB 書き込みなし）

--- a/backend/src/services/domestic_stock.rs
+++ b/backend/src/services/domestic_stock.rs
@@ -71,15 +71,13 @@ pub async fn bulk_create(
     user_id: Uuid,
     items: &[CreateDomesticStockRequest],
 ) -> Result<BulkCreateResponse, ApiError> {
-    let total = items.len();
-    let timer = BulkTimer::new("domestic_stock", total);
-
-    if items.is_empty() {
-        return Ok(timer.finish(0));
-    }
+    let timer = match BulkTimer::new_with_guard("domestic_stock", items) {
+        Ok(t) => t,
+        Err(empty) => return Ok(empty),
+    };
 
     // 各フィールドを配列に変換
-    let user_ids = user_ids_for_bulk_insert(user_id, total);
+    let user_ids = user_ids_for_bulk_insert(user_id, items.len());
     let trade_dates: Vec<chrono::NaiveDate> = items.iter().map(|i| i.trade_date).collect();
     let settlement_dates: Vec<chrono::NaiveDate> =
         items.iter().map(|i| i.settlement_date).collect();
@@ -174,8 +172,7 @@ pub async fn bulk_create(
     .execute(pool)
     .await?;
 
-    let inserted = result.rows_affected() as usize;
-    Ok(timer.finish(inserted))
+    Ok(timer.finish_from_result(result))
 }
 
 /// CSV バイト列から国内株式取引をパースしてプレビュー情報を返す（DB 書き込みなし）

--- a/backend/src/services/mutualfund.rs
+++ b/backend/src/services/mutualfund.rs
@@ -61,15 +61,13 @@ pub async fn bulk_create(
     user_id: Uuid,
     items: &[CreateMutualfundRequest],
 ) -> Result<BulkCreateResponse, ApiError> {
-    let total = items.len();
-    let timer = BulkTimer::new("mutualfund", total);
-
-    if items.is_empty() {
-        return Ok(timer.finish(0));
-    }
+    let timer = match BulkTimer::new_with_guard("mutualfund", items) {
+        Ok(t) => t,
+        Err(empty) => return Ok(empty),
+    };
 
     // 各フィールドを配列に変換
-    let user_ids = user_ids_for_bulk_insert(user_id, total);
+    let user_ids = user_ids_for_bulk_insert(user_id, items.len());
     let trade_dates: Vec<chrono::NaiveDate> = items.iter().map(|i| i.trade_date).collect();
     let settlement_dates: Vec<chrono::NaiveDate> =
         items.iter().map(|i| i.settlement_date).collect();
@@ -128,8 +126,7 @@ pub async fn bulk_create(
     .execute(pool)
     .await?;
 
-    let inserted = result.rows_affected() as usize;
-    Ok(timer.finish(inserted))
+    Ok(timer.finish_from_result(result))
 }
 
 /// CSV バイト列から投資信託をパースしてプレビュー情報を返す（DB 書き込みなし）

--- a/backend/src/services/mutualfund.rs
+++ b/backend/src/services/mutualfund.rs
@@ -126,7 +126,7 @@ pub async fn bulk_create(
     .execute(pool)
     .await?;
 
-    Ok(timer.finish_from_result(result))
+    timer.finish_from_result(result)
 }
 
 /// CSV バイト列から投資信託をパースしてプレビュー情報を返す（DB 書き込みなし）

--- a/backend/src/services/shared.rs
+++ b/backend/src/services/shared.rs
@@ -47,8 +47,12 @@ impl BulkTimer {
     }
 
     /// PgQueryResult から rows_affected を取り出して finish する。
-    pub fn finish_from_result(self, result: PgQueryResult) -> BulkCreateResponse {
-        self.finish(result.rows_affected() as usize)
+    /// u64 → usize の変換が失敗した場合は ApiError を返す。
+    pub fn finish_from_result(self, result: PgQueryResult) -> Result<BulkCreateResponse, ApiError> {
+        let inserted = usize::try_from(result.rows_affected()).map_err(|_| {
+            ApiError::ApiError("bulk insert の rows_affected が usize に収まりません".to_string())
+        })?;
+        Ok(self.finish(inserted))
     }
 }
 

--- a/backend/src/services/shared.rs
+++ b/backend/src/services/shared.rs
@@ -1,5 +1,6 @@
 use crate::errors::ApiError;
 use crate::models::common::BulkCreateResponse;
+use sqlx::postgres::PgQueryResult;
 use sqlx::PgPool;
 use std::time::Instant;
 use tracing::info;
@@ -22,6 +23,19 @@ impl BulkTimer {
         }
     }
 
+    /// 空配列の場合は Err(即時レスポンス) を返し、非空なら Ok(タイマー) を返す。
+    pub fn new_with_guard<T>(
+        domain: &'static str,
+        items: &[T],
+    ) -> Result<Self, BulkCreateResponse> {
+        let timer = Self::new(domain, items.len());
+        if items.is_empty() {
+            Err(timer.finish(0))
+        } else {
+            Ok(timer)
+        }
+    }
+
     pub fn finish(self, inserted: usize) -> BulkCreateResponse {
         let skipped = self.total - inserted;
         let elapsed_ms = self.start.elapsed().as_secs_f64() * 1000.0;
@@ -30,6 +44,11 @@ impl BulkTimer {
             self.domain, inserted, skipped, elapsed_ms
         );
         BulkCreateResponse { inserted, skipped }
+    }
+
+    /// PgQueryResult から rows_affected を取り出して finish する。
+    pub fn finish_from_result(self, result: PgQueryResult) -> BulkCreateResponse {
+        self.finish(result.rows_affected() as usize)
     }
 }
 


### PR DESCRIPTION
## Summary

- v1 CSV 系 delete_all handlers の `MessageResponse` 生成を `handlers::common::ok_message` へ共通化しました
- `BulkTimer` に空配列ガードと `PgQueryResult` からの完了レスポンス生成 helper を追加しました
- dividend / domestic_stock / mutualfund の bulk_create 重複処理を共通 helper に寄せました

## Scope

- API path / status / JSON 形式は変更していません
- DB schema は変更していません
- CSV parse / validate / import の挙動は変更していません
- OpenAPI / generated API は pre-push hook で同期済み確認しました

## Review

- Codex review: findings none
- CodeRabbit comments will be checked and addressed before merge

## Tests

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo clippy --all-targets -- -D warnings`
- `env -u PORT -u BACKEND_URL cargo test`
- pre-push OpenAPI/generated API check

Note: plain `cargo test` failed in this shell because inherited `PORT=9000` conflicts with the existing `config::tests::test_config_creation` expectation. With `PORT` and `BACKEND_URL` unset, the full backend test suite passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 一括登録時の空入力を安全に終了し、進捗/集計処理の挙動を改善しました。
* **Bug Fixes**
  * 一括登録の登録件数の算出を見直し、完了結果の返却をより安定化しました。
  * 複数の削除エンドポイントで成功レスポンスのメッセージ形式を統一し、表示や連携時の挙動を揃えました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->