### PR TITLE
fix: StatItemの不要なラッパー関数を削除しformatters.tsを直接使用

### DIFF
--- a/frontend/src/components/atoms/StatItem.tsx
+++ b/frontend/src/components/atoms/StatItem.tsx
@@ -2,9 +2,6 @@ import React from 'react';
 import { cn } from '../../lib/utils/classNames';
 import { formatNumber, formatPercentageValue } from '../../lib/utils/formatters';
 
-const defaultValueFormat = (value: number): string => formatNumber(value);
-const defaultRateFormat = (rate: number): string => formatPercentageValue(rate, 2);
-
 interface StatItemProps {
   title: string;
   value: string | React.ReactNode;
@@ -89,8 +86,8 @@ export const StatItemWithRate: React.FC<StatItemWithRateProps> = ({
   title,
   value,
   rate,
-  format = defaultValueFormat,
-  rateFormat = defaultRateFormat,
+  format = (value: number) => formatNumber(value),
+  rateFormat = (rate: number) => formatPercentageValue(rate, 2),
   className = '',
   showRate = true,
   variant = 'default'


### PR DESCRIPTION
## 概要

- `StatItem.tsx` の不要なラッパー関数 `defaultValueFormat` / `defaultRateFormat` を削除
- `formatNumber` / `formatPercentageValue` を `formatters.ts` から直接使用

## 調査メモ

その他の対象ファイル（`assetReviewPrompt.ts`、`DividendInfo.tsx`、`PortfolioPieChart.tsx`）はすでに共通ユーティリティを使用済みで変更不要だった。

## テスト

- `npm run typecheck` PASS

🤖 Generated with [Claude Code](https://claude.ai/claude-code)