### PR TITLE
資産管理一覧をDB検索に対応

### DIFF
--- a/backend/migrations/0005_asset_balances_search_indexes.sql
+++ b/backend/migrations/0005_asset_balances_search_indexes.sql
@@ -4,6 +4,12 @@
 CREATE INDEX IF NOT EXISTS idx_asset_balances_user_security_code ON asset_balances (user_id, security_code);
 CREATE INDEX IF NOT EXISTS idx_asset_balances_user_security_name ON asset_balances (user_id, security_name);
 
+-- q の部分一致検索（ILIKE '%token%'）向け。pg_trgm は 0001_initial_schema.sql で有効化済み。
+CREATE INDEX IF NOT EXISTS idx_asset_balances_security_code_trgm
+    ON asset_balances USING gin (security_code gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_asset_balances_security_name_trgm
+    ON asset_balances USING gin (security_name gin_trgm_ops);
+
 -- 一覧のデフォルトソート（security_code ASC, id ASC）向けの複合インデックス
 CREATE INDEX IF NOT EXISTS idx_asset_balances_user_security_code_id
     ON asset_balances (user_id, security_code ASC, id ASC);

--- a/backend/migrations/0005_asset_balances_search_indexes.sql
+++ b/backend/migrations/0005_asset_balances_search_indexes.sql
@@ -1,0 +1,9 @@
+-- 保有銘柄検索（security_code / security_name での絞り込み・facets集計）向けの複合インデックス
+-- 注意: 既存データがある本番DBでは CREATE INDEX 実行中にテーブルへの書き込みがブロックされうるため、
+-- 本番適用はメンテナンスウィンドウ内で実施すること
+CREATE INDEX IF NOT EXISTS idx_asset_balances_user_security_code ON asset_balances (user_id, security_code);
+CREATE INDEX IF NOT EXISTS idx_asset_balances_user_security_name ON asset_balances (user_id, security_name);
+
+-- 一覧のデフォルトソート（security_code ASC, id ASC）向けの複合インデックス
+CREATE INDEX IF NOT EXISTS idx_asset_balances_user_security_code_id
+    ON asset_balances (user_id, security_code ASC, id ASC);

--- a/backend/migrations/README.md
+++ b/backend/migrations/README.md
@@ -13,6 +13,7 @@ SQLx migration の baseline 管理。
 | 0002 | `0002_dividends_search_indexes.sql` | 配当金検索（product/account/security_code/security_name の絞り込み、settlement_date/id 順の一覧取得）向け index を追加 |
 | 0003 | `0003_domestic_stocks_search_indexes.sql` | 国内株式検索（account/security_code/security_name の絞り込み、trade_date/id 順の一覧取得）向け index を追加 |
 | 0004 | `0004_mutualfunds_search_indexes.sql` | 投資信託検索（account/fund_name/dividends の絞り込み、trade_date/id 順の一覧取得）向け index を追加 |
+| 0005 | `0005_asset_balances_search_indexes.sql` | 保有銘柄検索（security_code/security_name の絞り込み、security_code/id 順の一覧取得）向け index を追加 |
 
 ## 重要な注意
 

--- a/backend/src/handlers/v1/asset_balances.rs
+++ b/backend/src/handlers/v1/asset_balances.rs
@@ -3,8 +3,11 @@ use crate::{
     extractors::{auth::AuthenticatedUser, validated_json::ValidatedJson},
     handlers::common::ok_message,
     models::{
-        asset_balance::{AssetBalance, BulkCreateAssetBalanceRequest},
-        common::{BulkCreateResponse, MessageResponse, PaginatedResponse, PaginationParams},
+        asset_balance::{
+            AssetBalance, AssetBalanceSearchQueryParams, AssetBalanceSummary,
+            BulkCreateAssetBalanceRequest,
+        },
+        common::{BulkCreateResponse, MessageResponse, PaginatedSearchResponse, SearchFacets},
         csv_import::{CsvPreviewResponse, CsvUploadForm, CsvUploadResponse},
     },
     services::{asset_balance as asset_balance_service, csv_domain::AssetBalanceDomain},
@@ -27,9 +30,15 @@ use axum::{
     params(
         ("page" = Option<i64>, Query, description = "ページ番号（デフォルト: 1）"),
         ("per_page" = Option<i64>, Query, description = "1ページあたりの件数（デフォルト: 200、最大: 1000）"),
+        ("q" = Option<String>, Query, description = "フリーワード検索（銘柄コード/銘柄名の token AND 検索）"),
+        ("security_code" = Option<String>, Query, description = "銘柄コードでの絞り込み"),
+        ("security_name" = Option<String>, Query, description = "銘柄名での絞り込み"),
+        ("include_summary" = Option<bool>, Query, description = "検索条件全体の集計を含めるか"),
+        ("include_facets" = Option<bool>, Query, description = "検索候補 facets を含めるか"),
     ),
     responses(
-        (status = 200, body = PaginatedResponse<AssetBalance>),
+        (status = 200, body = PaginatedSearchResponse<AssetBalance, AssetBalanceSummary, SearchFacets>),
+        (status = 400, body = ErrorResponse),
         (status = 401, body = ErrorResponse),
     ),
     security(("cookieAuth" = []))
@@ -37,9 +46,9 @@ use axum::{
 pub async fn list(
     State(state): State<AppState>,
     auth_user: AuthenticatedUser,
-    Query(params): Query<PaginationParams>,
+    Query(params): Query<AssetBalanceSearchQueryParams>,
 ) -> Result<impl IntoResponse, ApiError> {
-    let result = asset_balance_service::list(&state.pool, auth_user.id(), &params).await?;
+    let result = asset_balance_service::search(&state.pool, auth_user.id(), &params).await?;
     Ok((StatusCode::OK, Json(result)))
 }
 

--- a/backend/src/models/asset_balance.rs
+++ b/backend/src/models/asset_balance.rs
@@ -1,4 +1,4 @@
-use crate::models::common::validate_length_field;
+use crate::models::common::{validate_length_field, SearchQueryParams};
 use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
@@ -101,6 +101,55 @@ impl Validate for BulkCreateAssetBalanceRequest {
         }
     }
 }
+
+/// 保有銘柄一覧の検索クエリパラメータ（共通 `SearchQueryParams` + 保有銘柄固有の絞り込み）
+///
+/// asset_balances には snapshot 日付がないため、`search` の date 系フィールドは
+/// この検索では使用しない（対象外）。
+#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
+pub struct AssetBalanceSearchQueryParams {
+    #[serde(flatten)]
+    pub search: SearchQueryParams,
+    /// 銘柄コードでの絞り込み
+    pub security_code: Option<String>,
+    /// 銘柄名での絞り込み
+    pub security_name: Option<String>,
+}
+
+impl AssetBalanceSearchQueryParams {
+    pub fn page(&self) -> i64 {
+        self.search.page()
+    }
+
+    pub fn per_page(&self) -> i64 {
+        self.search.per_page()
+    }
+
+    pub fn offset(&self) -> i64 {
+        self.search.offset()
+    }
+
+    pub fn should_include_summary(&self) -> bool {
+        self.search.should_include_summary()
+    }
+
+    pub fn should_include_facets(&self) -> bool {
+        self.search.should_include_facets()
+    }
+}
+
+/// 保有銘柄 検索条件全体の集計
+///
+/// profit_loss_rate は銘柄ごとの比率のため単純合算せず、summary には含めない。
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
+pub struct AssetBalanceSummary {
+    #[schema(value_type = f64)]
+    pub total_market_value: Decimal,
+    #[schema(value_type = f64)]
+    pub total_purchase_amount: Decimal,
+    #[schema(value_type = f64)]
+    pub total_daily_change: Decimal,
+}
 #[cfg(test)]
 mod tests {
     use {super::*, rust_decimal_macros::dec};
@@ -162,5 +211,17 @@ mod tests {
         }
         .validate()
         .is_ok());
+    }
+
+    #[test]
+    fn test_asset_balance_search_query_params_delegate_include_flags() {
+        let mut params = AssetBalanceSearchQueryParams::default();
+        assert!(!params.should_include_summary());
+        assert!(!params.should_include_facets());
+
+        params.search.include_summary = Some(true);
+        params.search.include_facets = Some(true);
+        assert!(params.should_include_summary());
+        assert!(params.should_include_facets());
     }
 }

