### PR TITLE
feat: 一覧APIの全ページ取得に対応

### DIFF
--- a/frontend/src/features/assetBalance/hooks/__tests__/useAssetBalance.test.ts
+++ b/frontend/src/features/assetBalance/hooks/__tests__/useAssetBalance.test.ts
@@ -208,6 +208,38 @@ describe('useAssetBalance', () => {
     expect(result.current.getTotalMarketValue()).toBe(100000);
   });
 
+  it('total が per_page を超える場合は次ページを取得し全件を返す', async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockImplementation(
+      ({ page = 1 }: { page?: number; per_page?: number } = {}) => {
+        if (page === 1) {
+          return Promise.resolve({
+            data: Array.from({ length: 1000 }, (_, index) =>
+              makeAssetBalanceData({ id: String(index + 1), security_code: String(7000 + index) })
+            ),
+            total: 1001, page: 1, per_page: 1000,
+          });
+        }
+        return Promise.resolve({
+          data: [makeAssetBalanceData({ id: '1001', security_code: '6758' })],
+          total: 1001, page: 2, per_page: 1000,
+        });
+      }
+    );
+
+    const { result } = renderHook(() => useAssetBalance(), { wrapper: makeWrapper(qc) });
+
+    await waitFor(() => {
+      expect(result.current.assetBalanceData).toHaveLength(1001);
+    });
+    expect(assetBalanceApiModule.assetBalanceApi.list).toHaveBeenCalledTimes(2);
+    expect(assetBalanceApiModule.assetBalanceApi.list).toHaveBeenNthCalledWith(1, { per_page: 1000, page: 1 });
+    expect(assetBalanceApiModule.assetBalanceApi.list).toHaveBeenNthCalledWith(2, { per_page: 1000, page: 2 });
+  });
+
   it('refetch は assetBalance クエリを invalidate する', async () => {
     const qc = new QueryClient({
       defaultOptions: { queries: { retry: false, staleTime: Infinity } },

--- a/frontend/src/features/assetBalance/hooks/__tests__/useAssetBalanceDataSource.test.ts
+++ b/frontend/src/features/assetBalance/hooks/__tests__/useAssetBalanceDataSource.test.ts
@@ -117,6 +117,36 @@ describe('useAssetBalanceDataSource: 基本動作', () => {
     });
   });
 
+  it('total が per_page を超える場合は次ページを取得し全件を dbData に含める', async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: Infinity } } });
+    vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({}));
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockImplementation(
+      ({ page = 1 }: { page?: number; per_page?: number } = {}) => {
+        if (page === 1) {
+          return Promise.resolve({
+            data: Array.from({ length: 1000 }, (_, index) =>
+              ({ security_code: String(7000 + index), security_name: '銘柄' + index, shares: 100 }) as never
+            ),
+            total: 1001, page: 1, per_page: 1000,
+          });
+        }
+        return Promise.resolve({
+          data: [{ security_code: '6758', security_name: 'ソニーグループ', shares: 50 } as never],
+          total: 1001, page: 2, per_page: 1000,
+        });
+      }
+    );
+
+    const { result } = renderHook(() => useAssetBalanceDataSource(), { wrapper: makeWrapper(qc) });
+
+    await waitFor(() => {
+      expect(result.current.dbData).toHaveLength(1001);
+    });
+    expect(assetBalanceApiModule.assetBalanceApi.list).toHaveBeenCalledTimes(2);
+    expect(assetBalanceApiModule.assetBalanceApi.list).toHaveBeenNthCalledWith(1, { per_page: 1000, page: 1 });
+    expect(assetBalanceApiModule.assetBalanceApi.list).toHaveBeenNthCalledWith(2, { per_page: 1000, page: 2 });
+  });
+
   it('deleteAll完了後にcacheキーが存在しない場合setQueryDataを呼ばない', async () => {
     const qc = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: Infinity } } });
     vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({}));

