### PR TITLE
docs: Markdownの保守情報を最新化

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ cd frontend && npm run dev -- --host 127.0.0.1 --port 8080
 ```bash
 cd frontend
 npm run lint
-npx tsc --noEmit
+npm run typecheck
 npm test
 npm run build
 ```
@@ -145,81 +145,10 @@ cargo test
 cargo build
 ```
 
-## API エンドポイント
+## API ドキュメント
 
-業務 API は `/api/v1` プレフィックスを持つ。プローブ（`/health`, `/ready`）は例外としてルート直下に置く。詳細は [docs/api/v1-rest-design.md](docs/api/v1-rest-design.md) を参照。
-
-### プローブ
-
-| Method | Path | 説明 | 認証 |
-|---|---|---|---|
-| GET | `/health` | 生存確認 | 不要 |
-| GET | `/ready` | 起動レディネス確認 | 不要 |
-
-### セッション・アカウント
-
-| Method | Path | 説明 | 認証 |
-|---|---|---|---|
-| GET | `/api/v1/session` | 現在ユーザーのセッション取得 | 必要 |
-| DELETE | `/api/v1/session` | ログアウト | 必要 |
-| POST | `/api/v1/account-deletion-confirmations` | アカウント削除確認（確認クッキー発行） | 必要 |
-| DELETE | `/api/v1/account` | アカウント削除（確認クッキー必須） | 必要 |
-| GET | `/api/v1/oauth/google/authorize` | Google OAuth 認証開始 | 不要 |
-| GET | `/api/v1/oauth/google/callback` | Google OAuth コールバック | 不要 |
-
-### 銘柄
-
-| Method | Path | 説明 | 認証 |
-|---|---|---|---|
-| GET | `/api/v1/stocks?query=7203` | 銘柄検索（コード・社名） | 不要 |
-| POST | `/api/v1/stocks` | 銘柄追加 | 必要 |
-
-### 配当金（認証必須）
-
-| Method | Path | 説明 |
-|---|---|---|
-| GET | `/api/v1/dividends` | 配当金一覧取得 |
-| DELETE | `/api/v1/dividends` | 配当金全削除 |
-| POST | `/api/v1/dividend-import-validations` | 配当金 CSV バリデーション（DB書込なし） |
-| POST | `/api/v1/dividend-imports` | 配当金 CSV インポート |
-| POST | `/api/v1/dividend-per-share-estimates` | 配当利回り一括取得 |
-
-### 国内株式明細（認証必須）
-
-| Method | Path | 説明 |
-|---|---|---|
-| GET | `/api/v1/domestic-stock-transactions` | 国内株式一覧取得 |
-| DELETE | `/api/v1/domestic-stock-transactions` | 国内株式全削除 |
-| POST | `/api/v1/domestic-stock-import-validations` | 国内株式 CSV バリデーション |
-| POST | `/api/v1/domestic-stock-imports` | 国内株式 CSV インポート |
-
-### 投資信託明細（認証必須）
-
-| Method | Path | 説明 |
-|---|---|---|
-| GET | `/api/v1/mutual-fund-transactions` | 投資信託一覧取得 |
-| DELETE | `/api/v1/mutual-fund-transactions` | 投資信託全削除 |
-| POST | `/api/v1/mutual-fund-import-validations` | 投資信託 CSV バリデーション |
-| POST | `/api/v1/mutual-fund-imports` | 投資信託 CSV インポート |
-
-### 保有銘柄（認証必須）
-
-| Method | Path | 説明 |
-|---|---|---|
-| GET | `/api/v1/asset-balances` | 保有銘柄一覧取得 |
-| PUT | `/api/v1/asset-balances` | 保有銘柄全置換（CSV 全件更新） |
-| DELETE | `/api/v1/asset-balances` | 保有銘柄全削除 |
-| POST | `/api/v1/asset-balance-import-validations` | 保有銘柄 CSV バリデーション |
-| POST | `/api/v1/asset-balance-imports` | 保有銘柄 CSV インポート |
-
-### マーケットデータ
-
-| Method | Path | 説明 | 認証 |
-|---|---|---|---|
-| GET | `/api/v1/financial-statements?code=7203` | 決算サマリー取得 | 不要 |
-
-> 旧ルート（`/auth/google`、`/stock/{query}`、`/dividends/all` 等）は v1 移行完了後に削除済み。
-> 移行履歴は [docs/api/v1-rest-design.md](docs/api/v1-rest-design.md) の「Legacy Route Migration History」を参照。
+API の一覧と設計方針は [docs/api/v1-rest-design.md](docs/api/v1-rest-design.md) に集約しています。
+API 契約の正本は [docs/openapi.json](docs/openapi.json) です。
 
 ## ディレクトリ構成
 
@@ -280,11 +209,6 @@ shoken-webapp/
 | [運用ランブック](docs/runbook.md) | ローカル起動・デプロイ・DBマイグレーション・トラブルシューティング |
 | [テストガイド](docs/testing.md) | フロントエンド・バックエンド・E2Eテストの実行方法と方針 |
 | [技術者倫理ガイドライン](docs/ethics.md) | データ最小化・透明性・セキュリティ・アクセシビリティの判断基準 |
-
-## 補足
-
-- フロントエンド詳細: `frontend/README.md`
-- バックエンド詳細: `backend/README.md`
 
 ## セキュリティ
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -5,7 +5,7 @@
 ## 技術スタック
 
 - **フレームワーク**: Axum 0.8
-- **データベース**: PostgreSQL (Neon)
+- **データベース**: PostgreSQL
 - **ORM**: SQLx
 - **認証**: Google OAuth 2.0
 - **デプロイ**: Fly.io
@@ -17,82 +17,16 @@
 - **Google OAuth認証**: セッションベースの認証
 - **ヘルスチェック**: サービス監視用エンドポイント
 
-## APIエンドポイント
+## API ドキュメント
 
-### プローブ
-
-| メソッド | パス | 説明 |
-|---------|------|------|
-| GET | `/health` | Liveness チェック |
-| GET | `/ready` | 起動完了チェック |
-
-### 認証・セッション
-
-| メソッド | パス | 説明 |
-|---------|------|------|
-| GET | `/api/v1/session` | 現在のセッション情報取得 |
-| DELETE | `/api/v1/session` | ログアウト |
-| POST | `/api/v1/account-deletion-confirmations` | アカウント削除確認（短命Cookie発行） |
-| DELETE | `/api/v1/account` | アカウント削除（確認Cookie必須） |
-| GET | `/api/v1/oauth/google/authorize` | Google OAuth 開始 |
-| GET | `/api/v1/oauth/google/callback` | Google OAuth コールバック |
-
-### 証券情報
-
-| メソッド | パス | 説明 | 認証 |
-|---------|------|------|------|
-| GET | `/api/v1/stocks?query=7203` | 株式情報を検索 | 不要 |
-| POST | `/api/v1/stocks` | 株式情報を追加 | **必須** |
-
-### 配当金（すべて認証必須）
-
-| メソッド | パス | 説明 |
-|---------|------|------|
-| GET | `/api/v1/dividends` | 配当金一覧を取得 |
-| DELETE | `/api/v1/dividends` | 配当金を全削除 |
-| POST | `/api/v1/dividend-import-validations` | 配当金CSV バリデーション（DB書き込みなし） |
-| POST | `/api/v1/dividend-imports` | 配当金CSV 取り込み |
-| POST | `/api/v1/dividend-per-share-estimates` | 1株配当一括推計 |
-
-### 国内株式取引（すべて認証必須）
-
-| メソッド | パス | 説明 |
-|---------|------|------|
-| GET | `/api/v1/domestic-stock-transactions` | 国内株式取引一覧を取得 |
-| DELETE | `/api/v1/domestic-stock-transactions` | 国内株式取引を全削除 |
-| POST | `/api/v1/domestic-stock-import-validations` | 国内株式CSV バリデーション |
-| POST | `/api/v1/domestic-stock-imports` | 国内株式CSV 取り込み |
-
-### 投資信託取引（すべて認証必須）
-
-| メソッド | パス | 説明 |
-|---------|------|------|
-| GET | `/api/v1/mutual-fund-transactions` | 投資信託取引一覧を取得 |
-| DELETE | `/api/v1/mutual-fund-transactions` | 投資信託取引を全削除 |
-| POST | `/api/v1/mutual-fund-import-validations` | 投資信託CSV バリデーション |
-| POST | `/api/v1/mutual-fund-imports` | 投資信託CSV 取り込み |
-
-### 保有銘柄（すべて認証必須）
-
-| メソッド | パス | 説明 |
-|---------|------|------|
-| GET | `/api/v1/asset-balances` | 保有銘柄一覧を取得 |
-| PUT | `/api/v1/asset-balances` | 保有銘柄を全件置換 |
-| DELETE | `/api/v1/asset-balances` | 保有銘柄を全削除 |
-| POST | `/api/v1/asset-balance-import-validations` | 保有銘柄CSV バリデーション |
-| POST | `/api/v1/asset-balance-imports` | 保有銘柄CSV 取り込み |
-
-### 市場データ（認証必須）
-
-| メソッド | パス | 説明 |
-|---------|------|------|
-| GET | `/api/v1/financial-statements?code=7203` | 財務サマリーを取得 |
+API の一覧と設計方針は [`../docs/api/v1-rest-design.md`](../docs/api/v1-rest-design.md) に集約しています。
+API 契約の正本は [`../docs/openapi.json`](../docs/openapi.json) です。
 
 ## 開発
 
 ### 前提条件
 
-- Rust 1.70+
+- Rust 1.96+（`rust-toolchain.toml` を正本とする）
 - PostgreSQL データベース
 - 環境変数の設定
 
@@ -187,7 +121,7 @@ DATABASE_URL=postgresql://user:password@localhost:5432/shoken_db
 
 ```bash
 # マイグレーション実行
