### PR TITLE
refactor: rate control を provider key で管理

### DIFF
--- a/backend/migrations/0001_initial_schema.sql
+++ b/backend/migrations/0001_initial_schema.sql
@@ -146,11 +146,10 @@ CREATE TABLE IF NOT EXISTS dividend_per_share_cache (
 );
 
 CREATE TABLE IF NOT EXISTS market_data_provider_rate_control (
-    id                INTEGER PRIMARY KEY,
-    next_available_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    CONSTRAINT single_row CHECK (id = 1)
+    provider          VARCHAR(50) PRIMARY KEY,
+    next_available_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
-INSERT INTO market_data_provider_rate_control (id, next_available_at)
-    VALUES (1, NOW())
-    ON CONFLICT (id) DO NOTHING;
+INSERT INTO market_data_provider_rate_control (provider, next_available_at)
+    VALUES ('jquants', NOW())
+    ON CONFLICT (provider) DO NOTHING;

--- a/backend/src/services/dividend_cache.rs
+++ b/backend/src/services/dividend_cache.rs
@@ -16,6 +16,9 @@ use logic::compute_is_stale;
 /// 429 発生時の全インスタンス共有 cooldown 期間（秒）
 const RATE_LIMIT_COOLDOWN_SECS: i32 = 60;
 
+/// market_data_provider_rate_control.provider の J-Quants 用キー
+const JQUANTS_PROVIDER: &str = "jquants";
+
 /// キャッシュをバッチ取得し、未取得/TTL切れ銘柄のバックグラウンド更新をキック
 pub async fn get_batch(
     pool: &PgPool,
@@ -106,15 +109,16 @@ pub async fn acquire_rate_slot(pool: &PgPool) -> Result<(), ApiError> {
     // UPSERT でスロットを予約し、前のスロット開始時刻を返す
     let row: (Option<chrono::DateTime<chrono::Utc>>,) = sqlx::query_as(
         r#"
-        INSERT INTO market_data_provider_rate_control (id, next_available_at)
-            VALUES (1, NOW() + INTERVAL '12 seconds')
-        ON CONFLICT (id) DO UPDATE
+        INSERT INTO market_data_provider_rate_control (provider, next_available_at)
+            VALUES ($1, NOW() + INTERVAL '12 seconds')
+        ON CONFLICT (provider) DO UPDATE
             SET next_available_at =
                 GREATEST(market_data_provider_rate_control.next_available_at, NOW()) + INTERVAL '12 seconds'
         RETURNING
             GREATEST(next_available_at - INTERVAL '12 seconds', NOW() - INTERVAL '1 second')
         "#,
     )
+    .bind(JQUANTS_PROVIDER)
     .fetch_one(pool)
     .await?;
 
@@ -137,13 +141,14 @@ pub async fn acquire_rate_slot(pool: &PgPool) -> Result<(), ApiError> {
 async fn push_rate_control_cooldown(pool: &PgPool) -> Result<(), ApiError> {
     sqlx::query(
         r#"
-        INSERT INTO market_data_provider_rate_control (id, next_available_at)
-            VALUES (1, NOW() + $1 * INTERVAL '1 second')
-        ON CONFLICT (id) DO UPDATE
+        INSERT INTO market_data_provider_rate_control (provider, next_available_at)
+            VALUES ($1, NOW() + $2 * INTERVAL '1 second')
+        ON CONFLICT (provider) DO UPDATE
             SET next_available_at =
-                GREATEST(market_data_provider_rate_control.next_available_at, NOW() + $1 * INTERVAL '1 second')
+                GREATEST(market_data_provider_rate_control.next_available_at, NOW() + $2 * INTERVAL '1 second')
         "#,
     )
+    .bind(JQUANTS_PROVIDER)
     .bind(RATE_LIMIT_COOLDOWN_SECS)
     .execute(pool)
     .await?;


### PR DESCRIPTION
## Summary
- market_data_provider_rate_control を id=1 の単一行設計から provider primary key に変更
- 初期 provider 行を jquants として作成
- J-Quants の rate slot / cooldown UPSERT を provider conflict key に変更
- runtime SQL では provider 名を bind parameter で渡す

## Verification
- single_row / id=1 / ON CONFLICT(id) search: no matches
- backend/src mod.rs search: no matches
- git diff --check
- cd backend && cargo fmt --check
- cd backend && cargo clippy --all-targets -- -D warnings
- cd backend && cargo test dividend_cache
- cd backend && cargo test
- bash scripts/check-openapi.sh
- push hook: openapi.json / api.ts regenerated and no diff

## Notes
- API path / response JSON / OpenAPI schema / frontend は変更なし
- 複数 provider 実装は別PRに分離しています