### PR TITLE
refactor: market data frontend の内部名を domain 名へ整理

### DIFF
--- a/frontend/src/features/marketData/api/__tests__/client.test.ts
+++ b/frontend/src/features/marketData/api/__tests__/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { JQuantsApiClient } from '../client';
+import { MarketDataApiClient } from '../client';
 import { apiClient } from '@/lib/api/client';
 import { ApiError, ApiErrorType } from '@/lib/types/api';
 
@@ -9,12 +9,12 @@ vi.mock('@/lib/api/client', () => ({
   },
 }));
 
-describe('JQuantsApiClient', () => {
-  let client: JQuantsApiClient;
+describe('MarketDataApiClient', () => {
+  let client: MarketDataApiClient;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    client = new JQuantsApiClient();
+    client = new MarketDataApiClient();
   });
 
   describe('getSummary', () => {

--- a/frontend/src/features/marketData/api/client.ts
+++ b/frontend/src/features/marketData/api/client.ts
@@ -1,12 +1,12 @@
-import { JQuantsFinSummaryResponse } from './types';
+import { FinancialStatementsResponse } from './types';
 import { apiClient } from '@/lib/api/client';
 import { ApiError, ApiErrorType } from '@/lib/types/api';
 
 /**
- * J-Quants API クライアント（バックエンド経由）
+ * 決算情報 API クライアント（バックエンド経由）
  * バックエンドがAPIキー認証を処理するため、フロントエンドではトークン管理不要
  */
-export class JQuantsApiClient {
+export class MarketDataApiClient {
   /**
    * 決算サマリーを取得
    * @param code 銘柄コード
@@ -17,13 +17,13 @@ export class JQuantsApiClient {
     code: string,
     from?: string,
     to?: string
-  ): Promise<JQuantsFinSummaryResponse> {
+  ): Promise<FinancialStatementsResponse> {
     try {
       const params: Record<string, string> = { code };
       if (from) params.from = from;
       if (to) params.to = to;
 
-      const response = await apiClient.get<JQuantsFinSummaryResponse>(
+      const response = await apiClient.get<FinancialStatementsResponse>(
         '/api/v1/financial-statements',
         { params, withCredentials: true }
       );
@@ -42,4 +42,4 @@ export class JQuantsApiClient {
 }
 
 // シングルトンインスタンス
-export const jquantsApiClient = new JQuantsApiClient();
+export const marketDataApiClient = new MarketDataApiClient();

--- a/frontend/src/features/marketData/api/types.ts
+++ b/frontend/src/features/marketData/api/types.ts
@@ -1,10 +1,9 @@
-// J-Quants API レスポンスの型定義
+// 決算情報 API レスポンスの型定義
 
 /**
- * J-Quants API V2 決算サマリーデータ
- * V2では省略形フィールド名を使用
+ * 決算サマリーデータ（V2、省略形フィールド名を使用）
  */
-export interface JQuantsStatementData {
+export interface FinancialStatementData {
   // 基本情報
   DiscDate: string; // 開示日
   DiscTime?: string; // 開示時刻
@@ -140,10 +139,9 @@ export interface JQuantsStatementData {
 }
 
 /**
- * J-Quants API V2 決算サマリーレスポンス
- * V2では fins/summary を使用し、ルートフィールドは "data"
+ * 決算サマリーレスポンス（V2、fins/summary を使用し、ルートフィールドは "data"）
  */
-export interface JQuantsFinSummaryResponse {
-  data: JQuantsStatementData[];
+export interface FinancialStatementsResponse {
+  data: FinancialStatementData[];
   pagination_key?: string;
 }

--- a/frontend/src/features/marketData/hooks/__tests__/useFinancialStatementDividend.test.ts
+++ b/frontend/src/features/marketData/hooks/__tests__/useFinancialStatementDividend.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
-import { useJQuantsDividend } from '../useJQuantsDividend';
-import { jquantsApiClient } from '../../api/client';
+import { useFinancialStatementDividend } from '../useFinancialStatementDividend';
+import { marketDataApiClient } from '../../api/client';
 import { parseNumber } from '@/lib/utils/formatters';
 
 vi.mock('../../api/client', () => ({
-  jquantsApiClient: {
+  marketDataApiClient: {
     getSummary: vi.fn(),
   },
 }));
@@ -18,28 +18,28 @@ vi.mock('@/lib/utils/formatters', async (importOriginal) => {
   };
 });
 
-describe('useJQuantsDividend', () => {
+describe('useFinancialStatementDividend', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (parseNumber as Mock).mockImplementation((val) => Number(val) || 0);
   });
 
   it('enabledがfalseの場合、配当情報を取得しない', () => {
-    const { result } = renderHook(() => useJQuantsDividend('1234', false));
+    const { result } = renderHook(() => useFinancialStatementDividend('1234', false));
 
     expect(result.current.dividendPerShare).toBeUndefined();
     expect(result.current.loading).toBe(false);
     expect(result.current.error).toBeNull();
-    expect(jquantsApiClient.getSummary).not.toHaveBeenCalled();
+    expect(marketDataApiClient.getSummary).not.toHaveBeenCalled();
   });
 
   it('securityCodeが空の場合、配当情報を取得しない', () => {
-    const { result } = renderHook(() => useJQuantsDividend('', true));
+    const { result } = renderHook(() => useFinancialStatementDividend('', true));
 
     expect(result.current.dividendPerShare).toBeUndefined();
     expect(result.current.loading).toBe(false);
     expect(result.current.error).toBeNull();
-    expect(jquantsApiClient.getSummary).not.toHaveBeenCalled();
+    expect(marketDataApiClient.getSummary).not.toHaveBeenCalled();
   });
 
   it('最新の決算データから配当情報を取得する（開示日でソート）', async () => {
@@ -52,10 +52,10 @@ describe('useJQuantsDividend', () => {
       ],
     };
 
-    (jquantsApiClient.getSummary as Mock).mockResolvedValue(mockResponse);
+    (marketDataApiClient.getSummary as Mock).mockResolvedValue(mockResponse);
     (parseNumber as Mock).mockReturnValue(70);
 
-    const { result } = renderHook(() => useJQuantsDividend('1234', true));
+    const { result } = renderHook(() => useFinancialStatementDividend('1234', true));
 
     expect(result.current.loading).toBe(true);
     expect(result.current.dividendPerShare).toBeUndefined();
@@ -64,7 +64,7 @@ describe('useJQuantsDividend', () => {
       expect(result.current.loading).toBe(false);
     });
 
-    expect(jquantsApiClient.getSummary).toHaveBeenCalledWith('1234');
+    expect(marketDataApiClient.getSummary).toHaveBeenCalledWith('1234');
     // 最新データ（2024-07-15）の70.00が取得されること
     expect(parseNumber).toHaveBeenCalledWith('70.00');
     expect(result.current.dividendPerShare).toBe(70);
@@ -82,10 +82,10 @@ describe('useJQuantsDividend', () => {
       ],
     };
 
-    (jquantsApiClient.getSummary as Mock).mockResolvedValue(mockResponse);
+    (marketDataApiClient.getSummary as Mock).mockResolvedValue(mockResponse);
     (parseNumber as Mock).mockReturnValue(45);
 
-    const { result } = renderHook(() => useJQuantsDividend('1234', true));
+    const { result } = renderHook(() => useFinancialStatementDividend('1234', true));
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
@@ -107,10 +107,10 @@ describe('useJQuantsDividend', () => {
       ],
     };
 
-    (jquantsApiClient.getSummary as Mock).mockResolvedValue(mockResponse);
+    (marketDataApiClient.getSummary as Mock).mockResolvedValue(mockResponse);
     (parseNumber as Mock).mockReturnValue(40);
 
-    const { result } = renderHook(() => useJQuantsDividend('1234', true));
+    const { result } = renderHook(() => useFinancialStatementDividend('1234', true));
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
@@ -128,10 +128,10 @@ describe('useJQuantsDividend', () => {
       ],
     };
 
-    (jquantsApiClient.getSummary as Mock).mockResolvedValue(mockResponse);
+    (marketDataApiClient.getSummary as Mock).mockResolvedValue(mockResponse);
     (parseNumber as Mock).mockReturnValue(50);
 
-    const { result } = renderHook(() => useJQuantsDividend('1234', true));
+    const { result } = renderHook(() => useFinancialStatementDividend('1234', true));
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
@@ -151,10 +151,10 @@ describe('useJQuantsDividend', () => {
       ],
     };
 
-    (jquantsApiClient.getSummary as Mock).mockResolvedValue(mockResponse);
+    (marketDataApiClient.getSummary as Mock).mockResolvedValue(mockResponse);
     (parseNumber as Mock).mockReturnValue(0);
 
-    const { result } = renderHook(() => useJQuantsDividend('1234', true));
+    const { result } = renderHook(() => useFinancialStatementDividend('1234', true));
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
@@ -167,9 +167,9 @@ describe('useJQuantsDividend', () => {
   it('エラーが発生した場合、エラーメッセージを設定する', async () => {
     const mockError = new Error('API Error');
 
-    (jquantsApiClient.getSummary as Mock).mockRejectedValue(mockError);
+    (marketDataApiClient.getSummary as Mock).mockRejectedValue(mockError);
 
-    const { result } = renderHook(() => useJQuantsDividend('1234', true));
+    const { result } = renderHook(() => useFinancialStatementDividend('1234', true));
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
@@ -180,9 +180,9 @@ describe('useJQuantsDividend', () => {
   });
 
   it('非Errorオブジェクトのエラーの場合、デフォルトメッセージを設定する', async () => {
-    (jquantsApiClient.getSummary as Mock).mockRejectedValue('string error');
+    (marketDataApiClient.getSummary as Mock).mockRejectedValue('string error');
 
-    const { result } = renderHook(() => useJQuantsDividend('1234', true));
+    const { result } = renderHook(() => useFinancialStatementDividend('1234', true));
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
@@ -195,9 +195,9 @@ describe('useJQuantsDividend', () => {
   it('response.dataがundefinedの場合、undefinedを返す', async () => {
     const mockResponse = { data: undefined };
 
-    (jquantsApiClient.getSummary as Mock).mockResolvedValue(mockResponse);
+    (marketDataApiClient.getSummary as Mock).mockResolvedValue(mockResponse);
 
-    const { result } = renderHook(() => useJQuantsDividend('1234', true));
+    const { result } = renderHook(() => useFinancialStatementDividend('1234', true));
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
@@ -210,9 +210,9 @@ describe('useJQuantsDividend', () => {
   it('response.dataが配列でない場合、undefinedを返す', async () => {
     const mockResponse = { data: { some: 'object' } };
 
-    (jquantsApiClient.getSummary as Mock).mockResolvedValue(mockResponse);
+    (marketDataApiClient.getSummary as Mock).mockResolvedValue(mockResponse);
 
-    const { result } = renderHook(() => useJQuantsDividend('1234', true));
+    const { result } = renderHook(() => useFinancialStatementDividend('1234', true));
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
@@ -230,10 +230,10 @@ describe('useJQuantsDividend', () => {
       ],
     };
 
-    (jquantsApiClient.getSummary as Mock).mockResolvedValue(mockResponse);
+    (marketDataApiClient.getSummary as Mock).mockResolvedValue(mockResponse);
     (parseNumber as Mock).mockReturnValue(40);
 
-    const { result } = renderHook(() => useJQuantsDividend('1234', true));
+    const { result } = renderHook(() => useFinancialStatementDividend('1234', true));
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
@@ -249,9 +249,9 @@ describe('useJQuantsDividend', () => {
       resolvePromise = resolve;
     });
 
-    (jquantsApiClient.getSummary as Mock).mockReturnValue(pendingPromise);
+    (marketDataApiClient.getSummary as Mock).mockReturnValue(pendingPromise);
 
-    const { result, unmount } = renderHook(() => useJQuantsDividend('1234', true));
+    const { result, unmount } = renderHook(() => useFinancialStatementDividend('1234', true));
 
     expect(result.current.loading).toBe(true);
 
@@ -271,11 +271,11 @@ describe('useJQuantsDividend', () => {
       data: [{ NxFDivAnn: '50.00' }],
     };
 
-    (jquantsApiClient.getSummary as Mock).mockResolvedValue(mockResponse);
+    (marketDataApiClient.getSummary as Mock).mockResolvedValue(mockResponse);
     (parseNumber as Mock).mockReturnValue(50);
 
     const { result, rerender } = renderHook(
-      ({ code, enabled }) => useJQuantsDividend(code, enabled),
+      ({ code, enabled }) => useFinancialStatementDividend(code, enabled),
       { initialProps: { code: '1234', enabled: true } }
     );
 
@@ -283,14 +283,14 @@ describe('useJQuantsDividend', () => {
       expect(result.current.loading).toBe(false);
     }, { timeout: 5000 });
 
-    expect(jquantsApiClient.getSummary).toHaveBeenCalledWith('1234');
+    expect(marketDataApiClient.getSummary).toHaveBeenCalledWith('1234');
     expect(result.current.dividendPerShare).toBe(50);
 
     // securityCodeを変更
     rerender({ code: '5678', enabled: true });
 
     await waitFor(() => {
-      expect(jquantsApiClient.getSummary).toHaveBeenCalledWith('5678');
+      expect(marketDataApiClient.getSummary).toHaveBeenCalledWith('5678');
     }, { timeout: 5000 });
   }, 15000);
 });

--- a/frontend/src/features/marketData/hooks/__tests__/useFinancialStatementDividendBatch.test.ts
+++ b/frontend/src/features/marketData/hooks/__tests__/useFinancialStatementDividendBatch.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
 import { act, renderHook, waitFor } from '@testing-library/react';
-import { useJQuantsDividendBatch } from '../useJQuantsDividendBatch';
-import * as dividendHook from '../useJQuantsDividend';
-import { jquantsApiClient } from '../../api/client';
+import { useFinancialStatementDividendBatch } from '../useFinancialStatementDividendBatch';
+import * as dividendHook from '../useFinancialStatementDividend';
+import { marketDataApiClient } from '../../api/client';
 import { parseNumber } from '@/lib/utils/formatters';
 
 vi.mock('../../api/client', () => ({
-  jquantsApiClient: {
+  marketDataApiClient: {
     getSummary: vi.fn(),
   },
 }));
@@ -19,8 +19,8 @@ vi.mock('@/lib/utils/formatters', async (importOriginal) => {
   };
 });
 
-vi.mock('../useJQuantsDividend', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../useJQuantsDividend')>();
+vi.mock('../useFinancialStatementDividend', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../useFinancialStatementDividend')>();
   return {
     ...actual,
     extractDividendFromSummary: vi.fn(actual.extractDividendFromSummary),
@@ -34,7 +34,7 @@ const flushAsyncUpdates = async () => {
   });
 };
 
-describe('useJQuantsDividendBatch', () => {
+describe('useFinancialStatementDividendBatch', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (parseNumber as Mock).mockImplementation((val) => Number(val) || 0);
@@ -56,7 +56,7 @@ describe('useJQuantsDividendBatch', () => {
     let maxInFlight = 0;
     const resolvers: Array<() => void> = [];
 
-    (jquantsApiClient.getSummary as Mock).mockImplementation((code: string) => {
+    (marketDataApiClient.getSummary as Mock).mockImplementation((code: string) => {
       inFlight += 1;
       maxInFlight = Math.max(maxInFlight, inFlight);
       return new Promise((resolve) => {
@@ -69,16 +69,16 @@ describe('useJQuantsDividendBatch', () => {
       });
     });
 
-    const { result } = renderHook(() => useJQuantsDividendBatch(codes, true));
+    const { result } = renderHook(() => useFinancialStatementDividendBatch(codes, true));
 
     await waitFor(() => {
-      expect(jquantsApiClient.getSummary).toHaveBeenCalledTimes(3);
+      expect(marketDataApiClient.getSummary).toHaveBeenCalledTimes(3);
     });
 
     resolvers.splice(0, 3).forEach((resolve) => resolve());
 
     await waitFor(() => {
-      expect(jquantsApiClient.getSummary).toHaveBeenCalledTimes(6);
+      expect(marketDataApiClient.getSummary).toHaveBeenCalledTimes(6);
     });
 
     resolvers.splice(0).forEach((resolve) => resolve());
@@ -97,7 +97,7 @@ describe('useJQuantsDividendBatch', () => {
 
     const extractionCount: Record<string, number> = {};
 
-    (jquantsApiClient.getSummary as Mock).mockImplementation((code: string) =>
+    (marketDataApiClient.getSummary as Mock).mockImplementation((code: string) =>
       Promise.resolve({
         data: [{ DiscDate: '2025-01-01', NxFDivAnn: code === '1605' ? '30.0' : '15.5', Code: code }],
       })
@@ -111,11 +111,11 @@ describe('useJQuantsDividendBatch', () => {
       return summary.NxFDivAnn;
     });
 
-    const { result } = renderHook(() => useJQuantsDividendBatch(codes, true));
+    const { result } = renderHook(() => useFinancialStatementDividendBatch(codes, true));
 
     await flushAsyncUpdates();
 
-    expect(jquantsApiClient.getSummary).toHaveBeenCalledTimes(2);
+    expect(marketDataApiClient.getSummary).toHaveBeenCalledTimes(2);
     expect(result.current.loading).toBe(false);
     expect(result.current.dividendPerShareMap.get('1605')).toBe(30);
     expect(result.current.dividendPerShareMap.has('2933')).toBe(false);
@@ -125,7 +125,7 @@ describe('useJQuantsDividendBatch', () => {
     });
     await flushAsyncUpdates();
 
-    expect(jquantsApiClient.getSummary).toHaveBeenCalledTimes(4);
+    expect(marketDataApiClient.getSummary).toHaveBeenCalledTimes(4);
     expect(result.current.loading).toBe(false);
     expect(result.current.dividendPerShareMap.get('2933')).toBe(15.5);
   });
@@ -134,7 +134,7 @@ describe('useJQuantsDividendBatch', () => {
     vi.useFakeTimers();
     const codes = ['1605', '2933'];
 
-    (jquantsApiClient.getSummary as Mock).mockImplementation((code: string) =>
+    (marketDataApiClient.getSummary as Mock).mockImplementation((code: string) =>
       Promise.resolve({
         data: [{ DiscDate: '2025-01-01', NxFDivAnn: code === '1605' ? '30.0' : '15.5', Code: code }],
       })
@@ -147,11 +147,11 @@ describe('useJQuantsDividendBatch', () => {
       return summary.NxFDivAnn;
     });
 
-    const { result } = renderHook(() => useJQuantsDividendBatch(codes, true));
+    const { result } = renderHook(() => useFinancialStatementDividendBatch(codes, true));
 
     await flushAsyncUpdates();
 
-    expect(jquantsApiClient.getSummary).toHaveBeenCalledTimes(2);
+    expect(marketDataApiClient.getSummary).toHaveBeenCalledTimes(2);
     expect(result.current.loading).toBe(false);
     expect(result.current.dividendPerShareMap.get('1605')).toBe(30);
     expect(result.current.dividendPerShareMap.has('2933')).toBe(false);
@@ -163,7 +163,7 @@ describe('useJQuantsDividendBatch', () => {
       await flushAsyncUpdates();
     }
 
-    expect(jquantsApiClient.getSummary).toHaveBeenCalledTimes(8);
+    expect(marketDataApiClient.getSummary).toHaveBeenCalledTimes(8);
     expect(result.current.loading).toBe(false);
     expect(result.current.dividendPerShareMap.get('1605')).toBe(30);
     expect(result.current.dividendPerShareMap.has('2933')).toBe(false);
@@ -173,22 +173,22 @@ describe('useJQuantsDividendBatch', () => {
     });
     await flushAsyncUpdates();
 
-    expect(jquantsApiClient.getSummary).toHaveBeenCalledTimes(8);
+    expect(marketDataApiClient.getSummary).toHaveBeenCalledTimes(8);
   });
 
   it('アンマウント時にリトライタイマーがクリアされる', async () => {
     vi.useFakeTimers();
     const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
 
-    (jquantsApiClient.getSummary as Mock).mockResolvedValue({ data: [] });
+    (marketDataApiClient.getSummary as Mock).mockResolvedValue({ data: [] });
 
     try {
       const codes = ['1605'];
-      const { result, unmount } = renderHook(() => useJQuantsDividendBatch(codes, true));
+      const { result, unmount } = renderHook(() => useFinancialStatementDividendBatch(codes, true));
 
       await flushAsyncUpdates();
 
-      expect(jquantsApiClient.getSummary).toHaveBeenCalledTimes(1);
+      expect(marketDataApiClient.getSummary).toHaveBeenCalledTimes(1);
       expect(result.current.loading).toBe(false);
 
       unmount();

--- a/frontend/src/features/marketData/hooks/useFinancialStatementDividend.ts
+++ b/frontend/src/features/marketData/hooks/useFinancialStatementDividend.ts
@@ -1,13 +1,13 @@
 import { useState, useEffect } from 'react';
-import { jquantsApiClient } from '../api/client';
-import { JQuantsFinSummaryResponse, JQuantsStatementData } from '../api/types';
+import { marketDataApiClient } from '../api/client';
+import { FinancialStatementsResponse, FinancialStatementData } from '../api/types';
 import { parseNumber } from '@/lib/utils/formatters';
 
 /**
  * 決算データから配当情報を抽出する
  * 優先順位: 来期予想 > 今期予想 > 実績
  */
-export const extractDividendFromSummary = (summary: JQuantsStatementData): string | null => {
+export const extractDividendFromSummary = (summary: FinancialStatementData): string | null => {
   if (summary.NxFDivAnn && summary.NxFDivAnn !== '') {
     return summary.NxFDivAnn;
   }
@@ -21,10 +21,10 @@ export const extractDividendFromSummary = (summary: JQuantsStatementData): strin
 };
 
 /**
- * J-Quants APIを使用して配当情報を取得するフック
+ * 決算情報APIを使用して配当情報を取得するフック
  * 最新の決算データから配当情報を優先的に取得する
  */
-export const useJQuantsDividend = (
+export const useFinancialStatementDividend = (
   securityCode: string,
   enabled: boolean = true
 ) => {
@@ -50,8 +50,8 @@ export const useJQuantsDividend = (
 
       try {
         // V2 API では data フィールドを使用
-        const response: JQuantsFinSummaryResponse =
-          await jquantsApiClient.getSummary(securityCode);
+        const response: FinancialStatementsResponse =
+          await marketDataApiClient.getSummary(securityCode);
         if (!isActive) return;
 
         // レスポンスの data フィールドが配列でない場合はスキップ

--- a/frontend/src/features/marketData/hooks/useFinancialStatementDividendBatch.ts
+++ b/frontend/src/features/marketData/hooks/useFinancialStatementDividendBatch.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
-import { jquantsApiClient } from '../api/client';
+import { marketDataApiClient } from '../api/client';
 import { parseNumber } from '@/lib/utils/formatters';
-import { extractDividendFromSummary } from './useJQuantsDividend';
+import { extractDividendFromSummary } from './useFinancialStatementDividend';
 
 const MAX_CONCURRENT_REQUESTS = 3;
 const MAX_RETRIES = 3;
@@ -9,11 +9,11 @@ const RETRY_DELAY_MS = 60_000;
 
 /**
  * 複数銘柄の1株配当を一括取得するフック
- * J-Quants APIから最新予想配当を取得し、Map<銘柄コード, 1株配当>を返す
+ * 決算情報APIから最新予想配当を取得し、Map<銘柄コード, 1株配当>を返す
  *
  * @deprecated バックエンド集約API移行後は useDividendBatch を使用すること
  */
-export const useJQuantsDividendBatch = (
+export const useFinancialStatementDividendBatch = (
   securityCodes: string[],
   enabled: boolean = true
 ) => {
@@ -42,7 +42,7 @@ export const useJQuantsDividendBatch = (
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
 
     const fetchOneCode = async (code: string) => {
-      const response = await jquantsApiClient.getSummary(code);
+      const response = await marketDataApiClient.getSummary(code);
       if (!response?.data || !Array.isArray(response.data)) return { code, value: null };
 
       // 開示日で降順ソート（最新データを優先）


### PR DESCRIPTION
## Summary
- features/marketData の client / response type / hook 名から provider 固有名を削除
- JQuantsApiClient / jquantsApiClient を MarketDataApiClient / marketDataApiClient に rename
- useJQuantsDividend 系 hook と test file を financial statement dividend 名へ rename
- API path / JSON shape / UI 表示 / generated api.ts は変更なし

## Verification
- marketData scoped old-name search: no matches
- git diff --check
- cd frontend && npm test -- --run src/features/marketData
- cd frontend && npm run typecheck
- cd frontend && vp lint

## Notes
- generated api.ts と backend OpenAPI schema 名はこのPRでは変更していません
- feature 外の UI コメントや provider 表示文言は別PRで扱います

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 決算情報APIを使った配当情報の取得に切り替わり、最新の配当予想をより安定して表示できるようになりました。
  * 複数銘柄の配当情報をまとめて取得する処理が新しい取得方式に対応しました。

* **Bug Fixes**
  * エラー時の表示や再取得の挙動を見直し、配当情報がない場合でも安全に処理されるよう改善しました。
  * データの並び替えや再試行の動作を保ったまま、表示の信頼性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->