### PR TITLE
validator derive 依存を除去

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -908,36 +908,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.118",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -955,22 +931,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
  "syn 2.0.118",
 ]
@@ -2764,28 +2729,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3699,7 +3642,7 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -4762,21 +4705,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "url",
- "validator_derive",
-]
-
-[[package]]
-name = "validator_derive"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7df16e474ef958526d1205f6dda359fdfab79d9aa6d54bafcb92dcd07673dca"
-dependencies = [
- "darling 0.20.11",
- "once_cell",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -23,7 +23,7 @@ sqlx = { version = "0.9.0", features = [
 ] }
 thiserror = "2.0.18"
 tokio = { version = "1.52.3", features = ["full"] }
-validator = { version = "0.20.0", features = ["derive"] }
+validator = "0.20.0"
 tower = "0.5.3"
 tower-http = { version = "0.7.0", features = ["cors", "limit", "trace", "request-id"] }
 governor = "0.10"

--- a/backend/src/extractors/validated_json.rs
+++ b/backend/src/extractors/validated_json.rs
@@ -48,14 +48,28 @@ mod tests {
         },
         serde::{Deserialize, Serialize},
         tower::ServiceExt,
-        validator::Validate,
+        validator::{Validate, ValidateLength, ValidateRange, ValidationError, ValidationErrors},
     };
