### PR TITLE
feat: 配当金一覧をDB検索に対応

### DIFF
--- a/backend/migrations/0002_dividends_search_indexes.sql
+++ b/backend/migrations/0002_dividends_search_indexes.sql
@@ -1,0 +1,9 @@
+-- 配当金検索（product / account / security_code / security_name での絞り込み・facets集計）向けの複合インデックス
+CREATE INDEX IF NOT EXISTS idx_dividends_user_product ON dividends (user_id, product);
+CREATE INDEX IF NOT EXISTS idx_dividends_user_account ON dividends (user_id, account);
+CREATE INDEX IF NOT EXISTS idx_dividends_user_security_code ON dividends (user_id, security_code);
+CREATE INDEX IF NOT EXISTS idx_dividends_user_security_name ON dividends (user_id, security_name);
+
+-- 一覧のデフォルトソート（settlement_date DESC, id DESC）向けの複合インデックス
+CREATE INDEX IF NOT EXISTS idx_dividends_user_settlement_date_id
+    ON dividends (user_id, settlement_date DESC, id DESC);

--- a/backend/migrations/README.md
+++ b/backend/migrations/README.md
@@ -10,6 +10,7 @@ SQLx migration の baseline 管理。
 | No. | ファイル | 内容 |
 |-----|---------|------|
 | 0001 | `0001_initial_schema.sql` | 拡張、全テーブル、全 index、初期 seed を作成 |
+| 0002 | `0002_dividends_search_indexes.sql` | 配当金検索（product/account/security_code/security_name の絞り込み、settlement_date/id 順の一覧取得）向け index を追加 |
 
 ## 重要な注意
 

