### PR TITLE
test: 実backend接続の配当金スモークを追加

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -73,7 +73,17 @@ cargo test -- --ignored
 
 # CSV CRUD フローのみ
 ./scripts/run-ui-e2e.sh --skip-main
+
+# 実 backend 接続の配当金一覧スモーク
+./scripts/run-real-backend-receipts-smoke.sh
 ```
+
+### 実 backend 接続スモーク
+
+`./scripts/run-real-backend-receipts-smoke.sh` は local PostgreSQL、backend、frontend を起動し、認証済み session と配当金 fixture を投入してから Playwright で `/receipts` を確認します。
+
+このスモークは `page.route()` の mock を使わないため、backend の query deserialize、認証 cookie、CORS、migration、DB schema の不整合を検出できます。
+検証対象は `/api/v1/dividends?per_page=1000&page=1` と summary/facets 付き API、および配当金タブの銘柄表示です。
 
 ### 失敗系テスト（API モック使用）
 

--- a/frontend/e2e/real-backend-receipts-smoke.spec.ts
+++ b/frontend/e2e/real-backend-receipts-smoke.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from '@playwright/test';
+
+const BACKEND_URL = process.env.REAL_BACKEND_URL || process.env.VITE_SHOKEN_WEBAPI_API_URL || 'http://127.0.0.1:3001';
+const FRONTEND_URL = process.env.REAL_FRONTEND_URL || process.env.BASE_URL || 'http://127.0.0.1:8080';
+const SESSION_TOKEN = process.env.REAL_BACKEND_SESSION_TOKEN || '00000000-0000-0000-0000-000000000102';
+const EXPECTED_SECURITY_NAME = process.env.REAL_BACKEND_EXPECTED_SECURITY_NAME || 'ＫＤＤＩ';
+const REQUEST_TIMEOUT_MS = 5_000;
+
+function cookieDomain(url: string) {
+  return new URL(url).hostname;
+}
+
+test('実 backend 接続で配当金一覧の初期表示と集計付きAPIが成功する', async ({ page, request }) => {
+  await page.context().addCookies([
+    {
+      name: 'session_token',
+      value: SESSION_TOKEN,
+      domain: cookieDomain(FRONTEND_URL),
+      path: '/',
+      httpOnly: true,
+      sameSite: 'Lax',
+    },
+  ]);
+
+  const cookieHeader = `session_token=${SESSION_TOKEN}`;
+  const listResponse = await request.get(`${BACKEND_URL}/api/v1/dividends?per_page=1000&page=1`, {
+    headers: { Cookie: cookieHeader },
+    timeout: REQUEST_TIMEOUT_MS,
+  });
+  expect(listResponse.status()).toBe(200);
+
+  const summaryResponse = await request.get(
+    `${BACKEND_URL}/api/v1/dividends?per_page=1000&page=1&include_summary=true&include_facets=true`,
+    { headers: { Cookie: cookieHeader }, timeout: REQUEST_TIMEOUT_MS },
+  );
+  expect(summaryResponse.status()).toBe(200);
+
+  await page.goto('/receipts');
+
+  await expect(page.getByRole('heading', { name: '取引明細' })).toBeVisible();
+  await expect(page.getByText(EXPECTED_SECURITY_NAME).first()).toBeVisible();
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "ui:screenshot:csv-crud": "STORAGE_STATE=.auth/storage-state.json npx playwright test e2e/csv-crud.spec.ts",
     "ui:csv-crud:auth": "npm run ui:screenshot:csv-crud",
     "ui:save-auth": "npx tsx e2e/save-auth.spec.ts",
+    "test:e2e:real-backend:receipts": "npx playwright test e2e/real-backend-receipts-smoke.spec.ts",
     "test:e2e:ci": "npx playwright test --config playwright.ci.config.ts",
     "generate:types": "FRONTEND_DIR=$(dirname \"$npm_package_json\") && cd /tmp && npx --yes --package typescript@5.9.3 --package openapi-typescript@7.13.0 openapi-typescript \"$FRONTEND_DIR/../docs/openapi.json\" -o \"$FRONTEND_DIR/src/generated/api.ts\"",
     "typecheck": "node ./node_modules/typescript-next/bin/tsc --noEmit"

--- a/scripts/run-real-backend-receipts-smoke.sh
+++ b/scripts/run-real-backend-receipts-smoke.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BACKEND_DIR="$ROOT_DIR/backend"
+FRONTEND_DIR="$ROOT_DIR/frontend"
+
+BACKEND_URL="${BACKEND_URL:-http://127.0.0.1:3001}"
+FRONTEND_URL="${FRONTEND_URL:-http://127.0.0.1:8080}"
+FRONTEND_PORT="${FRONTEND_PORT:-8080}"
+
+BACKEND_LOG="${BACKEND_LOG:-/tmp/shoken-real-backend-smoke-backend.log}"
+FRONTEND_LOG="${FRONTEND_LOG:-/tmp/shoken-real-backend-smoke-frontend.log}"
+DB_LOG="${DB_LOG:-/tmp/shoken-real-backend-smoke-db.log}"
+START_LOCAL_LOG="${START_LOCAL_LOG:-/tmp/shoken-real-backend-smoke-start-local.log}"
+
+SMOKE_USER_ID="${SMOKE_USER_ID:-00000000-0000-0000-0000-000000000101}"
+SMOKE_SESSION_TOKEN="${SMOKE_SESSION_TOKEN:-00000000-0000-0000-0000-000000000102}"
+SMOKE_SECURITY_NAME="${SMOKE_SECURITY_NAME:-ＫＤＤＩ}"
+
+START_LOCAL_PID=""
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./scripts/run-real-backend-receipts-smoke.sh
+
+Starts the local stack, seeds an authenticated dividend fixture into the local
+PostgreSQL database, runs a Playwright smoke test against the real backend, and
+stops the local stack afterward.
+
+Environment overrides:
+  BACKEND_URL / FRONTEND_URL / FRONTEND_PORT
+  SMOKE_USER_ID / SMOKE_SESSION_TOKEN / SMOKE_SECURITY_NAME
+  BACKEND_LOG / FRONTEND_LOG / DB_LOG / START_LOCAL_LOG
+EOF
+}
+
+print_log_tail() {
+  local label="$1"
+  local path="$2"
+
+  if [[ -f "$path" ]]; then
+    echo "--- ${label}: ${path} ---" >&2
+    tail -n 100 "$path" >&2 || true
+  fi
+}
+
+cleanup() {
+  local status=$?
+
+  if [[ -n "$START_LOCAL_PID" ]] && kill -0 "$START_LOCAL_PID" >/dev/null 2>&1; then
+    kill "$START_LOCAL_PID" >/dev/null 2>&1 || true
+    wait "$START_LOCAL_PID" >/dev/null 2>&1 || true
+  fi
+
+  "$ROOT_DIR/scripts/stop-local.sh" >/dev/null 2>&1 || true
+
+  if [[ "$status" -ne 0 ]]; then
+    print_log_tail "start-local" "$START_LOCAL_LOG"
+    print_log_tail "db" "$DB_LOG"
+    print_log_tail "backend" "$BACKEND_LOG"
+    print_log_tail "frontend" "$FRONTEND_LOG"
+  fi
+
+  exit "$status"
+}
+
+http_ok() {
+  local url="$1"
+  curl -sSf --connect-timeout 1 --max-time 2 "$url" >/dev/null 2>&1
+}
+
+wait_for_http_ok() {
+  local url="$1"
+  local label="$2"
+
+  for _ in $(seq 1 180); do
+    if http_ok "$url"; then
+      return 0
+    fi
+
+    if [[ -n "$START_LOCAL_PID" ]] && ! kill -0 "$START_LOCAL_PID" >/dev/null 2>&1; then
+      echo "start-local.sh exited before ${label} became ready." >&2
+      return 1
+    fi
+
+    sleep 0.5
+  done
+
+  echo "${label} did not become ready: ${url}" >&2
+  return 1
+}
+
+seed_fixture() {
+  echo "Seeding real-backend smoke fixture..."
+  (
+    cd "$BACKEND_DIR"
+    docker compose -f docker-compose.yml exec -T postgres \
+      psql -U user -d shoken_db -v ON_ERROR_STOP=1 \
+        -v user_id="$SMOKE_USER_ID" \
+        -v session_token="$SMOKE_SESSION_TOKEN" \
+        -v security_name="$SMOKE_SECURITY_NAME" <<'SQL'
+BEGIN;
+
+DELETE FROM dividends WHERE user_id = :'user_id'::uuid;
+DELETE FROM sessions WHERE id = :'session_token'::uuid OR user_id = :'user_id'::uuid;
+DELETE FROM users WHERE id = :'user_id'::uuid;
+
+INSERT INTO users (id, google_id, email, name, picture_url)
+VALUES (:'user_id'::uuid, 'real-backend-smoke-user', 'real-backend-smoke@example.com', '実backendスモーク', NULL);
+
+INSERT INTO sessions (id, user_id, expires_at)
+VALUES (:'session_token'::uuid, :'user_id'::uuid, NOW() + INTERVAL '7 days');
+
+INSERT INTO dividends (
+    user_id,
+    settlement_date,
+    product,
+    account,
+    security_code,
+    security_name,
+    unit_price,
+    shares,
+    dividends_before_tax,
+    taxes,
+    net_amount_received
+)
+VALUES (
+    :'user_id'::uuid,
+    DATE '2026-06-01',
+    '国内株式',
+    '特定・一般',
+    '9433',
+    :'security_name',
+    7.95,
+    2000,
+    15900,
+    3228,
+    12672
+);
+
+COMMIT;
+SQL
+  )
+}
+
+run_smoke() {
+  echo "Running Playwright real-backend receipts smoke..."
+  (
+    cd "$FRONTEND_DIR"
+    REAL_BACKEND_URL="$BACKEND_URL" \
+      REAL_FRONTEND_URL="$FRONTEND_URL" \
+      REAL_BACKEND_SESSION_TOKEN="$SMOKE_SESSION_TOKEN" \
+      REAL_BACKEND_EXPECTED_SECURITY_NAME="$SMOKE_SECURITY_NAME" \
+      BASE_URL="$FRONTEND_URL" \
+      VITE_SHOKEN_WEBAPI_API_URL="$BACKEND_URL" \
+      npx playwright test e2e/real-backend-receipts-smoke.spec.ts
+  )
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+trap cleanup EXIT INT TERM
+
+echo "Stopping existing local stack..."
+"$ROOT_DIR/scripts/stop-local.sh" >/dev/null 2>&1 || true
+
+echo "Starting local stack..."
+BACKEND_URL="$BACKEND_URL" \
+  FRONTEND_URL="$FRONTEND_URL" \
+  FRONTEND_PORT="$FRONTEND_PORT" \
+  BACKEND_LOG="$BACKEND_LOG" \
+  FRONTEND_LOG="$FRONTEND_LOG" \
+  DB_LOG="$DB_LOG" \
+  "$ROOT_DIR/scripts/start-local.sh" >"$START_LOCAL_LOG" 2>&1 &
+START_LOCAL_PID=$!
+
+wait_for_http_ok "$BACKEND_URL/ready" "Backend readiness"
+wait_for_http_ok "$FRONTEND_URL/" "Frontend"
+
+seed_fixture
+run_smoke
+
+echo "Real-backend receipts smoke passed."


### PR DESCRIPTION
## 概要
- 実 backend / local PostgreSQL / frontend を使う配当金一覧スモークを追加
- session と配当金 fixture を自動投入し、API 200 と /receipts の銘柄表示を検証
- テストガイドと frontend npm script を追加

## 背景
- mock E2E では backend の query deserialize / 認証 / CORS / migration / DB schema の不整合を検出できない
- 配当金一覧 400 のような事故をマージ前のローカル確認で拾うための入口を追加

## 確認
- [x] RED確認: backend未起動状態で real-backend spec が API 到達不可で失敗することを確認
- [x] bash -n scripts/run-real-backend-receipts-smoke.sh
- [x] ./scripts/run-real-backend-receipts-smoke.sh
- [x] cd frontend && npm run lint
- [x] cd frontend && npm run typecheck
- [x] cd backend && cargo test search_query_params_deserialize_from_url_query_strings
- [x] git diff --check
- [x] git diff --cached --check

## Claude
- Claude に差分レビューと不足実装を依頼したが、フルスモーク実行の承認確認で停止し、コード変更はなし
- 実装は Codex がTDDで実施したため、コミットに Claude co-author は付けていない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 実バックエンド接続のレシート確認用スモークテストを追加しました。
  * ローカル環境でバックエンド・フロントエンド・DB を起動し、配当金データの表示まで一連で確認できます。

* **Documentation**
  * E2E テスト手順に、実バックエンド接続スモークの実行方法と確認内容を追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->