### PR TITLE
anyhowのRustSec警告を解消

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -208,9 +208,9 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arrayvec"


### PR DESCRIPTION
## 概要
- anyhow を 1.0.102 から 1.0.103 に更新
- RUSTSEC-2026-0190 の cargo audit 警告を解消

## 変更種別
- [ ] 新機能
- [x] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] 依存関係更新

## 主な変更内容
- backend/Cargo.lock の anyhow checksum/version のみ更新

## 関連 issue
- Closes #640

## テスト
- [x] cd backend && cargo audit
- [x] cd backend && cargo test --lib