--- a/backend/src/handlers/v1/dividends.rs
+++ b/backend/src/handlers/v1/dividends.rs
@@ -3,9 +3,9 @@ use crate::{
     extractors::{auth::AuthenticatedUser, validated_json::ValidatedJson},
     handlers::common::ok_message,
     models::{
-        common::{MessageResponse, PaginatedResponse, PaginationParams},
+        common::{MessageResponse, PaginatedSearchResponse, SearchFacets},
         csv_import::{CsvPreviewResponse, CsvUploadForm, CsvUploadResponse},
-        dividend::Dividend,
+        dividend::{Dividend, DividendSearchQueryParams, DividendSummary},
         dividend_cache::{DividendPerShareBatchRequest, DividendPerShareBatchResponse},
     },
     services::{csv_domain::DividendDomain, dividend as dividend_service},
@@ -28,9 +28,22 @@ use axum::{
     params(
         ("page" = Option<i64>, Query, description = "ページ番号（デフォルト: 1）"),
         ("per_page" = Option<i64>, Query, description = "1ページあたりの件数（デフォルト: 200、最大: 1000）"),
+        ("q" = Option<String>, Query, description = "フリーワード検索（商品/口座/銘柄コード/銘柄名の token AND 検索）"),
+        ("date_from" = Option<String>, Query, description = "決済日の開始日（YYYY-MM-DD）"),
+        ("date_to" = Option<String>, Query, description = "決済日の終了日（YYYY-MM-DD）"),
+        ("year" = Option<i32>, Query, description = "決済日の年（YYYY）"),
+        ("year_month" = Option<String>, Query, description = "決済日の年月（YYYY-MM）"),
+        ("date" = Option<String>, Query, description = "決済日の単日指定（YYYY-MM-DD）"),
+        ("product" = Option<String>, Query, description = "商品での絞り込み"),
+        ("account" = Option<String>, Query, description = "口座での絞り込み"),
+        ("security_code" = Option<String>, Query, description = "銘柄コードでの絞り込み"),
+        ("security_name" = Option<String>, Query, description = "銘柄名での絞り込み"),
+        ("include_summary" = Option<bool>, Query, description = "検索条件全体の集計を含めるか"),
+        ("include_facets" = Option<bool>, Query, description = "検索候補 facets を含めるか"),
     ),
     responses(
-        (status = 200, body = PaginatedResponse<Dividend>),
+        (status = 200, body = PaginatedSearchResponse<Dividend, DividendSummary, SearchFacets>),
+        (status = 400, body = ErrorResponse),
         (status = 401, body = ErrorResponse),
     ),
     security(("cookieAuth" = []))
@@ -38,9 +51,9 @@ use axum::{
 pub async fn list(
     State(state): State<AppState>,
     auth_user: AuthenticatedUser,
-    Query(params): Query<PaginationParams>,
+    Query(params): Query<DividendSearchQueryParams>,
 ) -> Result<impl IntoResponse, ApiError> {
-    let result = dividend_service::list(&state.pool, auth_user.id(), &params).await?;
+    let result = dividend_service::search(&state.pool, auth_user.id(), &params).await?;
     Ok((StatusCode::OK, Json(result)))
 }
 

--- a/backend/src/models/common.rs
+++ b/backend/src/models/common.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
 use std::borrow::Cow;
 use utoipa::ToSchema;
 use validator::{ValidateLength, ValidationError, ValidationErrors};
@@ -46,12 +47,11 @@ impl PaginationParams {
 }
 
 /// 検索・集計付き一覧の共通クエリパラメータ。
-#[allow(dead_code)]
 #[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
 pub struct SearchQueryParams {
     #[serde(flatten)]
     pub pagination: PaginationParams,
-    /// フリーワード検索。後続PRで token AND 条件としてSQLへ変換する。
+    /// フリーワード検索。各ドメインが定義する検索対象カラムへの token AND 条件としてSQLへ変換する。
     pub q: Option<String>,
     /// 開始日（YYYY-MM-DD）
     pub date_from: Option<String>,
@@ -69,7 +69,6 @@ pub struct SearchQueryParams {
     pub include_facets: Option<bool>,
 }
 
-#[allow(dead_code)]
 impl SearchQueryParams {
     pub fn page(&self) -> i64 {
         self.pagination.page()
@@ -102,8 +101,7 @@ pub struct PaginatedResponse<T: ToSchema + 'static> {
 }
 
 /// 検索候補の共通表現。
-#[allow(dead_code)]
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
 pub struct FacetOption {
     pub value: String,
     pub label: String,
@@ -112,7 +110,6 @@ pub struct FacetOption {
 }
 
 /// 検索候補レスポンスの共通枠。
-#[allow(dead_code)]
 #[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
 pub struct SearchFacets {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -130,7 +127,6 @@ pub struct SearchFacets {
 }
 
 /// 検索・集計付きページネーションレスポンス。
-#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct PaginatedSearchResponse<
     T: ToSchema + 'static,

--- a/backend/src/models/dividend.rs
+++ b/backend/src/models/dividend.rs
@@ -1,4 +1,4 @@
-use crate::models::common::validate_length_field;
+use crate::models::common::{validate_length_field, SearchQueryParams};
 use chrono::{DateTime, NaiveDate, Utc};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
@@ -31,6 +31,54 @@ pub struct Dividend {
     pub net_amount_received: Decimal,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+}
+
+/// 配当金一覧の検索クエリパラメータ（共通 `SearchQueryParams` + 配当金固有の絞り込み）
+#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
+pub struct DividendSearchQueryParams {
+    #[serde(flatten)]
+    pub search: SearchQueryParams,
+    /// 商品での絞り込み
+    pub product: Option<String>,
+    /// 口座での絞り込み
+    pub account: Option<String>,
+    /// 銘柄コードでの絞り込み
+    pub security_code: Option<String>,
+    /// 銘柄名での絞り込み
+    pub security_name: Option<String>,
+}
+
+impl DividendSearchQueryParams {
+    pub fn page(&self) -> i64 {
+        self.search.page()
+    }
+
+    pub fn per_page(&self) -> i64 {
+        self.search.per_page()
+    }
+
+    pub fn offset(&self) -> i64 {
+        self.search.offset()
+    }
+
+    pub fn should_include_summary(&self) -> bool {
+        self.search.should_include_summary()
+    }
+
+    pub fn should_include_facets(&self) -> bool {
+        self.search.should_include_facets()
+    }
+}
+
+/// 配当金 検索条件全体の集計
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
+pub struct DividendSummary {
+    #[schema(value_type = f64)]
+    pub total_dividends_before_tax: Decimal,
+    #[schema(value_type = f64)]
+    pub total_taxes: Decimal,
+    #[schema(value_type = f64)]
+    pub total_net_amount_received: Decimal,
 }
 
 /// 配当金作成リクエスト

--- a/backend/src/services/dividend.rs
+++ b/backend/src/services/dividend.rs
@@ -1,7 +1,11 @@
 use crate::errors::ApiError;
-use crate::models::common::{BulkCreateResponse, PaginatedResponse, PaginationParams};
+use crate::models::common::{
+    BulkCreateResponse, FacetOption, PaginatedSearchResponse, SearchFacets,
+};
 use crate::models::csv_import::{CsvPreviewResponse, CsvRowError, CsvUploadResponse};
-use crate::models::dividend::{CreateDividendRequest, Dividend};
+use crate::models::dividend::{
+    CreateDividendRequest, Dividend, DividendSearchQueryParams, DividendSummary,
+};
 use crate::services::csv_import::{build_csv_preview, run_csv_upload, validate_csv_rows};
 use crate::services::csv_pipeline::{CsvParserConfig, CsvRow};
 use crate::services::csv_util::{
@@ -11,8 +15,9 @@ use crate::services::csv_util::{
 use crate::services::shared::{
     delete_all_for_user, user_ids_for_bulk_insert, BulkTimer, DeleteTarget,
 };
+use chrono::NaiveDate;
 use rust_decimal::Decimal;
-use sqlx::PgPool;
+use sqlx::{PgPool, Postgres, QueryBuilder};
 use tracing::info;
 use uuid::Uuid;
 
@@ -33,41 +38,297 @@ const DIVIDEND_CSV_CONFIG: CsvParserConfig = CsvParserConfig {
     ],
 };
 
-/// 認証ユーザーの配当金一覧を取得（ページネーション対応）
-pub async fn list(
+/// 配当金検索条件を SQL 条件へ変換した中間表現
+#[derive(Debug)]
+struct DividendFilter {
+    date_eq: Option<NaiveDate>,
+    date_from: Option<NaiveDate>,
+    date_to: Option<NaiveDate>,
+    year_range: Option<(NaiveDate, NaiveDate)>,
+    year_month_range: Option<(NaiveDate, NaiveDate)>,
+    tokens: Vec<String>,
+    product: Option<String>,
+    account: Option<String>,
+    security_code: Option<String>,
+    security_name: Option<String>,
+}
+
+impl DividendFilter {
+    fn from_params(params: &DividendSearchQueryParams) -> Result<Self, ApiError> {
+        let search = &params.search;
+        let date_eq = search
+            .date
+            .as_deref()
+            .map(|v| parse_date_param("date", v))
+            .transpose()?;
+        let date_from = search
+            .date_from
+            .as_deref()
+            .map(|v| parse_date_param("date_from", v))
+            .transpose()?;
+        let date_to = search
+            .date_to
+            .as_deref()
+            .map(|v| parse_date_param("date_to", v))
+            .transpose()?;
+        let year_range = search.year.map(year_to_range).transpose()?;
+        let year_month_range = search
+            .year_month
+            .as_deref()
+            .map(parse_year_month_range)
+            .transpose()?;
+        let tokens = search
+            .q
+            .as_deref()
+            .map(|q| q.split_whitespace().map(str::to_string).collect())
+            .unwrap_or_default();
+
+        Ok(Self {
+            date_eq,
+            date_from,
+            date_to,
+            year_range,
+            year_month_range,
+            tokens,
+            product: params.product.clone(),
+            account: params.account.clone(),
+            security_code: params.security_code.clone(),
+            security_name: params.security_name.clone(),
+        })
+    }
+}
+
+fn parse_date_param(field: &str, value: &str) -> Result<NaiveDate, ApiError> {
+    NaiveDate::parse_from_str(value, "%Y-%m-%d")
+        .map_err(|_| ApiError::ValidationError(format!("{field} の形式が不正です（YYYY-MM-DD）")))
+}
+
+fn year_to_range(year: i32) -> Result<(NaiveDate, NaiveDate), ApiError> {
+    let invalid = || ApiError::ValidationError("year の値が不正です".to_string());
+    let start = NaiveDate::from_ymd_opt(year, 1, 1).ok_or_else(invalid)?;
+    let end = NaiveDate::from_ymd_opt(year + 1, 1, 1).ok_or_else(invalid)?;
+    Ok((start, end))
+}
+
+fn parse_year_month_range(value: &str) -> Result<(NaiveDate, NaiveDate), ApiError> {
+    let invalid =
+        || ApiError::ValidationError("year_month の形式が不正です（YYYY-MM）".to_string());
+    let (year_str, month_str) = value.split_once('-').ok_or_else(invalid)?;
+    let year: i32 = year_str.parse().map_err(|_| invalid())?;
+    let month: u32 = month_str.parse().map_err(|_| invalid())?;
+    let start = NaiveDate::from_ymd_opt(year, month, 1).ok_or_else(invalid)?;
+    let end = if month == 12 {
+        NaiveDate::from_ymd_opt(year + 1, 1, 1)
+    } else {
+        NaiveDate::from_ymd_opt(year, month + 1, 1)
+    }
+    .ok_or_else(invalid)?;
+    Ok((start, end))
+}
+
+/// user_id と検索条件を WHERE 句として QueryBuilder へ積む
+fn push_filters(qb: &mut QueryBuilder<Postgres>, user_id: Uuid, filter: &DividendFilter) {
+    qb.push(" WHERE user_id = ").push_bind(user_id);
+    if let Some(v) = filter.date_eq {
+        qb.push(" AND settlement_date = ").push_bind(v);
+    }
+    if let Some(v) = filter.date_from {
+        qb.push(" AND settlement_date >= ").push_bind(v);
+    }
+    if let Some(v) = filter.date_to {
+        qb.push(" AND settlement_date <= ").push_bind(v);
+    }
+    if let Some((start, end)) = filter.year_range {
+        qb.push(" AND settlement_date >= ").push_bind(start);
+        qb.push(" AND settlement_date < ").push_bind(end);
+    }
+    if let Some((start, end)) = filter.year_month_range {
+        qb.push(" AND settlement_date >= ").push_bind(start);
+        qb.push(" AND settlement_date < ").push_bind(end);
+    }
+    if let Some(v) = &filter.product {
+        qb.push(" AND product = ").push_bind(v.clone());
+    }
+    if let Some(v) = &filter.account {
+        qb.push(" AND account = ").push_bind(v.clone());
+    }
+    if let Some(v) = &filter.security_code {
+        qb.push(" AND security_code = ").push_bind(v.clone());
+    }
+    if let Some(v) = &filter.security_name {
+        qb.push(" AND security_name = ").push_bind(v.clone());
+    }
+    for token in &filter.tokens {
+        let pattern = escape_like_pattern(token);
+        qb.push(" AND (product ILIKE ")
+            .push_bind(pattern.clone())
+            .push(" ESCAPE '\\' OR account ILIKE ")
+            .push_bind(pattern.clone())
+            .push(" ESCAPE '\\' OR security_code ILIKE ")
+            .push_bind(pattern.clone())
+            .push(" ESCAPE '\\' OR security_name ILIKE ")
+            .push_bind(pattern)
+            .push(" ESCAPE '\\')");
+    }
+}
+
+/// ILIKE の wildcard 文字（%, _, \）をリテラル扱いにエスケープしてから前後を % で囲む
+fn escape_like_pattern(token: &str) -> String {
+    let escaped = token
+        .replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_");
+    format!("%{escaped}%")
+}
+
+/// 認証ユーザーの配当金一覧を検索（ページネーション・summary・facets 対応）
+pub async fn search(
     pool: &PgPool,
     user_id: Uuid,
-    params: &PaginationParams,
-) -> Result<PaginatedResponse<Dividend>, ApiError> {
-    info!("[dividend.list] リクエスト受信");
-    let total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM dividends WHERE user_id = $1")
-        .bind(user_id)
-        .fetch_one(pool)
-        .await?;
+    params: &DividendSearchQueryParams,
+) -> Result<PaginatedSearchResponse<Dividend, DividendSummary, SearchFacets>, ApiError> {
+    info!("[dividend.search] リクエスト受信");
+    let filter = DividendFilter::from_params(params)?;
 
-    let data = sqlx::query_as::<_, Dividend>(
-        r#"
-        SELECT id, user_id, settlement_date, product, account, security_code, security_name,
-               unit_price, shares, dividends_before_tax, taxes, net_amount_received,
-               created_at, updated_at
-        FROM dividends
-        WHERE user_id = $1
-        ORDER BY settlement_date DESC, id DESC
-        LIMIT $2 OFFSET $3
-        "#,
-    )
-    .bind(user_id)
-    .bind(params.per_page())
-    .bind(params.offset())
-    .fetch_all(pool)
-    .await?;
+    let mut count_qb: QueryBuilder<Postgres> = QueryBuilder::new("SELECT COUNT(*) FROM dividends");
+    push_filters(&mut count_qb, user_id, &filter);
+    let count_fut = async move {
+        let total: i64 = count_qb.build_query_scalar().fetch_one(pool).await?;
+        Ok::<_, ApiError>(total)
+    };
 
-    Ok(PaginatedResponse {
+    let mut data_qb: QueryBuilder<Postgres> = QueryBuilder::new(
+        "SELECT id, user_id, settlement_date, product, account, security_code, security_name, \
+         unit_price, shares, dividends_before_tax, taxes, net_amount_received, created_at, updated_at \
+         FROM dividends",
+    );
+    push_filters(&mut data_qb, user_id, &filter);
+    data_qb.push(" ORDER BY settlement_date DESC, id DESC LIMIT ");
+    data_qb.push_bind(params.per_page());
+    data_qb.push(" OFFSET ");
+    data_qb.push_bind(params.offset());
+    let data_fut = async move {
+        let data = data_qb.build_query_as::<Dividend>().fetch_all(pool).await?;
+        Ok::<_, ApiError>(data)
+    };
+
+    let summary_fut = async {
+        if params.should_include_summary() {
+            fetch_summary(pool, user_id, &filter).await.map(Some)
+        } else {
+            Ok(None)
+        }
+    };
+
+    let facets_fut = async {
+        if params.should_include_facets() {
+            fetch_facets(pool, user_id, &filter).await.map(Some)
+        } else {
+            Ok(None)
+        }
+    };
+
+    // count/data/summary/facets は相互に依存しないため並行実行する
+    let (total, data, summary, facets) =
+        tokio::try_join!(count_fut, data_fut, summary_fut, facets_fut)?;
+
+    Ok(PaginatedSearchResponse {
         data,
         total,
         page: params.page(),
         per_page: params.per_page(),
+        summary,
+        facets,
     })
+}
+
+async fn fetch_summary(
+    pool: &PgPool,
+    user_id: Uuid,
+    filter: &DividendFilter,
+) -> Result<DividendSummary, ApiError> {
+    let mut qb: QueryBuilder<Postgres> = QueryBuilder::new(
+        "SELECT COALESCE(SUM(dividends_before_tax), 0) AS total_dividends_before_tax, \
+         COALESCE(SUM(taxes), 0) AS total_taxes, \
+         COALESCE(SUM(net_amount_received), 0) AS total_net_amount_received \
+         FROM dividends",
+    );
+    push_filters(&mut qb, user_id, filter);
+    Ok(qb
+        .build_query_as::<DividendSummary>()
+        .fetch_one(pool)
+        .await?)
+}
+
+async fn fetch_facets(
+    pool: &PgPool,
+    user_id: Uuid,
+    filter: &DividendFilter,
+) -> Result<SearchFacets, ApiError> {
+    let products = fetch_group_facets(pool, user_id, filter, "product", true).await?;
+    let accounts = fetch_group_facets(pool, user_id, filter, "account", true).await?;
+    let securities = fetch_security_facets(pool, user_id, filter).await?;
+    let years = fetch_group_facets(
+        pool,
+        user_id,
+        filter,
+        "EXTRACT(YEAR FROM settlement_date)::integer::text",
+        false,
+    )
+    .await?;
+    let year_months = fetch_group_facets(
+        pool,
+        user_id,
+        filter,
+        "TO_CHAR(settlement_date, 'YYYY-MM')",
+        false,
+    )
+    .await?;
+
+    Ok(SearchFacets {
+        products: Some(products),
+        accounts: Some(accounts),
+        securities: Some(securities),
+        funds: None,
+        years: Some(years),
+        year_months: Some(year_months),
+    })
+}
+
+/// group_expr の値ごとに件数を集計して FacetOption を返す共通ヘルパー
+async fn fetch_group_facets(
+    pool: &PgPool,
+    user_id: Uuid,
+    filter: &DividendFilter,
+    group_expr: &str,
+    order_asc: bool,
+) -> Result<Vec<FacetOption>, ApiError> {
+    let mut qb: QueryBuilder<Postgres> = QueryBuilder::new(format!(
+        "SELECT {group_expr} AS value, {group_expr} AS label, COUNT(*) AS count FROM dividends"
+    ));
+    push_filters(&mut qb, user_id, filter);
+    qb.push(format!(
+        " GROUP BY {group_expr} ORDER BY {group_expr} {}",
+        if order_asc { "ASC" } else { "DESC" }
+    ));
+    Ok(qb.build_query_as::<FacetOption>().fetch_all(pool).await?)
+}
+
+/// 銘柄コードごとに最新の銘柄名を label として件数付きで返す
+async fn fetch_security_facets(
+    pool: &PgPool,
+    user_id: Uuid,
+    filter: &DividendFilter,
+) -> Result<Vec<FacetOption>, ApiError> {
+    let mut qb: QueryBuilder<Postgres> = QueryBuilder::new(
+        "SELECT security_code AS value, \
+         (ARRAY_AGG(security_name ORDER BY settlement_date DESC, id DESC))[1] AS label, \
+         COUNT(*) AS count \
+         FROM dividends",
+    );
+    push_filters(&mut qb, user_id, filter);
+    qb.push(" GROUP BY security_code ORDER BY security_code");
+    Ok(qb.build_query_as::<FacetOption>().fetch_all(pool).await?)
 }
 
 /// 配当金を一括追加（重複はスキップ）
@@ -246,5 +507,169 @@ mod tests {
                 (1, 0, true)
             );
         }
+    }
+
+    #[test]
+    fn test_dividend_search_query_params_delegate_include_flags() {
+        let mut params = DividendSearchQueryParams::default();
+        assert!(!params.should_include_summary());
+        assert!(!params.should_include_facets());
+
+        params.search.include_summary = Some(true);
+        params.search.include_facets = Some(true);
+        assert!(params.should_include_summary());
+        assert!(params.should_include_facets());
+    }
+
+    #[test]
+    fn test_year_to_range_produces_year_boundaries() {
+        let (start, end) = year_to_range(2026).expect("2026年は有効な範囲");
+        assert_eq!(start, NaiveDate::from_ymd_opt(2026, 1, 1).unwrap());
+        assert_eq!(end, NaiveDate::from_ymd_opt(2027, 1, 1).unwrap());
+    }
+
+    #[test]
+    fn test_parse_year_month_range_handles_december_wrap_and_invalid_values() {
+        let (start, end) = parse_year_month_range("2026-06").expect("2026-06 は有効");
+        assert_eq!(start, NaiveDate::from_ymd_opt(2026, 6, 1).unwrap());
+        assert_eq!(end, NaiveDate::from_ymd_opt(2026, 7, 1).unwrap());
+
+        // 12月は年をまたいで翌年1月1日になる
+        let (_, end) = parse_year_month_range("2026-12").expect("2026-12 は有効");
+        assert_eq!(end, NaiveDate::from_ymd_opt(2027, 1, 1).unwrap());
+
+        for invalid in ["2026/06", "2026-13", "abcd-06", "2026-06-01"] {
+            assert!(
+                matches!(
+                    parse_year_month_range(invalid),
+                    Err(ApiError::ValidationError(_))
+                ),
+                "value={invalid} は ValidationError になるべき"
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_date_param_accepts_iso_format_and_rejects_others() {
+        assert!(parse_date_param("date", "2026-01-15").is_ok());
+        for invalid in ["2026/01/15", "15-01-2026", "not-a-date", ""] {
+            assert!(
+                matches!(
+                    parse_date_param("date", invalid),
+                    Err(ApiError::ValidationError(_))
+                ),
+                "value={invalid} は ValidationError になるべき"
+            );
+        }
+    }
+
+    #[test]
+    fn test_dividend_filter_from_params_accepts_valid_date_axis_values() {
+        let mut params = DividendSearchQueryParams::default();
+        params.search.date = Some("2026-01-15".to_string());
+        params.search.date_from = Some("2026-01-01".to_string());
+        params.search.date_to = Some("2026-12-31".to_string());
+        params.search.year = Some(2026);
+        params.search.year_month = Some("2026-06".to_string());
+
+        let filter =
+            DividendFilter::from_params(&params).expect("正しい日付フォーマットは検証を通過する");
+
+        assert_eq!(filter.date_eq, NaiveDate::from_ymd_opt(2026, 1, 15));
+        assert_eq!(filter.date_from, NaiveDate::from_ymd_opt(2026, 1, 1));
+        assert_eq!(filter.date_to, NaiveDate::from_ymd_opt(2026, 12, 31));
+        assert_eq!(
+            filter.year_range,
+            Some((
+                NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+                NaiveDate::from_ymd_opt(2027, 1, 1).unwrap()
+            ))
+        );
+        assert_eq!(
+            filter.year_month_range,
+            Some((
+                NaiveDate::from_ymd_opt(2026, 6, 1).unwrap(),
+                NaiveDate::from_ymd_opt(2026, 7, 1).unwrap()
+            ))
+        );
+    }
+
+    #[test]
+    fn test_dividend_filter_from_params_rejects_invalid_date_axis_values() {
+        type Apply = fn(&mut DividendSearchQueryParams);
+        let cases: [(&str, Apply); 5] = [
+            ("date", |p| p.search.date = Some("2026/01/15".to_string())),
+            ("date_from", |p| {
+                p.search.date_from = Some("20260101".to_string())
+            }),
+            ("date_to", |p| {
+                p.search.date_to = Some("not-a-date".to_string())
+            }),
+            ("year", |p| p.search.year = Some(i32::MIN)),
+            ("year_month", |p| {
+                p.search.year_month = Some("2026-13".to_string())
+            }),
+        ];
+
+        for (field, apply) in cases {
+            let mut params = DividendSearchQueryParams::default();
+            apply(&mut params);
+            let err = DividendFilter::from_params(&params)
+                .expect_err(&format!("{field} は不正値で ValidationError になるべき"));
+            assert!(
+                matches!(err, ApiError::ValidationError(_)),
+                "field={field} の失敗が ValidationError ではない"
+            );
+        }
+    }
+
+    #[test]
+    fn test_push_filters_combines_q_tokens_as_and_of_or_across_all_columns() {
+        let mut params = DividendSearchQueryParams::default();
+        params.search.q = Some("AA BB".to_string());
+        let filter = DividendFilter::from_params(&params).expect("q のみなら検証を通過する");
+
+        let mut qb: QueryBuilder<Postgres> = QueryBuilder::new("SELECT 1 FROM dividends");
+        push_filters(&mut qb, Uuid::nil(), &filter);
+        let sql = qb.sql();
+        let sql = sql.as_str();
+
+        // token ごとに 1 つの AND (...) ブロックが生成され、ブロック内は4カラムの OR になる
+        assert_eq!(sql.matches(" AND (").count(), 2);
+        assert_eq!(sql.matches("product ILIKE").count(), 2);
+        assert_eq!(sql.matches("account ILIKE").count(), 2);
+        assert_eq!(sql.matches("security_code ILIKE").count(), 2);
+        assert_eq!(sql.matches("security_name ILIKE").count(), 2);
+    }
+
+    #[test]
+    fn test_escape_like_pattern_escapes_wildcard_characters() {
+        assert_eq!(escape_like_pattern("abc"), "%abc%");
+        assert_eq!(escape_like_pattern("50%"), "%50\\%%");
+        assert_eq!(escape_like_pattern("A_B"), "%A\\_B%");
+        assert_eq!(escape_like_pattern("a\\b"), "%a\\\\b%");
+        assert_eq!(escape_like_pattern("100%_off\\"), "%100\\%\\_off\\\\%");
+    }
+
+    #[test]
+    fn test_push_filters_binds_dividend_specific_field_filters() {
+        let params = DividendSearchQueryParams {
+            product: Some("国内株式".to_string()),
+            account: Some("特定".to_string()),
+            security_code: Some("1234".to_string()),
+            security_name: Some("テスト株式会社".to_string()),
+            ..Default::default()
+        };
+        let filter = DividendFilter::from_params(&params).expect("フィルタのみなら検証を通過する");
+
+        let mut qb: QueryBuilder<Postgres> = QueryBuilder::new("SELECT 1 FROM dividends");
+        push_filters(&mut qb, Uuid::nil(), &filter);
+        let sql = qb.sql();
+        let sql = sql.as_str();
+
+        assert!(sql.contains("AND product = "));
+        assert!(sql.contains("AND account = "));
+        assert!(sql.contains("AND security_code = "));
+        assert!(sql.contains("AND security_name = "));
     }
 }

--- a/backend/tests/db_integration.rs
+++ b/backend/tests/db_integration.rs
@@ -6,8 +6,8 @@ use backend::{
     config::Config,
     db::run_migrations,
     models::asset_balance::CreateAssetBalanceRequest,
-    models::common::PaginationParams,
-    models::dividend::CreateDividendRequest,
+    models::common::{PaginationParams, SearchQueryParams},
+    models::dividend::{CreateDividendRequest, DividendSearchQueryParams},
     models::domestic_stock::CreateDomesticStockRequest,
     models::mutualfund::CreateMutualfundRequest,
     routes::app_router,
@@ -22,6 +22,22 @@ fn default_pagination() -> PaginationParams {
     PaginationParams {
         page: None,
         per_page: None,
+    }
+}
+
+fn default_dividend_search_params() -> DividendSearchQueryParams {
+    DividendSearchQueryParams::default()
+}
+
+fn dividend_search_params_with_pagination(
+    pagination: PaginationParams,
+) -> DividendSearchQueryParams {
+    DividendSearchQueryParams {
+        search: SearchQueryParams {
+            pagination,
+            ..Default::default()
+        },
+        ..Default::default()
     }
 }
 use chrono::NaiveDate;
@@ -342,11 +358,13 @@ async fn service_coverage_all_domains() {
         .data
         .is_empty());
 
-    assert!(dividend_svc::list(&pool, user_id, &default_pagination())
-        .await
-        .expect("initial dividend list failed")
-        .data
-        .is_empty());
+    assert!(
+        dividend_svc::search(&pool, user_id, &default_dividend_search_params())
+            .await
+            .expect("initial dividend list failed")
+            .data
+            .is_empty()
+    );
     let dividend_empty = dividend_svc::bulk_create(&pool, user_id, &[])
         .await
         .expect("empty dividend bulk_create failed");
@@ -369,7 +387,7 @@ async fn service_coverage_all_domains() {
     assert!(dividend_uploaded.errors.is_empty());
 
     assert_eq!(
-        dividend_svc::list(&pool, user_id, &default_pagination())
+        dividend_svc::search(&pool, user_id, &default_dividend_search_params())
             .await
             .expect("dividend list failed")
             .data
@@ -382,11 +400,13 @@ async fn service_coverage_all_domains() {
             .expect("dividend delete_all failed"),
         3
     );
-    assert!(dividend_svc::list(&pool, user_id, &default_pagination())
-        .await
-        .expect("dividend list after delete failed")
-        .data
-        .is_empty());
+    assert!(
+        dividend_svc::search(&pool, user_id, &default_dividend_search_params())
+            .await
+            .expect("dividend list after delete failed")
+            .data
+            .is_empty()
+    );
 
     assert!(
         domestic_stock_svc::list(&pool, user_id, &default_pagination())
@@ -598,19 +618,19 @@ async fn dividend_bulk_create_and_list() {
     assert_eq!(created.inserted, 3);
     assert_eq!(created.skipped, 0);
 
-    let rows = dividend_svc::list(&pool, user_id, &default_pagination())
+    let rows = dividend_svc::search(&pool, user_id, &default_dividend_search_params())
         .await
         .expect("dividend list failed")
         .data;
     assert_eq!(rows.len(), 3);
 
-    let first_page = dividend_svc::list(
+    let first_page = dividend_svc::search(
         &pool,
         user_id,
-        &PaginationParams {
+        &dividend_search_params_with_pagination(PaginationParams {
             page: Some(1),
             per_page: Some(2),
-        },
+        }),
     )
     .await
     .expect("dividend first page list failed");
@@ -618,14 +638,16 @@ async fn dividend_bulk_create_and_list() {
     assert_eq!(first_page.page, 1);
     assert_eq!(first_page.per_page, 2);
     assert_eq!(first_page.data.len(), 2);
+    assert!(first_page.summary.is_none());
+    assert!(first_page.facets.is_none());
 
-    let second_page = dividend_svc::list(
+    let second_page = dividend_svc::search(
         &pool,
         user_id,
-        &PaginationParams {
+        &dividend_search_params_with_pagination(PaginationParams {
             page: Some(2),
             per_page: Some(2),
-        },
+        }),
     )
     .await
     .expect("dividend second page list failed");
@@ -633,14 +655,16 @@ async fn dividend_bulk_create_and_list() {
     assert_eq!(second_page.page, 2);
     assert_eq!(second_page.per_page, 2);
     assert_eq!(second_page.data.len(), 1);
+    assert!(second_page.summary.is_none());
+    assert!(second_page.facets.is_none());
 
-    let clamped_page = dividend_svc::list(
+    let clamped_page = dividend_svc::search(
         &pool,
         user_id,
-        &PaginationParams {
+        &dividend_search_params_with_pagination(PaginationParams {
             page: Some(1),
             per_page: Some(5000),
-        },
+        }),
     )
     .await
     .expect("dividend clamped page list failed");
@@ -652,7 +676,7 @@ async fn dividend_bulk_create_and_list() {
         .expect("dividend delete_all failed");
     assert_eq!(deleted, 3);
 
-    let rows = dividend_svc::list(&pool, user_id, &default_pagination())
+    let rows = dividend_svc::search(&pool, user_id, &default_dividend_search_params())
         .await
         .expect("dividend list after delete failed")
         .data;

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -554,6 +554,115 @@
               "type": "integer",
               "format": "int64"
             }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "description": "フリーワード検索（商品/口座/銘柄コード/銘柄名の token AND 検索）",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "date_from",
+            "in": "query",
+            "description": "決済日の開始日（YYYY-MM-DD）",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "date_to",
+            "in": "query",
+            "description": "決済日の終了日（YYYY-MM-DD）",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "year",
+            "in": "query",
+            "description": "決済日の年（YYYY）",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "year_month",
+            "in": "query",
+            "description": "決済日の年月（YYYY-MM）",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "date",
+            "in": "query",
+            "description": "決済日の単日指定（YYYY-MM-DD）",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "product",
+            "in": "query",
+            "description": "商品での絞り込み",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "account",
+            "in": "query",
+            "description": "口座での絞り込み",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "security_code",
+            "in": "query",
+            "description": "銘柄コードでの絞り込み",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "security_name",
+            "in": "query",
+            "description": "銘柄名での絞り込み",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "include_summary",
+            "in": "query",
+            "description": "検索条件全体の集計を含めるか",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "include_facets",
+            "in": "query",
+            "description": "検索候補 facets を含めるか",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -562,7 +671,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PaginatedResponse_Dividend"
+                  "$ref": "#/components/schemas/PaginatedSearchResponse_Dividend_DividendSummary_SearchFacets"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1746,6 +1865,29 @@
           }
         }
       },
+      "DividendSummary": {
+        "type": "object",
+        "description": "配当金 検索条件全体の集計",
+        "required": [
+          "total_dividends_before_tax",
+          "total_taxes",
+          "total_net_amount_received"
+        ],
+        "properties": {
+          "total_dividends_before_tax": {
+            "type": "number",
+            "format": "double"
+          },
+          "total_net_amount_received": {
+            "type": "number",
+            "format": "double"
+          },
+          "total_taxes": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
       "DomesticStock": {
         "type": "object",
         "description": "国内株式取引モデル（DB + APIレスポンス兼用）",
@@ -1855,6 +1997,29 @@
         "properties": {
           "error": {
             "$ref": "#/components/schemas/ErrorDetails"
+          }
+        }
+      },
+      "FacetOption": {
+        "type": "object",
+        "description": "検索候補の共通表現。",
+        "required": [
+          "value",
+          "label"
+        ],
+        "properties": {
+          "count": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64"
+          },
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
           }
         }
       },
@@ -2829,102 +2994,6 @@
           }
         }
       },
-      "PaginatedResponse_Dividend": {
-        "type": "object",
-        "description": "ページネーションレスポンス（全ドメイン共通）",
-        "required": [
-          "data",
-          "total",
-          "page",
-          "per_page"
-        ],
-        "properties": {
-          "data": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "description": "配当金モデル（DB + APIレスポンス兼用）",
-              "required": [
-                "id",
-                "settlement_date",
-                "product",
-                "account",
-                "security_code",
-                "security_name",
-                "unit_price",
-                "shares",
-                "dividends_before_tax",
-                "taxes",
-                "net_amount_received",
-                "created_at",
-                "updated_at"
-              ],
-              "properties": {
-                "account": {
-                  "type": "string"
-                },
-                "created_at": {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                "dividends_before_tax": {
-                  "type": "number",
-                  "format": "double"
-                },
-                "id": {
-                  "type": "string",
-                  "format": "uuid"
-                },
-                "net_amount_received": {
-                  "type": "number",
-                  "format": "double"
-                },
-                "product": {
-                  "type": "string"
-                },
-                "security_code": {
-                  "type": "string"
-                },
-                "security_name": {
-                  "type": "string"
-                },
-                "settlement_date": {
-                  "type": "string",
-                  "format": "date"
-                },
-                "shares": {
-                  "type": "number",
-                  "format": "double"
-                },
-                "taxes": {
-                  "type": "number",
-                  "format": "double"
-                },
-                "unit_price": {
-                  "type": "number",
-                  "format": "double"
-                },
-                "updated_at": {
-                  "type": "string",
-                  "format": "date-time"
-                }
-              }
-            }
-          },
-          "page": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "per_page": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "total": {
-            "type": "integer",
-            "format": "int64"
-          }
-        }
-      },
       "PaginatedResponse_DomesticStock": {
         "type": "object",
         "description": "ページネーションレスポンス（全ドメイン共通）",
@@ -3143,6 +3212,245 @@
           "total": {
             "type": "integer",
             "format": "int64"
+          }
+        }
+      },
+      "PaginatedSearchResponse_Dividend_DividendSummary_SearchFacets": {
+        "type": "object",
+        "description": "検索・集計付きページネーションレスポンス。",
+        "required": [
+          "data",
+          "total",
+          "page",
+          "per_page"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "description": "配当金モデル（DB + APIレスポンス兼用）",
+              "required": [
+                "id",
+                "settlement_date",
+                "product",
+                "account",
+                "security_code",
+                "security_name",
+                "unit_price",
+                "shares",
+                "dividends_before_tax",
+                "taxes",
+                "net_amount_received",
+                "created_at",
+                "updated_at"
+              ],
+              "properties": {
+                "account": {
+                  "type": "string"
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "dividends_before_tax": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "id": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "net_amount_received": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "product": {
+                  "type": "string"
+                },
+                "security_code": {
+                  "type": "string"
+                },
+                "security_name": {
+                  "type": "string"
+                },
+                "settlement_date": {
+                  "type": "string",
+                  "format": "date"
+                },
+                "shares": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "taxes": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "unit_price": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              }
+            }
+          },
+          "facets": {
+            "type": "object",
+            "description": "検索候補レスポンスの共通枠。",
+            "properties": {
+              "accounts": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "$ref": "#/components/schemas/FacetOption"
+                }
+              },
+              "funds": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "$ref": "#/components/schemas/FacetOption"
+                }
+              },
+              "products": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "$ref": "#/components/schemas/FacetOption"
+                }
+              },
+              "securities": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "$ref": "#/components/schemas/FacetOption"
+                }
+              },
+              "year_months": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "$ref": "#/components/schemas/FacetOption"
+                }
+              },
+              "years": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "$ref": "#/components/schemas/FacetOption"
+                }
+              }
+            }
+          },
+          "page": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "per_page": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "summary": {
+            "type": "object",
+            "description": "配当金 検索条件全体の集計",
+            "required": [
+              "total_dividends_before_tax",
+              "total_taxes",
+              "total_net_amount_received"
+            ],
+            "properties": {
+              "total_dividends_before_tax": {
+                "type": "number",
+                "format": "double"
+              },
+              "total_net_amount_received": {
+                "type": "number",
+                "format": "double"
+              },
+              "total_taxes": {
+                "type": "number",
+                "format": "double"
+              }
+            }
+          },
+          "total": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "SearchFacets": {
+        "type": "object",
+        "description": "検索候補レスポンスの共通枠。",
+        "properties": {
+          "accounts": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/FacetOption"
+            }
+          },
+          "funds": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/FacetOption"
+            }
+          },
+          "products": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/FacetOption"
+            }
+          },
+          "securities": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/FacetOption"
+            }
+          },
+          "year_months": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/FacetOption"
+            }
+          },
+          "years": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/FacetOption"
+            }
           }
         }
       },

