### PR TITLE
market data table 名を provider 非依存化

### DIFF
--- a/backend/migrations/0011_rename_jquants_market_data_tables.sql
+++ b/backend/migrations/0011_rename_jquants_market_data_tables.sql
@@ -1,0 +1,3 @@
+-- provider 非依存の table 名へ rename（J-Quants 固有名の解消）
+ALTER TABLE jquants_dividend_cache RENAME TO dividend_per_share_cache;
+ALTER TABLE jquants_rate_control RENAME TO market_data_provider_rate_control;

--- a/backend/migrations/README.md
+++ b/backend/migrations/README.md
@@ -18,6 +18,8 @@ SQLx マイグレーション管理。
 | 0007 | `0007_mutualfunds.sql` | 投資信託取引 |
 | 0008 | `0008_asset_balances.sql` | 資産残高（保有銘柄） |
 | 0009 | `0009_jquants.sql` | J-Quants API キャッシュ・レートコントロール |
+| 0010 | `0010_add_pg_trgm_index.sql` | 銘柄名の部分一致検索向け pg_trgm index |
+| 0011 | `0011_rename_jquants_market_data_tables.sql` | market data table を provider 非依存名へ rename |
 
 ---
 

--- a/backend/src/services/dividend_cache.rs
+++ b/backend/src/services/dividend_cache.rs
@@ -33,7 +33,7 @@ pub async fn get_batch(
         r#"
         SELECT security_code, dividend_per_share, status, fetched_at, stale_at, source,
                created_at, updated_at
-        FROM jquants_dividend_cache
+        FROM dividend_per_share_cache
         WHERE security_code = ANY($1)
         "#,
     )
@@ -106,11 +106,11 @@ pub async fn acquire_rate_slot(pool: &PgPool) -> Result<(), ApiError> {
     // UPSERT でスロットを予約し、前のスロット開始時刻を返す
     let row: (Option<chrono::DateTime<chrono::Utc>>,) = sqlx::query_as(
         r#"
-        INSERT INTO jquants_rate_control (id, next_available_at)
+        INSERT INTO market_data_provider_rate_control (id, next_available_at)
             VALUES (1, NOW() + INTERVAL '12 seconds')
         ON CONFLICT (id) DO UPDATE
             SET next_available_at =
-                GREATEST(jquants_rate_control.next_available_at, NOW()) + INTERVAL '12 seconds'
+                GREATEST(market_data_provider_rate_control.next_available_at, NOW()) + INTERVAL '12 seconds'
         RETURNING
             GREATEST(next_available_at - INTERVAL '12 seconds', NOW() - INTERVAL '1 second')
         "#,
@@ -132,16 +132,16 @@ pub async fn acquire_rate_slot(pool: &PgPool) -> Result<(), ApiError> {
     Ok(())
 }
 
-/// 429 発生時に jquants_rate_control.next_available_at を少なくとも cooldown 分先へ延ばす
+/// 429 発生時に market_data_provider_rate_control.next_available_at を少なくとも cooldown 分先へ延ばす
 /// 既存の future 値がある場合は後退させず、GREATEST で大きい方を維持する
 async fn push_rate_control_cooldown(pool: &PgPool) -> Result<(), ApiError> {
     sqlx::query(
         r#"
-        INSERT INTO jquants_rate_control (id, next_available_at)
+        INSERT INTO market_data_provider_rate_control (id, next_available_at)
             VALUES (1, NOW() + $1 * INTERVAL '1 second')
         ON CONFLICT (id) DO UPDATE
             SET next_available_at =
-                GREATEST(jquants_rate_control.next_available_at, NOW() + $1 * INTERVAL '1 second')
+                GREATEST(market_data_provider_rate_control.next_available_at, NOW() + $1 * INTERVAL '1 second')
         "#,
     )
     .bind(RATE_LIMIT_COOLDOWN_SECS)

--- a/backend/src/services/dividend_cache/persistence.rs
+++ b/backend/src/services/dividend_cache/persistence.rs
@@ -23,7 +23,7 @@ pub async fn fetch_and_cache(
 
     sqlx::query(
         r#"
-        INSERT INTO jquants_dividend_cache
+        INSERT INTO dividend_per_share_cache
             (security_code, dividend_per_share, status, fetched_at, stale_at, source, updated_at)
         VALUES ($1, $2, $3, NOW(), NOW() + INTERVAL '7 days', 'jquants', NOW())
         ON CONFLICT (security_code) DO UPDATE
@@ -57,7 +57,7 @@ pub async fn update_cache_error_with_cooldown(
 
     sqlx::query(
         r#"
-        INSERT INTO jquants_dividend_cache
+        INSERT INTO dividend_per_share_cache
             (security_code, dividend_per_share, status, error_message, stale_at, source, updated_at)
         VALUES ($1, NULL, 'error', $2, NOW() + $3 * INTERVAL '1 second', 'jquants', NOW())
         ON CONFLICT (security_code) DO UPDATE
@@ -99,7 +99,7 @@ pub async fn update_cache_error(
 
     sqlx::query(
         r#"
-        INSERT INTO jquants_dividend_cache
+        INSERT INTO dividend_per_share_cache
             (security_code, dividend_per_share, status, error_message, stale_at, source, updated_at)
         VALUES ($1, NULL, 'error', $2, NULL, 'jquants', NOW())
         ON CONFLICT (security_code) DO UPDATE


### PR DESCRIPTION
## 概要
- J-Quants 固有名の DB table を provider 非依存名へ rename する migration を追加
- 配当キャッシュと rate control の SQL 参照を新 table 名へ更新
- API path / response / OpenAPI は変更なし

## 変更種別
- [ ] 新機能
- [ ] バグ修正
- [x] リファクタリング
- [ ] ドキュメント

## テスト
- [x] rg "jquants_dividend_cache|jquants_rate_control" backend/src で旧 table 参照なし
- [x] cd backend && cargo fmt --check
- [x] cd backend && cargo clippy --all-targets -- -D warnings
- [x] cd backend && cargo test
- [x] bash scripts/check-openapi.sh