### PR TITLE
feat: 一覧APIにLIMIT/OFFSETページネーションを実装

### DIFF
--- a/backend/src/handlers/v1/asset_balances.rs
+++ b/backend/src/handlers/v1/asset_balances.rs
@@ -4,14 +4,14 @@ use crate::{
     handlers::common::ok_message,
     models::{
         asset_balance::{AssetBalance, BulkCreateAssetBalanceRequest},
-        common::{BulkCreateResponse, MessageResponse},
+        common::{BulkCreateResponse, MessageResponse, PaginatedResponse, PaginationParams},
         csv_import::{CsvPreviewResponse, CsvUploadForm, CsvUploadResponse},
     },
     services::{asset_balance as asset_balance_service, csv_domain::AssetBalanceDomain},
     state::AppState,
 };
 use axum::{
-    extract::{Multipart, State},
+    extract::{Multipart, Query, State},
     http::StatusCode,
     response::{IntoResponse, Json},
 };
@@ -24,8 +24,12 @@ use axum::{
     get,
     path = "/api/v1/asset-balances",
     operation_id = "v1_asset_balance_list",
+    params(
+        ("page" = Option<i64>, Query, description = "ページ番号（デフォルト: 1）"),
+        ("per_page" = Option<i64>, Query, description = "1ページあたりの件数（デフォルト: 200、最大: 1000）"),
+    ),
     responses(
-        (status = 200, body = Vec<AssetBalance>),
+        (status = 200, body = PaginatedResponse<AssetBalance>),
         (status = 401, body = ErrorResponse),
     ),
     security(("cookieAuth" = []))
@@ -33,9 +37,10 @@ use axum::{
 pub async fn list(
     State(state): State<AppState>,
     auth_user: AuthenticatedUser,
+    Query(params): Query<PaginationParams>,
 ) -> Result<impl IntoResponse, ApiError> {
-    let balances = asset_balance_service::list(&state.pool, auth_user.id()).await?;
-    Ok((StatusCode::OK, Json(balances)))
+    let result = asset_balance_service::list(&state.pool, auth_user.id(), &params).await?;
+    Ok((StatusCode::OK, Json(result)))
 }
 
 /// 保有銘柄を全置換（v1）

--- a/backend/src/handlers/v1/dividends.rs
+++ b/backend/src/handlers/v1/dividends.rs
@@ -3,7 +3,7 @@ use crate::{
     extractors::{auth::AuthenticatedUser, validated_json::ValidatedJson},
     handlers::common::ok_message,
     models::{
-        common::MessageResponse,
+        common::{MessageResponse, PaginatedResponse, PaginationParams},
         csv_import::{CsvPreviewResponse, CsvUploadForm, CsvUploadResponse},
         dividend::Dividend,
         dividend_cache::{DividendPerShareBatchRequest, DividendPerShareBatchResponse},
@@ -12,7 +12,7 @@ use crate::{
     state::AppState,
 };
 use axum::{
-    extract::{Multipart, State},
+    extract::{Multipart, Query, State},
     http::StatusCode,
     response::{IntoResponse, Json},
 };
@@ -25,8 +25,12 @@ use axum::{
     get,
     path = "/api/v1/dividends",
     operation_id = "v1_dividend_list",
+    params(
+        ("page" = Option<i64>, Query, description = "ページ番号（デフォルト: 1）"),
+        ("per_page" = Option<i64>, Query, description = "1ページあたりの件数（デフォルト: 200、最大: 1000）"),
+    ),
     responses(
-        (status = 200, body = Vec<Dividend>),
+        (status = 200, body = PaginatedResponse<Dividend>),
         (status = 401, body = ErrorResponse),
     ),
     security(("cookieAuth" = []))
@@ -34,9 +38,10 @@ use axum::{
 pub async fn list(
     State(state): State<AppState>,
     auth_user: AuthenticatedUser,
+    Query(params): Query<PaginationParams>,
 ) -> Result<impl IntoResponse, ApiError> {
-    let dividends = dividend_service::list(&state.pool, auth_user.id()).await?;
-    Ok((StatusCode::OK, Json(dividends)))
+    let result = dividend_service::list(&state.pool, auth_user.id(), &params).await?;
+    Ok((StatusCode::OK, Json(result)))
 }
 
 /// 配当金を全削除（v1）

--- a/backend/src/handlers/v1/domestic_stocks.rs
+++ b/backend/src/handlers/v1/domestic_stocks.rs
@@ -3,7 +3,7 @@ use crate::{
     extractors::auth::AuthenticatedUser,
     handlers::common::ok_message,
     models::{
-        common::MessageResponse,
+        common::{MessageResponse, PaginatedResponse, PaginationParams},
         csv_import::{CsvPreviewResponse, CsvUploadForm, CsvUploadResponse},
         domestic_stock::DomesticStock,
     },
@@ -11,7 +11,7 @@ use crate::{
     state::AppState,
 };
 use axum::{
-    extract::{Multipart, State},
+    extract::{Multipart, Query, State},
     http::StatusCode,
     response::{IntoResponse, Json},
 };
@@ -24,8 +24,12 @@ use axum::{
     get,
     path = "/api/v1/domestic-stock-transactions",
     operation_id = "v1_domestic_stock_transaction_list",
+    params(
+        ("page" = Option<i64>, Query, description = "ページ番号（デフォルト: 1）"),
+        ("per_page" = Option<i64>, Query, description = "1ページあたりの件数（デフォルト: 200、最大: 1000）"),
+    ),
     responses(
-        (status = 200, body = Vec<DomesticStock>),
+        (status = 200, body = PaginatedResponse<DomesticStock>),
         (status = 401, body = ErrorResponse),
     ),
     security(("cookieAuth" = []))
@@ -33,9 +37,10 @@ use axum::{
 pub async fn list_transactions(
     State(state): State<AppState>,
     auth_user: AuthenticatedUser,
+    Query(params): Query<PaginationParams>,
 ) -> Result<impl IntoResponse, ApiError> {
-    let stocks = domestic_stock_service::list(&state.pool, auth_user.id()).await?;
-    Ok((StatusCode::OK, Json(stocks)))
+    let result = domestic_stock_service::list(&state.pool, auth_user.id(), &params).await?;
+    Ok((StatusCode::OK, Json(result)))
 }
 
 /// 国内株式取引を全削除（v1）

--- a/backend/src/handlers/v1/mutual_funds.rs
+++ b/backend/src/handlers/v1/mutual_funds.rs
@@ -3,7 +3,7 @@ use crate::{
     extractors::auth::AuthenticatedUser,
     handlers::common::ok_message,
     models::{
-        common::MessageResponse,
+        common::{MessageResponse, PaginatedResponse, PaginationParams},
         csv_import::{CsvPreviewResponse, CsvUploadForm, CsvUploadResponse},
         mutualfund::Mutualfund,
     },
@@ -11,7 +11,7 @@ use crate::{
     state::AppState,
 };
 use axum::{
-    extract::{Multipart, State},
+    extract::{Multipart, Query, State},
     http::StatusCode,
     response::{IntoResponse, Json},
 };
@@ -24,8 +24,12 @@ use axum::{
     get,
     path = "/api/v1/mutual-fund-transactions",
     operation_id = "v1_mutual_fund_transaction_list",
+    params(
+        ("page" = Option<i64>, Query, description = "ページ番号（デフォルト: 1）"),
+        ("per_page" = Option<i64>, Query, description = "1ページあたりの件数（デフォルト: 200、最大: 1000）"),
+    ),
     responses(
-        (status = 200, body = Vec<Mutualfund>),
+        (status = 200, body = PaginatedResponse<Mutualfund>),
         (status = 401, body = ErrorResponse),
     ),
     security(("cookieAuth" = []))
@@ -33,9 +37,10 @@ use axum::{
 pub async fn list_transactions(
     State(state): State<AppState>,
     auth_user: AuthenticatedUser,
+    Query(params): Query<PaginationParams>,
 ) -> Result<impl IntoResponse, ApiError> {
-    let funds = mutualfund_service::list(&state.pool, auth_user.id()).await?;
-    Ok((StatusCode::OK, Json(funds)))
+    let result = mutualfund_service::list(&state.pool, auth_user.id(), &params).await?;
+    Ok((StatusCode::OK, Json(result)))
 }
 
 /// 投資信託を全削除（v1）

--- a/backend/src/models/common.rs
+++ b/backend/src/models/common.rs
@@ -1,6 +1,34 @@
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
+/// ページネーションクエリパラメータ（全ドメイン共通）
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PaginationParams {
+    pub page: Option<i64>,
+    pub per_page: Option<i64>,
+}
+
+impl PaginationParams {
+    pub fn page(&self) -> i64 {
+        self.page.unwrap_or(1).max(1)
+    }
+    pub fn per_page(&self) -> i64 {
+        self.per_page.unwrap_or(200).clamp(1, 1000)
+    }
+    pub fn offset(&self) -> i64 {
+        (self.page() - 1) * self.per_page()
+    }
+}
+
+/// ページネーションレスポンス（全ドメイン共通）
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct PaginatedResponse<T: ToSchema + 'static> {
+    pub data: Vec<T>,
+    pub total: i64,
+    pub page: i64,
+    pub per_page: i64,
+}
+
 /// 一括作成レスポンス（全ドメイン共通）
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct BulkCreateResponse {

--- a/backend/src/services/asset_balance.rs
+++ b/backend/src/services/asset_balance.rs
@@ -1,6 +1,6 @@
 use crate::errors::ApiError;
 use crate::models::asset_balance::{AssetBalance, CreateAssetBalanceRequest};
-use crate::models::common::BulkCreateResponse;
+use crate::models::common::{BulkCreateResponse, PaginatedResponse, PaginationParams};
 use crate::models::csv_import::{CsvPreviewResponse, CsvRowError, CsvUploadResponse};
 use crate::services::csv_import::{build_csv_preview, run_csv_upload, validate_csv_rows};
 #[cfg(test)]
@@ -34,10 +34,19 @@ const ASSET_BALANCE_CSV_CONFIG: CsvParserConfig = CsvParserConfig {
     ],
 };
 
-/// 認証ユーザーの保有銘柄一覧を取得
-pub async fn list(pool: &PgPool, user_id: Uuid) -> Result<Vec<AssetBalance>, ApiError> {
+/// 認証ユーザーの保有銘柄一覧を取得（ページネーション対応）
+pub async fn list(
+    pool: &PgPool,
+    user_id: Uuid,
+    params: &PaginationParams,
+) -> Result<PaginatedResponse<AssetBalance>, ApiError> {
     info!("[asset_balance.list] リクエスト受信");
-    let balances = sqlx::query_as::<_, AssetBalance>(
+    let total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM asset_balances WHERE user_id = $1")
+        .bind(user_id)
+        .fetch_one(pool)
+        .await?;
+
+    let data = sqlx::query_as::<_, AssetBalance>(
         r#"
         SELECT id, user_id, security_code, security_name, shares, executing_shares,
                average_purchase_price, total_purchase_amount, current_price,
@@ -45,13 +54,16 @@ pub async fn list(pool: &PgPool, user_id: Uuid) -> Result<Vec<AssetBalance>, Api
         FROM asset_balances
         WHERE user_id = $1
         ORDER BY security_code
+        LIMIT $2 OFFSET $3
         "#,
     )
     .bind(user_id)
+    .bind(params.per_page())
+    .bind(params.offset())
     .fetch_all(pool)
     .await?;
 
-    Ok(balances)
+    Ok(PaginatedResponse { data, total, page: params.page(), per_page: params.per_page() })
 }
 
 /// 保有銘柄を一括登録（既存データを全削除してから挿入）

--- a/backend/src/services/dividend.rs
+++ b/backend/src/services/dividend.rs
@@ -52,7 +52,7 @@ pub async fn list(
                created_at, updated_at
         FROM dividends
         WHERE user_id = $1
-        ORDER BY settlement_date DESC
+        ORDER BY settlement_date DESC, id DESC
         LIMIT $2 OFFSET $3
         "#,
     )

--- a/backend/src/services/dividend.rs
+++ b/backend/src/services/dividend.rs
@@ -1,5 +1,5 @@
 use crate::errors::ApiError;
-use crate::models::common::BulkCreateResponse;
+use crate::models::common::{BulkCreateResponse, PaginatedResponse, PaginationParams};
 use crate::models::csv_import::{CsvPreviewResponse, CsvRowError, CsvUploadResponse};
 use crate::models::dividend::{CreateDividendRequest, Dividend};
 use crate::services::csv_import::{build_csv_preview, run_csv_upload, validate_csv_rows};
@@ -33,10 +33,19 @@ const DIVIDEND_CSV_CONFIG: CsvParserConfig = CsvParserConfig {
     ],
 };
 
-/// 認証ユーザーの配当金一覧を取得
-pub async fn list(pool: &PgPool, user_id: Uuid) -> Result<Vec<Dividend>, ApiError> {
+/// 認証ユーザーの配当金一覧を取得（ページネーション対応）
+pub async fn list(
+    pool: &PgPool,
+    user_id: Uuid,
+    params: &PaginationParams,
+) -> Result<PaginatedResponse<Dividend>, ApiError> {
     info!("[dividend.list] リクエスト受信");
-    let dividends = sqlx::query_as::<_, Dividend>(
+    let total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM dividends WHERE user_id = $1")
+        .bind(user_id)
+        .fetch_one(pool)
+        .await?;
+
+    let data = sqlx::query_as::<_, Dividend>(
         r#"
         SELECT id, user_id, settlement_date, product, account, security_code, security_name,
                unit_price, shares, dividends_before_tax, taxes, net_amount_received,
@@ -44,13 +53,16 @@ pub async fn list(pool: &PgPool, user_id: Uuid) -> Result<Vec<Dividend>, ApiErro
         FROM dividends
         WHERE user_id = $1
         ORDER BY settlement_date DESC
+        LIMIT $2 OFFSET $3
         "#,
     )
     .bind(user_id)
+    .bind(params.per_page())
+    .bind(params.offset())
     .fetch_all(pool)
     .await?;
 
-    Ok(dividends)
+    Ok(PaginatedResponse { data, total, page: params.page(), per_page: params.per_page() })
 }
 
 /// 配当金を一括追加（重複はスキップ）

--- a/backend/src/services/domestic_stock.rs
+++ b/backend/src/services/domestic_stock.rs
@@ -53,7 +53,7 @@ pub async fn list(
                created_at, updated_at
         FROM domestic_stocks
         WHERE user_id = $1
-        ORDER BY trade_date DESC
+        ORDER BY trade_date DESC, id DESC
         LIMIT $2 OFFSET $3
         "#,
     )

--- a/backend/src/services/domestic_stock.rs
+++ b/backend/src/services/domestic_stock.rs
@@ -1,5 +1,5 @@
 use crate::errors::ApiError;
-use crate::models::common::BulkCreateResponse;
+use crate::models::common::{BulkCreateResponse, PaginatedResponse, PaginationParams};
 use crate::models::csv_import::{CsvPreviewResponse, CsvRowError, CsvUploadResponse};
 use crate::models::domestic_stock::{CreateDomesticStockRequest, DomesticStock};
 use crate::services::csv_import::{build_csv_preview, run_csv_upload, validate_csv_rows};
@@ -33,10 +33,19 @@ const DOMESTIC_STOCK_CSV_CONFIG: CsvParserConfig = CsvParserConfig {
     ],
 };
 
-/// 認証ユーザーの国内株式取引一覧を取得
-pub async fn list(pool: &PgPool, user_id: Uuid) -> Result<Vec<DomesticStock>, ApiError> {
+/// 認証ユーザーの国内株式取引一覧を取得（ページネーション対応）
+pub async fn list(
+    pool: &PgPool,
+    user_id: Uuid,
+    params: &PaginationParams,
+) -> Result<PaginatedResponse<DomesticStock>, ApiError> {
     info!("[domestic_stock.list] リクエスト受信");
-    let stocks = sqlx::query_as::<_, DomesticStock>(
+    let total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM domestic_stocks WHERE user_id = $1")
+        .bind(user_id)
+        .fetch_one(pool)
+        .await?;
+
+    let data = sqlx::query_as::<_, DomesticStock>(
         r#"
         SELECT id, user_id, trade_date, settlement_date, security_code, security_name,
                account, shares, asked_price, proceeds, purchase_price,
@@ -45,13 +54,16 @@ pub async fn list(pool: &PgPool, user_id: Uuid) -> Result<Vec<DomesticStock>, Ap
         FROM domestic_stocks
         WHERE user_id = $1
         ORDER BY trade_date DESC
+        LIMIT $2 OFFSET $3
         "#,
     )
     .bind(user_id)
+    .bind(params.per_page())
+    .bind(params.offset())
     .fetch_all(pool)
     .await?;
 
-    Ok(stocks)
+    Ok(PaginatedResponse { data, total, page: params.page(), per_page: params.per_page() })
 }
 
 /// 国内株式取引を一括追加（全件挿入）

--- a/backend/src/services/mutualfund.rs
+++ b/backend/src/services/mutualfund.rs
@@ -54,7 +54,7 @@ pub async fn list(
                realized_profit_and_loss_after_tax, created_at, updated_at
         FROM mutualfunds
         WHERE user_id = $1
-        ORDER BY trade_date DESC
+        ORDER BY trade_date DESC, id DESC
         LIMIT $2 OFFSET $3
         "#,
     )

--- a/backend/src/services/mutualfund.rs
+++ b/backend/src/services/mutualfund.rs
@@ -1,5 +1,5 @@
 use crate::errors::ApiError;
-use crate::models::common::BulkCreateResponse;
+use crate::models::common::{BulkCreateResponse, PaginatedResponse, PaginationParams};
 use crate::models::csv_import::{CsvPreviewResponse, CsvRowError, CsvUploadResponse};
 use crate::models::mutualfund::{CreateMutualfundRequest, Mutualfund};
 use crate::services::csv_import::{build_csv_preview, run_csv_upload, validate_csv_rows};
@@ -34,10 +34,19 @@ const MUTUALFUND_CSV_CONFIG: CsvParserConfig = CsvParserConfig {
     ],
 };
 
-/// 認証ユーザーの投資信託一覧を取得
-pub async fn list(pool: &PgPool, user_id: Uuid) -> Result<Vec<Mutualfund>, ApiError> {
+/// 認証ユーザーの投資信託一覧を取得（ページネーション対応）
+pub async fn list(
+    pool: &PgPool,
+    user_id: Uuid,
+    params: &PaginationParams,
+) -> Result<PaginatedResponse<Mutualfund>, ApiError> {
     info!("[mutualfund.list] リクエスト受信");
-    let funds = sqlx::query_as::<_, Mutualfund>(
+    let total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM mutualfunds WHERE user_id = $1")
+        .bind(user_id)
+        .fetch_one(pool)
+        .await?;
+
+    let data = sqlx::query_as::<_, Mutualfund>(
         r#"
         SELECT id, user_id, trade_date, settlement_date, fund_name, dividends, account,
                shares, exchange_rate, cancellation_unit_price_yen, cancellation_amount_yen,
@@ -46,13 +55,16 @@ pub async fn list(pool: &PgPool, user_id: Uuid) -> Result<Vec<Mutualfund>, ApiEr
         FROM mutualfunds
         WHERE user_id = $1
         ORDER BY trade_date DESC
+        LIMIT $2 OFFSET $3
         "#,
     )
     .bind(user_id)
+    .bind(params.per_page())
+    .bind(params.offset())
     .fetch_all(pool)
     .await?;
 
-    Ok(funds)
+    Ok(PaginatedResponse { data, total, page: params.page(), per_page: params.per_page() })
 }
 
 /// 投資信託を一括追加（重複はスキップ）

--- a/backend/tests/db_integration.rs
+++ b/backend/tests/db_integration.rs
@@ -581,6 +581,40 @@ async fn dividend_bulk_create_and_list() {
         .data;
     assert_eq!(rows.len(), 3);
 
+    let first_page = dividend_svc::list(
+        &pool,
+        user_id,
+        &PaginationParams { page: Some(1), per_page: Some(2) },
+    )
+    .await
+    .expect("dividend first page list failed");
+    assert_eq!(first_page.total, 3);
+    assert_eq!(first_page.page, 1);
+    assert_eq!(first_page.per_page, 2);
+    assert_eq!(first_page.data.len(), 2);
+
+    let second_page = dividend_svc::list(
+        &pool,
+        user_id,
+        &PaginationParams { page: Some(2), per_page: Some(2) },
+    )
+    .await
+    .expect("dividend second page list failed");
+    assert_eq!(second_page.total, 3);
+    assert_eq!(second_page.page, 2);
+    assert_eq!(second_page.per_page, 2);
+    assert_eq!(second_page.data.len(), 1);
+
+    let clamped_page = dividend_svc::list(
+        &pool,
+        user_id,
+        &PaginationParams { page: Some(1), per_page: Some(5000) },
+    )
+    .await
+    .expect("dividend clamped page list failed");
+    assert_eq!(clamped_page.total, 3);
+    assert_eq!(clamped_page.per_page, 1000);
+
     let deleted = dividend_svc::delete_all(&pool, user_id)
         .await
         .expect("dividend delete_all failed");

--- a/backend/tests/db_integration.rs
+++ b/backend/tests/db_integration.rs
@@ -6,6 +6,7 @@ use backend::{
     config::Config,
     db::run_migrations,
     models::asset_balance::CreateAssetBalanceRequest,
+    models::common::PaginationParams,
     models::dividend::CreateDividendRequest,
     models::domestic_stock::CreateDomesticStockRequest,
     models::mutualfund::CreateMutualfundRequest,
@@ -16,6 +17,10 @@ use backend::{
     services::mutualfund as mutualfund_svc,
     state::{AppState, Secrets},
 };
+
+fn default_pagination() -> PaginationParams {
+    PaginationParams { page: None, per_page: None }
+}
 use chrono::NaiveDate;
 use reqwest::Client;
 use rust_decimal_macros::dec;
@@ -285,10 +290,10 @@ async fn service_coverage_all_domains() {
     let (pool, _node) = start_test_pool().await;
     let user_id = create_test_user(&pool).await;
 
-    assert!(mutualfund_svc::list(&pool, user_id)
+    assert!(mutualfund_svc::list(&pool, user_id, &default_pagination())
         .await
         .expect("initial mutualfund list failed")
-        .is_empty());
+        .data.is_empty());
     let mutualfund_empty = mutualfund_svc::bulk_create(&pool, user_id, &[])
         .await
         .expect("empty mutualfund bulk_create failed");
@@ -314,10 +319,10 @@ async fn service_coverage_all_domains() {
     assert!(mutualfund_uploaded.errors.is_empty());
 
     assert_eq!(
-        mutualfund_svc::list(&pool, user_id)
+        mutualfund_svc::list(&pool, user_id, &default_pagination())
             .await
             .expect("mutualfund list failed")
-            .len(),
+            .data.len(),
         3
     );
     assert_eq!(
@@ -326,15 +331,15 @@ async fn service_coverage_all_domains() {
             .expect("mutualfund delete_all failed"),
         3
     );
-    assert!(mutualfund_svc::list(&pool, user_id)
+    assert!(mutualfund_svc::list(&pool, user_id, &default_pagination())
         .await
         .expect("mutualfund list after delete failed")
-        .is_empty());
+        .data.is_empty());
 
-    assert!(dividend_svc::list(&pool, user_id)
+    assert!(dividend_svc::list(&pool, user_id, &default_pagination())
         .await
         .expect("initial dividend list failed")
-        .is_empty());
+        .data.is_empty());
     let dividend_empty = dividend_svc::bulk_create(&pool, user_id, &[])
         .await
         .expect("empty dividend bulk_create failed");
@@ -357,10 +362,10 @@ async fn service_coverage_all_domains() {
     assert!(dividend_uploaded.errors.is_empty());
 
     assert_eq!(
-        dividend_svc::list(&pool, user_id)
+        dividend_svc::list(&pool, user_id, &default_pagination())
             .await
             .expect("dividend list failed")
-            .len(),
+            .data.len(),
         3
     );
     assert_eq!(
@@ -369,15 +374,15 @@ async fn service_coverage_all_domains() {
             .expect("dividend delete_all failed"),
         3
     );
-    assert!(dividend_svc::list(&pool, user_id)
+    assert!(dividend_svc::list(&pool, user_id, &default_pagination())
         .await
         .expect("dividend list after delete failed")
-        .is_empty());
+        .data.is_empty());
 
-    assert!(domestic_stock_svc::list(&pool, user_id)
+    assert!(domestic_stock_svc::list(&pool, user_id, &default_pagination())
         .await
         .expect("initial domestic_stock list failed")
-        .is_empty());
+        .data.is_empty());
     let domestic_stock_empty = domestic_stock_svc::bulk_create(&pool, user_id, &[])
         .await
         .expect("empty domestic_stock bulk_create failed");
@@ -404,10 +409,10 @@ async fn service_coverage_all_domains() {
     assert!(domestic_stock_uploaded.errors.is_empty());
 
     assert_eq!(
-        domestic_stock_svc::list(&pool, user_id)
+        domestic_stock_svc::list(&pool, user_id, &default_pagination())
             .await
             .expect("domestic_stock list failed")
-            .len(),
+            .data.len(),
         3
     );
     assert_eq!(
@@ -416,15 +421,15 @@ async fn service_coverage_all_domains() {
             .expect("domestic_stock delete_all failed"),
         3
     );
-    assert!(domestic_stock_svc::list(&pool, user_id)
+    assert!(domestic_stock_svc::list(&pool, user_id, &default_pagination())
         .await
         .expect("domestic_stock list after delete failed")
-        .is_empty());
+        .data.is_empty());
 
-    assert!(asset_balance_svc::list(&pool, user_id)
+    assert!(asset_balance_svc::list(&pool, user_id, &default_pagination())
         .await
         .expect("initial asset_balance list failed")
-        .is_empty());
+        .data.is_empty());
     let asset_balance_empty = asset_balance_svc::bulk_create(&pool, user_id, &[])
         .await
         .expect("empty asset_balance bulk_create failed");
@@ -439,10 +444,10 @@ async fn service_coverage_all_domains() {
     assert_eq!(asset_balance_created.inserted, 2);
     assert_eq!(asset_balance_created.skipped, 0);
     assert_eq!(
-        asset_balance_svc::list(&pool, user_id)
+        asset_balance_svc::list(&pool, user_id, &default_pagination())
             .await
             .expect("asset_balance list after bulk_create failed")
-            .len(),
+            .data.len(),
         2
     );
 
@@ -454,9 +459,10 @@ async fn service_coverage_all_domains() {
     assert_eq!(asset_balance_uploaded.skipped, 0);
     assert!(asset_balance_uploaded.errors.is_empty());
 
-    let asset_balance_rows = asset_balance_svc::list(&pool, user_id)
+    let asset_balance_rows = asset_balance_svc::list(&pool, user_id, &default_pagination())
         .await
-        .expect("asset_balance list failed");
+        .expect("asset_balance list failed")
+        .data;
     assert_eq!(asset_balance_rows.len(), 1);
     assert_eq!(asset_balance_rows[0].security_code, "7203");
 
@@ -466,10 +472,10 @@ async fn service_coverage_all_domains() {
             .expect("asset_balance delete_all failed"),
         1
     );
-    assert!(asset_balance_svc::list(&pool, user_id)
+    assert!(asset_balance_svc::list(&pool, user_id, &default_pagination())
         .await
         .expect("asset_balance list after delete failed")
-        .is_empty());
+        .data.is_empty());
 }
 
 #[tokio::test]
@@ -494,9 +500,10 @@ async fn asset_balance_bulk_create_replaces_previous_snapshot() {
         .await
         .expect("2回目 bulk_create 失敗");
 
-    let rows = asset_balance_svc::list(&pool, user_id)
+    let rows = asset_balance_svc::list(&pool, user_id, &default_pagination())
         .await
-        .expect("list 失敗");
+        .expect("list 失敗")
+        .data;
     assert_eq!(
         rows.len(),
         3,
@@ -538,9 +545,10 @@ async fn asset_balance_bulk_create_concurrent_same_user_no_mix() {
     res_a.unwrap().expect("task_a 失敗");
     res_b.unwrap().expect("task_b 失敗");
 
-    let rows = asset_balance_svc::list(&pool, user_id)
+    let rows = asset_balance_svc::list(&pool, user_id, &default_pagination())
         .await
-        .expect("list 失敗");
+        .expect("list 失敗")
+        .data;
 
     // advisory lock で直列化されるため、A(2件) か B(3件) のいずれかのみ存在する
     assert!(
@@ -567,9 +575,10 @@ async fn dividend_bulk_create_and_list() {
     assert_eq!(created.inserted, 3);
     assert_eq!(created.skipped, 0);
 
-    let rows = dividend_svc::list(&pool, user_id)
+    let rows = dividend_svc::list(&pool, user_id, &default_pagination())
         .await
-        .expect("dividend list failed");
+        .expect("dividend list failed")
+        .data;
     assert_eq!(rows.len(), 3);
 
     let deleted = dividend_svc::delete_all(&pool, user_id)
@@ -577,9 +586,10 @@ async fn dividend_bulk_create_and_list() {
         .expect("dividend delete_all failed");
     assert_eq!(deleted, 3);
 
-    let rows = dividend_svc::list(&pool, user_id)
+    let rows = dividend_svc::list(&pool, user_id, &default_pagination())
         .await
-        .expect("dividend list after delete failed");
+        .expect("dividend list after delete failed")
+        .data;
     assert_eq!(rows.len(), 0);
 }
 
@@ -620,9 +630,10 @@ async fn domestic_stock_bulk_create_and_list() {
     assert_eq!(created.inserted, 3);
     assert_eq!(created.skipped, 0);
 
-    let rows = domestic_stock_svc::list(&pool, user_id)
+    let rows = domestic_stock_svc::list(&pool, user_id, &default_pagination())
         .await
-        .expect("domestic_stock list failed");
+        .expect("domestic_stock list failed")
+        .data;
     assert_eq!(rows.len(), 3);
 
     let deleted = domestic_stock_svc::delete_all(&pool, user_id)
@@ -630,9 +641,10 @@ async fn domestic_stock_bulk_create_and_list() {
         .expect("domestic_stock delete_all failed");
     assert_eq!(deleted, 3);
 
-    let rows = domestic_stock_svc::list(&pool, user_id)
+    let rows = domestic_stock_svc::list(&pool, user_id, &default_pagination())
         .await
-        .expect("domestic_stock list after delete failed");
+        .expect("domestic_stock list after delete failed")
+        .data;
     assert_eq!(rows.len(), 0);
 }
 
@@ -672,9 +684,10 @@ async fn mutualfund_bulk_create_and_list() {
     assert_eq!(created.inserted, 2);
     assert_eq!(created.skipped, 0);
 
-    let rows = mutualfund_svc::list(&pool, user_id)
+    let rows = mutualfund_svc::list(&pool, user_id, &default_pagination())
         .await
-        .expect("mutualfund list failed");
+        .expect("mutualfund list failed")
+        .data;
     assert_eq!(rows.len(), 2);
 
     let deleted = mutualfund_svc::delete_all(&pool, user_id)
@@ -682,9 +695,10 @@ async fn mutualfund_bulk_create_and_list() {
         .expect("mutualfund delete_all failed");
     assert_eq!(deleted, 2);
 
-    let rows = mutualfund_svc::list(&pool, user_id)
+    let rows = mutualfund_svc::list(&pool, user_id, &default_pagination())
         .await
-        .expect("mutualfund list after delete failed");
+        .expect("mutualfund list after delete failed")
+        .data;
     assert_eq!(rows.len(), 0);
 }
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -220,16 +220,35 @@
         ],
         "summary": "保有銘柄一覧を取得（v1）",
         "operationId": "v1_asset_balance_list",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "ページ番号（デフォルト: 1）",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "per_page",
+            "in": "query",
+            "description": "1ページあたりの件数（デフォルト: 200、最大: 1000）",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/AssetBalance"
-                  }
+                  "$ref": "#/components/schemas/PaginatedResponse_AssetBalance"
                 }
               }
             }
@@ -515,16 +534,35 @@
         ],
         "summary": "配当金一覧を取得（v1）",
         "operationId": "v1_dividend_list",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "ページ番号（デフォルト: 1）",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "per_page",
+            "in": "query",
+            "description": "1ページあたりの件数（デフォルト: 200、最大: 1000）",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Dividend"
-                  }
+                  "$ref": "#/components/schemas/PaginatedResponse_Dividend"
                 }
               }
             }
@@ -700,16 +738,35 @@
         ],
         "summary": "国内株式取引一覧を取得（v1）",
         "operationId": "v1_domestic_stock_transaction_list",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "ページ番号（デフォルト: 1）",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "per_page",
+            "in": "query",
+            "description": "1ページあたりの件数（デフォルト: 200、最大: 1000）",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/DomesticStock"
-                  }
+                  "$ref": "#/components/schemas/PaginatedResponse_DomesticStock"
                 }
               }
             }
@@ -980,16 +1037,35 @@
         ],
         "summary": "投資信託一覧を取得（v1）",
         "operationId": "v1_mutual_fund_transaction_list",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "ページ番号（デフォルト: 1）",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "per_page",
+            "in": "query",
+            "description": "1ページあたりの件数（デフォルト: 200、最大: 1000）",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Mutualfund"
-                  }
+                  "$ref": "#/components/schemas/PaginatedResponse_Mutualfund"
                 }
               }
             }
@@ -2652,6 +2728,421 @@
           "updated_at": {
             "type": "string",
             "format": "date-time"
+          }
+        }
+      },
+      "PaginatedResponse_AssetBalance": {
+        "type": "object",
+        "description": "ページネーションレスポンス（全ドメイン共通）",
+        "required": [
+          "data",
+          "total",
+          "page",
+          "per_page"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "description": "保有銘柄モデル（DB + APIレスポンス兼用）",
+              "required": [
+                "id",
+                "security_code",
+                "security_name",
+                "shares",
+                "executing_shares",
+                "average_purchase_price",
+                "total_purchase_amount",
+                "current_price",
+                "daily_change",
+                "market_value",
+                "profit_loss_rate",
+                "created_at",
+                "updated_at"
+              ],
+              "properties": {
+                "average_purchase_price": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "current_price": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "daily_change": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "executing_shares": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "id": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "market_value": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "profit_loss_rate": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "security_code": {
+                  "type": "string"
+                },
+                "security_name": {
+                  "type": "string"
+                },
+                "shares": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "total_purchase_amount": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              }
+            }
+          },
+          "page": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "per_page": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "total": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "PaginatedResponse_Dividend": {
+        "type": "object",
+        "description": "ページネーションレスポンス（全ドメイン共通）",
+        "required": [
+          "data",
+          "total",
+          "page",
+          "per_page"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "description": "配当金モデル（DB + APIレスポンス兼用）",
+              "required": [
+                "id",
+                "settlement_date",
+                "product",
+                "account",
+                "security_code",
+                "security_name",
+                "unit_price",
+                "shares",
+                "dividends_before_tax",
+                "taxes",
+                "net_amount_received",
+                "created_at",
+                "updated_at"
+              ],
+              "properties": {
+                "account": {
+                  "type": "string"
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "dividends_before_tax": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "id": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "net_amount_received": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "product": {
+                  "type": "string"
+                },
+                "security_code": {
+                  "type": "string"
+                },
+                "security_name": {
+                  "type": "string"
+                },
+                "settlement_date": {
+                  "type": "string",
+                  "format": "date"
+                },
+                "shares": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "taxes": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "unit_price": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              }
+            }
+          },
+          "page": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "per_page": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "total": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "PaginatedResponse_DomesticStock": {
+        "type": "object",
+        "description": "ページネーションレスポンス（全ドメイン共通）",
+        "required": [
+          "data",
+          "total",
+          "page",
+          "per_page"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "description": "国内株式取引モデル（DB + APIレスポンス兼用）",
+              "required": [
+                "id",
+                "trade_date",
+                "settlement_date",
+                "security_code",
+                "security_name",
+                "account",
+                "shares",
+                "asked_price",
+                "proceeds",
+                "purchase_price",
+                "realized_profit_and_loss",
+                "taxes",
+                "realized_profit_and_loss_after_tax",
+                "created_at",
+                "updated_at"
+              ],
+              "properties": {
+                "account": {
+                  "type": "string"
+                },
+                "asked_price": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "id": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "proceeds": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "purchase_price": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "realized_profit_and_loss": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "realized_profit_and_loss_after_tax": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "security_code": {
+                  "type": "string"
+                },
+                "security_name": {
+                  "type": "string"
+                },
+                "settlement_date": {
+                  "type": "string",
+                  "format": "date"
+                },
+                "shares": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "taxes": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "trade_date": {
+                  "type": "string",
+                  "format": "date"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              }
+            }
+          },
+          "page": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "per_page": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "total": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "PaginatedResponse_Mutualfund": {
+        "type": "object",
+        "description": "ページネーションレスポンス（全ドメイン共通）",
+        "required": [
+          "data",
+          "total",
+          "page",
+          "per_page"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "description": "投資信託モデル（DB + APIレスポンス兼用）",
+              "required": [
+                "id",
+                "trade_date",
+                "settlement_date",
+                "fund_name",
+                "account",
+                "shares",
+                "exchange_rate",
+                "cancellation_unit_price_yen",
+                "cancellation_amount_yen",
+                "average_acquisition_price_yen",
+                "realized_profit_and_loss",
+                "taxes",
+                "realized_profit_and_loss_after_tax",
+                "created_at",
+                "updated_at"
+              ],
+              "properties": {
+                "account": {
+                  "type": "string"
+                },
+                "average_acquisition_price_yen": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "cancellation_amount_yen": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "cancellation_unit_price_yen": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "dividends": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "exchange_rate": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "fund_name": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "realized_profit_and_loss": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "realized_profit_and_loss_after_tax": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "settlement_date": {
+                  "type": "string",
+                  "format": "date"
+                },
+                "shares": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "taxes": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "trade_date": {
+                  "type": "string",
+                  "format": "date"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              }
+            }
+          },
+          "page": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "per_page": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "total": {
+            "type": "integer",
+            "format": "int64"
           }
         }
       },

--- a/frontend/e2e/a11y.spec.ts
+++ b/frontend/e2e/a11y.spec.ts
@@ -21,21 +21,23 @@ const ROUTES = {
   stock: /\/api\/v1\/stocks(?:\?.*)?$/,
 };
 
+const EMPTY_PAGINATED_RESPONSE = JSON.stringify({ data: [], total: 0, page: 1, per_page: 0 });
+
 async function setupAuthMocks(page: import('@playwright/test').Page) {
   await page.route(ROUTES.authMe, (route) =>
     route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(MOCK_USER) }),
   );
   await page.route(ROUTES.dividends, (route) =>
-    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+    route.fulfill({ status: 200, contentType: 'application/json', body: EMPTY_PAGINATED_RESPONSE }),
   );
   await page.route(ROUTES.domesticStocks, (route) =>
-    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+    route.fulfill({ status: 200, contentType: 'application/json', body: EMPTY_PAGINATED_RESPONSE }),
   );
   await page.route(ROUTES.mutualfunds, (route) =>
-    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+    route.fulfill({ status: 200, contentType: 'application/json', body: EMPTY_PAGINATED_RESPONSE }),
   );
   await page.route(ROUTES.assetBalances, (route) =>
-    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+    route.fulfill({ status: 200, contentType: 'application/json', body: EMPTY_PAGINATED_RESPONSE }),
   );
 }
 

--- a/frontend/e2e/a11y.spec.ts
+++ b/frontend/e2e/a11y.spec.ts
@@ -14,10 +14,10 @@ const MOCK_USER = { id: 1, email: 'test@example.com', name: 'テストユーザ�
 
 const ROUTES = {
   authMe: /\/api\/v1\/session$/,
-  dividends: /\/api\/v1\/dividends$/,
-  domesticStocks: /\/api\/v1\/domestic-stock-transactions$/,
-  mutualfunds: /\/api\/v1\/mutual-fund-transactions$/,
-  assetBalances: /\/api\/v1\/asset-balances$/,
+  dividends: /\/api\/v1\/dividends(?:\?.*)?$/,
+  domesticStocks: /\/api\/v1\/domestic-stock-transactions(?:\?.*)?$/,
+  mutualfunds: /\/api\/v1\/mutual-fund-transactions(?:\?.*)?$/,
+  assetBalances: /\/api\/v1\/asset-balances(?:\?.*)?$/,
   stock: /\/api\/v1\/stocks(?:\?.*)?$/,
 };
 

--- a/frontend/e2e/assetbalance-flow.spec.ts
+++ b/frontend/e2e/assetbalance-flow.spec.ts
@@ -11,7 +11,7 @@ const MOCK_USER = {
 
 const ROUTES = {
   authMe: /\/api\/v1\/session$/,
-  assetBalances: /\/api\/v1\/asset-balances$/,
+  assetBalances: /\/api\/v1\/asset-balances(?:\?.*)?$/,
   assetBalancePreview: /\/api\/v1\/asset-balance-import-validations$/,
   assetBalanceUpload: /\/api\/v1\/asset-balance-imports$/,
   dividendPerShareBatch: /\/api\/v1\/dividend-per-share-estimates(?:\?.*)?$/,

--- a/frontend/e2e/assetbalance-flow.spec.ts
+++ b/frontend/e2e/assetbalance-flow.spec.ts
@@ -153,7 +153,10 @@ async function setupAssetBalanceMocks(
 
     if (method === 'GET') {
       listRequestCount += 1;
-      return route.fulfill(jsonResponse(cloneAssetBalances(assetBalances)));
+      const data = cloneAssetBalances(assetBalances);
+      return route.fulfill(
+        jsonResponse({ data, total: data.length, page: 1, per_page: data.length }),
+      );
     }
 
     return route.fallback();

--- a/frontend/e2e/error-scenarios.spec.ts
+++ b/frontend/e2e/error-scenarios.spec.ts
@@ -21,11 +21,11 @@ const MOCK_USER = { id: 1, email: 'test@example.com', name: 'テストユーザ�
 // ホスト非依存のパターン（VITE_SHOKEN_WEBAPI_API_URL の値に関わらず一致する）
 const ROUTES = {
   authMe: /\/api\/v1\/session$/,
-  dividends: /\/api\/v1\/dividends$/,
+  dividends: /\/api\/v1\/dividends(?:\?.*)?$/,
   dividendsCsvPreview: /\/api\/v1\/dividend-import-validations$/,
-  domesticStocks: /\/api\/v1\/domestic-stock-transactions$/,
-  mutualfunds: /\/api\/v1\/mutual-fund-transactions$/,
-  assetBalances: /\/api\/v1\/asset-balances$/,
+  domesticStocks: /\/api\/v1\/domestic-stock-transactions(?:\?.*)?$/,
+  mutualfunds: /\/api\/v1\/mutual-fund-transactions(?:\?.*)?$/,
+  assetBalances: /\/api\/v1\/asset-balances(?:\?.*)?$/,
 };
 
 async function setupCommonMocks(page: Page) {

--- a/frontend/e2e/receipt-flow.spec.ts
+++ b/frontend/e2e/receipt-flow.spec.ts
@@ -8,9 +8,9 @@ const MOCK_USER = {
 
 const ROUTES = {
   authMe: /\/api\/v1\/session$/,
-  dividends: /\/api\/v1\/dividends$/,
-  domesticStocks: /\/api\/v1\/domestic-stock-transactions$/,
-  mutualfunds: /\/api\/v1\/mutual-fund-transactions$/,
+  dividends: /\/api\/v1\/dividends(?:\?.*)?$/,
+  domesticStocks: /\/api\/v1\/domestic-stock-transactions(?:\?.*)?$/,
+  mutualfunds: /\/api\/v1\/mutual-fund-transactions(?:\?.*)?$/,
 };
 
 const DIVIDEND_RECORD = [

--- a/frontend/e2e/receipt-flow.spec.ts
+++ b/frontend/e2e/receipt-flow.spec.ts
@@ -32,6 +32,15 @@ const DIVIDEND_RECORD = [
   },
 ];
 
+function paginatedResponse(data: unknown[]) {
+  return {
+    data,
+    total: data.length,
+    page: 1,
+    per_page: data.length,
+  };
+}
+
 async function setupAuthMocks(
   page: Page,
   {
@@ -55,21 +64,21 @@ async function setupAuthMocks(
     route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify(dividends),
+      body: JSON.stringify(paginatedResponse(dividends)),
     }),
   );
   await page.route(ROUTES.domesticStocks, (route) =>
     route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify(domesticStocks),
+      body: JSON.stringify(paginatedResponse(domesticStocks)),
     }),
   );
   await page.route(ROUTES.mutualfunds, (route) =>
     route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify(mutualfunds),
+      body: JSON.stringify(paginatedResponse(mutualfunds)),
     }),
   );
 }

--- a/frontend/src/features/assetBalance/api/__tests__/assetBalanceApi.test.ts
+++ b/frontend/src/features/assetBalance/api/__tests__/assetBalanceApi.test.ts
@@ -30,6 +30,15 @@ describe('assetBalanceApi', () => {
     });
   });
 
+  it('list(params) はページング条件を送る', () => {
+    assetBalanceApi.list({ per_page: 1000 });
+
+    expect(apiClient.get).toHaveBeenCalledWith('/api/v1/asset-balances', {
+      params: { per_page: 1000 },
+      withCredentials: true,
+    });
+  });
+
   it('previewCsv(file) は previewCsvFile を呼ぶ', () => {
     const file = new File(['id,name\n1,test'], 'asset-balances.csv', { type: 'text/csv' });
 

--- a/frontend/src/features/assetBalance/api/assetBalanceApi.ts
+++ b/frontend/src/features/assetBalance/api/assetBalanceApi.ts
@@ -11,9 +11,13 @@ const API_PATHS = {
 type AssetBalanceListResponse = paths['/api/v1/asset-balances']['get']['responses'][200]['content']['application/json'];
 type AssetBalanceDeleteResponse = paths['/api/v1/asset-balances']['delete']['responses'][200]['content']['application/json'];
 
+type AssetBalanceListQueryParams = NonNullable<paths['/api/v1/asset-balances']['get']['parameters']['query']>;
+const listRequestConfig = (params?: AssetBalanceListQueryParams) =>
+  params ? { params, withCredentials: true } : { withCredentials: true };
+
 export const assetBalanceApi = {
-  list: () =>
-    apiClient.get<AssetBalanceListResponse>(API_PATHS.assetBalanceList, { withCredentials: true }),
+  list: (params?: AssetBalanceListQueryParams) =>
+    apiClient.get<AssetBalanceListResponse>(API_PATHS.assetBalanceList, listRequestConfig(params)),
 
   previewCsv: (file: File) => previewCsvFile(API_PATHS.assetBalancePreview, file),
 

--- a/frontend/src/features/assetBalance/hooks/__tests__/useAssetBalance.test.ts
+++ b/frontend/src/features/assetBalance/hooks/__tests__/useAssetBalance.test.ts
@@ -19,8 +19,9 @@ import type { AssetBalanceApiData } from '@/types/api';
 // ────────────────────────────────────────────────────────
 
 vi.mock('@/features/assetBalance/api/assetBalanceApi', () => ({
-  assetBalanceApi: { list: vi.fn().mockResolvedValue([]) },
+  assetBalanceApi: { list: vi.fn().mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 }) },
 }));
+const emptyPage = { data: [], total: 0, page: 1, per_page: 200 };
 
 vi.mock('@/features/auth/hooks/useAuth');
 
@@ -82,7 +83,7 @@ describe('useAssetBalance', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({}));
-    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue([]);
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue(emptyPage);
   });
 
   it('onLogout コールバック実行で assetBalance キャッシュが除去される', async () => {
@@ -94,9 +95,10 @@ describe('useAssetBalance', () => {
     vi.mocked(authHook.useAuth).mockReturnValue(
       makeAuthMock({ onLogoutCapture: (cb) => { capturedCallback = cb; } })
     );
-    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue([
-      { security_code: '7203', security_name: 'トヨタ自動車', shares: 100 } as never,
-    ]);
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue({
+      data: [{ security_code: '7203', security_name: 'トヨタ自動車', shares: 100 } as never],
+      total: 1, page: 1, per_page: 200,
+    });
 
     renderHook(() => useAssetBalance(), { wrapper: makeWrapper(qc) });
 
@@ -131,14 +133,13 @@ describe('useAssetBalance', () => {
       defaultOptions: { queries: { retry: false, staleTime: Infinity } },
     });
 
-    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue([
-      makeAssetBalanceData({ security_code: '7203' }),
-      makeAssetBalanceData({
-        id: 'asset-balance-2',
-        security_code: '6758',
-        security_name: 'ソニーグループ',
-      }),
-    ]);
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue({
+      data: [
+        makeAssetBalanceData({ security_code: '7203' }),
+        makeAssetBalanceData({ id: 'asset-balance-2', security_code: '6758', security_name: 'ソニーグループ' }),
+      ],
+      total: 2, page: 1, per_page: 200,
+    });
 
     const { result } = renderHook(() => useAssetBalance(), { wrapper: makeWrapper(qc) });
 
@@ -157,15 +158,13 @@ describe('useAssetBalance', () => {
       defaultOptions: { queries: { retry: false, staleTime: Infinity } },
     });
 
-    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue([
-      makeAssetBalanceData({ security_code: '7203', market_value: 210000 }),
-      makeAssetBalanceData({
-        id: 'asset-balance-2',
-        security_code: '6758',
-        security_name: 'ソニーグループ',
-        market_value: 180000,
-      }),
-    ]);
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue({
+      data: [
+        makeAssetBalanceData({ security_code: '7203', market_value: 210000 }),
+        makeAssetBalanceData({ id: 'asset-balance-2', security_code: '6758', security_name: 'ソニーグループ', market_value: 180000 }),
+      ],
+      total: 2, page: 1, per_page: 200,
+    });
 
     const { result } = renderHook(() => useAssetBalance(), { wrapper: makeWrapper(qc) });
 
@@ -192,10 +191,13 @@ describe('useAssetBalance', () => {
       defaultOptions: { queries: { retry: false, staleTime: Infinity } },
     });
 
-    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue([
-      makeAssetBalanceData({ security_code: '7203', market_value: 100000 }),
-      makeAssetBalanceData({ id: 'asset-balance-2', security_code: '6758', market_value: 0 }),
-    ]);
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue({
+      data: [
+        makeAssetBalanceData({ security_code: '7203', market_value: 100000 }),
+        makeAssetBalanceData({ id: 'asset-balance-2', security_code: '6758', market_value: 0 }),
+      ],
+      total: 2, page: 1, per_page: 200,
+    });
 
     const { result } = renderHook(() => useAssetBalance(), { wrapper: makeWrapper(qc) });
 

--- a/frontend/src/features/assetBalance/hooks/__tests__/useAssetBalanceDataSource.test.ts
+++ b/frontend/src/features/assetBalance/hooks/__tests__/useAssetBalanceDataSource.test.ts
@@ -155,9 +155,10 @@ describe('useAssetBalanceDataSource: キャッシュ境界', () => {
     vi.mocked(authHook.useAuth).mockReturnValue(
       makeAuthMock({ onLogoutCapture: (cb) => { capturedCallbacks.push(cb); } })
     );
-    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue([
-      { security_code: '7203', security_name: 'トヨタ自動車', shares: 100 } as never,
-    ]);
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue({
+      data: [{ security_code: '7203', security_name: 'トヨタ自動車', shares: 100 } as never],
+      total: 1, page: 1, per_page: 200,
+    });
 
     const { result } = renderHook(
       () => useAssetBalanceDataSource(),

--- a/frontend/src/features/assetBalance/hooks/__tests__/useAssetBalanceDataSource.test.ts
+++ b/frontend/src/features/assetBalance/hooks/__tests__/useAssetBalanceDataSource.test.ts
@@ -19,7 +19,7 @@ import * as authHook from '@/features/auth/hooks/useAuth';
 
 vi.mock('@/features/assetBalance/api/assetBalanceApi', () => ({
   assetBalanceApi: {
-    list: vi.fn().mockResolvedValue([]),
+    list: vi.fn().mockResolvedValue({ data: [], total: 0, page: 1, per_page: 1000 }),
     previewCsv: vi.fn().mockResolvedValue({ total_rows: 0, valid_rows: 0, errors: [], rows: [] }),
     uploadCsv: vi.fn().mockResolvedValue({ inserted: 0, skipped: 0, errors: [] }),
     deleteAll: vi.fn().mockResolvedValue({}),

--- a/frontend/src/features/assetBalance/hooks/useAssetBalance.ts
+++ b/frontend/src/features/assetBalance/hooks/useAssetBalance.ts
@@ -40,7 +40,7 @@ export function useAssetBalance(options: UseAssetBalanceOptions = {}): UseAssetB
   }, [onLogout, queryClient]);
 
   // 未認証時はキャッシュに残存データがあっても空を返す
-  const assetBalanceData = isAuthenticated ? (query.data ?? []) : [];
+  const assetBalanceData = isAuthenticated ? (query.data?.data ?? []) : [];
 
   const getAssetBalanceByCode = (code: string): AssetBalanceData | undefined => {
     const normalizedCode = normalizeSecurityCode(code);

--- a/frontend/src/features/assetBalance/hooks/useAssetBalance.ts
+++ b/frontend/src/features/assetBalance/hooks/useAssetBalance.ts
@@ -30,7 +30,7 @@ export function useAssetBalance(options: UseAssetBalanceOptions = {}): UseAssetB
 
   const query = useQuery({
     queryKey: assetBalanceQueryKeys.all(userId),
-    queryFn: () => assetBalanceApi.list(),
+    queryFn: () => assetBalanceApi.list({ per_page: 1000 }),
     enabled: isAuthenticated && !!userId && enabled,
   });
 
@@ -40,7 +40,8 @@ export function useAssetBalance(options: UseAssetBalanceOptions = {}): UseAssetB
   }, [onLogout, queryClient]);
 
   // 未認証時はキャッシュに残存データがあっても空を返す
-  const assetBalanceData = isAuthenticated ? (query.data?.data ?? []) : [];
+  const assetBalancePage = isAuthenticated ? query.data : undefined;
+  const assetBalanceData = assetBalancePage?.data ?? [];
 
   const getAssetBalanceByCode = (code: string): AssetBalanceData | undefined => {
     const normalizedCode = normalizeSecurityCode(code);

--- a/frontend/src/features/assetBalance/hooks/useAssetBalanceDataSource.ts
+++ b/frontend/src/features/assetBalance/hooks/useAssetBalanceDataSource.ts
@@ -56,24 +56,24 @@ export function useAssetBalanceDataSourceCore({
 
   const dbQuery = useQuery({
     queryKey: assetBalanceQueryKeys.all(userId),
-    queryFn: () => assetBalanceApi.list(),
+    queryFn: () => assetBalanceApi.list({ per_page: 1000 }),
     enabled: isAuthenticated && !authLoading && !!userId,
   });
 
   const previewMutation = useMutation({
     mutationFn: (file: File) => assetBalanceApi.previewCsv(file),
-    onSuccess: (data) => {
-      setPreviewRows(data.rows as unknown as AssetBalanceData[]);
+    onSuccess: (previewResult) => {
+      setPreviewRows(previewResult.rows as unknown as AssetBalanceData[]);
     },
   });
 
   const uploadCsvMutation = useMutation({
     mutationFn: (file: File) => assetBalanceApi.uploadCsv(file),
     onMutate: () => ({ snapshotUserId: userId }),
-    onSuccess: (data, _, context) => {
+    onSuccess: (uploadResult, _, context) => {
       setRawFile(null);
       setPreviewRows([]);
-      setLastSavedResult(data ?? null);
+      setLastSavedResult(uploadResult ?? null);
       queryClient.invalidateQueries({ queryKey: assetBalanceQueryKeys.all(context?.snapshotUserId ?? userId) });
     },
   });
@@ -84,7 +84,7 @@ export function useAssetBalanceDataSourceCore({
     onSuccess: (_, __, context) => {
       const key = assetBalanceQueryKeys.all(context?.snapshotUserId ?? userId);
       if (queryClient.getQueryState(key) !== undefined) {
-        queryClient.setQueryData(key, []);
+        queryClient.setQueryData(key, { data: [], total: 0, page: 1, per_page: 1000 });
       }
       setLastSavedResult(null);
     },
@@ -127,7 +127,8 @@ export function useAssetBalanceDataSourceCore({
     await deleteAllMutation.mutateAsync();
   }, [deleteAllMutation, isAuthenticated]);
 
-  const dbData = dbQuery.data?.data ?? [];
+  const assetBalancePage = dbQuery.data;
+  const dbData = assetBalancePage?.data ?? [];
   const queryError = dbQuery.error;
   const mutationError = uploadCsvMutation.error ?? deleteAllMutation.error ?? previewMutation.error;
   const error = queryError

--- a/frontend/src/features/assetBalance/hooks/useAssetBalanceDataSource.ts
+++ b/frontend/src/features/assetBalance/hooks/useAssetBalanceDataSource.ts
@@ -127,7 +127,7 @@ export function useAssetBalanceDataSourceCore({
     await deleteAllMutation.mutateAsync();
   }, [deleteAllMutation, isAuthenticated]);
 
-  const dbData = dbQuery.data ?? [];
+  const dbData = dbQuery.data?.data ?? [];
   const queryError = dbQuery.error;
   const mutationError = uploadCsvMutation.error ?? deleteAllMutation.error ?? previewMutation.error;
   const error = queryError

--- a/frontend/src/features/receipt/api/__tests__/receiptApi.test.ts
+++ b/frontend/src/features/receipt/api/__tests__/receiptApi.test.ts
@@ -25,6 +25,14 @@ describe('dividendApi', () => {
     expect(apiClient.get).toHaveBeenCalledWith('/api/v1/dividends', { withCredentials: true });
   });
 
+  it('list が指定されたページング条件を送る', () => {
+    dividendApi.list({ per_page: 1000 });
+    expect(apiClient.get).toHaveBeenCalledWith('/api/v1/dividends', {
+      params: { per_page: 1000 },
+      withCredentials: true,
+    });
+  });
+
   it('previewCsv が /api/v1/dividend-import-validations にプレビューリクエストを送る', () => {
     const file = new File(['content'], 'test.csv', { type: 'text/csv' });
     dividendApi.previewCsv(file);
@@ -53,6 +61,14 @@ describe('domesticStockApi', () => {
     expect(apiClient.get).toHaveBeenCalledWith('/api/v1/domestic-stock-transactions', { withCredentials: true });
   });
 
+  it('list が指定されたページング条件を送る', () => {
+    domesticStockApi.list({ per_page: 1000 });
+    expect(apiClient.get).toHaveBeenCalledWith('/api/v1/domestic-stock-transactions', {
+      params: { per_page: 1000 },
+      withCredentials: true,
+    });
+  });
+
   it('previewCsv が /api/v1/domestic-stock-import-validations にプレビューリクエストを送る', () => {
     const file = new File(['content'], 'test.csv', { type: 'text/csv' });
     domesticStockApi.previewCsv(file);
@@ -79,6 +95,14 @@ describe('mutualfundApi', () => {
   it('list が /api/v1/mutual-fund-transactions に GET リクエストを送る', () => {
     mutualfundApi.list();
     expect(apiClient.get).toHaveBeenCalledWith('/api/v1/mutual-fund-transactions', { withCredentials: true });
+  });
+
+  it('list が指定されたページング条件を送る', () => {
+    mutualfundApi.list({ per_page: 1000 });
+    expect(apiClient.get).toHaveBeenCalledWith('/api/v1/mutual-fund-transactions', {
+      params: { per_page: 1000 },
+      withCredentials: true,
+    });
   });
 
   it('previewCsv が /api/v1/mutual-fund-import-validations にプレビューリクエストを送る', () => {

--- a/frontend/src/features/receipt/api/receiptApi.ts
+++ b/frontend/src/features/receipt/api/receiptApi.ts
@@ -21,10 +21,14 @@ type DomesticStockDeleteResponse = paths['/api/v1/domestic-stock-transactions'][
 type MutualfundListResponse = paths['/api/v1/mutual-fund-transactions']['get']['responses'][200]['content']['application/json'];
 type MutualfundDeleteResponse = paths['/api/v1/mutual-fund-transactions']['delete']['responses'][200]['content']['application/json'];
 
+type ListQueryParams = NonNullable<paths['/api/v1/dividends']['get']['parameters']['query']>;
+const listRequestConfig = (params?: ListQueryParams) =>
+  params ? { params, withCredentials: true } : { withCredentials: true };
+
 // 配当金API
 export const dividendApi = {
-  list: () =>
-    apiClient.get<DividendListResponse>(API_PATHS.dividendList, { withCredentials: true }),
+  list: (params?: ListQueryParams) =>
+    apiClient.get<DividendListResponse>(API_PATHS.dividendList, listRequestConfig(params)),
 
   previewCsv: (file: File) => previewCsvFile(API_PATHS.dividendPreview, file),
 
@@ -36,8 +40,8 @@ export const dividendApi = {
 
 // 国内株式API
 export const domesticStockApi = {
-  list: () =>
-    apiClient.get<DomesticStockListResponse>(API_PATHS.domesticStockList, { withCredentials: true }),
+  list: (params?: ListQueryParams) =>
+    apiClient.get<DomesticStockListResponse>(API_PATHS.domesticStockList, listRequestConfig(params)),
 
   previewCsv: (file: File) => previewCsvFile(API_PATHS.domesticStockPreview, file),
 
@@ -49,8 +53,8 @@ export const domesticStockApi = {
 
 // 投資信託API
 export const mutualfundApi = {
-  list: () =>
-    apiClient.get<MutualfundListResponse>(API_PATHS.mutualfundList, { withCredentials: true }),
+  list: (params?: ListQueryParams) =>
+    apiClient.get<MutualfundListResponse>(API_PATHS.mutualfundList, listRequestConfig(params)),
 
   previewCsv: (file: File) => previewCsvFile(API_PATHS.mutualfundPreview, file),
 

--- a/frontend/src/features/receipt/hooks/__tests__/useReceiptsData.test.ts
+++ b/frontend/src/features/receipt/hooks/__tests__/useReceiptsData.test.ts
@@ -84,7 +84,7 @@ function makeWrapper(qc: QueryClient) {
 describe('useReceiptsData: 認証境界・キャッシュ境界', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(receiptApiModule.dividendApi.list).mockResolvedValue([]);
+    vi.mocked(receiptApiModule.dividendApi.list).mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 } as never);
     vi.mocked(receiptApiModule.dividendApi.deleteAll).mockResolvedValue({} as never);
     vi.mocked(receiptApiModule.dividendApi.uploadCsv).mockResolvedValue({
       inserted: 0,
@@ -98,7 +98,7 @@ describe('useReceiptsData: 認証境界・キャッシュ境界', () => {
       rows: [],
     } as never);
 
-    vi.mocked(receiptApiModule.domesticStockApi.list).mockResolvedValue([]);
+    vi.mocked(receiptApiModule.domesticStockApi.list).mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 } as never);
     vi.mocked(receiptApiModule.domesticStockApi.deleteAll).mockResolvedValue({} as never);
     vi.mocked(receiptApiModule.domesticStockApi.uploadCsv).mockResolvedValue({
       inserted: 0,
@@ -112,7 +112,7 @@ describe('useReceiptsData: 認証境界・キャッシュ境界', () => {
       rows: [],
     } as never);
 
-    vi.mocked(receiptApiModule.mutualfundApi.list).mockResolvedValue([]);
+    vi.mocked(receiptApiModule.mutualfundApi.list).mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 } as never);
     vi.mocked(receiptApiModule.mutualfundApi.deleteAll).mockResolvedValue({} as never);
     vi.mocked(receiptApiModule.mutualfundApi.uploadCsv).mockResolvedValue({
       inserted: 0,
@@ -158,9 +158,10 @@ describe('useReceiptsData: 認証境界・キャッシュ境界', () => {
     vi.mocked(authHook.useAuth).mockReturnValue(
       makeAuthMock({ onLogoutCapture: (cb) => { capturedCallbacks.push(cb); } })
     );
-    vi.mocked(receiptApiModule.dividendApi.list).mockResolvedValue([
-      { id: '1', payment_date: '2023-01-01' } as never,
-    ]);
+    vi.mocked(receiptApiModule.dividendApi.list).mockResolvedValue({
+      data: [{ id: '1', payment_date: '2023-01-01' } as never],
+      total: 1, page: 1, per_page: 200,
+    } as never);
 
     const { result } = renderHook(() => useReceiptsData(), { wrapper: makeWrapper(qc) });
 
@@ -200,9 +201,10 @@ describe('useReceiptsData: 認証境界・キャッシュ境界', () => {
     vi.mocked(authHook.useAuth).mockReturnValue(
       makeAuthMock({ onLogoutCapture: (cb) => { capturedCallback = cb; } })
     );
-    vi.mocked(receiptApiModule.dividendApi.list).mockResolvedValue([
-      { id: '1', payment_date: '2023-01-01' } as never,
-    ]);
+    vi.mocked(receiptApiModule.dividendApi.list).mockResolvedValue({
+      data: [{ id: '1', payment_date: '2023-01-01' } as never],
+      total: 1, page: 1, per_page: 200,
+    } as never);
 
     renderHook(() => useReceiptsData(), { wrapper: makeWrapper(qc) });
 

--- a/frontend/src/features/receipt/hooks/__tests__/useReceiptsData.test.ts
+++ b/frontend/src/features/receipt/hooks/__tests__/useReceiptsData.test.ts
@@ -19,19 +19,19 @@ import * as authHook from '@/features/auth/hooks/useAuth';
 
 vi.mock('@/features/receipt/api/receiptApi', () => ({
   dividendApi: {
-    list: vi.fn().mockResolvedValue([]),
+    list: vi.fn().mockResolvedValue({ data: [], total: 0, page: 1, per_page: 1000 }),
     deleteAll: vi.fn().mockResolvedValue({}),
     uploadCsv: vi.fn().mockResolvedValue({ inserted: 0, skipped: 0, errors: [] }),
     previewCsv: vi.fn().mockResolvedValue({ total_rows: 0, valid_rows: 0, errors: [], rows: [] }),
   },
   domesticStockApi: {
-    list: vi.fn().mockResolvedValue([]),
+    list: vi.fn().mockResolvedValue({ data: [], total: 0, page: 1, per_page: 1000 }),
     deleteAll: vi.fn().mockResolvedValue({}),
     uploadCsv: vi.fn().mockResolvedValue({ inserted: 0, skipped: 0, errors: [] }),
     previewCsv: vi.fn().mockResolvedValue({ total_rows: 0, valid_rows: 0, errors: [], rows: [] }),
   },
   mutualfundApi: {
-    list: vi.fn().mockResolvedValue([]),
+    list: vi.fn().mockResolvedValue({ data: [], total: 0, page: 1, per_page: 1000 }),
     deleteAll: vi.fn().mockResolvedValue({}),
     uploadCsv: vi.fn().mockResolvedValue({ inserted: 0, skipped: 0, errors: [] }),
     previewCsv: vi.fn().mockResolvedValue({ total_rows: 0, valid_rows: 0, errors: [], rows: [] }),

--- a/frontend/src/features/receipt/hooks/useReceiptsData.ts
+++ b/frontend/src/features/receipt/hooks/useReceiptsData.ts
@@ -63,21 +63,24 @@ export function useReceiptsData(): UseReceiptsDataResult {
   const dividendQuery = useQuery({
     queryKey: receiptQueryKeys.dividend(userId),
     queryFn: () =>
-      dividendApi.list().then(res => res.data.map(transformDBDividend)),
+      dividendApi.list({ per_page: 1000 }).then(({ data: dividendRows }) =>
+        dividendRows.map(transformDBDividend)),
     enabled: isAuthenticated && !authLoading && !!userId,
   });
 
   const domesticstockQuery = useQuery({
     queryKey: receiptQueryKeys.domesticstock(userId),
     queryFn: () =>
-      domesticStockApi.list().then(res => res.data.map(transformDBDomesticStock)),
+      domesticStockApi.list({ per_page: 1000 }).then(({ data: domesticStockRows }) =>
+        domesticStockRows.map(transformDBDomesticStock)),
     enabled: isAuthenticated && !authLoading && !!userId,
   });
 
   const mutualfundQuery = useQuery({
     queryKey: receiptQueryKeys.mutualfund(userId),
     queryFn: () =>
-      mutualfundApi.list().then(res => res.data.map(transformDBMutualfund)),
+      mutualfundApi.list({ per_page: 1000 }).then(({ data: mutualfundRows }) =>
+        mutualfundRows.map(transformDBMutualfund)),
     enabled: isAuthenticated && !authLoading && !!userId,
   });
 
@@ -92,12 +95,12 @@ export function useReceiptsData(): UseReceiptsDataResult {
           return mutualfundApi.previewCsv(file);
       }
     },
-    onSuccess: (data, { onSuccess }) => {
+    onSuccess: (previewResult, { onSuccess }) => {
       onSuccess?.({
-        totalRows: data.total_rows,
-        validRows: data.valid_rows,
-        errors: data.errors,
-        rows: (data.rows ?? []) as Record<string, unknown>[],
+        totalRows: previewResult.total_rows,
+        validRows: previewResult.valid_rows,
+        errors: previewResult.errors,
+        rows: (previewResult.rows ?? []) as Record<string, unknown>[],
       });
     },
     onError: (error, { onError }) => {

--- a/frontend/src/features/receipt/hooks/useReceiptsData.ts
+++ b/frontend/src/features/receipt/hooks/useReceiptsData.ts
@@ -63,21 +63,21 @@ export function useReceiptsData(): UseReceiptsDataResult {
   const dividendQuery = useQuery({
     queryKey: receiptQueryKeys.dividend(userId),
     queryFn: () =>
-      dividendApi.list().then(items => items.map(transformDBDividend)),
+      dividendApi.list().then(res => res.data.map(transformDBDividend)),
     enabled: isAuthenticated && !authLoading && !!userId,
   });
 
   const domesticstockQuery = useQuery({
     queryKey: receiptQueryKeys.domesticstock(userId),
     queryFn: () =>
-      domesticStockApi.list().then(items => items.map(transformDBDomesticStock)),
+      domesticStockApi.list().then(res => res.data.map(transformDBDomesticStock)),
     enabled: isAuthenticated && !authLoading && !!userId,
   });
 
   const mutualfundQuery = useQuery({
     queryKey: receiptQueryKeys.mutualfund(userId),
     queryFn: () =>
-      mutualfundApi.list().then(items => items.map(transformDBMutualfund)),
+      mutualfundApi.list().then(res => res.data.map(transformDBMutualfund)),
     enabled: isAuthenticated && !authLoading && !!userId,
   });
 

--- a/frontend/src/generated/api.ts
+++ b/frontend/src/generated/api.ts
@@ -794,6 +794,152 @@ export interface components {
             /** Format: date-time */
             updated_at: string;
         };
+        /** @description ページネーションレスポンス（全ドメイン共通） */
+        PaginatedResponse_AssetBalance: {
+            data: {
+                /** Format: double */
+                average_purchase_price: number;
+                /** Format: date-time */
+                created_at: string;
+                /** Format: double */
+                current_price: number;
+                /** Format: double */
+                daily_change: number;
+                /** Format: double */
+                executing_shares: number;
+                /** Format: uuid */
+                id: string;
+                /** Format: double */
+                market_value: number;
+                /** Format: double */
+                profit_loss_rate: number;
+                security_code: string;
+                security_name: string;
+                /** Format: double */
+                shares: number;
+                /** Format: double */
+                total_purchase_amount: number;
+                /** Format: date-time */
+                updated_at: string;
+            }[];
+            /** Format: int64 */
+            page: number;
+            /** Format: int64 */
+            per_page: number;
+            /** Format: int64 */
+            total: number;
+        };
+        /** @description ページネーションレスポンス（全ドメイン共通） */
+        PaginatedResponse_Dividend: {
+            data: {
+                account: string;
+                /** Format: date-time */
+                created_at: string;
+                /** Format: double */
+                dividends_before_tax: number;
+                /** Format: uuid */
+                id: string;
+                /** Format: double */
+                net_amount_received: number;
+                product: string;
+                security_code: string;
+                security_name: string;
+                /** Format: date */
+                settlement_date: string;
+                /** Format: double */
+                shares: number;
+                /** Format: double */
+                taxes: number;
+                /** Format: double */
+                unit_price: number;
+                /** Format: date-time */
+                updated_at: string;
+            }[];
+            /** Format: int64 */
+            page: number;
+            /** Format: int64 */
+            per_page: number;
+            /** Format: int64 */
+            total: number;
+        };
+        /** @description ページネーションレスポンス（全ドメイン共通） */
+        PaginatedResponse_DomesticStock: {
+            data: {
+                account: string;
+                /** Format: double */
+                asked_price: number;
+                /** Format: date-time */
+                created_at: string;
+                /** Format: uuid */
+                id: string;
+                /** Format: double */
+                proceeds: number;
+                /** Format: double */
+                purchase_price: number;
+                /** Format: double */
+                realized_profit_and_loss: number;
+                /** Format: double */
+                realized_profit_and_loss_after_tax: number;
+                security_code: string;
+                security_name: string;
+                /** Format: date */
+                settlement_date: string;
+                /** Format: double */
+                shares: number;
+                /** Format: double */
+                taxes: number;
+                /** Format: date */
+                trade_date: string;
+                /** Format: date-time */
+                updated_at: string;
+            }[];
+            /** Format: int64 */
+            page: number;
+            /** Format: int64 */
+            per_page: number;
+            /** Format: int64 */
+            total: number;
+        };
+        /** @description ページネーションレスポンス（全ドメイン共通） */
+        PaginatedResponse_Mutualfund: {
+            data: {
+                account: string;
+                /** Format: double */
+                average_acquisition_price_yen: number;
+                /** Format: double */
+                cancellation_amount_yen: number;
+                /** Format: double */
+                cancellation_unit_price_yen: number;
+                /** Format: date-time */
+                created_at: string;
+                dividends?: string | null;
+                /** Format: double */
+                exchange_rate: number;
+                fund_name: string;
+                /** Format: uuid */
+                id: string;
+                /** Format: double */
+                realized_profit_and_loss: number;
+                /** Format: double */
+                realized_profit_and_loss_after_tax: number;
+                /** Format: date */
+                settlement_date: string;
+                /** Format: double */
+                shares: number;
+                /** Format: double */
+                taxes: number;
+                /** Format: date */
+                trade_date: string;
+                /** Format: date-time */
+                updated_at: string;
+            }[];
+            /** Format: int64 */
+            page: number;
+            /** Format: int64 */
+            per_page: number;
+            /** Format: int64 */
+            total: number;
+        };
         Stock: {
             code: string;
             /** Format: date */
@@ -973,7 +1119,12 @@ export interface operations {
     };
     v1_asset_balance_list: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description ページ番号（デフォルト: 1） */
+                page?: number;
+                /** @description 1ページあたりの件数（デフォルト: 200、最大: 1000） */
+                per_page?: number;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -985,7 +1136,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["AssetBalance"][];
+                    "application/json": components["schemas"]["PaginatedResponse_AssetBalance"];
                 };
             };
             401: {
@@ -1183,7 +1334,12 @@ export interface operations {
     };
     v1_dividend_list: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description ページ番号（デフォルト: 1） */
+                page?: number;
+                /** @description 1ページあたりの件数（デフォルト: 200、最大: 1000） */
+                per_page?: number;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -1195,7 +1351,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["Dividend"][];
+                    "application/json": components["schemas"]["PaginatedResponse_Dividend"];
                 };
             };
             401: {
@@ -1315,7 +1471,12 @@ export interface operations {
     };
     v1_domestic_stock_transaction_list: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description ページ番号（デフォルト: 1） */
+                page?: number;
+                /** @description 1ページあたりの件数（デフォルト: 200、最大: 1000） */
+                per_page?: number;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -1327,7 +1488,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["DomesticStock"][];
+                    "application/json": components["schemas"]["PaginatedResponse_DomesticStock"];
                 };
             };
             401: {
@@ -1505,7 +1666,12 @@ export interface operations {
     };
     v1_mutual_fund_transaction_list: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description ページ番号（デフォルト: 1） */
+                page?: number;
+                /** @description 1ページあたりの件数（デフォルト: 200、最大: 1000） */
+                per_page?: number;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -1517,7 +1683,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["Mutualfund"][];
+                    "application/json": components["schemas"]["PaginatedResponse_Mutualfund"];
                 };
             };
             401: {

--- a/frontend/src/pages/__tests__/AssetBalancePage.test.tsx
+++ b/frontend/src/pages/__tests__/AssetBalancePage.test.tsx
@@ -202,7 +202,7 @@ const secondMockDbRow: AssetBalanceApiData = {
 describe('AssetBalancePage 認証境界・キャッシュ境界', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue([]);
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 } as never);
     vi.mocked(assetBalanceApiModule.assetBalanceApi.previewCsv).mockResolvedValue({
       total_rows: 0,
       valid_rows: 0,
@@ -257,7 +257,7 @@ describe('AssetBalancePage 認証境界・キャッシュ境界', () => {
     vi.mocked(authHook.useAuth).mockReturnValue(
       makeAuthMock({ isAuthenticated: true, userId: 'user-1' })
     );
-    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue([mockDbRow]);
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue({ data: [mockDbRow], total: 1, page: 1, per_page: 200 } as never);
 
     await act(async () => { renderWithQuery(<AssetBalancePage />); });
 
@@ -270,7 +270,7 @@ describe('AssetBalancePage 認証境界・キャッシュ境界', () => {
     vi.mocked(authHook.useAuth).mockReturnValue(
       makeAuthMock({ isAuthenticated: true, userId: 'user-1' })
     );
-    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue([mockDbRow]);
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue({ data: [mockDbRow], total: 1, page: 1, per_page: 200 } as never);
 
     await act(async () => { renderWithQuery(<AssetBalancePage />); });
 
@@ -286,7 +286,7 @@ describe('AssetBalancePage 認証境界・キャッシュ境界', () => {
     vi.mocked(authHook.useAuth).mockReturnValue(
       makeAuthMock({ isAuthenticated: true, userId: 'user-1' })
     );
-    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue([]);
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 } as never);
     vi.mocked(assetBalanceApiModule.assetBalanceApi.previewCsv).mockResolvedValue({
       total_rows: 2,
       valid_rows: 2,
@@ -337,7 +337,7 @@ describe('AssetBalancePage 認証境界・キャッシュ境界', () => {
     vi.mocked(authHook.useAuth).mockReturnValue(
       makeAuthMock({ isAuthenticated: true, userId: 'user-1' })
     );
-    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue([mockDbRow]);
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue({ data: [mockDbRow], total: 1, page: 1, per_page: 200 } as never);
 
     await act(async () => { renderWithQuery(<AssetBalancePage />); });
 
@@ -350,7 +350,7 @@ describe('AssetBalancePage 認証境界・キャッシュ境界', () => {
     vi.mocked(authHook.useAuth).mockReturnValue(
       makeAuthMock({ isAuthenticated: true, userId: 'user-1' })
     );
-    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue([mockDbRow, secondMockDbRow]);
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue({ data: [mockDbRow, secondMockDbRow], total: 2, page: 1, per_page: 200 } as never);
 
     await act(async () => { renderWithQuery(<AssetBalancePage />); });
 
@@ -380,7 +380,7 @@ describe('AssetBalancePage 認証境界・キャッシュ境界', () => {
     vi.mocked(authHook.useAuth).mockReturnValue(
       makeAuthMock({ isAuthenticated: true, userId: 'user-1' })
     );
-    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue([mockDbRow]);
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue({ data: [mockDbRow], total: 1, page: 1, per_page: 200 } as never);
 
     await act(async () => { renderWithQuery(<AssetBalancePage />); });
 
@@ -404,7 +404,7 @@ describe('AssetBalancePage 認証境界・キャッシュ境界', () => {
     vi.mocked(authHook.useAuth).mockReturnValue(
       makeAuthMock({ isAuthenticated: true, userId: 'user-1' })
     );
-    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue([mockDbRow]);
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue({ data: [mockDbRow], total: 1, page: 1, per_page: 200 } as never);
 
     await act(async () => { renderWithQuery(<AssetBalancePage />); });
 
@@ -478,7 +478,7 @@ describe('AssetBalancePage 認証境界・キャッシュ境界', () => {
         onLogoutCapture: (cb) => { capturedCallback = cb; },
       })
     );
-    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue([mockDbRow]);
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue({ data: [mockDbRow], total: 1, page: 1, per_page: 200 } as never);
 
     await act(async () => { renderWithQuery(<AssetBalancePage />, qc); });
 

--- a/frontend/src/pages/__tests__/Receipts.test.tsx
+++ b/frontend/src/pages/__tests__/Receipts.test.tsx
@@ -666,7 +666,6 @@ describe('ReceiptsPage', () => {
     );
 
     const mockDbRow = { id: '1', payment_date: '2023-01-01' };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(receiptApi.dividendApi.list).mockResolvedValue({ data: [mockDbRow], total: 1, page: 1, per_page: 200 } as never);
     vi.mocked(receiptApi.domesticStockApi.list).mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 } as never);
     vi.mocked(receiptApi.mutualfundApi.list).mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 } as never);
@@ -702,7 +701,6 @@ describe('ReceiptsPage', () => {
     );
 
     const mockDbRow = { id: '1', payment_date: '2023-01-01' };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(receiptApi.dividendApi.list).mockResolvedValue({ data: [mockDbRow], total: 1, page: 1, per_page: 200 } as never);
     vi.mocked(receiptApi.domesticStockApi.list).mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 } as never);
     vi.mocked(receiptApi.mutualfundApi.list).mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 } as never);
@@ -750,7 +748,6 @@ describe('ReceiptsPage', () => {
     );
 
     const mockDbRow = { id: '1', payment_date: '2023-01-01' };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(receiptApi.dividendApi.list).mockResolvedValue({ data: [mockDbRow], total: 1, page: 1, per_page: 200 } as never);
     vi.mocked(receiptApi.domesticStockApi.list).mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 } as never);
     vi.mocked(receiptApi.mutualfundApi.list).mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 } as never);

--- a/frontend/src/pages/__tests__/Receipts.test.tsx
+++ b/frontend/src/pages/__tests__/Receipts.test.tsx
@@ -150,19 +150,19 @@ vi.mock('@/pages/Receipt/Mutualfund', () => ({
 import * as receiptApi from '@/features/receipt/api/receiptApi';
 vi.mock('@/features/receipt/api/receiptApi', () => ({
   dividendApi: {
-    list: vi.fn().mockResolvedValue([]),
+    list: vi.fn().mockResolvedValue({ data: [], total: 0, page: 1, per_page: 1000 }),
     previewCsv: vi.fn().mockResolvedValue({ total_rows: 0, valid_rows: 0, errors: [] }),
     uploadCsv: vi.fn().mockResolvedValue({ inserted: 0, skipped: 0, errors: [] }),
     deleteAll: vi.fn().mockResolvedValue({}),
   },
   domesticStockApi: {
-    list: vi.fn().mockResolvedValue([]),
+    list: vi.fn().mockResolvedValue({ data: [], total: 0, page: 1, per_page: 1000 }),
     previewCsv: vi.fn().mockResolvedValue({ total_rows: 0, valid_rows: 0, errors: [] }),
     uploadCsv: vi.fn().mockResolvedValue({ inserted: 0, skipped: 0, errors: [] }),
     deleteAll: vi.fn().mockResolvedValue({}),
   },
   mutualfundApi: {
-    list: vi.fn().mockResolvedValue([]),
+    list: vi.fn().mockResolvedValue({ data: [], total: 0, page: 1, per_page: 1000 }),
     previewCsv: vi.fn().mockResolvedValue({ total_rows: 0, valid_rows: 0, errors: [] }),
     uploadCsv: vi.fn().mockResolvedValue({ inserted: 0, skipped: 0, errors: [] }),
     deleteAll: vi.fn().mockResolvedValue({}),

--- a/frontend/src/pages/__tests__/Receipts.test.tsx
+++ b/frontend/src/pages/__tests__/Receipts.test.tsx
@@ -282,9 +282,9 @@ describe('ReceiptsPage', () => {
 
   async function setupKeyboardNavigationTest() {
     vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({ isAuthenticated: true }));
-    vi.mocked(receiptApi.dividendApi.list).mockResolvedValue([] as never[]);
-    vi.mocked(receiptApi.domesticStockApi.list).mockResolvedValue([] as never[]);
-    vi.mocked(receiptApi.mutualfundApi.list).mockResolvedValue([] as never[]);
+    vi.mocked(receiptApi.dividendApi.list).mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 } as never);
+    vi.mocked(receiptApi.domesticStockApi.list).mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 } as never);
+    vi.mocked(receiptApi.mutualfundApi.list).mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 } as never);
 
     renderWithQuery(<ReceiptsPage />);
 
@@ -340,9 +340,9 @@ describe('ReceiptsPage', () => {
 
   it('CSV preview: 配当金のプレビュー行を Dividend に渡す', async () => {
     vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({ isAuthenticated: true }));
-    vi.mocked(receiptApi.dividendApi.list).mockResolvedValue([] as never[]);
-    vi.mocked(receiptApi.domesticStockApi.list).mockResolvedValue([] as never[]);
-    vi.mocked(receiptApi.mutualfundApi.list).mockResolvedValue([] as never[]);
+    vi.mocked(receiptApi.dividendApi.list).mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 } as never);
+    vi.mocked(receiptApi.domesticStockApi.list).mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 } as never);
+    vi.mocked(receiptApi.mutualfundApi.list).mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 } as never);
     vi.mocked(receiptApi.dividendApi.previewCsv).mockResolvedValue({
       total_rows: 2,
       valid_rows: 2,
@@ -382,9 +382,9 @@ describe('ReceiptsPage', () => {
 
   it('CSV preview: 国内株式タブで DomesticStock コンポーネントにプレビューが渡る', async () => {
     vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({ isAuthenticated: true }));
-    vi.mocked(receiptApi.dividendApi.list).mockResolvedValue([] as never[]);
-    vi.mocked(receiptApi.domesticStockApi.list).mockResolvedValue([] as never[]);
-    vi.mocked(receiptApi.mutualfundApi.list).mockResolvedValue([] as never[]);
+    vi.mocked(receiptApi.dividendApi.list).mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 } as never);
+    vi.mocked(receiptApi.domesticStockApi.list).mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 } as never);
+    vi.mocked(receiptApi.mutualfundApi.list).mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 } as never);
     vi.mocked(receiptApi.domesticStockApi.previewCsv).mockResolvedValue({
       total_rows: 1,
       valid_rows: 1,
@@ -420,9 +420,9 @@ describe('ReceiptsPage', () => {
 
   it('CSV preview: 投資信託タブで Mutualfund コンポーネントにプレビューが渡る', async () => {
     vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({ isAuthenticated: true }));
-    vi.mocked(receiptApi.dividendApi.list).mockResolvedValue([] as never[]);
-    vi.mocked(receiptApi.domesticStockApi.list).mockResolvedValue([] as never[]);
-    vi.mocked(receiptApi.mutualfundApi.list).mockResolvedValue([] as never[]);
+    vi.mocked(receiptApi.dividendApi.list).mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 } as never);
+    vi.mocked(receiptApi.domesticStockApi.list).mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 } as never);
+    vi.mocked(receiptApi.mutualfundApi.list).mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 } as never);
     vi.mocked(receiptApi.mutualfundApi.previewCsv).mockResolvedValue({
       total_rows: 1,
       valid_rows: 1,
@@ -584,9 +584,9 @@ describe('ReceiptsPage', () => {
     vi.mocked(authHook.useAuth).mockReturnValue(
       makeAuthMock({ isAuthenticated: true })
     );
-    vi.mocked(receiptApi.dividendApi.list).mockResolvedValue([]);
-    vi.mocked(receiptApi.domesticStockApi.list).mockResolvedValue([]);
-    vi.mocked(receiptApi.mutualfundApi.list).mockResolvedValue([]);
+    vi.mocked(receiptApi.dividendApi.list).mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 } as never);
+    vi.mocked(receiptApi.domesticStockApi.list).mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 } as never);
+    vi.mocked(receiptApi.mutualfundApi.list).mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 } as never);
     vi.mocked(receiptApi.dividendApi.uploadCsv).mockResolvedValue({ inserted: 0, skipped: 0, errors: [] });
 
     renderWithQuery(<ReceiptsPage />);
@@ -622,9 +622,9 @@ describe('ReceiptsPage', () => {
     vi.mocked(authHook.useAuth).mockReturnValue(
       makeAuthMock({ isAuthenticated: true })
     );
-    vi.mocked(receiptApi.dividendApi.list).mockResolvedValue([]);
-    vi.mocked(receiptApi.domesticStockApi.list).mockResolvedValue([]);
-    vi.mocked(receiptApi.mutualfundApi.list).mockResolvedValue([]);
+    vi.mocked(receiptApi.dividendApi.list).mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 } as never);
+    vi.mocked(receiptApi.domesticStockApi.list).mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 } as never);
+    vi.mocked(receiptApi.mutualfundApi.list).mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 } as never);
     vi.mocked(receiptApi.dividendApi.uploadCsv).mockResolvedValue({ inserted: 3, skipped: 2, errors: [] });
 
     renderWithQuery(<ReceiptsPage />);
@@ -667,9 +667,9 @@ describe('ReceiptsPage', () => {
 
     const mockDbRow = { id: '1', payment_date: '2023-01-01' };
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    vi.mocked(receiptApi.dividendApi.list).mockResolvedValue([mockDbRow] as any);
-    vi.mocked(receiptApi.domesticStockApi.list).mockResolvedValue([]);
-    vi.mocked(receiptApi.mutualfundApi.list).mockResolvedValue([]);
+    vi.mocked(receiptApi.dividendApi.list).mockResolvedValue({ data: [mockDbRow], total: 1, page: 1, per_page: 200 } as never);
+    vi.mocked(receiptApi.domesticStockApi.list).mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 } as never);
+    vi.mocked(receiptApi.mutualfundApi.list).mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 } as never);
     vi.mocked(receiptApi.dividendApi.deleteAll).mockResolvedValue({ message: '' });
 
     renderWithQuery(<ReceiptsPage />);
@@ -703,9 +703,9 @@ describe('ReceiptsPage', () => {
 
     const mockDbRow = { id: '1', payment_date: '2023-01-01' };
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    vi.mocked(receiptApi.dividendApi.list).mockResolvedValue([mockDbRow] as any);
-    vi.mocked(receiptApi.domesticStockApi.list).mockResolvedValue([]);
-    vi.mocked(receiptApi.mutualfundApi.list).mockResolvedValue([]);
+    vi.mocked(receiptApi.dividendApi.list).mockResolvedValue({ data: [mockDbRow], total: 1, page: 1, per_page: 200 } as never);
+    vi.mocked(receiptApi.domesticStockApi.list).mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 } as never);
+    vi.mocked(receiptApi.mutualfundApi.list).mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 } as never);
     vi.mocked(receiptApi.dividendApi.deleteAll).mockResolvedValue({ message: '' });
 
     renderWithQuery(<ReceiptsPage />);
@@ -751,9 +751,9 @@ describe('ReceiptsPage', () => {
 
     const mockDbRow = { id: '1', payment_date: '2023-01-01' };
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    vi.mocked(receiptApi.dividendApi.list).mockResolvedValue([mockDbRow] as any);
-    vi.mocked(receiptApi.domesticStockApi.list).mockResolvedValue([]);
-    vi.mocked(receiptApi.mutualfundApi.list).mockResolvedValue([]);
+    vi.mocked(receiptApi.dividendApi.list).mockResolvedValue({ data: [mockDbRow], total: 1, page: 1, per_page: 200 } as never);
+    vi.mocked(receiptApi.domesticStockApi.list).mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 } as never);
+    vi.mocked(receiptApi.mutualfundApi.list).mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 } as never);
 
     renderWithQuery(<ReceiptsPage />, qc);
 
@@ -782,14 +782,9 @@ describe('ReceiptsPage', () => {
 
   it('desktop向けworkspaceレイアウトとタブ件数が表示される', async () => {
     vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({ isAuthenticated: true }));
-    vi.mocked(receiptApi.dividendApi.list).mockResolvedValue([
-      { id: 'd1', payment_date: '2025-01-01' },
-      { id: 'd2', payment_date: '2025-02-01' },
-    ] as never[]);
-    vi.mocked(receiptApi.domesticStockApi.list).mockResolvedValue([
-      { id: 's1', trade_date: '2025-01-01' },
-    ] as never[]);
-    vi.mocked(receiptApi.mutualfundApi.list).mockResolvedValue([] as never[]);
+    vi.mocked(receiptApi.dividendApi.list).mockResolvedValue({ data: [{ id: 'd1', payment_date: '2025-01-01' }, { id: 'd2', payment_date: '2025-02-01' }], total: 2, page: 1, per_page: 200 } as never);
+    vi.mocked(receiptApi.domesticStockApi.list).mockResolvedValue({ data: [{ id: 's1', trade_date: '2025-01-01' }], total: 1, page: 1, per_page: 200 } as never);
+    vi.mocked(receiptApi.mutualfundApi.list).mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 } as never);
 
     renderWithQuery(<ReceiptsPage />);
 


### PR DESCRIPTION
## 概要

dividend / domestic_stock / mutualfund / asset_balance の list() API にページネーションを追加。

## 変更内容

### バックエンド
- `models/common.rs`: `PaginationParams`（クエリパラメータ）と `PaginatedResponse<T>`（汎用レスポンス型）を追加
- 4サービス: `list()` に `COUNT` クエリ + `LIMIT/OFFSET` を追加
- 4ハンドラ: `Query<PaginationParams>` を受け取り、`PaginatedResponse<T>` を返す

### API 変更
| 変更点 | Before | After |
|---|---|---|
| クエリパラメータ | なし | `?page=1&per_page=200`（省略可） |
| レスポンス型 | `T[]` | `{ data: T[], total: number, page: number, per_page: number }` |

### openapi.json / generated/api.ts
- `bash scripts/check-openapi.sh` で再生成・同期済み

### フロントエンド
- `useReceiptsData.ts`: `.then(items => ...)` → `.then(res => res.data.map(...))` に更新
- `useAssetBalance.ts` / `useAssetBalanceDataSource.ts`: `query.data?.data ?? []` に更新
- テストモックを新しいレスポンス型に更新（5ファイル）

## 設計メモ
- デフォルト: `page=1, per_page=200`（大半のユーザーは全件取得でき、極端な大量データでのメモリ消費を抑制）
- `per_page` は最大 1000 に clamp
- ページネーション UI（次へ/前へボタン）は後続タスク

## テスト
- `SQLX_OFFLINE=true cargo test`: PASS (1 passed, 10 ignored)
- `npm run typecheck`: PASS (0 errors)
- `npm test`: PASS (959 tests)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 一覧取得APIがページネーションに対応し、`page` / `per_page` で件数指定できるようになりました。
  * 一覧レスポンスが `data`・`total`・`page`・`per_page` を含む形式に統一されました。
  * API仕様（OpenAPI）が更新されました。
* **Bug Fixes**
  * ページネーション形式に合わせて画面表示・データ取得・空データ時の挙動を調整しました。
* **Tests**
  * フロント/バックのテスト・E2Eモックを新レスポンス形式に更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->