### PR TITLE
fix: className結合をcn()ユーティリティへ統一（13箇所）

### DIFF
--- a/frontend/src/components/molecules/PortfolioPieChart/PortfolioPieChart.tsx
+++ b/frontend/src/components/molecules/PortfolioPieChart/PortfolioPieChart.tsx
@@ -168,7 +168,7 @@ function PortfolioItemCard({ item, index, dividendPerShareMap, dividendStatusMap
         <div className="min-w-0 border-l border-emerald-100/80 px-2 py-2 text-xs text-slate-600">
           <p className="truncate text-[10px] font-medium text-slate-500">年間配当</p>
           <p
-            className={`mt-0.5 truncate text-[12px] font-semibold ${divInfo?.annual !== null && divInfo?.annual !== undefined ? 'text-emerald-600' : 'text-slate-500'}`}
+            className={cn('mt-0.5 truncate text-[12px] font-semibold', divInfo?.annual != null ? 'text-emerald-600' : 'text-slate-500')}
             title={formatAnnual(divInfo)}
           >
             {formatAnnual(divInfo)}
@@ -177,7 +177,7 @@ function PortfolioItemCard({ item, index, dividendPerShareMap, dividendStatusMap
         <div className="min-w-0 border-l border-emerald-100/80 px-2 py-2 text-xs text-slate-600">
           <p className="truncate text-[10px] font-medium text-slate-500">配当利回り</p>
           <p
-            className={`mt-0.5 truncate text-[12px] font-semibold ${divInfo?.yieldValue !== null && divInfo?.yieldValue !== undefined ? 'text-emerald-600' : 'text-slate-500'}`}
+            className={cn('mt-0.5 truncate text-[12px] font-semibold', divInfo?.yieldValue != null ? 'text-emerald-600' : 'text-slate-500')}
             title={formatYield(divInfo)}
           >
             {formatYield(divInfo)}

--- a/frontend/src/components/organisms/Footer.tsx
+++ b/frontend/src/components/organisms/Footer.tsx
@@ -1,3 +1,4 @@
+import { cn } from '@/lib/utils/classNames';
 import { APP_SHELL_CONTAINER } from '@/lib/layout';
 
 const REPO_BASE = 'https://github.com/zaichu/shoken-webapp/blob/main/docs';
@@ -11,7 +12,7 @@ const LINKS = [
 export function Footer() {
   return (
     <footer className="mt-auto border-t border-slate-200 bg-white py-4">
-      <div className={`${APP_SHELL_CONTAINER} flex flex-wrap justify-center gap-x-6 gap-y-1 text-sm text-slate-500`}>
+      <div className={cn(APP_SHELL_CONTAINER, 'flex flex-wrap justify-center gap-x-6 gap-y-1 text-sm text-slate-500')}>
         {LINKS.map(({ label, href }) => (
           <a
             key={href}

--- a/frontend/src/components/organisms/SearchCard/SearchCard.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchCard.tsx
@@ -155,7 +155,7 @@ interface SearchFieldsGridProps {
 const SearchFieldsGrid: React.FC<SearchFieldsGridProps> = ({
     categories, gridClassName, selectedQueries, onSearch, hasData,
 }) => (
-    <div className={`grid ${gridClassName}`}>
+    <div className={cn('grid', gridClassName)}>
         {DROPDOWN_CONFIGS.map(({ key, label }) =>
             // yearsはdatesブロックが有効な場合は期間ブロック側で表示するため除外
             hasData(categories[key]) && !(key === 'years' && Boolean(categories.dates)) && (
@@ -357,11 +357,12 @@ const DatePeriodBlock: React.FC<DatePeriodBlockProps> = ({
                     type="button"
                     aria-pressed={visibleDateSegment === seg}
                     onClick={() => onSegmentChange(seg)}
-                    className={`flex-1 rounded px-2 py-1 text-xs font-semibold transition-colors ${
+                    className={cn(
+                        'flex-1 rounded px-2 py-1 text-xs font-semibold transition-colors',
                         visibleDateSegment === seg
                             ? 'bg-slate-950 text-white'
                             : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
-                    }`}
+                    )}
                 >
                     {seg}
                 </button>
@@ -377,13 +378,13 @@ const DatePeriodBlock: React.FC<DatePeriodBlockProps> = ({
                     aria-expanded={isYearPickerOpen}
                     onClick={onToggleYearPicker}
                     onKeyDown={handleTriggerKeyDown}
-                    className={`w-full flex items-center gap-2 border px-3 py-2 text-sm transition-colors focus:outline-none focus:ring-2 focus:border-amber-600 focus:ring-amber-500/25 ${
-                        isYearPickerOpen ? 'rounded-t-md rounded-b-none' : 'rounded-md'
-                    } ${
+                    className={cn(
+                        'w-full flex items-center gap-2 border px-3 py-2 text-sm transition-colors focus:outline-none focus:ring-2 focus:border-amber-600 focus:ring-amber-500/25',
+                        isYearPickerOpen ? 'rounded-t-md rounded-b-none' : 'rounded-md',
                         yearValue
                             ? 'border-amber-500 bg-amber-50 text-amber-900 font-semibold'
                             : 'border-slate-300 bg-white text-slate-500 hover:border-slate-400'
-                    }`}
+                    )}
                 >
                     <svg className="w-3.5 h-3.5 shrink-0 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
@@ -392,7 +393,7 @@ const DatePeriodBlock: React.FC<DatePeriodBlockProps> = ({
                         {yearValue ? (years.find(y => y.value === yearValue)?.label ?? yearValue) : '年を選択'}
                     </span>
                     <svg
-                        className={`w-4 h-4 shrink-0 text-slate-400 transition-transform duration-150 ${isYearPickerOpen ? 'rotate-180' : ''}`}
+                        className={cn('w-4 h-4 shrink-0 text-slate-400 transition-transform duration-150', isYearPickerOpen && 'rotate-180')}
                         fill="none"
                         stroke="currentColor"
                         viewBox="0 0 24 24"
@@ -707,7 +708,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                                     e.stopPropagation();
                                 }
                             }}
-                            className={`whitespace-nowrap rounded-md border-slate-300 bg-white px-2 py-1 text-xs text-slate-700 hover:bg-slate-50 transition-opacity${isDefaultState ? ' opacity-0 pointer-events-none' : ''}`}
+                            className={cn('whitespace-nowrap rounded-md border-slate-300 bg-white px-2 py-1 text-xs text-slate-700 hover:bg-slate-50 transition-opacity', isDefaultState && 'opacity-0 pointer-events-none')}
                             aria-label="検索条件をクリア"
                             aria-hidden={isDefaultState}
                             tabIndex={isDefaultState ? -1 : 0}
@@ -717,7 +718,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                         </Button>
                         <span className="flex h-8 w-8 items-center justify-center rounded-md border border-slate-300 bg-white text-slate-700" aria-hidden="true">
                             <svg
-                                className={`h-4 w-4 text-slate-500 transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`}
+                                className={cn('h-4 w-4 text-slate-500 transition-transform duration-200', isExpanded && 'rotate-180')}
                                 fill="none"
                                 stroke="currentColor"
                                 viewBox="0 0 24 24"
@@ -747,11 +748,12 @@ export const SearchCard: React.FC<SearchCardProps> = ({
         <Card className="mt-1 overflow-hidden">
             <CardHeader
                 variant="secondary"
-                className={`flex items-center justify-between transition-colors focus-within:ring-2 focus-within:ring-white/50 focus-within:ring-inset ${
+                className={cn(
+                    'flex items-center justify-between transition-colors focus-within:ring-2 focus-within:ring-white/50 focus-within:ring-inset',
                     isExpanded
                         ? 'bg-slate-950 hover:bg-slate-900 border-b border-amber-500'
                         : 'bg-slate-800 hover:bg-slate-900'
-                }`}
+                )}
             >
                 <button
                     type="button"
@@ -788,11 +790,12 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                                 e.stopPropagation();
                             }
                         }}
-                        className={`text-xs px-2 py-0.5 transition-opacity ${
+                        className={cn(
+                            'text-xs px-2 py-0.5 transition-opacity',
                             isDefaultState
                                 ? 'opacity-0 pointer-events-none border-transparent text-transparent'
                                 : 'opacity-100 border-white text-white bg-white/20 font-semibold hover:bg-white/30 hover:border-white'
-                        }`}
+                        )}
                         aria-label="検索条件をクリア"
                         aria-hidden={isDefaultState}
                         tabIndex={isDefaultState ? -1 : 0}
@@ -812,7 +815,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                             {isExpanded ? '閉じる' : '開く'}
                         </span>
                         <svg
-                            className={`w-4 h-4 transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`}
+                            className={cn('w-4 h-4 transition-transform duration-200', isExpanded && 'rotate-180')}
                             fill="none"
                             stroke="currentColor"
                             viewBox="0 0 24 24"

--- a/frontend/src/components/templates/Layout.tsx
+++ b/frontend/src/components/templates/Layout.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react';
 import { Footer } from '../organisms/Footer';
 import { Header } from '../organisms/Header';
+import { cn } from '@/lib/utils/classNames';
 import { APP_SHELL_CONTAINER } from '@/lib/layout';
 
 interface LayoutProps {
@@ -19,7 +20,7 @@ export function Layout({ children }: LayoutProps) {
 
       <Header />
 
-      <main id="main-content" className={`${APP_SHELL_CONTAINER} flex flex-1 flex-col py-5`}>
+      <main id="main-content" className={cn(APP_SHELL_CONTAINER, 'flex flex-1 flex-col py-5')}>
         {children}
       </main>
 

--- a/frontend/src/features/receipt/components/ReceiptsTabNav.tsx
+++ b/frontend/src/features/receipt/components/ReceiptsTabNav.tsx
@@ -55,11 +55,12 @@ export function ReceiptsTabNav({
               {TAB_LABEL[tab]}
               <span
                 data-testid={`tab-count-${tab}`}
-                className={`inline-flex min-w-6 items-center justify-center rounded-full px-2 py-0.5 text-xs font-semibold ${
+                className={cn(
+                  'inline-flex min-w-6 items-center justify-center rounded-full px-2 py-0.5 text-xs font-semibold',
                   isActive
                     ? 'border border-white/20 bg-white text-slate-950'
                     : 'border border-slate-200 bg-white text-slate-700'
-                }`}
+                )}
               >
                 {counts[tab]}
               </span>


### PR DESCRIPTION
## 概要

テンプレートリテラルで条件クラスを構築していた13箇所を `cn()` に統一。

## 変更ファイル

- `PortfolioPieChart.tsx` — 2箇所
- `Footer.tsx` — 1箇所
- `SearchCard.tsx` — 9箇所
- `Layout.tsx` — 1箇所
- `ReceiptsTabNav.tsx` — 1箇所

## 調査メモ

当初指摘した6ファイル（CSVFileInput, ErrorBoundary 等）はすでに cn() 使用済みで変更不要だった。実際の違反は別ファイルに存在していた。

## テスト

- `npm run typecheck` PASS

🤖 Generated with [Claude Code](https://claude.ai/claude-code)