### PR TITLE
chore: 未使用のutoipa-axum依存を削除

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -444,7 +444,6 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "utoipa",
- "utoipa-axum",
  "uuid",
  "validator",
  "wiremock",
@@ -2653,12 +2652,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "pem-rfc7468"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4729,19 +4722,6 @@ dependencies = [
  "serde",
  "serde_json",
  "utoipa-gen",
-]
-
-[[package]]
-name = "utoipa-axum"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c25bae5bccc842449ec0c5ddc5cbb6a3a1eaeac4503895dc105a1138f8234a0"
-dependencies = [
- "axum",
- "paste",
- "tower-layer",
- "tower-service",
- "utoipa",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -39,7 +39,6 @@ tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 time = "0.3.51"
 csv = "1.4"
 utoipa = { version = "5", features = ["axum_extras", "chrono", "uuid"] }
-utoipa-axum = "0.2"
 sentry = "0.48"
 sentry-tower = "0.48"
 url = "2.5"


### PR DESCRIPTION
## 概要
未使用の backend 依存 `utoipa-axum` を削除します。
これにより `utoipa-axum` 経由で入っていた `paste` が依存グラフから外れ、RUSTSEC-2024-0436 の警告対象が消えます。

Closes #606

## 変更内容
- `backend/Cargo.toml` から未使用の `utoipa-axum` を削除
- `backend/Cargo.lock` から `utoipa-axum` と `paste` を削除

## 非対応
- #607 の `proc-macro-error2` は `validator_derive` 経由です
- `validator` derive を手書き実装へ置き換えると可読性・保守性が下がるため、このPRでは対応しません

## 確認
- `cd backend && cargo check`
- `cd backend && cargo fmt --check`
- `cd backend && cargo clippy -- -D warnings`
- `cd backend && cargo test`
- `cd backend && cargo tree | rg 'paste|utoipa-axum|proc-macro-error2|validator_derive'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 使われなくなった依存関係を整理し、アプリ全体の保守性を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->