--- a/frontend/src/generated/api.ts
+++ b/frontend/src/generated/api.ts
@@ -490,6 +490,15 @@ export interface components {
             /** @description ok / zero / pending / error */
             status: string;
         };
+        /** @description 配当金 検索条件全体の集計 */
+        DividendSummary: {
+            /** Format: double */
+            total_dividends_before_tax: number;
+            /** Format: double */
+            total_net_amount_received: number;
+            /** Format: double */
+            total_taxes: number;
+        };
         /** @description 国内株式取引モデル（DB + APIレスポンス兼用） */
         DomesticStock: {
             account: string;
@@ -527,6 +536,13 @@ export interface components {
         };
         ErrorResponse: {
             error: components["schemas"]["ErrorDetails"];
+        };
+        /** @description 検索候補の共通表現。 */
+        FacetOption: {
+            /** Format: int64 */
+            count?: number | null;
+            label: string;
+            value: string;
         };
         /**
          * @description 決算サマリーデータ
@@ -830,39 +846,6 @@ export interface components {
             total: number;
         };
         /** @description ページネーションレスポンス（全ドメイン共通） */
-        PaginatedResponse_Dividend: {
-            data: {
-                account: string;
-                /** Format: date-time */
-                created_at: string;
-                /** Format: double */
-                dividends_before_tax: number;
-                /** Format: uuid */
-                id: string;
-                /** Format: double */
-                net_amount_received: number;
-                product: string;
-                security_code: string;
-                security_name: string;
-                /** Format: date */
-                settlement_date: string;
-                /** Format: double */
-                shares: number;
-                /** Format: double */
-                taxes: number;
-                /** Format: double */
-                unit_price: number;
-                /** Format: date-time */
-                updated_at: string;
-            }[];
-            /** Format: int64 */
-            page: number;
-            /** Format: int64 */
-            per_page: number;
-            /** Format: int64 */
-            total: number;
-        };
-        /** @description ページネーションレスポンス（全ドメイン共通） */
         PaginatedResponse_DomesticStock: {
             data: {
                 account: string;
@@ -939,6 +922,66 @@ export interface components {
             per_page: number;
             /** Format: int64 */
             total: number;
+        };
+        /** @description 検索・集計付きページネーションレスポンス。 */
+        PaginatedSearchResponse_Dividend_DividendSummary_SearchFacets: {
+            data: {
+                account: string;
+                /** Format: date-time */
+                created_at: string;
+                /** Format: double */
+                dividends_before_tax: number;
+                /** Format: uuid */
+                id: string;
+                /** Format: double */
+                net_amount_received: number;
+                product: string;
+                security_code: string;
+                security_name: string;
+                /** Format: date */
+                settlement_date: string;
+                /** Format: double */
+                shares: number;
+                /** Format: double */
+                taxes: number;
+                /** Format: double */
+                unit_price: number;
+                /** Format: date-time */
+                updated_at: string;
+            }[];
+            /** @description 検索候補レスポンスの共通枠。 */
+            facets?: {
+                accounts?: components["schemas"]["FacetOption"][] | null;
+                funds?: components["schemas"]["FacetOption"][] | null;
+                products?: components["schemas"]["FacetOption"][] | null;
+                securities?: components["schemas"]["FacetOption"][] | null;
+                year_months?: components["schemas"]["FacetOption"][] | null;
+                years?: components["schemas"]["FacetOption"][] | null;
+            };
+            /** Format: int64 */
+            page: number;
+            /** Format: int64 */
+            per_page: number;
+            /** @description 配当金 検索条件全体の集計 */
+            summary?: {
+                /** Format: double */
+                total_dividends_before_tax: number;
+                /** Format: double */
+                total_net_amount_received: number;
+                /** Format: double */
+                total_taxes: number;
+            };
+            /** Format: int64 */
+            total: number;
+        };
+        /** @description 検索候補レスポンスの共通枠。 */
+        SearchFacets: {
+            accounts?: components["schemas"]["FacetOption"][] | null;
+            funds?: components["schemas"]["FacetOption"][] | null;
+            products?: components["schemas"]["FacetOption"][] | null;
+            securities?: components["schemas"]["FacetOption"][] | null;
+            year_months?: components["schemas"]["FacetOption"][] | null;
+            years?: components["schemas"]["FacetOption"][] | null;
         };
         Stock: {
             code: string;
@@ -1339,6 +1382,30 @@ export interface operations {
                 page?: number;
                 /** @description 1ページあたりの件数（デフォルト: 200、最大: 1000） */
                 per_page?: number;
+                /** @description フリーワード検索（商品/口座/銘柄コード/銘柄名の token AND 検索） */
+                q?: string;
+                /** @description 決済日の開始日（YYYY-MM-DD） */
+                date_from?: string;
+                /** @description 決済日の終了日（YYYY-MM-DD） */
+                date_to?: string;
+                /** @description 決済日の年（YYYY） */
+                year?: number;
+                /** @description 決済日の年月（YYYY-MM） */
+                year_month?: string;
+                /** @description 決済日の単日指定（YYYY-MM-DD） */
+                date?: string;
+                /** @description 商品での絞り込み */
+                product?: string;
+                /** @description 口座での絞り込み */
+                account?: string;
+                /** @description 銘柄コードでの絞り込み */
+                security_code?: string;
+                /** @description 銘柄名での絞り込み */
+                security_name?: string;
+                /** @description 検索条件全体の集計を含めるか */
+                include_summary?: boolean;
+                /** @description 検索候補 facets を含めるか */
+                include_facets?: boolean;
             };
             header?: never;
             path?: never;
@@ -1351,7 +1418,15 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["PaginatedResponse_Dividend"];
+                    "application/json": components["schemas"]["PaginatedSearchResponse_Dividend_DividendSummary_SearchFacets"];
+                };
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
             401: {


### PR DESCRIPTION
## 概要
- 配当金一覧 API に DB 側検索 query params を追加
- include_summary/include_facets 指定時のみ summary/facets を返却
- 配当金検索向け index と OpenAPI/generated API を更新

## 確認
- cd backend && cargo fmt --check
- cd backend && cargo clippy --all-targets -- -D warnings
- cd backend && cargo test
- bash scripts/check-openapi.sh（push hook で最新確認）
- cd frontend && npm run typecheck
- cd frontend && npm run lint
- cd frontend && npm test
- git diff --check

## 補足
- 既存の include flag 未指定時は summary/facets を JSON から省略し、既存 shape を維持します。
- task file はローカル管理のため PR には含めていません。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 配当一覧で、キーワード・日付・年/月・商品/口座/銘柄コード/銘柄名による検索ができるようになりました。
  * 検索結果に、合計金額の集計や検索候補の表示を含められるようになりました。
* **改善**
  * 配当一覧の表示が、検索条件に応じたより柔軟な取得方式に対応しました。
  * 配当検索の高速化のため、一覧表示に適したデータベース索引を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->