-cargo sqlx migrate run
+make migrate-local
 
 # SQLxクエリキャッシュ準備（オフラインビルド用）
 cargo sqlx prepare --merged

--- a/docs/api/v1-rest-design.md
+++ b/docs/api/v1-rest-design.md
@@ -52,6 +52,14 @@ API identifiers and must not collide with legacy operation IDs.
 HttpOnly confirmation cookie scoped to `/api/v1/account`. The delete endpoint
 requires both a valid session cookie and that confirmation cookie.
 
+## Pagination
+
+The list endpoints for dividends, domestic stock transactions, mutual fund transactions, and asset balances accept `page` and `per_page` query parameters.
+
+- `page`: defaults to `1`, minimum effective value is `1`.
+- `per_page`: defaults to `200`, clamped to `1..1000`.
+- Responses use `PaginatedResponse<T>`: `{ data, total, page, per_page }`.
+
 ## Proposed Routes
 
 ### Probes
@@ -83,7 +91,7 @@ requires both a valid session cookie and that confirmation cookie.
 
 | Method | Path | Description |
 |---|---|---|
-| GET | `/api/v1/dividends` | List dividends |
+| GET | `/api/v1/dividends?page=1&per_page=200` | List dividends |
 | DELETE | `/api/v1/dividends` | Delete all dividends for current user |
 | POST | `/api/v1/dividend-import-validations` | Validate dividend CSV without DB writes |
 | POST | `/api/v1/dividend-imports` | Import dividend CSV |
