### PR TITLE
chore: Codex プラグインを settings.json で有効化

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,6 +23,7 @@
   },
   "enabledPlugins": {
     "frontend-design@claude-plugins-official": true,
-    "code-review@claude-plugins-official": true
+    "code-review@claude-plugins-official": true,
+    "codex@openai-codex": true
   }
 }


### PR DESCRIPTION
## 概要

`.claude/settings.json` の `enabledPlugins` に `codex@openai-codex` を追加。

## 変更内容

```json
"codex@openai-codex": true
```

Codex CLI (codex-cli 0.142.4) がローカルで認証済みのため、設定を有効化して PR レビューや実装委譲に使用できる状態にする。

🤖 Generated with [Claude Code](https://claude.ai/claude-code)