--- a/backend/src/models/common.rs
+++ b/backend/src/models/common.rs
@@ -110,15 +110,6 @@ impl SearchQueryParams {
     }
 }
 
-/// ページネーションレスポンス（全ドメイン共通）
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
-pub struct PaginatedResponse<T: ToSchema + 'static> {
-    pub data: Vec<T>,
-    pub total: i64,
-    pub page: i64,
-    pub per_page: i64,
-}
-
 /// 検索候補の共通表現。
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
 pub struct FacetOption {
@@ -178,8 +169,8 @@ pub struct MessageResponse {
 #[cfg(test)]
 mod tests {
     use super::{
-        BulkCreateResponse, FacetOption, MessageResponse, PaginatedResponse,
-        PaginatedSearchResponse, PaginationParams, SearchFacets, SearchQueryParams,
+        BulkCreateResponse, FacetOption, MessageResponse, PaginatedSearchResponse,
+        PaginationParams, SearchFacets, SearchQueryParams,
     };
     use axum::{extract::Query, http::Uri};
     use serde::{Deserialize, Serialize};
@@ -264,28 +255,6 @@ mod tests {
         assert_eq!(params.year, Some(2026));
         assert!(params.should_include_summary());
         assert!(!params.should_include_facets());
-    }
-
-    #[test]
-    fn paginated_response_keeps_existing_shape() {
-        let response = PaginatedResponse {
-            data: vec![Row { id: 1 }],
-            total: 1,
-            page: 1,
-            per_page: 200,
-        };
-
-        let json = serde_json::to_value(response).expect("PaginatedResponse should serialize");
-
-        assert_eq!(
-            json,
-            serde_json::json!({
-                "data": [{"id": 1}],
-                "total": 1,
-                "page": 1,
-                "per_page": 200
-            })
-        );
     }
 
     #[test]

--- a/backend/src/services/asset_balance.rs
+++ b/backend/src/services/asset_balance.rs
@@ -1,6 +1,10 @@
 use crate::errors::ApiError;
-use crate::models::asset_balance::{AssetBalance, CreateAssetBalanceRequest};
-use crate::models::common::{BulkCreateResponse, PaginatedResponse, PaginationParams};
+use crate::models::asset_balance::{
+    AssetBalance, AssetBalanceSearchQueryParams, AssetBalanceSummary, CreateAssetBalanceRequest,
+};
+use crate::models::common::{
+    BulkCreateResponse, FacetOption, PaginatedSearchResponse, SearchFacets,
+};
 use crate::models::csv_import::{CsvPreviewResponse, CsvRowError, CsvUploadResponse};
 use crate::services::csv_import::{build_csv_preview, run_csv_upload, validate_csv_rows};
 #[cfg(test)]
@@ -13,7 +17,7 @@ use crate::services::shared::{
     delete_all_for_user, user_ids_for_bulk_insert, BulkTimer, DeleteTarget,
 };
 use rust_decimal::Decimal;
-use sqlx::PgPool;
+use sqlx::{PgPool, Postgres, QueryBuilder};
 use tracing::info;
 use uuid::Uuid;
 
@@ -34,41 +38,178 @@ const ASSET_BALANCE_CSV_CONFIG: CsvParserConfig = CsvParserConfig {
     ],
 };
 
-/// 認証ユーザーの保有銘柄一覧を取得（ページネーション対応）
-pub async fn list(
+/// 保有銘柄検索条件を SQL 条件へ変換した中間表現
+///
+/// asset_balances には snapshot 日付がないため、date 系の条件は扱わない。
+#[derive(Debug)]
+struct AssetBalanceFilter {
+    tokens: Vec<String>,
+    security_code: Option<String>,
+    security_name: Option<String>,
+}
+
+impl AssetBalanceFilter {
+    fn from_params(params: &AssetBalanceSearchQueryParams) -> Self {
+        let tokens = params
+            .search
+            .q
+            .as_deref()
+            .map(|q| q.split_whitespace().map(str::to_string).collect())
+            .unwrap_or_default();
+
+        Self {
+            tokens,
+            security_code: params.security_code.clone(),
+            security_name: params.security_name.clone(),
+        }
+    }
+}
+
+/// ILIKE の wildcard 文字（%, _, \）をリテラル扱いにエスケープしてから前後を % で囲む
+fn escape_like_pattern(token: &str) -> String {
+    let escaped = token
+        .replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_");
+    format!("%{escaped}%")
+}
+
+/// user_id と検索条件を WHERE 句として QueryBuilder へ積む
+fn push_filters(qb: &mut QueryBuilder<Postgres>, user_id: Uuid, filter: &AssetBalanceFilter) {
+    qb.push(" WHERE user_id = ").push_bind(user_id);
+    if let Some(v) = &filter.security_code {
+        qb.push(" AND security_code = ").push_bind(v.clone());
+    }
+    if let Some(v) = &filter.security_name {
+        qb.push(" AND security_name = ").push_bind(v.clone());
+    }
+    for token in &filter.tokens {
+        let pattern = escape_like_pattern(token);
+        qb.push(" AND (security_code ILIKE ")
+            .push_bind(pattern.clone())
+            .push(" ESCAPE '\\' OR security_name ILIKE ")
+            .push_bind(pattern)
+            .push(" ESCAPE '\\')");
+    }
+}
+
+/// 認証ユーザーの保有銘柄一覧を検索（ページネーション・summary・facets 対応）
+pub async fn search(
     pool: &PgPool,
     user_id: Uuid,
-    params: &PaginationParams,
-) -> Result<PaginatedResponse<AssetBalance>, ApiError> {
-    info!("[asset_balance.list] リクエスト受信");
-    let total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM asset_balances WHERE user_id = $1")
-        .bind(user_id)
-        .fetch_one(pool)
-        .await?;
+    params: &AssetBalanceSearchQueryParams,
+) -> Result<PaginatedSearchResponse<AssetBalance, AssetBalanceSummary, SearchFacets>, ApiError> {
+    info!("[asset_balance.search] リクエスト受信");
+    let filter = AssetBalanceFilter::from_params(params);
 
-    let data = sqlx::query_as::<_, AssetBalance>(
-        r#"
-        SELECT id, user_id, security_code, security_name, shares, executing_shares,
-               average_purchase_price, total_purchase_amount, current_price,
-               daily_change, market_value, profit_loss_rate, created_at, updated_at
-        FROM asset_balances
-        WHERE user_id = $1
-        ORDER BY security_code
-        LIMIT $2 OFFSET $3
-        "#,
-    )
-    .bind(user_id)
-    .bind(params.per_page())
-    .bind(params.offset())
-    .fetch_all(pool)
-    .await?;
+    let mut count_qb: QueryBuilder<Postgres> =
+        QueryBuilder::new("SELECT COUNT(*) FROM asset_balances");
+    push_filters(&mut count_qb, user_id, &filter);
+    let count_fut = async move {
+        let total: i64 = count_qb.build_query_scalar().fetch_one(pool).await?;
+        Ok::<_, ApiError>(total)
+    };
 
-    Ok(PaginatedResponse {
+    let mut data_qb: QueryBuilder<Postgres> = QueryBuilder::new(
+        "SELECT id, user_id, security_code, security_name, shares, executing_shares, \
+         average_purchase_price, total_purchase_amount, current_price, daily_change, \
+         market_value, profit_loss_rate, created_at, updated_at \
+         FROM asset_balances",
+    );
+    push_filters(&mut data_qb, user_id, &filter);
+    data_qb.push(" ORDER BY security_code ASC, id ASC LIMIT ");
+    data_qb.push_bind(params.per_page());
+    data_qb.push(" OFFSET ");
+    data_qb.push_bind(params.offset());
+    let data_fut = async move {
+        let data = data_qb
+            .build_query_as::<AssetBalance>()
+            .fetch_all(pool)
+            .await?;
+        Ok::<_, ApiError>(data)
+    };
+
+    let summary_fut = async {
+        if params.should_include_summary() {
+            fetch_summary(pool, user_id, &filter).await.map(Some)
+        } else {
+            Ok(None)
+        }
+    };
+
+    let facets_fut = async {
+        if params.should_include_facets() {
+            fetch_facets(pool, user_id, &filter).await.map(Some)
+        } else {
+            Ok(None)
+        }
+    };
+
+    // count/data/summary/facets は相互に依存しないため並行実行する
+    let (total, data, summary, facets) =
+        tokio::try_join!(count_fut, data_fut, summary_fut, facets_fut)?;
+
+    Ok(PaginatedSearchResponse {
         data,
         total,
         page: params.page(),
         per_page: params.per_page(),
+        summary,
+        facets,
     })
+}
+
+/// 検索条件全体の summary を算出する（ページ内だけでなく検索条件全体の合計）
+async fn fetch_summary(
+    pool: &PgPool,
+    user_id: Uuid,
+    filter: &AssetBalanceFilter,
+) -> Result<AssetBalanceSummary, ApiError> {
+    let mut qb: QueryBuilder<Postgres> = QueryBuilder::new(
+        "SELECT COALESCE(SUM(market_value), 0) AS total_market_value, \
+         COALESCE(SUM(total_purchase_amount), 0) AS total_purchase_amount, \
+         COALESCE(SUM(daily_change), 0) AS total_daily_change \
+         FROM asset_balances",
+    );
+    push_filters(&mut qb, user_id, filter);
+    Ok(qb
+        .build_query_as::<AssetBalanceSummary>()
+        .fetch_one(pool)
+        .await?)
+}
+
+async fn fetch_facets(
+    pool: &PgPool,
+    user_id: Uuid,
+    filter: &AssetBalanceFilter,
+) -> Result<SearchFacets, ApiError> {
+    let securities = fetch_security_facets(pool, user_id, filter).await?;
+
+    Ok(SearchFacets {
+        products: None,
+        accounts: None,
+        securities: Some(securities),
+        funds: None,
+        years: None,
+        year_months: None,
+    })
+}
+
+/// 銘柄コードごとに銘柄名・件数を facets として返す
+async fn fetch_security_facets(
+    pool: &PgPool,
+    user_id: Uuid,
+    filter: &AssetBalanceFilter,
+) -> Result<Vec<FacetOption>, ApiError> {
+    let mut qb: QueryBuilder<Postgres> = QueryBuilder::new(
+        "SELECT security_code AS value, \
+         (ARRAY_AGG(security_name ORDER BY id))[1] AS label, \
+         COUNT(*) AS count \
+         FROM asset_balances",
+    );
+    push_filters(&mut qb, user_id, filter);
+    qb.push(" GROUP BY security_code ORDER BY security_code");
+    Ok(qb.build_query_as::<FacetOption>().fetch_all(pool).await?)
 }
 
 /// 保有銘柄を一括登録（既存データを全削除してから挿入）
@@ -407,5 +548,61 @@ mod tests {
                 expected_codes
             );
         }
+    }
+
+    #[test]
+    fn test_asset_balance_search_query_params_delegate_include_flags() {
+        let mut params = AssetBalanceSearchQueryParams::default();
+        assert!(!params.should_include_summary());
+        assert!(!params.should_include_facets());
+
+        params.search.include_summary = Some(true);
+        params.search.include_facets = Some(true);
+        assert!(params.should_include_summary());
+        assert!(params.should_include_facets());
+    }
+
+    #[test]
+    fn test_push_filters_combines_q_tokens_as_and_of_or_across_all_columns() {
+        let mut params = AssetBalanceSearchQueryParams::default();
+        params.search.q = Some("AA BB".to_string());
+        let filter = AssetBalanceFilter::from_params(&params);
+
+        let mut qb: QueryBuilder<Postgres> = QueryBuilder::new("SELECT 1 FROM asset_balances");
+        push_filters(&mut qb, Uuid::nil(), &filter);
+        let sql = qb.sql();
+        let sql = sql.as_str();
+
+        // token ごとに 1 つの AND (...) ブロックが生成され、ブロック内は2カラムの OR になる
+        assert_eq!(sql.matches(" AND (").count(), 2);
+        assert_eq!(sql.matches("security_code ILIKE").count(), 2);
+        assert_eq!(sql.matches("security_name ILIKE").count(), 2);
+    }
+
+    #[test]
+    fn test_escape_like_pattern_escapes_wildcard_characters() {
+        assert_eq!(escape_like_pattern("abc"), "%abc%");
+        assert_eq!(escape_like_pattern("50%"), "%50\\%%");
+        assert_eq!(escape_like_pattern("A_B"), "%A\\_B%");
+        assert_eq!(escape_like_pattern("a\\b"), "%a\\\\b%");
+        assert_eq!(escape_like_pattern("100%_off\\"), "%100\\%\\_off\\\\%");
+    }
+
+    #[test]
+    fn test_push_filters_binds_asset_balance_specific_field_filters() {
+        let params = AssetBalanceSearchQueryParams {
+            security_code: Some("1234".to_string()),
+            security_name: Some("テスト株式会社".to_string()),
+            ..Default::default()
+        };
+        let filter = AssetBalanceFilter::from_params(&params);
+
+        let mut qb: QueryBuilder<Postgres> = QueryBuilder::new("SELECT 1 FROM asset_balances");
+        push_filters(&mut qb, Uuid::nil(), &filter);
+        let sql = qb.sql();
+        let sql = sql.as_str();
+
+        assert!(sql.contains("AND security_code = "));
+        assert!(sql.contains("AND security_name = "));
     }
 }

--- a/backend/src/services/asset_balance.rs
+++ b/backend/src/services/asset_balance.rs
@@ -145,7 +145,8 @@ pub async fn search(
         }
     };
 
-    // count/data/summary/facets は相互に依存しないため並行実行する
+    // count/data/summary/facets は相互に依存しないため並行実行する。
+    // summary/facets は include_* が true の場合だけ実クエリを発行する。
     let (total, data, summary, facets) =
         tokio::try_join!(count_fut, data_fut, summary_fut, facets_fut)?;
 

--- a/backend/tests/db_integration.rs
+++ b/backend/tests/db_integration.rs
@@ -5,7 +5,7 @@ use axum::{
 use backend::{
     config::Config,
     db::run_migrations,
-    models::asset_balance::CreateAssetBalanceRequest,
+    models::asset_balance::{AssetBalanceSearchQueryParams, CreateAssetBalanceRequest},
     models::common::{PaginationParams, SearchQueryParams},
     models::dividend::{CreateDividendRequest, DividendSearchQueryParams},
     models::domestic_stock::{CreateDomesticStockRequest, DomesticStockSearchQueryParams},
@@ -18,11 +18,8 @@ use backend::{
     state::{AppState, Secrets},
 };
 
-fn default_pagination() -> PaginationParams {
-    PaginationParams {
-        page: None,
-        per_page: None,
-    }
+fn default_asset_balance_search_params() -> AssetBalanceSearchQueryParams {
+    AssetBalanceSearchQueryParams::default()
 }
 
 fn default_dividend_search_params() -> DividendSearchQueryParams {
@@ -475,7 +472,7 @@ async fn service_coverage_all_domains() {
     );
 
     assert!(
-        asset_balance_svc::list(&pool, user_id, &default_pagination())
+        asset_balance_svc::search(&pool, user_id, &default_asset_balance_search_params())
             .await
             .expect("initial asset_balance list failed")
             .data
@@ -495,7 +492,7 @@ async fn service_coverage_all_domains() {
     assert_eq!(asset_balance_created.inserted, 2);
     assert_eq!(asset_balance_created.skipped, 0);
     assert_eq!(
-        asset_balance_svc::list(&pool, user_id, &default_pagination())
+        asset_balance_svc::search(&pool, user_id, &default_asset_balance_search_params())
             .await
             .expect("asset_balance list after bulk_create failed")
             .data
@@ -511,10 +508,11 @@ async fn service_coverage_all_domains() {
     assert_eq!(asset_balance_uploaded.skipped, 0);
     assert!(asset_balance_uploaded.errors.is_empty());
 
-    let asset_balance_rows = asset_balance_svc::list(&pool, user_id, &default_pagination())
-        .await
-        .expect("asset_balance list failed")
-        .data;
+    let asset_balance_rows =
+        asset_balance_svc::search(&pool, user_id, &default_asset_balance_search_params())
+            .await
+            .expect("asset_balance list failed")
+            .data;
     assert_eq!(asset_balance_rows.len(), 1);
     assert_eq!(asset_balance_rows[0].security_code, "7203");
 
@@ -525,7 +523,7 @@ async fn service_coverage_all_domains() {
         1
     );
     assert!(
-        asset_balance_svc::list(&pool, user_id, &default_pagination())
+        asset_balance_svc::search(&pool, user_id, &default_asset_balance_search_params())
             .await
             .expect("asset_balance list after delete failed")
             .data
@@ -555,7 +553,7 @@ async fn asset_balance_bulk_create_replaces_previous_snapshot() {
         .await
         .expect("2回目 bulk_create 失敗");
 
-    let rows = asset_balance_svc::list(&pool, user_id, &default_pagination())
+    let rows = asset_balance_svc::search(&pool, user_id, &default_asset_balance_search_params())
         .await
         .expect("list 失敗")
         .data;
@@ -600,7 +598,7 @@ async fn asset_balance_bulk_create_concurrent_same_user_no_mix() {
     res_a.unwrap().expect("task_a 失敗");
     res_b.unwrap().expect("task_b 失敗");
 
-    let rows = asset_balance_svc::list(&pool, user_id, &default_pagination())
+    let rows = asset_balance_svc::search(&pool, user_id, &default_asset_balance_search_params())
         .await
         .expect("list 失敗")
         .data;

--- a/docs/api/v1-rest-design.md
+++ b/docs/api/v1-rest-design.md
@@ -58,7 +58,7 @@ The list endpoints for dividends, domestic stock transactions, mutual fund trans
 
 - `page`: defaults to `1`, minimum effective value is `1`.
 - `per_page`: defaults to `200`, clamped to `1..1000`.
-- Responses use `PaginatedResponse<T>`: `{ data, total, page, per_page }`.
+- Responses use the pagination envelope `data`, `total`, `page`, and `per_page`; searchable list endpoints may also include optional `summary` and `facets`.
 
 ## Proposed Routes
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -240,6 +240,51 @@
               "type": "integer",
               "format": "int64"
             }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "description": "フリーワード検索（銘柄コード/銘柄名の token AND 検索）",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "security_code",
+            "in": "query",
+            "description": "銘柄コードでの絞り込み",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "security_name",
+            "in": "query",
+            "description": "銘柄名での絞り込み",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "include_summary",
+            "in": "query",
+            "description": "検索条件全体の集計を含めるか",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "include_facets",
+            "in": "query",
+            "description": "検索候補 facets を含めるか",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -248,7 +293,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PaginatedResponse_AssetBalance"
+                  "$ref": "#/components/schemas/PaginatedSearchResponse_AssetBalance_AssetBalanceSummary_SearchFacets"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -1769,6 +1824,29 @@
           }
         }
       },
+      "AssetBalanceSummary": {
+        "type": "object",
+        "description": "保有銘柄 検索条件全体の集計\n\nprofit_loss_rate は銘柄ごとの比率のため単純合算せず、summary には含めない。",
+        "required": [
+          "total_market_value",
+          "total_purchase_amount",
+          "total_daily_change"
+        ],
+        "properties": {
+          "total_daily_change": {
+            "type": "number",
+            "format": "double"
+          },
+          "total_market_value": {
+            "type": "number",
+            "format": "double"
+          },
+          "total_purchase_amount": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
       "BulkCreateAssetBalanceRequest": {
         "type": "object",
         "description": "保有銘柄一括作成リクエスト",
@@ -3162,9 +3240,9 @@
           }
         }
       },
-      "PaginatedResponse_AssetBalance": {
+      "PaginatedSearchResponse_AssetBalance_AssetBalanceSummary_SearchFacets": {
         "type": "object",
-        "description": "ページネーションレスポンス（全ドメイン共通）",
+        "description": "検索・集計付きページネーションレスポンス。",
         "required": [
           "data",
           "total",
@@ -3246,6 +3324,66 @@
               }
             }
           },
+          "facets": {
+            "type": "object",
+            "description": "検索候補レスポンスの共通枠。",
+            "properties": {
+              "accounts": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "$ref": "#/components/schemas/FacetOption"
+                }
+              },
+              "funds": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "$ref": "#/components/schemas/FacetOption"
+                }
+              },
+              "products": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "$ref": "#/components/schemas/FacetOption"
+                }
+              },
+              "securities": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "$ref": "#/components/schemas/FacetOption"
+                }
+              },
+              "year_months": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "$ref": "#/components/schemas/FacetOption"
+                }
+              },
+              "years": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "$ref": "#/components/schemas/FacetOption"
+                }
+              }
+            }
+          },
           "page": {
             "type": "integer",
             "format": "int64"
@@ -3253,6 +3391,29 @@
           "per_page": {
             "type": "integer",
             "format": "int64"
+          },
+          "summary": {
+            "type": "object",
+            "description": "保有銘柄 検索条件全体の集計\n\nprofit_loss_rate は銘柄ごとの比率のため単純合算せず、summary には含めない。",
+            "required": [
+              "total_market_value",
+              "total_purchase_amount",
+              "total_daily_change"
+            ],
+            "properties": {
+              "total_daily_change": {
+                "type": "number",
+                "format": "double"
+              },
+              "total_market_value": {
+                "type": "number",
+                "format": "double"
+              },
+              "total_purchase_amount": {
+                "type": "number",
+                "format": "double"
+              }
+            }
           },
           "total": {
             "type": "integer",

--- a/frontend/src/generated/api.ts
+++ b/frontend/src/generated/api.ts
@@ -382,6 +382,19 @@ export interface components {
             /** Format: date-time */
             updated_at: string;
         };
+        /**
+         * @description 保有銘柄 検索条件全体の集計
+         *
+         *     profit_loss_rate は銘柄ごとの比率のため単純合算せず、summary には含めない。
+         */
+        AssetBalanceSummary: {
+            /** Format: double */
+            total_daily_change: number;
+            /** Format: double */
+            total_market_value: number;
+            /** Format: double */
+            total_purchase_amount: number;
+        };
         /** @description 保有銘柄一括作成リクエスト */
         BulkCreateAssetBalanceRequest: {
             items: components["schemas"]["CreateAssetBalanceRequest"][];
@@ -834,8 +847,8 @@ export interface components {
             /** Format: double */
             total_taxes: number;
         };
-        /** @description ページネーションレスポンス（全ドメイン共通） */
-        PaginatedResponse_AssetBalance: {
+        /** @description 検索・集計付きページネーションレスポンス。 */
+        PaginatedSearchResponse_AssetBalance_AssetBalanceSummary_SearchFacets: {
             data: {
                 /** Format: double */
                 average_purchase_price: number;
@@ -862,10 +875,32 @@ export interface components {
                 /** Format: date-time */
                 updated_at: string;
             }[];
+            /** @description 検索候補レスポンスの共通枠。 */
+            facets?: {
+                accounts?: components["schemas"]["FacetOption"][] | null;
+                funds?: components["schemas"]["FacetOption"][] | null;
+                products?: components["schemas"]["FacetOption"][] | null;
+                securities?: components["schemas"]["FacetOption"][] | null;
+                year_months?: components["schemas"]["FacetOption"][] | null;
+                years?: components["schemas"]["FacetOption"][] | null;
+            };
             /** Format: int64 */
             page: number;
             /** Format: int64 */
             per_page: number;
+            /**
+             * @description 保有銘柄 検索条件全体の集計
+             *
+             *     profit_loss_rate は銘柄ごとの比率のため単純合算せず、summary には含めない。
+             */
+            summary?: {
+                /** Format: double */
+                total_daily_change: number;
+                /** Format: double */
+                total_market_value: number;
+                /** Format: double */
+                total_purchase_amount: number;
+            };
             /** Format: int64 */
             total: number;
         };
@@ -1233,6 +1268,16 @@ export interface operations {
                 page?: number;
                 /** @description 1ページあたりの件数（デフォルト: 200、最大: 1000） */
                 per_page?: number;
+                /** @description フリーワード検索（銘柄コード/銘柄名の token AND 検索） */
+                q?: string;
+                /** @description 銘柄コードでの絞り込み */
+                security_code?: string;
+                /** @description 銘柄名での絞り込み */
+                security_name?: string;
+                /** @description 検索条件全体の集計を含めるか */
+                include_summary?: boolean;
+                /** @description 検索候補 facets を含めるか */
+                include_facets?: boolean;
             };
             header?: never;
             path?: never;
@@ -1245,7 +1290,15 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["PaginatedResponse_AssetBalance"];
+                    "application/json": components["schemas"]["PaginatedSearchResponse_AssetBalance_AssetBalanceSummary_SearchFacets"];
+                };
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
             401: {


### PR DESCRIPTION
## 概要
- 資産管理一覧をDB側の検索・ページングに変更
- q/security_code/security_name の絞り込み、summary、facets を追加
- 検索・facets向けの index と OpenAPI/generated types を更新

## 検証
- cargo fmt
- cargo test asset_balance --lib
- cargo test --lib
- cargo clippy --all-targets -- -D warnings
- cargo run --bin generate_openapi
- npm run generate:types
- npm run typecheck
- npm run build
- bash scripts/check-openapi.sh
- git diff --check

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 保有銘柄一覧で、銘柄コード・銘柄名による検索や絞り込みができるようになりました。
  * 集計情報やファセットを必要に応じて表示できるようになりました。
  * 一覧の表示順が、銘柄コード昇順、ID昇順に統一されました。

* **ドキュメント**
  * API仕様と関連ドキュメントを、検索対応の新しいレスポンス形式に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->