@@ -93,7 +101,7 @@ requires both a valid session cookie and that confirmation cookie.
 
 | Method | Path | Description |
 |---|---|---|
-| GET | `/api/v1/domestic-stock-transactions` | List domestic stock transactions |
+| GET | `/api/v1/domestic-stock-transactions?page=1&per_page=200` | List domestic stock transactions |
 | DELETE | `/api/v1/domestic-stock-transactions` | Delete all domestic stock transactions |
 | POST | `/api/v1/domestic-stock-import-validations` | Validate domestic stock CSV |
 | POST | `/api/v1/domestic-stock-imports` | Import domestic stock CSV |
@@ -102,7 +110,7 @@ requires both a valid session cookie and that confirmation cookie.
 
 | Method | Path | Description |
 |---|---|---|
-| GET | `/api/v1/mutual-fund-transactions` | List mutual fund transactions |
+| GET | `/api/v1/mutual-fund-transactions?page=1&per_page=200` | List mutual fund transactions |
 | DELETE | `/api/v1/mutual-fund-transactions` | Delete all mutual fund transactions |
 | POST | `/api/v1/mutual-fund-import-validations` | Validate mutual fund CSV |
 | POST | `/api/v1/mutual-fund-imports` | Import mutual fund CSV |
@@ -111,7 +119,7 @@ requires both a valid session cookie and that confirmation cookie.
 
 | Method | Path | Description |
 |---|---|---|
