### PR TITLE
refactor: 配当キャッシュ取得元を provider 名へ統一

### DIFF
--- a/backend/migrations/0001_initial_schema.sql
+++ b/backend/migrations/0001_initial_schema.sql
@@ -138,7 +138,7 @@ CREATE TABLE IF NOT EXISTS dividend_per_share_cache (
     dividend_per_share DOUBLE PRECISION,
     status             VARCHAR(20)      NOT NULL DEFAULT 'pending',
     fetched_at         TIMESTAMPTZ,
-    source             VARCHAR(50)      NOT NULL DEFAULT 'jquants',
+    provider           VARCHAR(50)      NOT NULL DEFAULT 'jquants',
     error_message      TEXT,
     stale_at           TIMESTAMPTZ,
     created_at         TIMESTAMPTZ      NOT NULL DEFAULT NOW(),

--- a/backend/src/models/dividend_cache.rs
+++ b/backend/src/models/dividend_cache.rs
@@ -26,7 +26,7 @@ pub struct DividendCache {
     pub fetched_at: Option<DateTime<Utc>>,
     /// TTL期限。この時刻を過ぎると再取得対象（NULL かつ pending 以外 = 即再取得対象）
     pub stale_at: Option<DateTime<Utc>>,
-    pub source: String,
+    pub provider: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }

--- a/backend/src/services/dividend_cache.rs
+++ b/backend/src/services/dividend_cache.rs
@@ -31,7 +31,7 @@ pub async fn get_batch(
     // DB からキャッシュを一括取得（ANY がDB側で重複を除く）
     let cached: Vec<DividendCache> = sqlx::query_as::<_, DividendCache>(
         r#"
-        SELECT security_code, dividend_per_share, status, fetched_at, stale_at, source,
+        SELECT security_code, dividend_per_share, status, fetched_at, stale_at, provider,
                created_at, updated_at
         FROM dividend_per_share_cache
         WHERE security_code = ANY($1)
@@ -166,7 +166,7 @@ mod tests {
             status: status.to_string(),
             fetched_at: Some(Utc::now()),
             stale_at,
-            source: "jquants".to_string(),
+            provider: "jquants".to_string(),
             created_at: Utc::now(),
             updated_at: Utc::now(),
         }

--- a/backend/src/services/dividend_cache/persistence.rs
+++ b/backend/src/services/dividend_cache/persistence.rs
@@ -24,14 +24,14 @@ pub async fn fetch_and_cache(
     sqlx::query(
         r#"
         INSERT INTO dividend_per_share_cache
-            (security_code, dividend_per_share, status, fetched_at, stale_at, source, updated_at)
+            (security_code, dividend_per_share, status, fetched_at, stale_at, provider, updated_at)
         VALUES ($1, $2, $3, NOW(), NOW() + INTERVAL '7 days', 'jquants', NOW())
         ON CONFLICT (security_code) DO UPDATE
             SET dividend_per_share = EXCLUDED.dividend_per_share,
                 status             = EXCLUDED.status,
                 fetched_at         = EXCLUDED.fetched_at,
                 stale_at           = NOW() + INTERVAL '7 days',
-                source             = EXCLUDED.source,
+                provider           = EXCLUDED.provider,
                 error_message      = NULL,
                 updated_at         = NOW()
         "#,
@@ -58,7 +58,7 @@ pub async fn update_cache_error_with_cooldown(
     sqlx::query(
         r#"
         INSERT INTO dividend_per_share_cache
-            (security_code, dividend_per_share, status, error_message, stale_at, source, updated_at)
+            (security_code, dividend_per_share, status, error_message, stale_at, provider, updated_at)
         VALUES ($1, NULL, 'error', $2, NOW() + $3 * INTERVAL '1 second', 'jquants', NOW())
         ON CONFLICT (security_code) DO UPDATE
             SET status        = 'error',
@@ -100,7 +100,7 @@ pub async fn update_cache_error(
     sqlx::query(
         r#"
         INSERT INTO dividend_per_share_cache
-            (security_code, dividend_per_share, status, error_message, stale_at, source, updated_at)
+            (security_code, dividend_per_share, status, error_message, stale_at, provider, updated_at)
         VALUES ($1, NULL, 'error', $2, NULL, 'jquants', NOW())
         ON CONFLICT (security_code) DO UPDATE
             SET status        = 'error',


### PR DESCRIPTION
## Summary
- dividend_per_share_cache の取得元カラム名を source から provider へ変更
- DividendCache の内部フィールドと SQL SELECT / INSERT / UPDATE を provider に統一
- API path / response JSON / OpenAPI schema / frontend は変更なし

## Verification
- source reference search in dividend cache files: no matches
- backend/src mod.rs search: no matches
- cd backend && cargo fmt --check
- cd backend && cargo clippy --all-targets -- -D warnings
- cd backend && cargo test dividend_cache
- cd backend && cargo test
- bash scripts/check-openapi.sh
- push hook: openapi.json / api.ts regenerated and no diff

## Notes
- domain DTO 新設と rate control provider 複数行化は別PRに分離しています