### PR TITLE
国内株式一覧をDB検索に対応

### DIFF
--- a/backend/migrations/0003_domestic_stocks_search_indexes.sql
+++ b/backend/migrations/0003_domestic_stocks_search_indexes.sql
@@ -1,0 +1,8 @@
+-- 国内株式取引検索（account / security_code / security_name での絞り込み・facets集計）向けの複合インデックス
+CREATE INDEX IF NOT EXISTS idx_domestic_stocks_user_account ON domestic_stocks (user_id, account);
+CREATE INDEX IF NOT EXISTS idx_domestic_stocks_user_security_code ON domestic_stocks (user_id, security_code);
+CREATE INDEX IF NOT EXISTS idx_domestic_stocks_user_security_name ON domestic_stocks (user_id, security_name);
+
+-- 一覧のデフォルトソート（trade_date DESC, id DESC）向けの複合インデックス
+CREATE INDEX IF NOT EXISTS idx_domestic_stocks_user_trade_date_id
+    ON domestic_stocks (user_id, trade_date DESC, id DESC);

--- a/backend/migrations/README.md
+++ b/backend/migrations/README.md
@@ -11,6 +11,7 @@ SQLx migration の baseline 管理。
 |-----|---------|------|
 | 0001 | `0001_initial_schema.sql` | 拡張、全テーブル、全 index、初期 seed を作成 |
 | 0002 | `0002_dividends_search_indexes.sql` | 配当金検索（product/account/security_code/security_name の絞り込み、settlement_date/id 順の一覧取得）向け index を追加 |
+| 0003 | `0003_domestic_stocks_search_indexes.sql` | 国内株式検索（account/security_code/security_name の絞り込み、trade_date/id 順の一覧取得）向け index を追加 |
 
 ## 重要な注意
 

--- a/backend/src/handlers/v1/domestic_stocks.rs
+++ b/backend/src/handlers/v1/domestic_stocks.rs
@@ -3,9 +3,9 @@ use crate::{
     extractors::auth::AuthenticatedUser,
     handlers::common::ok_message,
     models::{
-        common::{MessageResponse, PaginatedResponse, PaginationParams},
+        common::{MessageResponse, PaginatedSearchResponse, SearchFacets},
         csv_import::{CsvPreviewResponse, CsvUploadForm, CsvUploadResponse},
-        domestic_stock::DomesticStock,
+        domestic_stock::{DomesticStock, DomesticStockSearchQueryParams, DomesticStockSummary},
     },
     services::{csv_domain::DomesticStockDomain, domestic_stock as domestic_stock_service},
     state::AppState,
@@ -27,9 +27,21 @@ use axum::{
     params(
         ("page" = Option<i64>, Query, description = "ページ番号（デフォルト: 1）"),
         ("per_page" = Option<i64>, Query, description = "1ページあたりの件数（デフォルト: 200、最大: 1000）"),
+        ("q" = Option<String>, Query, description = "フリーワード検索（口座/銘柄コード/銘柄名の token AND 検索）"),
+        ("date_from" = Option<String>, Query, description = "約定日の開始日（YYYY-MM-DD）"),
+        ("date_to" = Option<String>, Query, description = "約定日の終了日（YYYY-MM-DD）"),
+        ("year" = Option<i32>, Query, description = "約定日の年（YYYY）"),
+        ("year_month" = Option<String>, Query, description = "約定日の年月（YYYY-MM）"),
+        ("date" = Option<String>, Query, description = "約定日の単日指定（YYYY-MM-DD）"),
+        ("account" = Option<String>, Query, description = "口座での絞り込み"),
+        ("security_code" = Option<String>, Query, description = "銘柄コードでの絞り込み"),
+        ("security_name" = Option<String>, Query, description = "銘柄名での絞り込み"),
+        ("include_summary" = Option<bool>, Query, description = "検索条件全体の集計を含めるか"),
+        ("include_facets" = Option<bool>, Query, description = "検索候補 facets を含めるか"),
     ),
     responses(
-        (status = 200, body = PaginatedResponse<DomesticStock>),
+        (status = 200, body = PaginatedSearchResponse<DomesticStock, DomesticStockSummary, SearchFacets>),
+        (status = 400, body = ErrorResponse),
         (status = 401, body = ErrorResponse),
     ),
     security(("cookieAuth" = []))
@@ -37,9 +49,9 @@ use axum::{
 pub async fn list_transactions(
     State(state): State<AppState>,
     auth_user: AuthenticatedUser,
-    Query(params): Query<PaginationParams>,
+    Query(params): Query<DomesticStockSearchQueryParams>,
 ) -> Result<impl IntoResponse, ApiError> {
-    let result = domestic_stock_service::list(&state.pool, auth_user.id(), &params).await?;
+    let result = domestic_stock_service::search(&state.pool, auth_user.id(), &params).await?;
     Ok((StatusCode::OK, Json(result)))
 }
 

--- a/backend/src/models/domestic_stock.rs
+++ b/backend/src/models/domestic_stock.rs
@@ -1,4 +1,4 @@
-use crate::models::common::validate_length_field;
+use crate::models::common::{validate_length_field, SearchQueryParams};
 use chrono::{DateTime, NaiveDate, Utc};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
@@ -35,6 +35,56 @@ pub struct DomesticStock {
     pub realized_profit_and_loss_after_tax: Decimal,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+}
+
+/// 国内株式取引一覧の検索クエリパラメータ（共通 `SearchQueryParams` + 国内株式固有の絞り込み）
+#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
+pub struct DomesticStockSearchQueryParams {
+    #[serde(flatten)]
+    pub search: SearchQueryParams,
+    /// 口座での絞り込み
+    pub account: Option<String>,
+    /// 銘柄コードでの絞り込み
+    pub security_code: Option<String>,
+    /// 銘柄名での絞り込み
+    pub security_name: Option<String>,
+}
+
+impl DomesticStockSearchQueryParams {
+    pub fn page(&self) -> i64 {
+        self.search.page()
+    }
+
+    pub fn per_page(&self) -> i64 {
+        self.search.per_page()
+    }
+
+    pub fn offset(&self) -> i64 {
+        self.search.offset()
+    }
+
+    pub fn should_include_summary(&self) -> bool {
+        self.search.should_include_summary()
+    }
+
+    pub fn should_include_facets(&self) -> bool {
+        self.search.should_include_facets()
+    }
+}
+
+/// 国内株式取引 検索条件全体の集計
+///
+/// trade_date ごとに特定口座（account に「特定」を含む）と NISA 等口座を分離し、
+/// 特定口座の実現損益合計がプラスの時だけ `floor(合計 * 0.20315)` を日次税額とする
+/// frontend `calculateDailyData` と同じ仕様で日次集計した結果を合計する。
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
+pub struct DomesticStockSummary {
+    #[schema(value_type = f64)]
+    pub total_realized_profit_and_loss: Decimal,
+    #[schema(value_type = f64)]
+    pub total_taxes: Decimal,
+    #[schema(value_type = f64)]
+    pub total_realized_profit_and_loss_after_tax: Decimal,
 }
 
 /// 国内株式取引作成リクエスト
@@ -134,5 +184,17 @@ mod tests {
         }
         .validate()
         .is_err());
+    }
+
+    #[test]
+    fn test_domestic_stock_search_query_params_delegate_include_flags() {
+        let mut params = DomesticStockSearchQueryParams::default();
+        assert!(!params.should_include_summary());
+        assert!(!params.should_include_facets());
+
+        params.search.include_summary = Some(true);
+        params.search.include_facets = Some(true);
+        assert!(params.should_include_summary());
+        assert!(params.should_include_facets());
     }
 }