-| GET | `/api/v1/asset-balances` | List asset balances |
+| GET | `/api/v1/asset-balances?page=1&per_page=200` | List asset balances |
 | PUT | `/api/v1/asset-balances` | Replace all asset balances for current user |
 | DELETE | `/api/v1/asset-balances` | Delete all asset balances |
 | POST | `/api/v1/asset-balance-import-validations` | Validate asset balance CSV |

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -103,7 +103,7 @@ Google Cloud Console で以下の **Authorized redirect URIs** を登録する:
 ## PR マージ後のクリーンアップ
 
 worktree を使った作業ブランチをマージした後は、以下の順序で後片付けをする。
-`git branch -D` を先に実行すると worktree がそのブランチを参照中のためエラーになる場合があるので、
+ローカルブランチ削除を先に実行すると worktree がそのブランチを参照中のためエラーになる場合があるので、
 必ず **worktree 削除を先に行う**こと。
 
 ```bash
@@ -118,7 +118,7 @@ git pull --ff-only origin main
 git worktree remove /tmp/<repo>-<topic>
 
 # 4. ローカルブランチを削除（squash merge 済み短期ブランチのみ）
-git branch -D <branch-name>
+git branch -d <branch-name>
 
 # 5. リモートブランチを削除（gh pr merge --delete-branch を使わなかった場合）
 git push origin --delete <branch-name>
@@ -128,8 +128,9 @@ git fetch origin --prune
 ```
 
 > **注意**: `gh pr merge --delete-branch` はリモートブランチを削除するが、
-> ローカルに worktree が残っている状態では `git branch -D` が失敗する。
-> 上記の順序（merge → main pull → worktree remove → branch -D → push delete → fetch prune）を守ること。
+> ローカルに worktree が残っている状態ではブランチ削除が失敗する。
+> 上記の順序（merge → main pull → worktree remove → branch -d → push delete → fetch prune）を守ること。
+> `git branch -d` が拒否された場合は、PR が squash merge 済みで main に取り込まれていることを確認してから個別判断する。
 
 ## Dependabot PR 対応
 
@@ -156,7 +157,7 @@ git fetch origin --prune
 ### フロントエンドの型エラー
 
 ```bash
-(cd frontend && npx tsc --noEmit)  # 型エラー確認
+(cd frontend && npm run typecheck)  # 型エラー確認
 (cd frontend && npm run lint)      # Lint エラー確認
 ```
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -96,8 +96,8 @@ GitHub Actions で以下が自動実行されます（PR 時）:
 
 | ワークフロー | ファイル | ステップ |
 |---|---|---|