--- a/frontend/src/features/assetBalance/hooks/useAssetBalance.ts
+++ b/frontend/src/features/assetBalance/hooks/useAssetBalance.ts
@@ -4,6 +4,7 @@ import type { AssetBalanceData } from '@/types/api';
 import { assetBalanceApi } from '@/features/assetBalance/api/assetBalanceApi';
 import { useAuth } from '@/features/auth/hooks/useAuth';
 import { normalizeSecurityCode } from '@/lib/utils/formatters';
+import { fetchAllPages } from '@/lib/api/pagination';
 import { assetBalanceQueryKeys, clearAssetBalanceCache } from '../queryKeys';
 
 interface UseAssetBalanceReturn {
@@ -30,7 +31,7 @@ export function useAssetBalance(options: UseAssetBalanceOptions = {}): UseAssetB
 
   const query = useQuery({
     queryKey: assetBalanceQueryKeys.all(userId),
-    queryFn: () => assetBalanceApi.list({ per_page: 1000 }),
+    queryFn: () => fetchAllPages((page) => assetBalanceApi.list({ per_page: 1000, page })),
     enabled: isAuthenticated && !!userId && enabled,
   });
 
@@ -40,8 +41,7 @@ export function useAssetBalance(options: UseAssetBalanceOptions = {}): UseAssetB
   }, [onLogout, queryClient]);
 
   // 未認証時はキャッシュに残存データがあっても空を返す
