### PR TITLE
market data ルート内部名を整理

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -13,8 +13,8 @@ pub struct Config {
     pub database_max_connections: u32,
     /// `/auth/*` ルートへのレート制限（リクエスト/秒）。0 は無制限
     pub auth_rate_limit_rps: u32,
-    /// `/jquants/*` ルートへのレート制限（リクエスト/秒）。0 は無制限
-    pub jquants_rate_limit_rps: u32,
+    /// market data 系ルート（`/api/v1/financial-statements` 等）へのレート制限（リクエスト/秒）。0 は無制限
+    pub market_data_rate_limit_rps: u32,
     /// CSV アップロードルートへの IP 単位レート制限（リクエスト/秒）。0 は無制限
     pub csv_rate_limit_rps: u32,
 }
@@ -31,7 +31,7 @@ impl Default for Config {
             ],
             database_max_connections: 5,
             auth_rate_limit_rps: 10,
-            jquants_rate_limit_rps: 5,
+            market_data_rate_limit_rps: 5,
             csv_rate_limit_rps: 2,
         }
     }
@@ -52,8 +52,9 @@ impl Config {
         if let Some(v) = parse_rps("AUTH_RATE_LIMIT_RPS") {
             config.auth_rate_limit_rps = v;
         }
+        // JQUANTS_RATE_LIMIT_RPS は後方互換のため環境変数名を維持
         if let Some(v) = parse_rps("JQUANTS_RATE_LIMIT_RPS") {
-            config.jquants_rate_limit_rps = v;
+            config.market_data_rate_limit_rps = v;
         }
 
         config.csv_rate_limit_rps = csv_rate_limit_rps();
@@ -159,7 +160,7 @@ mod tests {
             cors_origins: vec!["http://example.com".to_string()],
             database_max_connections: 10,
             auth_rate_limit_rps: 10,
-            jquants_rate_limit_rps: 5,
+            market_data_rate_limit_rps: 5,
             csv_rate_limit_rps: 2,
         };
         assert_eq!(
@@ -182,14 +183,14 @@ mod tests {
         let _ = is_secure_cookie();
     }
     #[test]
-    fn test_config_from_env_jquants_rps() {
+    fn test_config_from_env_market_data_rps() {
         let _guard = ENV_MUTEX.blocking_lock();
         let _env = EnvGuard::set("JQUANTS_RATE_LIMIT_RPS", Some("7"));
         let _env2 = EnvGuard::set("FRONTEND_URL", None);
         let _env3 = EnvGuard::set("BACKEND_URL", None);
 
         let config = Config::from_env();
-        assert_eq!(config.jquants_rate_limit_rps, 7);
+        assert_eq!(config.market_data_rate_limit_rps, 7);
     }
     #[tokio::test]
     async fn test_config_from_env() {

--- a/backend/src/handlers/v1.rs
+++ b/backend/src/handlers/v1.rs
@@ -90,8 +90,8 @@ pub fn csv_upload_routes() -> Router<AppState> {
         )
 }
 
-/// J-Quants 系 v1 ルート（jquants_limiter 対象）
-pub fn jquants_routes() -> Router<AppState> {
+/// Market data 系 v1 ルート（market_data_limiter 対象）
+pub fn market_data_routes() -> Router<AppState> {
     Router::new().route(
         "/api/v1/financial-statements",
         get(market_data::get_financial_statements),
@@ -264,7 +264,7 @@ mod tests {
                 "/api/v1/asset-balances",
             ),
             (
-                jquants_routes().with_state(make_test_state()),
+                market_data_routes().with_state(make_test_state()),
                 Method::GET,
                 "/api/v1/financial-statements",
             ),

--- a/backend/src/routes.rs
+++ b/backend/src/routes.rs
@@ -44,14 +44,14 @@ pub fn app_router(state: AppState, config: &Config, startup_ready: Arc<AtomicBoo
     // auth は IP 単位の keyed limiter（ブルートフォース/DoS 対策）
     let auth_limiter = build_keyed_rate_limiter(config.auth_rate_limit_rps);
     let csv_limiter = build_keyed_rate_limiter(config.csv_rate_limit_rps);
-    let jquants_limiter = build_rate_limiter(config.jquants_rate_limit_rps);
+    let market_data_limiter = build_rate_limiter(config.market_data_rate_limit_rps);
     spawn_keyed_limiter_cleanup(&auth_limiter);
     spawn_keyed_limiter_cleanup(&csv_limiter);
 
     let allowed_origins = Arc::new(config.cors_origins.clone());
     let ready = Arc::clone(&startup_ready);
     let gated_domain =
-        domain_routes(jquants_limiter, auth_limiter, csv_limiter).layer(middleware::from_fn(
+        domain_routes(market_data_limiter, auth_limiter, csv_limiter).layer(middleware::from_fn(
             move |req: axum::extract::Request, next: axum::middleware::Next| {
                 let ready = Arc::clone(&ready);
                 async move {
@@ -109,17 +109,17 @@ pub fn app_router(state: AppState, config: &Config, startup_ready: Arc<AtomicBoo
 
 /// ドメインルートをまとめたルーター（認証・コア機能）
 fn domain_routes(
-    jquants_limiter: Option<Arc<governor::DefaultDirectRateLimiter>>,
+    market_data_limiter: Option<Arc<governor::DefaultDirectRateLimiter>>,
     auth_limiter: Option<Arc<governor::DefaultKeyedRateLimiter<std::net::IpAddr>>>,
     csv_limiter: Option<Arc<governor::DefaultKeyedRateLimiter<std::net::IpAddr>>>,
 ) -> Router<AppState> {
-    let jquants_routes = if let Some(l) = jquants_limiter {
-        handlers::v1::jquants_routes().layer(middleware::from_fn(move |req, next| {
+    let market_data_routes = if let Some(l) = market_data_limiter {
+        handlers::v1::market_data_routes().layer(middleware::from_fn(move |req, next| {
             let l = l.clone();
             async move { rate_limit(l, req, next).await }
         }))
     } else {
-        handlers::v1::jquants_routes()
+        handlers::v1::market_data_routes()
     };
     let auth_routes = if let Some(l) = auth_limiter {
         handlers::v1::auth_routes().layer(middleware::from_fn(move |req, next| {
@@ -139,7 +139,7 @@ fn domain_routes(
     };
 
     Router::new()
-        .merge(jquants_routes)
+        .merge(market_data_routes)
         .merge(auth_routes)
         .merge(csv_upload_routes)
         .merge(handlers::csv_import::csv_import_routes())
@@ -181,7 +181,7 @@ mod tests {
     #[test]
     fn test_all_routes_creation() {
         let _ = handlers::v1::auth_routes();
-        let _ = handlers::v1::jquants_routes();
+        let _ = handlers::v1::market_data_routes();
         let _ = handlers::v1::data_routes();
         let _ = handlers::v1::csv_upload_routes();
         let _ = handlers::csv_import::csv_import_routes();
@@ -199,12 +199,12 @@ mod tests {
         .with_state(make_test_state());
         assert_rate_limited(router, Method::GET, "/api/v1/session", Some("1.2.3.4")).await;
         let router = if let Some(l) = crate::middleware::build_rate_limiter(1) {
-            handlers::v1::jquants_routes().layer(middleware::from_fn(move |req, next| {
+            handlers::v1::market_data_routes().layer(middleware::from_fn(move |req, next| {
                 let l = l.clone();
                 async move { rate_limit(l, req, next).await }
             }))
         } else {
-            handlers::v1::jquants_routes()
+            handlers::v1::market_data_routes()
         }
         .with_state(make_test_state());
         assert_rate_limited(router, Method::GET, "/api/v1/financial-statements", None).await;
@@ -249,7 +249,7 @@ mod tests {
     async fn test_all_endpoints_require_auth() {
         for (router, method, uri) in [
             (
-                handlers::v1::jquants_routes(),
+                handlers::v1::market_data_routes(),
                 Method::GET,
                 "/api/v1/financial-statements?code=7203",
             ),


### PR DESCRIPTION
## 概要
J-Quants 固有だった route / limiter の内部命名を market data domain 名へ寄せました。
公開 API path と互換環境変数名は維持しています。

## 変更種別
- [ ] 新機能
- [ ] バグ修正
- [x] リファクタリング
- [ ] ドキュメント

## 主な変更内容
- `jquants_routes()` を `market_data_routes()` へ rename
- `jquants_limiter` / `jquants_rate_limit_rps` を `market_data_*` 内部名へ rename
- `JQUANTS_RATE_LIMIT_RPS` は後方互換のため env var として維持

## テスト
- [x] `cd backend && cargo fmt --check`
- [x] `cd backend && cargo clippy --all-targets -- -D warnings`
- [x] `cd backend && cargo test`
- [x] `bash scripts/check-openapi.sh`
- [x] push / PR hook の OpenAPI・backend test 確認

## 非対象
- API path / response JSON 変更
- DB migration
- provider adapter 抽出
- frontend `features/jquants` rename