-| フロント | `deploy-frontend.yml` | lint / test（1回） / build / E2E |
-| バックエンド | `deploy-backend.yml` | clippy / test / release check / OpenAPI 同期確認 / tsc |
+| フロント | `deploy-frontend.yml` | lint / typecheck / test（1回） / build / E2E |
+| バックエンド | `deploy-backend.yml` | clippy / test / OpenAPI 同期確認 / frontend typecheck |
 
 ### フロントエンド CI の方針
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -34,18 +34,18 @@
 - **`src/hooks/`**: カスタムReactフック
 - **`src/contexts/`**: Reactコンテキスト
 
-詳細は `/src/components/README.md` を参照してください。
-
 ## 使用技術
 
-- **React 19.2.3**: フロントエンド UI ライブラリ
-- **TypeScript 5.9.3**: 型安全なコーディング
-- **React Compiler 19.1.0**: 自動メモ化による最適化（babel-plugin-react-compiler）
-- **TanStack React Query 5.90.16**: サーバー状態管理
-- **React Router DOM 7.11.0**: クライアントサイドルーティング
-- **Tailwind CSS 4.1.18**: ユーティリティファーストのCSSフレームワーク
-- **Vite 7.3.0**: 高速な開発環境とビルドツール
-- **Vitest 4.0.16 + Testing Library 16.3.1**: ユニットテストとコンポーネントテスト
+- **React 19**: フロントエンド UI ライブラリ
+- **TypeScript 6**: 型安全なコーディング（実行は `npm run typecheck`）
+- **React Compiler**: 自動メモ化による最適化（babel-plugin-react-compiler）
+- **TanStack React Query 5**: サーバー状態管理
+- **React Router DOM 7**: クライアントサイドルーティング
+- **Tailwind CSS 4**: ユーティリティファーストのCSSフレームワーク
+- **Vite 8**: 高速な開発環境とビルドツール
+- **Vitest 4 + Testing Library**: ユニットテストとコンポーネントテスト
+
+実バージョンの正本は `package.json` と `package-lock.json` です。
 
 ### 主要アーキテクチャパターン
 - **Atomic Design**: 単一責任での厳密なコンポーネント階層
@@ -59,7 +59,7 @@
 ### NPMコマンド
 ```bash
 # 依存関係のインストール
-npm install
+npm ci
 
 # 開発サーバーの起動（ポート8080で自動ブラウザ起動）
 npm run dev
@@ -69,6 +69,9 @@ npm run build
 
 # ESLintによるコード検証（TypeScript + React + React Compilerルール）
 npm run lint
+
+# 型チェック
+npm run typecheck
 
 # テスト実行（メモリ最適化済み）
 npm test
@@ -110,7 +113,7 @@ make all
 
 - **ベースパス**: `/`（Vercel ルート）
 - **パスエイリアス**: `@/*` は `src/*` にマップ
-- **API 接続先**: `VITE_SHOKEN_WEBAPI_API_URL` でバックエンドURLを指定（J-Quants APIはバックエンド経由）
+- **API 接続先**: `VITE_SHOKEN_WEBAPI_API_URL` でバックエンドURLを指定。API 型は `docs/openapi.json` から生成した `src/generated/api.ts` を使用
 - **テスト環境**: jsdom環境での単一フォーク設定、10秒タイムアウト
 - **ビルド最適化**: Terser圧縮でのベンダーチャンク分割
 


### PR DESCRIPTION
## 概要
- README/API設計/運用ランブックの古い表記を最新化
- 一覧APIのページング仕様と OpenAPI 正本の位置づけを追記
- frontend README の古い固定バージョンと存在しない参照を整理

## 変更種別
- [x] ドキュメント
- [ ] バグ修正
- [ ] 新機能

## 確認
- [x] git diff --check
- [x] stale参照検索（古いバージョン、存在しないREADME参照、git branch -D など）