--- a/backend/src/services/domestic_stock.rs
+++ b/backend/src/services/domestic_stock.rs
@@ -1,7 +1,11 @@
 use crate::errors::ApiError;
-use crate::models::common::{BulkCreateResponse, PaginatedResponse, PaginationParams};
+use crate::models::common::{
+    BulkCreateResponse, FacetOption, PaginatedSearchResponse, SearchFacets,
+};
 use crate::models::csv_import::{CsvPreviewResponse, CsvRowError, CsvUploadResponse};
-use crate::models::domestic_stock::{CreateDomesticStockRequest, DomesticStock};
+use crate::models::domestic_stock::{
+    CreateDomesticStockRequest, DomesticStock, DomesticStockSearchQueryParams, DomesticStockSummary,
+};
 use crate::services::csv_import::{build_csv_preview, run_csv_upload, validate_csv_rows};
 use crate::services::csv_pipeline::{CsvParserConfig, CsvRow};
 use crate::services::csv_util::{
@@ -11,8 +15,9 @@ use crate::services::csv_util::{
 use crate::services::shared::{
     delete_all_for_user, user_ids_for_bulk_insert, BulkTimer, DeleteTarget,
 };
+use chrono::NaiveDate;
 use rust_decimal::Decimal;
-use sqlx::PgPool;
+use sqlx::{PgPool, Postgres, QueryBuilder};
 use tracing::info;
 use uuid::Uuid;
 
@@ -33,42 +38,317 @@ const DOMESTIC_STOCK_CSV_CONFIG: CsvParserConfig = CsvParserConfig {
     ],
 };
 
-/// 認証ユーザーの国内株式取引一覧を取得（ページネーション対応）
-pub async fn list(
+/// 国内株式検索条件を SQL 条件へ変換した中間表現
+#[derive(Debug)]
+struct DomesticStockFilter {
+    date_eq: Option<NaiveDate>,
+    date_from: Option<NaiveDate>,
+    date_to: Option<NaiveDate>,
+    year_range: Option<(NaiveDate, NaiveDate)>,
+    year_month_range: Option<(NaiveDate, NaiveDate)>,
+    tokens: Vec<String>,
+    account: Option<String>,
+    security_code: Option<String>,
+    security_name: Option<String>,
+}
+
+impl DomesticStockFilter {
+    fn from_params(params: &DomesticStockSearchQueryParams) -> Result<Self, ApiError> {
+        let search = &params.search;
+        let date_eq = search
+            .date
+            .as_deref()
+            .map(|v| parse_date_param("date", v))
+            .transpose()?;
+        let date_from = search
+            .date_from
+            .as_deref()
+            .map(|v| parse_date_param("date_from", v))
+            .transpose()?;
+        let date_to = search
+            .date_to
+            .as_deref()
+            .map(|v| parse_date_param("date_to", v))
+            .transpose()?;
+        let year_range = search.year.map(year_to_range).transpose()?;
+        let year_month_range = search
+            .year_month
+            .as_deref()
+            .map(parse_year_month_range)
+            .transpose()?;
+        let tokens = search
+            .q
+            .as_deref()
+            .map(|q| q.split_whitespace().map(str::to_string).collect())
+            .unwrap_or_default();
+
+        Ok(Self {
+            date_eq,
+            date_from,
+            date_to,
+            year_range,
+            year_month_range,
+            tokens,
+            account: params.account.clone(),
+            security_code: params.security_code.clone(),
+            security_name: params.security_name.clone(),
+        })
+    }
+}
+
+fn parse_date_param(field: &str, value: &str) -> Result<NaiveDate, ApiError> {
+    NaiveDate::parse_from_str(value, "%Y-%m-%d")
+        .map_err(|_| ApiError::ValidationError(format!("{field} の形式が不正です（YYYY-MM-DD）")))
+}
+
+fn year_to_range(year: i32) -> Result<(NaiveDate, NaiveDate), ApiError> {
+    let invalid = || ApiError::ValidationError("year の値が不正です".to_string());
+    let start = NaiveDate::from_ymd_opt(year, 1, 1).ok_or_else(invalid)?;
+    let end = NaiveDate::from_ymd_opt(year + 1, 1, 1).ok_or_else(invalid)?;
+    Ok((start, end))
+}
+
+fn parse_year_month_range(value: &str) -> Result<(NaiveDate, NaiveDate), ApiError> {
+    let invalid =
+        || ApiError::ValidationError("year_month の形式が不正です（YYYY-MM）".to_string());
+    let (year_str, month_str) = value.split_once('-').ok_or_else(invalid)?;
+    let year: i32 = year_str.parse().map_err(|_| invalid())?;
+    let month: u32 = month_str.parse().map_err(|_| invalid())?;
+    let start = NaiveDate::from_ymd_opt(year, month, 1).ok_or_else(invalid)?;
+    let end = if month == 12 {
+        NaiveDate::from_ymd_opt(year + 1, 1, 1)
+    } else {
+        NaiveDate::from_ymd_opt(year, month + 1, 1)
+    }
+    .ok_or_else(invalid)?;
+    Ok((start, end))
+}
+
+/// user_id と検索条件を WHERE 句として QueryBuilder へ積む
+fn push_filters(qb: &mut QueryBuilder<Postgres>, user_id: Uuid, filter: &DomesticStockFilter) {
+    qb.push(" WHERE user_id = ").push_bind(user_id);
+    if let Some(v) = filter.date_eq {
+        qb.push(" AND trade_date = ").push_bind(v);
+    }
+    if let Some(v) = filter.date_from {
+        qb.push(" AND trade_date >= ").push_bind(v);
+    }
+    if let Some(v) = filter.date_to {
+        qb.push(" AND trade_date <= ").push_bind(v);
+    }
+    if let Some((start, end)) = filter.year_range {
+        qb.push(" AND trade_date >= ").push_bind(start);
+        qb.push(" AND trade_date < ").push_bind(end);
+    }
+    if let Some((start, end)) = filter.year_month_range {
+        qb.push(" AND trade_date >= ").push_bind(start);
+        qb.push(" AND trade_date < ").push_bind(end);
+    }
+    if let Some(v) = &filter.account {
+        qb.push(" AND account = ").push_bind(v.clone());
+    }
+    if let Some(v) = &filter.security_code {
+        qb.push(" AND security_code = ").push_bind(v.clone());
+    }
+    if let Some(v) = &filter.security_name {
+        qb.push(" AND security_name = ").push_bind(v.clone());
+    }
+    for token in &filter.tokens {
+        let pattern = escape_like_pattern(token);
+        qb.push(" AND (account ILIKE ")
+            .push_bind(pattern.clone())
+            .push(" ESCAPE '\\' OR security_code ILIKE ")
+            .push_bind(pattern.clone())
+            .push(" ESCAPE '\\' OR security_name ILIKE ")
+            .push_bind(pattern)
+            .push(" ESCAPE '\\')");
+    }
+}
+
+/// ILIKE の wildcard 文字（%, _, \）をリテラル扱いにエスケープしてから前後を % で囲む
+fn escape_like_pattern(token: &str) -> String {
+    let escaped = token
+        .replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_");
+    format!("%{escaped}%")
+}
+
+/// 認証ユーザーの国内株式取引一覧を検索（ページネーション・summary・facets 対応）
+pub async fn search(
     pool: &PgPool,
     user_id: Uuid,
-    params: &PaginationParams,
-) -> Result<PaginatedResponse<DomesticStock>, ApiError> {
-    info!("[domestic_stock.list] リクエスト受信");
-    let total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM domestic_stocks WHERE user_id = $1")
-        .bind(user_id)
-        .fetch_one(pool)
-        .await?;
+    params: &DomesticStockSearchQueryParams,
+) -> Result<PaginatedSearchResponse<DomesticStock, DomesticStockSummary, SearchFacets>, ApiError> {
+    info!("[domestic_stock.search] リクエスト受信");
+    let filter = DomesticStockFilter::from_params(params)?;
 
-    let data = sqlx::query_as::<_, DomesticStock>(
-        r#"
-        SELECT id, user_id, trade_date, settlement_date, security_code, security_name,
-               account, shares, asked_price, proceeds, purchase_price,
-               realized_profit_and_loss, taxes, realized_profit_and_loss_after_tax,
-               created_at, updated_at
-        FROM domestic_stocks
-        WHERE user_id = $1
-        ORDER BY trade_date DESC, id DESC
-        LIMIT $2 OFFSET $3
-        "#,
-    )
-    .bind(user_id)
-    .bind(params.per_page())
-    .bind(params.offset())
-    .fetch_all(pool)
-    .await?;
+    let mut count_qb: QueryBuilder<Postgres> =
+        QueryBuilder::new("SELECT COUNT(*) FROM domestic_stocks");
+    push_filters(&mut count_qb, user_id, &filter);
+    let count_fut = async move {
+        let total: i64 = count_qb.build_query_scalar().fetch_one(pool).await?;
+        Ok::<_, ApiError>(total)
+    };
 
-    Ok(PaginatedResponse {
+    let mut data_qb: QueryBuilder<Postgres> = QueryBuilder::new(
+        "SELECT id, user_id, trade_date, settlement_date, security_code, security_name, \
+         account, shares, asked_price, proceeds, purchase_price, realized_profit_and_loss, \
+         taxes, realized_profit_and_loss_after_tax, created_at, updated_at \
+         FROM domestic_stocks",
+    );
+    push_filters(&mut data_qb, user_id, &filter);
+    data_qb.push(" ORDER BY trade_date DESC, id DESC LIMIT ");
+    data_qb.push_bind(params.per_page());
+    data_qb.push(" OFFSET ");
+    data_qb.push_bind(params.offset());
+    let data_fut = async move {
+        let data = data_qb
+            .build_query_as::<DomesticStock>()
+            .fetch_all(pool)
+            .await?;
+        Ok::<_, ApiError>(data)
+    };
+
+    let summary_fut = async {
+        if params.should_include_summary() {
+            fetch_summary(pool, user_id, &filter).await.map(Some)
+        } else {
+            Ok(None)
+        }
+    };
+
+    let facets_fut = async {
+        if params.should_include_facets() {
+            fetch_facets(pool, user_id, &filter).await.map(Some)
+        } else {
+            Ok(None)
+        }
+    };
+
+    // count/data/summary/facets は相互に依存しないため並行実行する
+    let (total, data, summary, facets) =
+        tokio::try_join!(count_fut, data_fut, summary_fut, facets_fut)?;
+
+    Ok(PaginatedSearchResponse {
         data,
         total,
         page: params.page(),
         per_page: params.per_page(),
+        summary,
+        facets,
     })
+}
+
+/// 検索条件全体の summary を算出する。
+///
+/// trade_date ごとに特定口座（account に「特定」を含む）と NISA 等口座の実現損益を分離し、
+/// 特定口座合計がプラスの時だけ `floor(合計 * 0.20315)` を日次税額として計算したうえで、
+/// 日次結果を合計する（frontend `calculateDailyData` / `calculateDomesticStock` と同一仕様）。
+async fn fetch_summary(
+    pool: &PgPool,
+    user_id: Uuid,
+    filter: &DomesticStockFilter,
+) -> Result<DomesticStockSummary, ApiError> {
+    let mut qb: QueryBuilder<Postgres> = QueryBuilder::new(
+        "WITH filtered AS (SELECT trade_date, account, realized_profit_and_loss FROM domestic_stocks",
+    );
+    push_filters(&mut qb, user_id, filter);
+    qb.push(
+        "), daily AS ( \
+             SELECT \
+                 trade_date, \
+                 COALESCE(SUM(realized_profit_and_loss) FILTER (WHERE POSITION('特定' IN account) > 0), 0) AS specific_total, \
+                 COALESCE(SUM(realized_profit_and_loss) FILTER (WHERE POSITION('特定' IN account) = 0), 0) AS nisa_total \
+             FROM filtered \
+             GROUP BY trade_date \
+         ), daily_tax AS ( \
+             SELECT \
+                 specific_total, \
+                 nisa_total, \
+                 FLOOR(GREATEST(specific_total, 0) * 0.20315) AS tax \
+             FROM daily \
+         ) \
+         SELECT \
+             COALESCE(SUM(specific_total + nisa_total), 0) AS total_realized_profit_and_loss, \
+             COALESCE(SUM(tax), 0) AS total_taxes, \
+             COALESCE(SUM(specific_total - tax + nisa_total), 0) AS total_realized_profit_and_loss_after_tax \
+         FROM daily_tax",
+    );
+    Ok(qb
+        .build_query_as::<DomesticStockSummary>()
+        .fetch_one(pool)
+        .await?)
+}
+
+async fn fetch_facets(
+    pool: &PgPool,
+    user_id: Uuid,
+    filter: &DomesticStockFilter,
+) -> Result<SearchFacets, ApiError> {
+    let accounts = fetch_group_facets(pool, user_id, filter, "account", true).await?;
+    let securities = fetch_security_facets(pool, user_id, filter).await?;
+    let years = fetch_group_facets(
+        pool,
+        user_id,
+        filter,
+        "EXTRACT(YEAR FROM trade_date)::integer::text",
+        false,
+    )
+    .await?;
+    let year_months = fetch_group_facets(
+        pool,
+        user_id,
+        filter,
+        "TO_CHAR(trade_date, 'YYYY-MM')",
+        false,
+    )
+    .await?;
+
+    Ok(SearchFacets {
+        products: None,
+        accounts: Some(accounts),
+        securities: Some(securities),
+        funds: None,
+        years: Some(years),
+        year_months: Some(year_months),
+    })
+}
+
+/// group_expr の値ごとに件数を集計して FacetOption を返す共通ヘルパー
+async fn fetch_group_facets(
+    pool: &PgPool,
+    user_id: Uuid,
+    filter: &DomesticStockFilter,
+    group_expr: &str,
+    order_asc: bool,
+) -> Result<Vec<FacetOption>, ApiError> {
+    let mut qb: QueryBuilder<Postgres> = QueryBuilder::new(format!(
+        "SELECT {group_expr} AS value, {group_expr} AS label, COUNT(*) AS count FROM domestic_stocks"
+    ));
+    push_filters(&mut qb, user_id, filter);
+    qb.push(format!(
+        " GROUP BY {group_expr} ORDER BY {group_expr} {}",
+        if order_asc { "ASC" } else { "DESC" }
+    ));
+    Ok(qb.build_query_as::<FacetOption>().fetch_all(pool).await?)
+}
+
+/// 銘柄コードごとに最新の銘柄名を label として件数付きで返す
+async fn fetch_security_facets(
+    pool: &PgPool,
+    user_id: Uuid,
+    filter: &DomesticStockFilter,
+) -> Result<Vec<FacetOption>, ApiError> {
+    let mut qb: QueryBuilder<Postgres> = QueryBuilder::new(
+        "SELECT security_code AS value, \
+         (ARRAY_AGG(security_name ORDER BY trade_date DESC, id DESC))[1] AS label, \
+         COUNT(*) AS count \
+         FROM domestic_stocks",
+    );
+    push_filters(&mut qb, user_id, filter);
+    qb.push(" GROUP BY security_code ORDER BY security_code");
+    Ok(qb.build_query_as::<FacetOption>().fetch_all(pool).await?)
 }
 
 /// 国内株式取引を一括追加（全件挿入）
@@ -388,5 +668,214 @@ mod tests {
 
         let second = bulk_create(&pool, user_id, &items).await.unwrap();
         assert_eq!((second.inserted, second.skipped), (0, 5));
+    }
+
+    #[test]
+    fn test_domestic_stock_search_query_params_delegate_include_flags() {
+        let mut params = DomesticStockSearchQueryParams::default();
+        assert!(!params.should_include_summary());
+        assert!(!params.should_include_facets());
+
+        params.search.include_summary = Some(true);
+        params.search.include_facets = Some(true);
+        assert!(params.should_include_summary());
+        assert!(params.should_include_facets());
+    }
+
+    #[test]
+    fn test_parse_date_param_accepts_iso_format_and_rejects_others() {
+        assert!(parse_date_param("date", "2026-01-15").is_ok());
+        for invalid in ["2026/01/15", "15-01-2026", "not-a-date", ""] {
+            assert!(
+                matches!(
+                    parse_date_param("date", invalid),
+                    Err(ApiError::ValidationError(_))
+                ),
+                "value={invalid} は ValidationError になるべき"
+            );
+        }
+    }
+
+    #[test]
+    fn test_domestic_stock_filter_from_params_accepts_valid_date_axis_values() {
+        let mut params = DomesticStockSearchQueryParams::default();
+        params.search.date = Some("2026-01-15".to_string());
+        params.search.date_from = Some("2026-01-01".to_string());
+        params.search.date_to = Some("2026-12-31".to_string());
+        params.search.year = Some(2026);
+        params.search.year_month = Some("2026-06".to_string());
+
+        let filter = DomesticStockFilter::from_params(&params)
+            .expect("正しい日付フォーマットは検証を通過する");
+
+        assert_eq!(filter.date_eq, NaiveDate::from_ymd_opt(2026, 1, 15));
+        assert_eq!(filter.date_from, NaiveDate::from_ymd_opt(2026, 1, 1));
+        assert_eq!(filter.date_to, NaiveDate::from_ymd_opt(2026, 12, 31));
+        assert_eq!(
+            filter.year_range,
+            Some((
+                NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+                NaiveDate::from_ymd_opt(2027, 1, 1).unwrap()
+            ))
+        );
+        assert_eq!(
+            filter.year_month_range,
+            Some((
+                NaiveDate::from_ymd_opt(2026, 6, 1).unwrap(),
+                NaiveDate::from_ymd_opt(2026, 7, 1).unwrap()
+            ))
+        );
+    }
+
+    #[test]
+    fn test_domestic_stock_filter_from_params_rejects_invalid_date_axis_values() {
+        type Apply = fn(&mut DomesticStockSearchQueryParams);
+        let cases: [(&str, Apply); 5] = [
+            ("date", |p| p.search.date = Some("2026/01/15".to_string())),
+            ("date_from", |p| {
+                p.search.date_from = Some("20260101".to_string())
+            }),
+            ("date_to", |p| {
+                p.search.date_to = Some("not-a-date".to_string())
+            }),
+            ("year", |p| p.search.year = Some(i32::MIN)),
+            ("year_month", |p| {
+                p.search.year_month = Some("2026-13".to_string())
+            }),
+        ];
+
+        for (field, apply) in cases {
+            let mut params = DomesticStockSearchQueryParams::default();
+            apply(&mut params);
+            let err = DomesticStockFilter::from_params(&params)
+                .expect_err(&format!("{field} は不正値で ValidationError になるべき"));
+            assert!(
+                matches!(err, ApiError::ValidationError(_)),
+                "field={field} の失敗が ValidationError ではない"
+            );
+        }
+    }
+
+    #[test]
+    fn test_push_filters_combines_q_tokens_as_and_of_or_across_all_columns() {
+        let mut params = DomesticStockSearchQueryParams::default();
+        params.search.q = Some("AA BB".to_string());
+        let filter = DomesticStockFilter::from_params(&params).expect("q のみなら検証を通過する");
+
+        let mut qb: QueryBuilder<Postgres> = QueryBuilder::new("SELECT 1 FROM domestic_stocks");
+        push_filters(&mut qb, Uuid::nil(), &filter);
+        let sql = qb.sql();
+        let sql = sql.as_str();
+
+        // token ごとに 1 つの AND (...) ブロックが生成され、ブロック内は3カラムの OR になる
+        assert_eq!(sql.matches(" AND (").count(), 2);
+        assert_eq!(sql.matches("account ILIKE").count(), 2);
+        assert_eq!(sql.matches("security_code ILIKE").count(), 2);
+        assert_eq!(sql.matches("security_name ILIKE").count(), 2);
+    }
+
+    #[test]
+    fn test_escape_like_pattern_escapes_wildcard_characters() {
+        assert_eq!(escape_like_pattern("abc"), "%abc%");
+        assert_eq!(escape_like_pattern("50%"), "%50\\%%");
+        assert_eq!(escape_like_pattern("A_B"), "%A\\_B%");
+        assert_eq!(escape_like_pattern("a\\b"), "%a\\\\b%");
+        assert_eq!(escape_like_pattern("100%_off\\"), "%100\\%\\_off\\\\%");
+    }
+
+    #[test]
+    fn test_push_filters_binds_domestic_stock_specific_field_filters() {
+        let params = DomesticStockSearchQueryParams {
+            account: Some("特定".to_string()),
+            security_code: Some("1234".to_string()),
+            security_name: Some("テスト株式会社".to_string()),
+            ..Default::default()
+        };
+        let filter =
+            DomesticStockFilter::from_params(&params).expect("フィルタのみなら検証を通過する");
+
+        let mut qb: QueryBuilder<Postgres> = QueryBuilder::new("SELECT 1 FROM domestic_stocks");
+        push_filters(&mut qb, Uuid::nil(), &filter);
+        let sql = qb.sql();
+        let sql = sql.as_str();
+
+        assert!(sql.contains("AND account = "));
+        assert!(sql.contains("AND security_code = "));
+        assert!(sql.contains("AND security_name = "));
+    }
+
+    fn make_summary_item(
+        trade_date: NaiveDate,
+        account: &str,
+        security_code: &str,
+        realized_profit_and_loss: Decimal,
+    ) -> CreateDomesticStockRequest {
+        CreateDomesticStockRequest {
+            trade_date,
+            settlement_date: trade_date,
+            security_code: security_code.to_string(),
+            security_name: "テスト株式会社".to_string(),
+            account: account.to_string(),
+            shares: dec!(100),
+            asked_price: dec!(1000),
+            proceeds: dec!(100000),
+            purchase_price: dec!(900),
+            realized_profit_and_loss,
+            taxes: dec!(0),
+            realized_profit_and_loss_after_tax: realized_profit_and_loss,
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Docker"]
+    async fn test_search_summary_matches_frontend_daily_tax_calculation() {
+        use testcontainers::runners::AsyncRunner;
+        use testcontainers_modules::postgres::Postgres as PgContainer;
+
+        let container = PgContainer::default().start().await.unwrap();
+        let url = format!(
+            "postgres://postgres:postgres@{}:{}/postgres",
+            container.get_host().await.unwrap(),
+            container.get_host_port_ipv4(5432).await.unwrap()
+        );
+        let pool = sqlx::PgPool::connect(&url).await.unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+
+        let user_id = Uuid::new_v4();
+        sqlx::query("INSERT INTO users (id, google_id, email) VALUES ($1, $2, $3)")
+            .bind(user_id)
+            .bind(format!("test_google_{user_id}"))
+            .bind(format!("test_{user_id}@example.com"))
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let day1 = NaiveDate::from_ymd_opt(2026, 2, 10).unwrap();
+        let day2 = NaiveDate::from_ymd_opt(2026, 2, 11).unwrap();
+
+        // day1: 特定口座 +10000 / +5000（合計 +15000、税額 floor(15000*0.20315)=3047）、NISA +2000（非課税）
+        // day2: 特定口座 -3000（マイナスのため非課税）
+        let items = vec![
+            make_summary_item(day1, "特定", "5020", dec!(10000)),
+            make_summary_item(day1, "特定", "5020", dec!(5000)),
+            make_summary_item(day1, "NISA", "9433", dec!(2000)),
+            make_summary_item(day2, "特定", "5020", dec!(-3000)),
+        ];
+        bulk_create(&pool, user_id, &items).await.unwrap();
+
+        let mut params = DomesticStockSearchQueryParams::default();
+        params.search.include_summary = Some(true);
+
+        let result = search(&pool, user_id, &params).await.unwrap();
+        let summary = result
+            .summary
+            .expect("include_summary=true で summary を返す");
+
+        assert_eq!(summary.total_realized_profit_and_loss, dec!(14000));
+        assert_eq!(summary.total_taxes, dec!(3047));
+        assert_eq!(
+            summary.total_realized_profit_and_loss_after_tax,
+            dec!(10953)
+        );
     }
 }

--- a/backend/tests/db_integration.rs
+++ b/backend/tests/db_integration.rs
@@ -8,7 +8,7 @@ use backend::{
     models::asset_balance::CreateAssetBalanceRequest,
     models::common::{PaginationParams, SearchQueryParams},
     models::dividend::{CreateDividendRequest, DividendSearchQueryParams},
-    models::domestic_stock::CreateDomesticStockRequest,
+    models::domestic_stock::{CreateDomesticStockRequest, DomesticStockSearchQueryParams},
     models::mutualfund::CreateMutualfundRequest,
     routes::app_router,
     services::asset_balance as asset_balance_svc,
@@ -27,6 +27,10 @@ fn default_pagination() -> PaginationParams {
 
 fn default_dividend_search_params() -> DividendSearchQueryParams {
     DividendSearchQueryParams::default()
+}
+
+fn default_domestic_stock_search_params() -> DomesticStockSearchQueryParams {
+    DomesticStockSearchQueryParams::default()
 }
 
 fn dividend_search_params_with_pagination(
@@ -409,7 +413,7 @@ async fn service_coverage_all_domains() {
     );
 
     assert!(
-        domestic_stock_svc::list(&pool, user_id, &default_pagination())
+        domestic_stock_svc::search(&pool, user_id, &default_domestic_stock_search_params())
             .await
             .expect("initial domestic_stock list failed")
             .data
@@ -441,7 +445,7 @@ async fn service_coverage_all_domains() {
     assert!(domestic_stock_uploaded.errors.is_empty());
 
     assert_eq!(
-        domestic_stock_svc::list(&pool, user_id, &default_pagination())
+        domestic_stock_svc::search(&pool, user_id, &default_domestic_stock_search_params())
             .await
             .expect("domestic_stock list failed")
             .data
@@ -455,7 +459,7 @@ async fn service_coverage_all_domains() {
         3
     );
     assert!(
-        domestic_stock_svc::list(&pool, user_id, &default_pagination())
+        domestic_stock_svc::search(&pool, user_id, &default_domestic_stock_search_params())
             .await
             .expect("domestic_stock list after delete failed")
             .data
@@ -720,7 +724,7 @@ async fn domestic_stock_bulk_create_and_list() {
     assert_eq!(created.inserted, 3);
     assert_eq!(created.skipped, 0);
 
-    let rows = domestic_stock_svc::list(&pool, user_id, &default_pagination())
+    let rows = domestic_stock_svc::search(&pool, user_id, &default_domestic_stock_search_params())
         .await
         .expect("domestic_stock list failed")
         .data;
@@ -731,7 +735,7 @@ async fn domestic_stock_bulk_create_and_list() {
         .expect("domestic_stock delete_all failed");
     assert_eq!(deleted, 3);
 
-    let rows = domestic_stock_svc::list(&pool, user_id, &default_pagination())
+    let rows = domestic_stock_svc::search(&pool, user_id, &default_domestic_stock_search_params())
         .await
         .expect("domestic_stock list after delete failed")
         .data;

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -877,6 +877,106 @@
               "type": "integer",
               "format": "int64"
             }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "description": "フリーワード検索（口座/銘柄コード/銘柄名の token AND 検索）",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "date_from",
+            "in": "query",
+            "description": "約定日の開始日（YYYY-MM-DD）",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "date_to",
+            "in": "query",
+            "description": "約定日の終了日（YYYY-MM-DD）",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "year",
+            "in": "query",
+            "description": "約定日の年（YYYY）",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "year_month",
+            "in": "query",
+            "description": "約定日の年月（YYYY-MM）",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "date",
+            "in": "query",
+            "description": "約定日の単日指定（YYYY-MM-DD）",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "account",
+            "in": "query",
+            "description": "口座での絞り込み",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "security_code",
+            "in": "query",
+            "description": "銘柄コードでの絞り込み",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "security_name",
+            "in": "query",
+            "description": "銘柄名での絞り込み",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "include_summary",
+            "in": "query",
+            "description": "検索条件全体の集計を含めるか",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "include_facets",
+            "in": "query",
+            "description": "検索候補 facets を含めるか",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -885,7 +985,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PaginatedResponse_DomesticStock"
+                  "$ref": "#/components/schemas/PaginatedSearchResponse_DomesticStock_DomesticStockSummary_SearchFacets"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1968,6 +2078,29 @@
           }
         }
       },
+      "DomesticStockSummary": {
+        "type": "object",
+        "description": "国内株式取引 検索条件全体の集計\n\ntrade_date ごとに特定口座（account に「特定」を含む）と NISA 等口座を分離し、\n特定口座の実現損益合計がプラスの時だけ `floor(合計 * 0.20315)` を日次税額とする\nfrontend `calculateDailyData` と同じ仕様で日次集計した結果を合計する。",
+        "required": [
+          "total_realized_profit_and_loss",
+          "total_taxes",
+          "total_realized_profit_and_loss_after_tax"
+        ],
+        "properties": {
+          "total_realized_profit_and_loss": {
+            "type": "number",
+            "format": "double"
+          },
+          "total_realized_profit_and_loss_after_tax": {
+            "type": "number",
+            "format": "double"
+          },
+          "total_taxes": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
       "ErrorDetails": {
         "type": "object",
         "required": [
@@ -2994,113 +3127,6 @@
           }
         }
       },
-      "PaginatedResponse_DomesticStock": {
-        "type": "object",
-        "description": "ページネーションレスポンス（全ドメイン共通）",
-        "required": [
-          "data",
-          "total",
-          "page",
-          "per_page"
-        ],
-        "properties": {
-          "data": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "description": "国内株式取引モデル（DB + APIレスポンス兼用）",
-              "required": [
-                "id",
-                "trade_date",
-                "settlement_date",
-                "security_code",
-                "security_name",
-                "account",
-                "shares",
-                "asked_price",
-                "proceeds",
-                "purchase_price",
-                "realized_profit_and_loss",
-                "taxes",
-                "realized_profit_and_loss_after_tax",
-                "created_at",
-                "updated_at"
-              ],
-              "properties": {
-                "account": {
-                  "type": "string"
-                },
-                "asked_price": {
-                  "type": "number",
-                  "format": "double"
-                },
-                "created_at": {
-                  "type": "string",
-                  "format": "date-time"
-                },
-                "id": {
-                  "type": "string",
-                  "format": "uuid"
-                },
-                "proceeds": {
-                  "type": "number",
-                  "format": "double"
-                },
-                "purchase_price": {
-                  "type": "number",
-                  "format": "double"
-                },
-                "realized_profit_and_loss": {
-                  "type": "number",
-                  "format": "double"
-                },
-                "realized_profit_and_loss_after_tax": {
-                  "type": "number",
-                  "format": "double"
-                },
-                "security_code": {
-                  "type": "string"
-                },
-                "security_name": {
-                  "type": "string"
-                },
-                "settlement_date": {
-                  "type": "string",
-                  "format": "date"
-                },
-                "shares": {
-                  "type": "number",
-                  "format": "double"
-                },
-                "taxes": {
-                  "type": "number",
-                  "format": "double"
-                },
-                "trade_date": {
-                  "type": "string",
-                  "format": "date"
-                },
-                "updated_at": {
-                  "type": "string",
-                  "format": "date-time"
-                }
-              }
-            }
-          },
-          "page": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "per_page": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "total": {
-            "type": "integer",
-            "format": "int64"
-          }
-        }
-      },
       "PaginatedResponse_Mutualfund": {
         "type": "object",
         "description": "ページネーションレスポンス（全ドメイン共通）",
@@ -3379,6 +3405,196 @@
                 "format": "double"
               },
               "total_net_amount_received": {
+                "type": "number",
+                "format": "double"
+              },
+              "total_taxes": {
+                "type": "number",
+                "format": "double"
+              }
+            }
+          },
+          "total": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "PaginatedSearchResponse_DomesticStock_DomesticStockSummary_SearchFacets": {
+        "type": "object",
+        "description": "検索・集計付きページネーションレスポンス。",
+        "required": [
+          "data",
+          "total",
+          "page",
+          "per_page"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "description": "国内株式取引モデル（DB + APIレスポンス兼用）",
+              "required": [
+                "id",
+                "trade_date",
+                "settlement_date",
+                "security_code",
+                "security_name",
+                "account",
+                "shares",
+                "asked_price",
+                "proceeds",
+                "purchase_price",
+                "realized_profit_and_loss",
+                "taxes",
+                "realized_profit_and_loss_after_tax",
+                "created_at",
+                "updated_at"
+              ],
+              "properties": {
+                "account": {
+                  "type": "string"
+                },
+                "asked_price": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "id": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "proceeds": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "purchase_price": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "realized_profit_and_loss": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "realized_profit_and_loss_after_tax": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "security_code": {
+                  "type": "string"
+                },
+                "security_name": {
+                  "type": "string"
+                },
+                "settlement_date": {
+                  "type": "string",
+                  "format": "date"
+                },
+                "shares": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "taxes": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "trade_date": {
+                  "type": "string",
+                  "format": "date"
+                },
+                "updated_at": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              }
+            }
+          },
+          "facets": {
+            "type": "object",
+            "description": "検索候補レスポンスの共通枠。",
+            "properties": {
+              "accounts": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "$ref": "#/components/schemas/FacetOption"
+                }
+              },
+              "funds": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "$ref": "#/components/schemas/FacetOption"
+                }
+              },
+              "products": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "$ref": "#/components/schemas/FacetOption"
+                }
+              },
+              "securities": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "$ref": "#/components/schemas/FacetOption"
+                }
+              },
+              "year_months": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "$ref": "#/components/schemas/FacetOption"
+                }
+              },
+              "years": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "$ref": "#/components/schemas/FacetOption"
+                }
+              }
+            }
+          },
+          "page": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "per_page": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "summary": {
+            "type": "object",
+            "description": "国内株式取引 検索条件全体の集計\n\ntrade_date ごとに特定口座（account に「特定」を含む）と NISA 等口座を分離し、\n特定口座の実現損益合計がプラスの時だけ `floor(合計 * 0.20315)` を日次税額とする\nfrontend `calculateDailyData` と同じ仕様で日次集計した結果を合計する。",
+            "required": [
+              "total_realized_profit_and_loss",
+              "total_taxes",
+              "total_realized_profit_and_loss_after_tax"
+            ],
+            "properties": {
+              "total_realized_profit_and_loss": {
+                "type": "number",
+                "format": "double"
+              },
+              "total_realized_profit_and_loss_after_tax": {
                 "type": "number",
                 "format": "double"
               },

--- a/frontend/src/generated/api.ts
+++ b/frontend/src/generated/api.ts
@@ -529,6 +529,21 @@ export interface components {
             /** Format: date-time */
             updated_at: string;
         };
+        /**
+         * @description 国内株式取引 検索条件全体の集計
+         *
+         *     trade_date ごとに特定口座（account に「特定」を含む）と NISA 等口座を分離し、
+         *     特定口座の実現損益合計がプラスの時だけ `floor(合計 * 0.20315)` を日次税額とする
+         *     frontend `calculateDailyData` と同じ仕様で日次集計した結果を合計する。
+         */
+        DomesticStockSummary: {
+            /** Format: double */
+            total_realized_profit_and_loss: number;
+            /** Format: double */
+            total_realized_profit_and_loss_after_tax: number;
+            /** Format: double */
+            total_taxes: number;
+        };
         ErrorDetails: {
             code: string;
             details?: string | null;
@@ -846,44 +861,6 @@ export interface components {
             total: number;
         };
         /** @description ページネーションレスポンス（全ドメイン共通） */
-        PaginatedResponse_DomesticStock: {
-            data: {
-                account: string;
-                /** Format: double */
-                asked_price: number;
-                /** Format: date-time */
-                created_at: string;
-                /** Format: uuid */
-                id: string;
-                /** Format: double */
-                proceeds: number;
-                /** Format: double */
-                purchase_price: number;
-                /** Format: double */
-                realized_profit_and_loss: number;
-                /** Format: double */
-                realized_profit_and_loss_after_tax: number;
-                security_code: string;
-                security_name: string;
-                /** Format: date */
-                settlement_date: string;
-                /** Format: double */
-                shares: number;
-                /** Format: double */
-                taxes: number;
-                /** Format: date */
-                trade_date: string;
-                /** Format: date-time */
-                updated_at: string;
-            }[];
-            /** Format: int64 */
-            page: number;
-            /** Format: int64 */
-            per_page: number;
-            /** Format: int64 */
-            total: number;
-        };
-        /** @description ページネーションレスポンス（全ドメイン共通） */
         PaginatedResponse_Mutualfund: {
             data: {
                 account: string;
@@ -968,6 +945,68 @@ export interface components {
                 total_dividends_before_tax: number;
                 /** Format: double */
                 total_net_amount_received: number;
+                /** Format: double */
+                total_taxes: number;
+            };
+            /** Format: int64 */
+            total: number;
+        };
+        /** @description 検索・集計付きページネーションレスポンス。 */
+        PaginatedSearchResponse_DomesticStock_DomesticStockSummary_SearchFacets: {
+            data: {
+                account: string;
+                /** Format: double */
+                asked_price: number;
+                /** Format: date-time */
+                created_at: string;
+                /** Format: uuid */
+                id: string;
+                /** Format: double */
+                proceeds: number;
+                /** Format: double */
+                purchase_price: number;
+                /** Format: double */
+                realized_profit_and_loss: number;
+                /** Format: double */
+                realized_profit_and_loss_after_tax: number;
+                security_code: string;
+                security_name: string;
+                /** Format: date */
+                settlement_date: string;
+                /** Format: double */
+                shares: number;
+                /** Format: double */
+                taxes: number;
+                /** Format: date */
+                trade_date: string;
+                /** Format: date-time */
+                updated_at: string;
+            }[];
+            /** @description 検索候補レスポンスの共通枠。 */
+            facets?: {
+                accounts?: components["schemas"]["FacetOption"][] | null;
+                funds?: components["schemas"]["FacetOption"][] | null;
+                products?: components["schemas"]["FacetOption"][] | null;
+                securities?: components["schemas"]["FacetOption"][] | null;
+                year_months?: components["schemas"]["FacetOption"][] | null;
+                years?: components["schemas"]["FacetOption"][] | null;
+            };
+            /** Format: int64 */
+            page: number;
+            /** Format: int64 */
+            per_page: number;
+            /**
+             * @description 国内株式取引 検索条件全体の集計
+             *
+             *     trade_date ごとに特定口座（account に「特定」を含む）と NISA 等口座を分離し、
+             *     特定口座の実現損益合計がプラスの時だけ `floor(合計 * 0.20315)` を日次税額とする
+             *     frontend `calculateDailyData` と同じ仕様で日次集計した結果を合計する。
+             */
+            summary?: {
+                /** Format: double */
+                total_realized_profit_and_loss: number;
+                /** Format: double */
+                total_realized_profit_and_loss_after_tax: number;
                 /** Format: double */
                 total_taxes: number;
             };
@@ -1551,6 +1590,28 @@ export interface operations {
                 page?: number;
                 /** @description 1ページあたりの件数（デフォルト: 200、最大: 1000） */
                 per_page?: number;
+                /** @description フリーワード検索（口座/銘柄コード/銘柄名の token AND 検索） */
+                q?: string;
+                /** @description 約定日の開始日（YYYY-MM-DD） */
+                date_from?: string;
+                /** @description 約定日の終了日（YYYY-MM-DD） */
+                date_to?: string;
+                /** @description 約定日の年（YYYY） */
+                year?: number;
+                /** @description 約定日の年月（YYYY-MM） */
+                year_month?: string;
+                /** @description 約定日の単日指定（YYYY-MM-DD） */
+                date?: string;
+                /** @description 口座での絞り込み */
+                account?: string;
+                /** @description 銘柄コードでの絞り込み */
+                security_code?: string;
+                /** @description 銘柄名での絞り込み */
+                security_name?: string;
+                /** @description 検索条件全体の集計を含めるか */
+                include_summary?: boolean;
+                /** @description 検索候補 facets を含めるか */
+                include_facets?: boolean;
             };
             header?: never;
             path?: never;
@@ -1563,7 +1624,15 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["PaginatedResponse_DomesticStock"];
+                    "application/json": components["schemas"]["PaginatedSearchResponse_DomesticStock_DomesticStockSummary_SearchFacets"];
+                };
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
             401: {


### PR DESCRIPTION
## 概要
- 国内株式一覧APIに q/date/year/year_month/account/security_code/security_name 検索を追加
- include_summary/include_facets に対応し、summary は約定日ごとの特定口座課税ロジックでDB集計
- 国内株式検索向けindexとOpenAPI/generated typesを更新

## 確認
- cargo clippy --all-targets -- -D warnings
- cargo test --lib
- cargo test domestic_stock --lib
- npm run lint
- npm run typecheck
- bash scripts/check-openapi.sh

## 補足
- Claudeがservice/model実装の主要部分を作成し、Codexでhandler・migration・テスト互換・検証を仕上げています。