### PR TITLE
refactor: DB検索用の共通DTOを追加

### DIFF
--- a/backend/src/models/common.rs
+++ b/backend/src/models/common.rs
@@ -27,7 +27,7 @@ pub(crate) fn validate_length_field<T>(
 }
 
 /// ページネーションクエリパラメータ（全ドメイン共通）
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
 pub struct PaginationParams {
     pub page: Option<i64>,
     pub per_page: Option<i64>,
@@ -45,6 +45,53 @@ impl PaginationParams {
     }
 }
 
+/// 検索・集計付き一覧の共通クエリパラメータ。
+#[allow(dead_code)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
+pub struct SearchQueryParams {
+    #[serde(flatten)]
+    pub pagination: PaginationParams,
+    /// フリーワード検索。後続PRで token AND 条件としてSQLへ変換する。
+    pub q: Option<String>,
+    /// 開始日（YYYY-MM-DD）
+    pub date_from: Option<String>,
+    /// 終了日（YYYY-MM-DD）
+    pub date_to: Option<String>,
+    /// 年（YYYY）
+    pub year: Option<i32>,
+    /// 年月（YYYY-MM）
+    pub year_month: Option<String>,
+    /// 単日（YYYY-MM-DD）
+    pub date: Option<String>,
+    /// summary を返すかどうか
+    pub include_summary: Option<bool>,
+    /// facets を返すかどうか
+    pub include_facets: Option<bool>,
+}
+
+#[allow(dead_code)]
+impl SearchQueryParams {
+    pub fn page(&self) -> i64 {
+        self.pagination.page()
+    }
+
+    pub fn per_page(&self) -> i64 {
+        self.pagination.per_page()
+    }
+
+    pub fn offset(&self) -> i64 {
+        self.pagination.offset()
+    }
+
+    pub fn should_include_summary(&self) -> bool {
+        self.include_summary.unwrap_or(false)
+    }
+
+    pub fn should_include_facets(&self) -> bool {
+        self.include_facets.unwrap_or(false)
+    }
+}
+
 /// ページネーションレスポンス（全ドメイン共通）
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct PaginatedResponse<T: ToSchema + 'static> {
@@ -52,6 +99,52 @@ pub struct PaginatedResponse<T: ToSchema + 'static> {
     pub total: i64,
     pub page: i64,
     pub per_page: i64,
+}
+
+/// 検索候補の共通表現。
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct FacetOption {
+    pub value: String,
+    pub label: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub count: Option<i64>,
+}
+
+/// 検索候補レスポンスの共通枠。
+#[allow(dead_code)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
+pub struct SearchFacets {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub products: Option<Vec<FacetOption>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub accounts: Option<Vec<FacetOption>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub securities: Option<Vec<FacetOption>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub funds: Option<Vec<FacetOption>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub years: Option<Vec<FacetOption>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub year_months: Option<Vec<FacetOption>>,
+}
+
+/// 検索・集計付きページネーションレスポンス。
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct PaginatedSearchResponse<
+    T: ToSchema + 'static,
+    Summary: ToSchema + 'static,
+    Facets: ToSchema + 'static,
+> {
+    pub data: Vec<T>,
+    pub total: i64,
+    pub page: i64,
+    pub per_page: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<Summary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub facets: Option<Facets>,
 }
 
 /// 一括作成レスポンス（全ドメイン共通）
@@ -66,9 +159,26 @@ pub struct BulkCreateResponse {
 pub struct MessageResponse {
     pub message: String,
 }
+
 #[cfg(test)]
 mod tests {
-    use super::{BulkCreateResponse, MessageResponse};
+    use super::{
+        BulkCreateResponse, FacetOption, MessageResponse, PaginatedResponse,
+        PaginatedSearchResponse, PaginationParams, SearchFacets, SearchQueryParams,
+    };
+    use serde::{Deserialize, Serialize};
+    use utoipa::ToSchema;
+
+    #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+    struct Row {
+        id: i32,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+    struct Summary {
+        amount: i64,
+    }
+
     #[test]
     fn test_serde_round_trips() {
         let r = BulkCreateResponse {
@@ -86,5 +196,114 @@ mod tests {
         let d: MessageResponse =
             serde_json::from_str(&json).expect("MessageResponse should deserialize");
         assert_eq!(d.message, r.message);
+    }
+
+    #[test]
+    fn pagination_params_defaults_and_limits() {
+        let params = PaginationParams {
+            page: Some(0),
+            per_page: Some(5000),
+        };
+
+        assert_eq!(params.page(), 1);
+        assert_eq!(params.per_page(), 1000);
+        assert_eq!(params.offset(), 0);
+    }
+
+    #[test]
+    fn search_query_params_delegate_pagination_and_flags() {
+        let params = SearchQueryParams {
+            pagination: PaginationParams {
+                page: Some(3),
+                per_page: Some(50),
+            },
+            q: Some("NTT".to_string()),
+            date_from: Some("2026-01-01".to_string()),
+            date_to: Some("2026-12-31".to_string()),
+            year: Some(2026),
+            year_month: Some("2026-06".to_string()),
+            date: None,
+            include_summary: Some(true),
+            include_facets: None,
+        };
+
+        assert_eq!(params.page(), 3);
+        assert_eq!(params.per_page(), 50);
+        assert_eq!(params.offset(), 100);
+        assert!(params.should_include_summary());
+        assert!(!params.should_include_facets());
+    }
+
+    #[test]
+    fn paginated_response_keeps_existing_shape() {
+        let response = PaginatedResponse {
+            data: vec![Row { id: 1 }],
+            total: 1,
+            page: 1,
+            per_page: 200,
+        };
+
+        let json = serde_json::to_value(response).expect("PaginatedResponse should serialize");
+
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "data": [{"id": 1}],
+                "total": 1,
+                "page": 1,
+                "per_page": 200
+            })
+        );
+    }
+
+    #[test]
+    fn paginated_search_response_omits_optional_sections_when_absent() {
+        let response: PaginatedSearchResponse<Row, Summary, SearchFacets> =
+            PaginatedSearchResponse {
+                data: vec![Row { id: 1 }],
+                total: 1,
+                page: 1,
+                per_page: 200,
+                summary: None,
+                facets: None,
+            };
+
+        let json =
+            serde_json::to_value(response).expect("PaginatedSearchResponse should serialize");
+
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "data": [{"id": 1}],
+                "total": 1,
+                "page": 1,
+                "per_page": 200
+            })
+        );
+    }
+
+    #[test]
+    fn search_facets_support_common_option_groups() {
+        let facets = SearchFacets {
+            products: Some(vec![FacetOption {
+                value: "domestic_stock".to_string(),
+                label: "国内株式".to_string(),
+                count: Some(2),
+            }]),
+            ..SearchFacets::default()
+        };
+
+        let json = serde_json::to_value(facets).expect("SearchFacets should serialize");
+
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "products": [{
+                    "value": "domestic_stock",
+                    "label": "国内株式",
+                    "count": 2
+                }]
+            })
+        );
     }
 }


### PR DESCRIPTION
## 概要
- DB寄せ検索の後続実装に向けて SearchQueryParams を追加
- summary / facets 付きページングレスポンス用の共通DTOを追加
- 既存 PaginatedResponse の JSON shape は維持

## 確認
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test models::common
- cargo test
- bash scripts/check-openapi.sh
- npm run typecheck
- mod.rs 不使用確認