-    #[derive(Clone, Debug, Serialize, Deserialize, Validate, PartialEq)]
+    #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
     struct TestData {
-        #[validate(length(min = 1, max = 50))]
         name: String,
-        #[validate(range(min = 1, max = 150))]
         age: u8,
+    }
+    impl Validate for TestData {
+        fn validate(&self) -> Result<(), ValidationErrors> {
+            let mut errors = ValidationErrors::new();
+            if !self.name.validate_length(Some(1), Some(50), None) {
+                errors.add("name", ValidationError::new("length"));
+            }
+            if !self.age.validate_range(Some(1), Some(150), None, None) {
+                errors.add("age", ValidationError::new("range"));
+            }
+            if errors.is_empty() {
+                Ok(())
+            } else {
+                Err(errors)
+            }
+        }
     }
     fn json_request(body: impl Into<Body>) -> Request<Body> {
         Request::builder()

--- a/backend/src/models/asset_balance.rs
+++ b/backend/src/models/asset_balance.rs
@@ -1,10 +1,11 @@
+use crate::models::common::validate_length_field;
 use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use utoipa::ToSchema;
 use uuid::Uuid;
-use validator::Validate;
+use validator::{Validate, ValidationErrors};
 
 /// 保有銘柄モデル（DB + APIレスポンス兼用）
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
@@ -36,11 +37,9 @@ pub struct AssetBalance {
 }
 
 /// 保有銘柄作成リクエスト
-#[derive(Debug, Clone, Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct CreateAssetBalanceRequest {
-    #[validate(length(min = 1, max = 10))]
     pub security_code: String,
-    #[validate(length(min = 1, max = 200))]
     pub security_name: String,
     #[schema(value_type = f64)]
     pub shares: Decimal,
@@ -60,11 +59,47 @@ pub struct CreateAssetBalanceRequest {
     pub profit_loss_rate: Decimal,
 }
 
+impl Validate for CreateAssetBalanceRequest {
+    fn validate(&self) -> Result<(), ValidationErrors> {
+        let mut errors = ValidationErrors::new();
+        validate_length_field(
+            &mut errors,
+            "security_code",
+            &self.security_code,
+            Some(1),
+            Some(10),
+        );
+        validate_length_field(
+            &mut errors,
+            "security_name",
+            &self.security_name,
+            Some(1),
+            Some(200),
+        );
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
+}
+
 /// 保有銘柄一括作成リクエスト
-#[derive(Debug, Clone, Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct BulkCreateAssetBalanceRequest {
-    #[validate(length(min = 1))]
     pub items: Vec<CreateAssetBalanceRequest>,
+}
+
+impl Validate for BulkCreateAssetBalanceRequest {
+    fn validate(&self) -> Result<(), ValidationErrors> {
+        let mut errors = ValidationErrors::new();
+        validate_length_field(&mut errors, "items", &self.items, Some(1), None);
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
 }
 #[cfg(test)]
 mod tests {

--- a/backend/src/models/common.rs
+++ b/backend/src/models/common.rs
@@ -1,5 +1,30 @@
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 use utoipa::ToSchema;
+use validator::{ValidateLength, ValidationError, ValidationErrors};
+
+/// `validator` derive の length rule 相当を手実装するヘルパー。
+/// `String` / `Option<String>` / `Vec<T>` など `ValidateLength` 実装型に共通で使う。
+pub(crate) fn validate_length_field<T>(
+    errors: &mut ValidationErrors,
+    field: &'static str,
+    value: T,
+    min: Option<u64>,
+    max: Option<u64>,
+) where
+    T: ValidateLength<u64>,
+{
+    if !value.validate_length(min, max, None) {
+        let mut error = ValidationError::new("length");
+        if let Some(min) = min {
+            error.add_param(Cow::from("min"), &min);
+        }
+        if let Some(max) = max {
+            error.add_param(Cow::from("max"), &max);
+        }
+        errors.add(field, error);
+    }
+}
 
 /// ページネーションクエリパラメータ（全ドメイン共通）
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/backend/src/models/dividend.rs
+++ b/backend/src/models/dividend.rs
@@ -1,10 +1,11 @@
+use crate::models::common::validate_length_field;
 use chrono::{DateTime, NaiveDate, Utc};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use utoipa::ToSchema;
 use uuid::Uuid;
-use validator::Validate;
+use validator::{Validate, ValidationErrors};
 
 /// 配当金モデル（DB + APIレスポンス兼用）
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
@@ -33,16 +34,12 @@ pub struct Dividend {
 }
 
 /// 配当金作成リクエスト
-#[derive(Debug, Clone, Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct CreateDividendRequest {
     pub settlement_date: NaiveDate,
-    #[validate(length(min = 1, max = 100))]
     pub product: String,
-    #[validate(length(min = 1, max = 100))]
     pub account: String,
-    #[validate(length(max = 10))]
     pub security_code: String,
-    #[validate(length(min = 1, max = 200))]
     pub security_name: String,
     #[schema(value_type = f64)]
     pub unit_price: Decimal,
@@ -54,6 +51,33 @@ pub struct CreateDividendRequest {
     pub taxes: Decimal,
     #[schema(value_type = f64)]
     pub net_amount_received: Decimal,
+}
+
+impl Validate for CreateDividendRequest {
+    fn validate(&self) -> Result<(), ValidationErrors> {
+        let mut errors = ValidationErrors::new();
+        validate_length_field(&mut errors, "product", &self.product, Some(1), Some(100));
+        validate_length_field(&mut errors, "account", &self.account, Some(1), Some(100));
+        validate_length_field(
+            &mut errors,
+            "security_code",
+            &self.security_code,
+            None,
+            Some(10),
+        );
+        validate_length_field(
+            &mut errors,
+            "security_name",
+            &self.security_name,
+            Some(1),
+            Some(200),
+        );
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
 }
 #[cfg(test)]
 mod tests {

--- a/backend/src/models/dividend_cache.rs
+++ b/backend/src/models/dividend_cache.rs
@@ -1,8 +1,9 @@
+use crate::models::common::validate_length_field;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use utoipa::ToSchema;
-use validator::Validate;
+use validator::{Validate, ValidationErrors};
 
 /// 配当キャッシュレコード
 ///
@@ -31,10 +32,27 @@ pub struct DividendCache {
 }
 
 /// バッチリクエスト
-#[derive(Debug, Deserialize, Validate, ToSchema)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct DividendPerShareBatchRequest {
-    #[validate(length(min = 1, max = 100))]
     pub security_codes: Vec<String>,
+}
+
+impl Validate for DividendPerShareBatchRequest {
+    fn validate(&self) -> Result<(), ValidationErrors> {
+        let mut errors = ValidationErrors::new();
+        validate_length_field(
+            &mut errors,
+            "security_codes",
+            &self.security_codes,
+            Some(1),
+            Some(100),
+        );
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
 }
 
 /// レスポンス内の1銘柄アイテム

--- a/backend/src/models/domestic_stock.rs
+++ b/backend/src/models/domestic_stock.rs
@@ -1,10 +1,11 @@
+use crate::models::common::validate_length_field;
 use chrono::{DateTime, NaiveDate, Utc};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use utoipa::ToSchema;
 use uuid::Uuid;
-use validator::Validate;
+use validator::{Validate, ValidationErrors};
 
 /// 国内株式取引モデル（DB + APIレスポンス兼用）
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
@@ -37,15 +38,12 @@ pub struct DomesticStock {
 }
 
 /// 国内株式取引作成リクエスト
-#[derive(Debug, Clone, Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct CreateDomesticStockRequest {
     pub trade_date: NaiveDate,
     pub settlement_date: NaiveDate,
-    #[validate(length(min = 1, max = 10))]
     pub security_code: String,
-    #[validate(length(min = 1, max = 200))]
     pub security_name: String,
-    #[validate(length(min = 1, max = 100))]
     pub account: String,
     #[schema(value_type = f64)]
     pub shares: Decimal,
@@ -61,6 +59,32 @@ pub struct CreateDomesticStockRequest {
     pub taxes: Decimal,
     #[schema(value_type = f64)]
     pub realized_profit_and_loss_after_tax: Decimal,
+}
+
+impl Validate for CreateDomesticStockRequest {
+    fn validate(&self) -> Result<(), ValidationErrors> {
+        let mut errors = ValidationErrors::new();
+        validate_length_field(
+            &mut errors,
+            "security_code",
+            &self.security_code,
+            Some(1),
+            Some(10),
+        );
+        validate_length_field(
+            &mut errors,
+            "security_name",
+            &self.security_name,
+            Some(1),
+            Some(200),
+        );
+        validate_length_field(&mut errors, "account", &self.account, Some(1), Some(100));
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
 }
 #[cfg(test)]
 mod tests {

--- a/backend/src/models/mutualfund.rs
+++ b/backend/src/models/mutualfund.rs
@@ -1,10 +1,11 @@
+use crate::models::common::validate_length_field;
 use chrono::{DateTime, NaiveDate, Utc};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use utoipa::ToSchema;
 use uuid::Uuid;
-use validator::Validate;
+use validator::{Validate, ValidationErrors};
 
 /// 投資信託モデル（DB + APIレスポンス兼用）
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
@@ -39,15 +40,12 @@ pub struct Mutualfund {
 }
 
 /// 投資信託作成リクエスト
-#[derive(Debug, Clone, Serialize, Deserialize, Validate, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct CreateMutualfundRequest {
     pub trade_date: NaiveDate,
     pub settlement_date: NaiveDate,
-    #[validate(length(min = 1, max = 300))]
     pub fund_name: String,
-    #[validate(length(max = 100))]
     pub dividends: Option<String>,
-    #[validate(length(min = 1, max = 100))]
     pub account: String,
     #[schema(value_type = f64)]
     pub shares: Decimal,
@@ -65,6 +63,26 @@ pub struct CreateMutualfundRequest {
     pub taxes: Decimal,
     #[schema(value_type = f64)]
     pub realized_profit_and_loss_after_tax: Decimal,
+}
+
+impl Validate for CreateMutualfundRequest {
+    fn validate(&self) -> Result<(), ValidationErrors> {
+        let mut errors = ValidationErrors::new();
+        validate_length_field(
+            &mut errors,
+            "fund_name",
+            &self.fund_name,
+            Some(1),
+            Some(300),
+        );
+        validate_length_field(&mut errors, "dividends", &self.dividends, None, Some(100));
+        validate_length_field(&mut errors, "account", &self.account, Some(1), Some(100));
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
 }
 #[cfg(test)]
 mod tests {

--- a/backend/src/models/stock.rs
+++ b/backend/src/models/stock.rs
@@ -1,30 +1,78 @@
+use crate::models::common::validate_length_field;
 use chrono::NaiveDate;
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use utoipa::ToSchema;
-use validator::Validate;
+use validator::{Validate, ValidationErrors};
 
-#[derive(Serialize, Deserialize, FromRow, Validate, ToSchema)]
+#[derive(Serialize, Deserialize, FromRow, ToSchema)]
 pub struct Stock {
     pub date: NaiveDate,
-    #[validate(length(min = 1, max = 10))]
     pub code: String,
-    #[validate(length(min = 1, max = 100))]
     pub name: String,
-    #[validate(length(min = 1, max = 50))]
     pub market_category: String,
-    #[validate(length(max = 10))]
     pub industry_code_33: Option<String>,
-    #[validate(length(max = 100))]
     pub industry_category_33: Option<String>,
-    #[validate(length(max = 10))]
     pub industry_code_17: Option<String>,
-    #[validate(length(max = 100))]
     pub industry_category_17: Option<String>,
-    #[validate(length(max = 10))]
     pub size_code: Option<String>,
-    #[validate(length(max = 50))]
     pub size_category: Option<String>,
+}
+
+impl Validate for Stock {
+    fn validate(&self) -> Result<(), ValidationErrors> {
+        let mut errors = ValidationErrors::new();
+        validate_length_field(&mut errors, "code", &self.code, Some(1), Some(10));
+        validate_length_field(&mut errors, "name", &self.name, Some(1), Some(100));
+        validate_length_field(
+            &mut errors,
+            "market_category",
+            &self.market_category,
+            Some(1),
+            Some(50),
+        );
+        validate_length_field(
+            &mut errors,
+            "industry_code_33",
+            &self.industry_code_33,
+            None,
+            Some(10),
+        );
+        validate_length_field(
+            &mut errors,
+            "industry_category_33",
+            &self.industry_category_33,
+            None,
+            Some(100),
+        );
+        validate_length_field(
+            &mut errors,
+            "industry_code_17",
+            &self.industry_code_17,
+            None,
+            Some(10),
+        );
+        validate_length_field(
+            &mut errors,
+            "industry_category_17",
+            &self.industry_category_17,
+            None,
+            Some(100),
+        );
+        validate_length_field(&mut errors, "size_code", &self.size_code, None, Some(10));
+        validate_length_field(
+            &mut errors,
+            "size_category",
+            &self.size_category,
+            None,
+            Some(50),
+        );
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
 }
 #[cfg(test)]
 mod tests {

--- a/backend/src/services/asset_balance.rs
+++ b/backend/src/services/asset_balance.rs
@@ -63,7 +63,12 @@ pub async fn list(
     .fetch_all(pool)
     .await?;
 
-    Ok(PaginatedResponse { data, total, page: params.page(), per_page: params.per_page() })
+    Ok(PaginatedResponse {
+        data,
+        total,
+        page: params.page(),
+        per_page: params.per_page(),
+    })
 }
 
 /// 保有銘柄を一括登録（既存データを全削除してから挿入）

--- a/backend/src/services/dividend.rs
+++ b/backend/src/services/dividend.rs
@@ -62,7 +62,12 @@ pub async fn list(
     .fetch_all(pool)
     .await?;
 
-    Ok(PaginatedResponse { data, total, page: params.page(), per_page: params.per_page() })
+    Ok(PaginatedResponse {
+        data,
+        total,
+        page: params.page(),
+        per_page: params.per_page(),
+    })
 }
 
 /// 配当金を一括追加（重複はスキップ）

--- a/backend/src/services/domestic_stock.rs
+++ b/backend/src/services/domestic_stock.rs
@@ -63,7 +63,12 @@ pub async fn list(
     .fetch_all(pool)
     .await?;
 
-    Ok(PaginatedResponse { data, total, page: params.page(), per_page: params.per_page() })
+    Ok(PaginatedResponse {
+        data,
+        total,
+        page: params.page(),
+        per_page: params.per_page(),
+    })
 }
 
 /// 国内株式取引を一括追加（全件挿入）

--- a/backend/src/services/mutualfund.rs
+++ b/backend/src/services/mutualfund.rs
@@ -64,7 +64,12 @@ pub async fn list(
     .fetch_all(pool)
     .await?;
 
-    Ok(PaginatedResponse { data, total, page: params.page(), per_page: params.per_page() })
+    Ok(PaginatedResponse {
+        data,
+        total,
+        page: params.page(),
+        per_page: params.per_page(),
+    })
 }
 
 /// 投資信託を一括追加（重複はスキップ）

--- a/backend/tests/db_integration.rs
+++ b/backend/tests/db_integration.rs
@@ -19,7 +19,10 @@ use backend::{
 };
 
 fn default_pagination() -> PaginationParams {
-    PaginationParams { page: None, per_page: None }
+    PaginationParams {
+        page: None,
+        per_page: None,
+    }
 }
 use chrono::NaiveDate;
 use reqwest::Client;
@@ -293,7 +296,8 @@ async fn service_coverage_all_domains() {
     assert!(mutualfund_svc::list(&pool, user_id, &default_pagination())
         .await
         .expect("initial mutualfund list failed")
-        .data.is_empty());
+        .data
+        .is_empty());
     let mutualfund_empty = mutualfund_svc::bulk_create(&pool, user_id, &[])
         .await
         .expect("empty mutualfund bulk_create failed");
@@ -322,7 +326,8 @@ async fn service_coverage_all_domains() {
         mutualfund_svc::list(&pool, user_id, &default_pagination())
             .await
             .expect("mutualfund list failed")
-            .data.len(),
+            .data
+            .len(),
         3
     );
     assert_eq!(
@@ -334,12 +339,14 @@ async fn service_coverage_all_domains() {
     assert!(mutualfund_svc::list(&pool, user_id, &default_pagination())
         .await
         .expect("mutualfund list after delete failed")
-        .data.is_empty());
+        .data
+        .is_empty());
 
     assert!(dividend_svc::list(&pool, user_id, &default_pagination())
         .await
         .expect("initial dividend list failed")
-        .data.is_empty());
+        .data
+        .is_empty());
     let dividend_empty = dividend_svc::bulk_create(&pool, user_id, &[])
         .await
         .expect("empty dividend bulk_create failed");
@@ -365,7 +372,8 @@ async fn service_coverage_all_domains() {
         dividend_svc::list(&pool, user_id, &default_pagination())
             .await
             .expect("dividend list failed")
-            .data.len(),
+            .data
+            .len(),
         3
     );
     assert_eq!(
@@ -377,12 +385,16 @@ async fn service_coverage_all_domains() {
     assert!(dividend_svc::list(&pool, user_id, &default_pagination())
         .await
         .expect("dividend list after delete failed")
-        .data.is_empty());
+        .data
+        .is_empty());
 
-    assert!(domestic_stock_svc::list(&pool, user_id, &default_pagination())
-        .await
-        .expect("initial domestic_stock list failed")
-        .data.is_empty());
+    assert!(
+        domestic_stock_svc::list(&pool, user_id, &default_pagination())
+            .await
+            .expect("initial domestic_stock list failed")
+            .data
+            .is_empty()
+    );
     let domestic_stock_empty = domestic_stock_svc::bulk_create(&pool, user_id, &[])
         .await
         .expect("empty domestic_stock bulk_create failed");
@@ -412,7 +424,8 @@ async fn service_coverage_all_domains() {
         domestic_stock_svc::list(&pool, user_id, &default_pagination())
             .await
             .expect("domestic_stock list failed")
-            .data.len(),
+            .data
+            .len(),
         3
     );
     assert_eq!(
@@ -421,15 +434,21 @@ async fn service_coverage_all_domains() {
             .expect("domestic_stock delete_all failed"),
         3
     );
-    assert!(domestic_stock_svc::list(&pool, user_id, &default_pagination())
-        .await
-        .expect("domestic_stock list after delete failed")
-        .data.is_empty());
+    assert!(
+        domestic_stock_svc::list(&pool, user_id, &default_pagination())
+            .await
+            .expect("domestic_stock list after delete failed")
+            .data
+            .is_empty()
+    );
 
-    assert!(asset_balance_svc::list(&pool, user_id, &default_pagination())
-        .await
-        .expect("initial asset_balance list failed")
-        .data.is_empty());
+    assert!(
+        asset_balance_svc::list(&pool, user_id, &default_pagination())
+            .await
+            .expect("initial asset_balance list failed")
+            .data
+            .is_empty()
+    );
     let asset_balance_empty = asset_balance_svc::bulk_create(&pool, user_id, &[])
         .await
         .expect("empty asset_balance bulk_create failed");
@@ -447,7 +466,8 @@ async fn service_coverage_all_domains() {
         asset_balance_svc::list(&pool, user_id, &default_pagination())
             .await
             .expect("asset_balance list after bulk_create failed")
-            .data.len(),
+            .data
+            .len(),
         2
     );
 
@@ -472,10 +492,13 @@ async fn service_coverage_all_domains() {
             .expect("asset_balance delete_all failed"),
         1
     );
-    assert!(asset_balance_svc::list(&pool, user_id, &default_pagination())
-        .await
-        .expect("asset_balance list after delete failed")
-        .data.is_empty());
+    assert!(
+        asset_balance_svc::list(&pool, user_id, &default_pagination())
+            .await
+            .expect("asset_balance list after delete failed")
+            .data
+            .is_empty()
+    );
 }
 
 #[tokio::test]
@@ -584,7 +607,10 @@ async fn dividend_bulk_create_and_list() {
     let first_page = dividend_svc::list(
         &pool,
         user_id,
-        &PaginationParams { page: Some(1), per_page: Some(2) },
+        &PaginationParams {
+            page: Some(1),
+            per_page: Some(2),
+        },
     )
     .await
     .expect("dividend first page list failed");
@@ -596,7 +622,10 @@ async fn dividend_bulk_create_and_list() {
     let second_page = dividend_svc::list(
         &pool,
         user_id,
-        &PaginationParams { page: Some(2), per_page: Some(2) },
+        &PaginationParams {
+            page: Some(2),
+            per_page: Some(2),
+        },
     )
     .await
     .expect("dividend second page list failed");
@@ -608,7 +637,10 @@ async fn dividend_bulk_create_and_list() {
     let clamped_page = dividend_svc::list(
         &pool,
         user_id,
-        &PaginationParams { page: Some(1), per_page: Some(5000) },
+        &PaginationParams {
+            page: Some(1),
+            per_page: Some(5000),
+        },
     )
     .await
     .expect("dividend clamped page list failed");


### PR DESCRIPTION
## 概要
- validator の derive feature を外し、validator_derive / proc-macro-error2 の依存経路を除去
- 既存 DTO の validation を validator::Validate の手実装へ移行
- API エラー contract と OpenAPI 生成結果は維持

## 変更種別
- [ ] 新機能
- [ ] バグ修正
- [x] リファクタリング
- [ ] ドキュメント

## テスト
- [x] cd backend && cargo fmt --check
- [x] cd backend && cargo clippy --all-targets -- -D warnings
- [x] cd backend && cargo test
- [x] cd backend && cargo audit
- [x] cd backend && cargo tree -i proc-macro-error2 で依存除去を確認
- [x] bash scripts/check-openapi.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 入力検証を手動実装へ統一し、各種作成リクエストや銘柄データの長さ・件数チェックがより一貫して動作するようになりました。
  * 空入力、最大超過、件数不足/超過などの検証エラーが正しく返るようになりました。

* **Refactor**
  * ページネーション結果の返却形式を整理し、読みやすさを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->