### PR TITLE
fix: 配当金一覧のクエリ解析エラーを修正

### DIFF
--- a/backend/src/models/common.rs
+++ b/backend/src/models/common.rs
@@ -1,8 +1,22 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use sqlx::FromRow;
-use std::borrow::Cow;
+use std::{borrow::Cow, fmt::Display, str::FromStr};
 use utoipa::ToSchema;
 use validator::{ValidateLength, ValidationError, ValidationErrors};
+
+/// URL query は数値や boolean も文字列として届くため、対象型へ明示的に parse する。
+fn deserialize_optional_from_string<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: FromStr,
+    T::Err: Display,
+{
+    let value = Option::<String>::deserialize(deserializer)?;
+    value
+        .filter(|v| !v.is_empty())
+        .map(|v| v.parse::<T>().map_err(serde::de::Error::custom))
+        .transpose()
+}
 
 /// `validator` derive の length rule 相当を手実装するヘルパー。
 /// `String` / `Option<String>` / `Vec<T>` など `ValidateLength` 実装型に共通で使う。
@@ -30,7 +44,9 @@ pub(crate) fn validate_length_field<T>(
 /// ページネーションクエリパラメータ（全ドメイン共通）
 #[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
 pub struct PaginationParams {
+    #[serde(default, deserialize_with = "deserialize_optional_from_string")]
     pub page: Option<i64>,
+    #[serde(default, deserialize_with = "deserialize_optional_from_string")]
     pub per_page: Option<i64>,
 }
 
@@ -58,14 +74,17 @@ pub struct SearchQueryParams {
     /// 終了日（YYYY-MM-DD）
     pub date_to: Option<String>,
     /// 年（YYYY）
+    #[serde(default, deserialize_with = "deserialize_optional_from_string")]
     pub year: Option<i32>,
     /// 年月（YYYY-MM）
     pub year_month: Option<String>,
     /// 単日（YYYY-MM-DD）
     pub date: Option<String>,
     /// summary を返すかどうか
+    #[serde(default, deserialize_with = "deserialize_optional_from_string")]
     pub include_summary: Option<bool>,
     /// facets を返すかどうか
+    #[serde(default, deserialize_with = "deserialize_optional_from_string")]
     pub include_facets: Option<bool>,
 }
 
@@ -162,6 +181,7 @@ mod tests {
         BulkCreateResponse, FacetOption, MessageResponse, PaginatedResponse,
         PaginatedSearchResponse, PaginationParams, SearchFacets, SearchQueryParams,
     };
+    use axum::{extract::Query, http::Uri};
     use serde::{Deserialize, Serialize};
     use utoipa::ToSchema;
 
@@ -226,6 +246,22 @@ mod tests {
         assert_eq!(params.page(), 3);
         assert_eq!(params.per_page(), 50);
         assert_eq!(params.offset(), 100);
+        assert!(params.should_include_summary());
+        assert!(!params.should_include_facets());
+    }
+
+    #[test]
+    fn search_query_params_deserialize_from_url_query_strings() {
+        let uri: Uri = "/api/v1/dividends?per_page=1000&page=2&year=2026&include_summary=true&include_facets=false"
+            .parse()
+            .expect("valid URI");
+
+        let Query(params) =
+            Query::<SearchQueryParams>::try_from_uri(&uri).expect("query params should parse");
+
+        assert_eq!(params.page(), 2);
+        assert_eq!(params.per_page(), 1000);
+        assert_eq!(params.year, Some(2026));
         assert!(params.should_include_summary());
         assert!(!params.should_include_facets());
     }

--- a/scripts/start-local.sh
+++ b/scripts/start-local.sh
@@ -8,6 +8,8 @@ FRONTEND_DIR="$ROOT_DIR/frontend"
 BACKEND_URL="${BACKEND_URL:-http://127.0.0.1:3001}"
 FRONTEND_URL="${FRONTEND_URL:-http://127.0.0.1:8080}"
 FRONTEND_PORT="${FRONTEND_PORT:-8080}"
+DATABASE_URL="${DATABASE_URL:-postgresql://user:password@localhost:5432/shoken_db}"
+CORS_ORIGINS="${CORS_ORIGINS:-http://localhost:${FRONTEND_PORT},${FRONTEND_URL}}"
 
 BACKEND_LOG="${BACKEND_LOG:-/tmp/shoken-backend-dev.log}"
 FRONTEND_LOG="${FRONTEND_LOG:-/tmp/shoken-frontend-dev.log}"
@@ -58,7 +60,14 @@ for i in $(seq 1 120); do
 done
 
 echo "2/3 Starting backend..."
-(cd "${BACKEND_DIR}" && make run >"${BACKEND_LOG}" 2>&1) &
+(
+  cd "${BACKEND_DIR}"
+  DATABASE_URL="${DATABASE_URL}" \
+    BACKEND_URL="${BACKEND_URL}" \
+    FRONTEND_URL="${FRONTEND_URL}" \
+    CORS_ORIGINS="${CORS_ORIGINS}" \
+    make run >"${BACKEND_LOG}" 2>&1
+) &
 BACK_PID=$!
 
 if ! wait_for_http_ok "${BACKEND_URL}/health" "Backend" 120 0.5; then


### PR DESCRIPTION
## 概要
- 配当金一覧 API の page / per_page / year / include_summary / include_facets が URL query 文字列から正しく deserialize されるよう修正
- /api/v1/dividends?per_page=1000&page=1 が handler 到達前に 400 になる問題を再現テストで固定
- scripts/start-local.sh が worktree でも DATABASE_URL / CORS_ORIGINS を渡して起動できるよう修正

## 原因
- Axum の Query<DividendSearchQueryParams> が flatten された検索 params を deserialize する際、query string の 1000 / true を i64 / bool として読めず 400 を返していた
- ローカル確認フローでは start script が backend に DATABASE_URL を渡しておらず、worktree で起動確認できない穴があった

## 確認
- [x] cd backend && cargo fmt --check
- [x] cd backend && cargo test search_query_params_deserialize_from_url_query_strings
- [x] cd backend && cargo test
- [x] cd backend && cargo clippy --all-targets -- -D warnings
- [x] cd frontend && npm test -- receiptApi.test.ts
- [x] bash -n scripts/start-local.sh
- [x] ./scripts/start-local.sh で Ready まで起動
- [x] Playwright で http://127.0.0.1:8080/receipts を開き、/api/v1/dividends?per_page=1000&page=1 が 200、画面に ＫＤＤＩ 表示を確認