-  const assetBalancePage = isAuthenticated ? query.data : undefined;
-  const assetBalanceData = assetBalancePage?.data ?? [];
+  const assetBalanceData = (isAuthenticated ? query.data : undefined) ?? [];
 
   const getAssetBalanceByCode = (code: string): AssetBalanceData | undefined => {
     const normalizedCode = normalizeSecurityCode(code);

--- a/frontend/src/features/assetBalance/hooks/useAssetBalanceDataSource.ts
+++ b/frontend/src/features/assetBalance/hooks/useAssetBalanceDataSource.ts
@@ -4,6 +4,7 @@ import type { AssetBalanceData } from '@/types/api';
 import { assetBalanceApi } from '@/features/assetBalance/api/assetBalanceApi';
 import { useAuth } from '@/features/auth/hooks/useAuth';
 import { getDisplayErrorMessage } from '@/lib/utils/errorHandler';
+import { fetchAllPages } from '@/lib/api/pagination';
 import { assetBalanceQueryKeys, clearAssetBalanceCache } from '../queryKeys';
 import type { CsvUploadResult } from '@/lib/csvImport';
 
@@ -56,7 +57,7 @@ export function useAssetBalanceDataSourceCore({
 
   const dbQuery = useQuery({
     queryKey: assetBalanceQueryKeys.all(userId),
-    queryFn: () => assetBalanceApi.list({ per_page: 1000 }),
+    queryFn: () => fetchAllPages((page) => assetBalanceApi.list({ per_page: 1000, page })),
     enabled: isAuthenticated && !authLoading && !!userId,
   });
 
@@ -84,7 +85,7 @@ export function useAssetBalanceDataSourceCore({
     onSuccess: (_, __, context) => {
       const key = assetBalanceQueryKeys.all(context?.snapshotUserId ?? userId);
       if (queryClient.getQueryState(key) !== undefined) {
-        queryClient.setQueryData(key, { data: [], total: 0, page: 1, per_page: 1000 });
+        queryClient.setQueryData(key, []);
       }
       setLastSavedResult(null);
     },
@@ -127,8 +128,7 @@ export function useAssetBalanceDataSourceCore({
     await deleteAllMutation.mutateAsync();
   }, [deleteAllMutation, isAuthenticated]);
 
-  const assetBalancePage = dbQuery.data;
-  const dbData = assetBalancePage?.data ?? [];
+  const dbData = dbQuery.data ?? [];
   const queryError = dbQuery.error;
   const mutationError = uploadCsvMutation.error ?? deleteAllMutation.error ?? previewMutation.error;
   const error = queryError

--- a/frontend/src/features/receipt/hooks/__tests__/useReceiptsData.test.ts
+++ b/frontend/src/features/receipt/hooks/__tests__/useReceiptsData.test.ts
@@ -270,6 +270,120 @@ describe('useReceiptsData: 認証境界・キャッシュ境界', () => {
     });
   });
 
+  it('dividend: total が per_page を超える場合は次ページを取得し全件を返す', async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+
+    vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({ isAuthenticated: true }));
+    vi.mocked(receiptApiModule.dividendApi.list).mockImplementation(
+      ({ page = 1 }: { page?: number; per_page?: number } = {}) => {
+        if (page === 1) {
+          return Promise.resolve({
+            data: Array.from({ length: 1000 }, (_, index) =>
+              ({ id: String(index + 1), payment_date: '2023-01-01' }) as never
+            ),
+            total: 1001,
+            page: 1,
+            per_page: 1000,
+          } as never);
+        }
+        return Promise.resolve({
+          data: [{ id: '1001', payment_date: '2023-01-02' } as never],
+          total: 1001,
+          page: 2,
+          per_page: 1000,
+        } as never);
+      }
+    );
+
+    const { result } = renderHook(() => useReceiptsData(), { wrapper: makeWrapper(qc) });
+
+    await waitFor(() => {
+      expect(result.current.dividendData).toHaveLength(1001);
+    });
+    expect(result.current.dividendData).toContainEqual({ id: '1001', payment_date: '2023-01-02' });
+    expect(receiptApiModule.dividendApi.list).toHaveBeenCalledTimes(2);
+    expect(receiptApiModule.dividendApi.list).toHaveBeenNthCalledWith(1, { per_page: 1000, page: 1 });
+    expect(receiptApiModule.dividendApi.list).toHaveBeenNthCalledWith(2, { per_page: 1000, page: 2 });
+  });
+
+  it('domesticstock: total が per_page を超える場合は次ページを取得し全件を返す', async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+
+    vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({ isAuthenticated: true }));
+    vi.mocked(receiptApiModule.domesticStockApi.list).mockImplementation(
+      ({ page = 1 }: { page?: number; per_page?: number } = {}) => {
+        if (page === 1) {
+          return Promise.resolve({
+            data: Array.from({ length: 1000 }, (_, index) =>
+              ({ id: 'stock-' + String(index + 1), trade_date: '2023-02-01' }) as never
+            ),
+            total: 1001,
+            page: 1,
+            per_page: 1000,
+          } as never);
+        }
+        return Promise.resolve({
+          data: [{ id: 'stock-1001', trade_date: '2023-02-02' } as never],
+          total: 1001,
+          page: 2,
+          per_page: 1000,
+        } as never);
+      }
+    );
+
+    const { result } = renderHook(() => useReceiptsData(), { wrapper: makeWrapper(qc) });
+
+    await waitFor(() => {
+      expect(result.current.domesticstockData).toHaveLength(1001);
+    });
+    expect(result.current.domesticstockData).toContainEqual({ id: 'stock-1001', trade_date: '2023-02-02' });
+    expect(receiptApiModule.domesticStockApi.list).toHaveBeenCalledTimes(2);
+    expect(receiptApiModule.domesticStockApi.list).toHaveBeenNthCalledWith(1, { per_page: 1000, page: 1 });
+    expect(receiptApiModule.domesticStockApi.list).toHaveBeenNthCalledWith(2, { per_page: 1000, page: 2 });
+  });
+
+  it('mutualfund: total が per_page を超える場合は次ページを取得し全件を返す', async () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+
+    vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({ isAuthenticated: true }));
+    vi.mocked(receiptApiModule.mutualfundApi.list).mockImplementation(
+      ({ page = 1 }: { page?: number; per_page?: number } = {}) => {
+        if (page === 1) {
+          return Promise.resolve({
+            data: Array.from({ length: 1000 }, (_, index) =>
+              ({ id: 'fund-' + String(index + 1), trade_date: '2023-03-01' }) as never
+            ),
+            total: 1001,
+            page: 1,
+            per_page: 1000,
+          } as never);
+        }
+        return Promise.resolve({
+          data: [{ id: 'fund-1001', trade_date: '2023-03-02' } as never],
+          total: 1001,
+          page: 2,
+          per_page: 1000,
+        } as never);
+      }
+    );
+
+    const { result } = renderHook(() => useReceiptsData(), { wrapper: makeWrapper(qc) });
+
+    await waitFor(() => {
+      expect(result.current.mutualfundData).toHaveLength(1001);
+    });
+    expect(result.current.mutualfundData).toContainEqual({ id: 'fund-1001', trade_date: '2023-03-02' });
+    expect(receiptApiModule.mutualfundApi.list).toHaveBeenCalledTimes(2);
+    expect(receiptApiModule.mutualfundApi.list).toHaveBeenNthCalledWith(1, { per_page: 1000, page: 1 });
+    expect(receiptApiModule.mutualfundApi.list).toHaveBeenNthCalledWith(2, { per_page: 1000, page: 2 });
+  });
+
   it('deleteAll mutation: domesticstock と mutualfund を削除できる', async () => {
     const qc = new QueryClient({
       defaultOptions: { queries: { retry: false, staleTime: Infinity } },

--- a/frontend/src/features/receipt/hooks/useReceiptsData.ts
+++ b/frontend/src/features/receipt/hooks/useReceiptsData.ts
@@ -9,6 +9,7 @@ import {
 import { receiptQueryKeys, clearReceiptsCache } from '../queryKeys';
 import { type ReceiptsType } from '../reducer';
 import { getDisplayErrorMessage } from '@/lib/utils/errorHandler';
+import { fetchAllPages } from '@/lib/api/pagination';
 import { useAuth } from '@/features/auth/hooks/useAuth';
 import type { CsvImportError, CsvUploadResult } from '@/lib/csvImport';
 
@@ -63,7 +64,7 @@ export function useReceiptsData(): UseReceiptsDataResult {
   const dividendQuery = useQuery({
     queryKey: receiptQueryKeys.dividend(userId),
     queryFn: () =>
-      dividendApi.list({ per_page: 1000 }).then(({ data: dividendRows }) =>
+      fetchAllPages((page) => dividendApi.list({ per_page: 1000, page })).then((dividendRows) =>
         dividendRows.map(transformDBDividend)),
     enabled: isAuthenticated && !authLoading && !!userId,
   });
@@ -71,7 +72,7 @@ export function useReceiptsData(): UseReceiptsDataResult {
   const domesticstockQuery = useQuery({
     queryKey: receiptQueryKeys.domesticstock(userId),
     queryFn: () =>
-      domesticStockApi.list({ per_page: 1000 }).then(({ data: domesticStockRows }) =>
+      fetchAllPages((page) => domesticStockApi.list({ per_page: 1000, page })).then((domesticStockRows) =>
         domesticStockRows.map(transformDBDomesticStock)),
     enabled: isAuthenticated && !authLoading && !!userId,
   });
@@ -79,7 +80,7 @@ export function useReceiptsData(): UseReceiptsDataResult {
   const mutualfundQuery = useQuery({
     queryKey: receiptQueryKeys.mutualfund(userId),
     queryFn: () =>
-      mutualfundApi.list({ per_page: 1000 }).then(({ data: mutualfundRows }) =>
+      fetchAllPages((page) => mutualfundApi.list({ per_page: 1000, page })).then((mutualfundRows) =>
         mutualfundRows.map(transformDBMutualfund)),
     enabled: isAuthenticated && !authLoading && !!userId,
   });

--- a/frontend/src/lib/api/__tests__/pagination.test.ts
+++ b/frontend/src/lib/api/__tests__/pagination.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fetchAllPages } from '../pagination';
+
+interface Row {
+  id: number;
+}
+
+function makePage(page: number, total: number, perPage: number): { data: Row[]; total: number; page: number; per_page: number } {
+  const start = (page - 1) * perPage;
+  const end = Math.min(start + perPage, total);
+  const data = Array.from({ length: Math.max(end - start, 0) }, (_, i) => ({ id: start + i + 1 }));
+  return { data, total, page, per_page: perPage };
+}
+
+describe('fetchAllPages', () => {
+  it('total が 1 ページ分に収まる場合は 1 回のみ取得する', async () => {
+    const fetchPage = vi.fn((page: number) => Promise.resolve(makePage(page, 3, 1000)));
+
+    const rows = await fetchAllPages(fetchPage);
+
+    expect(rows).toHaveLength(3);
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('total が 1 ページを超える場合は次ページを取得し全件を返す', async () => {
+    const fetchPage = vi.fn((page: number) => Promise.resolve(makePage(page, 2500, 1000)));
+
+    const rows = await fetchAllPages(fetchPage);
+
+    expect(rows).toHaveLength(2500);
+    expect(rows[0]).toEqual({ id: 1 });
+    expect(rows[2499]).toEqual({ id: 2500 });
+    expect(fetchPage).toHaveBeenCalledTimes(3);
+    expect(fetchPage).toHaveBeenNthCalledWith(1, 1);
+    expect(fetchPage).toHaveBeenNthCalledWith(2, 2);
+    expect(fetchPage).toHaveBeenNthCalledWith(3, 3);
+  });
+
+  it('total が 0 件の場合は空配列を返す', async () => {
+    const fetchPage = vi.fn((page: number) => Promise.resolve(makePage(page, 0, 1000)));
+
+    const rows = await fetchAllPages(fetchPage);
+
+    expect(rows).toEqual([]);
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/lib/api/pagination.ts
+++ b/frontend/src/lib/api/pagination.ts
@@ -1,0 +1,26 @@
+interface PaginatedResponse<T> {
+  data: T[];
+  total: number;
+  page: number;
+  per_page: number;
+}
+
+/**
+ * per_page 上限（最大1000）を超えるレスポンスを、total に達するまで
+ * ページを繰り上げて取得し、全件を1つの配列に結合する
+ */
+export async function fetchAllPages<T>(
+  fetchPage: (page: number) => Promise<PaginatedResponse<T>>
+): Promise<T[]> {
+  const firstPage = await fetchPage(1);
+  const rows = [...firstPage.data];
+
+  const totalPages = Math.ceil(firstPage.total / firstPage.per_page);
+  for (let page = firstPage.page + 1; page <= totalPages; page += 1) {
+    const nextPage = await fetchPage(page);
+    if (nextPage.data.length === 0) break;
+    rows.push(...nextPage.data);
+  }
+
+  return rows;
+}


### PR DESCRIPTION
## 概要
一覧APIのページングレスポンスをフロントエンド側で全ページ取得するようにし、1000件超のデータでも既存の検索・集計・銘柄リンク解決から漏れないようにします。

## 主な変更
- 汎用 helper `fetchAllPages` を追加
- 配当金・国内株式・投資信託・資産管理の list API 呼び出しを全ページ取得へ変更
- asset balance の query cache を画面利用しやすい全件配列に統一
- 1000件超ケースのテストを追加

## 非対象
- ページングUIの追加
- backend API契約変更
- OpenAPI再生成

## テスト
- `npm test -- --run src/lib/api/__tests__/pagination.test.ts src/features/receipt/hooks/__tests__/useReceiptsData.test.ts src/features/assetBalance/hooks/__tests__/useAssetBalance.test.ts src/features/assetBalance/hooks/__tests__/useAssetBalanceDataSource.test.ts`
- `npm run typecheck`
- `vp lint`
- `npm test`