### PR TITLE
受領明細の全ページ取得を縮小

### DIFF
--- a/frontend/src/features/receipt/components/ReceiptsAlerts.tsx
+++ b/frontend/src/features/receipt/components/ReceiptsAlerts.tsx
@@ -3,6 +3,7 @@ import type { CsvPreview } from '../reducer';
 
 interface ReceiptsAlertsProps {
   dbError: string | null | undefined;
+  dbWarning: string | null | undefined;
   hasCsvFile: boolean;
   previewing: boolean;
   csvPreview: CsvPreview | null | undefined;
@@ -10,6 +11,7 @@ interface ReceiptsAlertsProps {
 
 export function ReceiptsAlerts({
   dbError,
+  dbWarning,
   hasCsvFile,
   previewing,
   csvPreview,
@@ -21,6 +23,12 @@ export function ReceiptsAlerts({
           <Alert variant="danger" role="alert" aria-live="assertive">
             <strong>エラー:</strong> {dbError}
           </Alert>
+        </section>
+      )}
+
+      {dbWarning && (
+        <section className="px-5 py-4" role="status" aria-live="polite">
+          <Alert variant="warning">{dbWarning}</Alert>
         </section>
       )}
 

--- a/frontend/src/features/receipt/components/ReceiptsUtilityRail.tsx
+++ b/frontend/src/features/receipt/components/ReceiptsUtilityRail.tsx
@@ -10,6 +10,7 @@ export interface ReceiptsUtilityRailProps {
   actionRailProps: DataActionRailProps;
   alertsProps: {
     dbError: string | null | undefined;
+    dbWarning: string | null | undefined;
     hasCsvFile: boolean;
     previewing: boolean;
     csvPreview: CsvPreview | null | undefined;

--- a/frontend/src/features/receipt/components/__tests__/ReceiptsAlerts.test.tsx
+++ b/frontend/src/features/receipt/components/__tests__/ReceiptsAlerts.test.tsx
@@ -14,6 +14,7 @@ describe('ReceiptsAlerts', () => {
     render(
       <ReceiptsAlerts
         dbError="DB からの取得に失敗しました"
+        dbWarning={null}
         hasCsvFile={false}
         previewing={false}
         csvPreview={null}
@@ -28,6 +29,7 @@ describe('ReceiptsAlerts', () => {
     render(
       <ReceiptsAlerts
         dbError={null}
+        dbWarning={null}
         hasCsvFile
         previewing={false}
         csvPreview={{ ...csvPreview, errors: [] }}
@@ -42,6 +44,7 @@ describe('ReceiptsAlerts', () => {
     render(
       <ReceiptsAlerts
         dbError={null}
+        dbWarning={null}
         hasCsvFile
         previewing={false}
         csvPreview={csvPreview}
@@ -52,10 +55,27 @@ describe('ReceiptsAlerts', () => {
     expect(screen.getByRole('alert')).toHaveTextContent('1件エラー');
   });
 
+  it('dbWarning があれば警告アラートが表示される', () => {
+    render(
+      <ReceiptsAlerts
+        dbError={null}
+        dbWarning="一覧は最大1000件まで表示しています。検索条件を絞り込んでください。"
+        hasCsvFile={false}
+        previewing={false}
+        csvPreview={null}
+      />
+    );
+
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '一覧は最大1000件まで表示しています。検索条件を絞り込んでください。'
+    );
+  });
+
   it('条件が満たされない場合は何も表示しない', () => {
     const { container } = render(
       <ReceiptsAlerts
         dbError={null}
+        dbWarning={null}
         hasCsvFile={false}
         previewing={false}
         csvPreview={null}

--- a/frontend/src/features/receipt/components/__tests__/ReceiptsUtilityRail.test.tsx
+++ b/frontend/src/features/receipt/components/__tests__/ReceiptsUtilityRail.test.tsx
@@ -26,6 +26,7 @@ const actionRailProps = {
 
 const alertsProps = {
   dbError: null,
+  dbWarning: null,
   hasCsvFile: false,
   previewing: false,
   csvPreview: null,

--- a/frontend/src/features/receipt/hooks/__tests__/useReceiptsData.test.ts
+++ b/frontend/src/features/receipt/hooks/__tests__/useReceiptsData.test.ts
@@ -270,7 +270,7 @@ describe('useReceiptsData: 認証境界・キャッシュ境界', () => {
     });
   });
 
-  it('dividend: total が per_page を超える場合は次ページを取得し全件を返す', async () => {
+  it('dividend: total が per_page を超えても API 検索では次ページを取得しない', async () => {
     const qc = new QueryClient({
       defaultOptions: { queries: { retry: false, staleTime: Infinity } },
     });
@@ -300,15 +300,15 @@ describe('useReceiptsData: 認証境界・キャッシュ境界', () => {
     const { result } = renderHook(() => useReceiptsData(), { wrapper: makeWrapper(qc) });
 
     await waitFor(() => {
-      expect(result.current.dividendData).toHaveLength(1001);
+      expect(result.current.dividendData).toHaveLength(1000);
     });
-    expect(result.current.dividendData).toContainEqual({ id: '1001', payment_date: '2023-01-02' });
-    expect(receiptApiModule.dividendApi.list).toHaveBeenCalledTimes(2);
-    expect(receiptApiModule.dividendApi.list).toHaveBeenNthCalledWith(1, { per_page: 1000, page: 1 });
-    expect(receiptApiModule.dividendApi.list).toHaveBeenNthCalledWith(2, { per_page: 1000, page: 2 });
+    expect(result.current.dividendData).not.toContainEqual({ id: '1001', payment_date: '2023-01-02' });
+    expect(receiptApiModule.dividendApi.list).toHaveBeenCalledTimes(1);
+    expect(receiptApiModule.dividendApi.list).toHaveBeenNthCalledWith(1, { per_page: 1000, page: 1, include_summary: true, include_facets: true });
+    expect(receiptApiModule.dividendApi.list).not.toHaveBeenCalledWith({ per_page: 1000, page: 2 });
   });
 
-  it('domesticstock: total が per_page を超える場合は次ページを取得し全件を返す', async () => {
+  it('domesticstock: total が per_page を超えても API 検索では次ページを取得しない', async () => {
     const qc = new QueryClient({
       defaultOptions: { queries: { retry: false, staleTime: Infinity } },
     });
@@ -338,15 +338,15 @@ describe('useReceiptsData: 認証境界・キャッシュ境界', () => {
     const { result } = renderHook(() => useReceiptsData(), { wrapper: makeWrapper(qc) });
 
     await waitFor(() => {
-      expect(result.current.domesticstockData).toHaveLength(1001);
+      expect(result.current.domesticstockData).toHaveLength(1000);
     });
-    expect(result.current.domesticstockData).toContainEqual({ id: 'stock-1001', trade_date: '2023-02-02' });
-    expect(receiptApiModule.domesticStockApi.list).toHaveBeenCalledTimes(2);
-    expect(receiptApiModule.domesticStockApi.list).toHaveBeenNthCalledWith(1, { per_page: 1000, page: 1 });
-    expect(receiptApiModule.domesticStockApi.list).toHaveBeenNthCalledWith(2, { per_page: 1000, page: 2 });
+    expect(result.current.domesticstockData).not.toContainEqual({ id: 'stock-1001', trade_date: '2023-02-02' });
+    expect(receiptApiModule.domesticStockApi.list).toHaveBeenCalledTimes(1);
+    expect(receiptApiModule.domesticStockApi.list).toHaveBeenNthCalledWith(1, { per_page: 1000, page: 1, include_summary: true, include_facets: true });
+    expect(receiptApiModule.domesticStockApi.list).not.toHaveBeenCalledWith({ per_page: 1000, page: 2 });
   });
 
-  it('mutualfund: total が per_page を超える場合は次ページを取得し全件を返す', async () => {
+  it('mutualfund: total が per_page を超えても API 検索では次ページを取得しない', async () => {
     const qc = new QueryClient({
       defaultOptions: { queries: { retry: false, staleTime: Infinity } },
     });
@@ -376,12 +376,12 @@ describe('useReceiptsData: 認証境界・キャッシュ境界', () => {
     const { result } = renderHook(() => useReceiptsData(), { wrapper: makeWrapper(qc) });
 
     await waitFor(() => {
-      expect(result.current.mutualfundData).toHaveLength(1001);
+      expect(result.current.mutualfundData).toHaveLength(1000);
     });
-    expect(result.current.mutualfundData).toContainEqual({ id: 'fund-1001', trade_date: '2023-03-02' });
-    expect(receiptApiModule.mutualfundApi.list).toHaveBeenCalledTimes(2);
-    expect(receiptApiModule.mutualfundApi.list).toHaveBeenNthCalledWith(1, { per_page: 1000, page: 1 });
-    expect(receiptApiModule.mutualfundApi.list).toHaveBeenNthCalledWith(2, { per_page: 1000, page: 2 });
+    expect(result.current.mutualfundData).not.toContainEqual({ id: 'fund-1001', trade_date: '2023-03-02' });
+    expect(receiptApiModule.mutualfundApi.list).toHaveBeenCalledTimes(1);
+    expect(receiptApiModule.mutualfundApi.list).toHaveBeenNthCalledWith(1, { per_page: 1000, page: 1, include_summary: true, include_facets: true });
+    expect(receiptApiModule.mutualfundApi.list).not.toHaveBeenCalledWith({ per_page: 1000, page: 2 });
   });
 
   it('deleteAll mutation: domesticstock と mutualfund を削除できる', async () => {

--- a/frontend/src/features/receipt/hooks/__tests__/useReceiptsData.test.ts
+++ b/frontend/src/features/receipt/hooks/__tests__/useReceiptsData.test.ts
@@ -302,9 +302,8 @@ describe('useReceiptsData: 認証境界・キャッシュ境界', () => {
     await waitFor(() => {
       expect(result.current.dividendData).toHaveLength(1000);
     });
-    expect(result.current.dividendData).not.toContainEqual({ id: '1001', payment_date: '2023-01-02' });
     expect(receiptApiModule.dividendApi.list).toHaveBeenCalledTimes(1);
-    expect(receiptApiModule.dividendApi.list).toHaveBeenNthCalledWith(1, { per_page: 1000, page: 1, include_summary: true, include_facets: true });
+    expect(receiptApiModule.dividendApi.list).toHaveBeenNthCalledWith(1, { per_page: 1000, page: 1 });
     expect(receiptApiModule.dividendApi.list).not.toHaveBeenCalledWith({ per_page: 1000, page: 2 });
   });
 
@@ -340,9 +339,8 @@ describe('useReceiptsData: 認証境界・キャッシュ境界', () => {
     await waitFor(() => {
       expect(result.current.domesticstockData).toHaveLength(1000);
     });
-    expect(result.current.domesticstockData).not.toContainEqual({ id: 'stock-1001', trade_date: '2023-02-02' });
     expect(receiptApiModule.domesticStockApi.list).toHaveBeenCalledTimes(1);
-    expect(receiptApiModule.domesticStockApi.list).toHaveBeenNthCalledWith(1, { per_page: 1000, page: 1, include_summary: true, include_facets: true });
+    expect(receiptApiModule.domesticStockApi.list).toHaveBeenNthCalledWith(1, { per_page: 1000, page: 1 });
     expect(receiptApiModule.domesticStockApi.list).not.toHaveBeenCalledWith({ per_page: 1000, page: 2 });
   });
 
@@ -378,9 +376,8 @@ describe('useReceiptsData: 認証境界・キャッシュ境界', () => {
     await waitFor(() => {
       expect(result.current.mutualfundData).toHaveLength(1000);
     });
-    expect(result.current.mutualfundData).not.toContainEqual({ id: 'fund-1001', trade_date: '2023-03-02' });
     expect(receiptApiModule.mutualfundApi.list).toHaveBeenCalledTimes(1);
-    expect(receiptApiModule.mutualfundApi.list).toHaveBeenNthCalledWith(1, { per_page: 1000, page: 1, include_summary: true, include_facets: true });
+    expect(receiptApiModule.mutualfundApi.list).toHaveBeenNthCalledWith(1, { per_page: 1000, page: 1 });
     expect(receiptApiModule.mutualfundApi.list).not.toHaveBeenCalledWith({ per_page: 1000, page: 2 });
   });
 

--- a/frontend/src/features/receipt/hooks/__tests__/useReceiptsState.test.ts
+++ b/frontend/src/features/receipt/hooks/__tests__/useReceiptsState.test.ts
@@ -45,6 +45,7 @@ function setupMocks(isAuthenticated = true) {
     saving: false,
     deleting: false,
     previewing: false,
+    receiptListLimit: 1000,
     uploadCsv: mockUploadCsv,
     previewCsv: mockPreviewCsv,
     deleteAll: mockDeleteAll,
@@ -66,6 +67,33 @@ describe('useReceiptsState', () => {
 
     expect(result.current.receiptsType).toBe('dividend');
     expect(result.current.showDeleteConfirm).toBe(false);
+  });
+
+  it('取得件数が一覧上限に達したら警告を渡す', () => {
+    const fullDividendData = Array.from({ length: 1000 }, () => ({})) as ReturnType<
+      typeof useReceiptsData
+    >['dividendData'];
+
+    vi.mocked(useReceiptsData).mockReturnValue({
+      dividendData: fullDividendData,
+      domesticstockData: [],
+      mutualfundData: [],
+      dbLoading: false,
+      dbError: null,
+      saving: false,
+      deleting: false,
+      previewing: false,
+      receiptListLimit: 1000,
+      uploadCsv: mockUploadCsv,
+      previewCsv: mockPreviewCsv,
+      deleteAll: mockDeleteAll,
+    });
+
+    const { result } = renderHook(() => useReceiptsState());
+
+    expect(result.current.utilityRailProps.alertsProps.dbWarning).toBe(
+      '一覧は最大1000件まで表示しています。検索条件を絞り込んでください。'
+    );
   });
 
   it('setReceiptsType: 呼び出すと receiptsType が変わる', () => {

--- a/frontend/src/features/receipt/hooks/useReceiptsData.ts
+++ b/frontend/src/features/receipt/hooks/useReceiptsData.ts
@@ -28,6 +28,7 @@ interface UseReceiptsDataResult {
   saving: boolean;
   deleting: boolean;
   previewing: boolean;
+  receiptListLimit: number;
   uploadCsv: (args: UploadCsvArgs) => void;
   previewCsv: (args: PreviewCsvArgs) => void;
   deleteAll: (type: ReceiptsType, options?: { onSuccess?: () => void }) => void;
@@ -46,11 +47,11 @@ interface PreviewCsvArgs {
   onError?: (error: string) => void;
 }
 
+const RECEIPT_LIST_LIMIT = 1000;
+
 const RECEIPT_LIST_PARAMS = {
-  per_page: 1000,
+  per_page: RECEIPT_LIST_LIMIT,
   page: 1,
-  include_summary: true,
-  include_facets: true,
 } as const;
 
 /**
@@ -176,6 +177,7 @@ export function useReceiptsData(): UseReceiptsDataResult {
     saving: uploadCsvMutation.isPending,
     deleting: deleteAllMutation.isPending,
     previewing: previewCsvMutation.isPending,
+    receiptListLimit: RECEIPT_LIST_LIMIT,
     uploadCsv: uploadCsvMutation.mutate,
     previewCsv: previewCsvMutation.mutate,
     deleteAll: (type, options) => deleteAllMutation.mutate(type, { onSuccess: options?.onSuccess }),

--- a/frontend/src/features/receipt/hooks/useReceiptsData.ts
+++ b/frontend/src/features/receipt/hooks/useReceiptsData.ts
@@ -9,7 +9,6 @@ import {
 import { receiptQueryKeys, clearReceiptsCache } from '../queryKeys';
 import { type ReceiptsType } from '../reducer';
 import { getDisplayErrorMessage } from '@/lib/utils/errorHandler';
-import { fetchAllPages } from '@/lib/api/pagination';
 import { useAuth } from '@/features/auth/hooks/useAuth';
 import type { CsvImportError, CsvUploadResult } from '@/lib/csvImport';
 
@@ -47,6 +46,13 @@ interface PreviewCsvArgs {
   onError?: (error: string) => void;
 }
 
+const RECEIPT_LIST_PARAMS = {
+  per_page: 1000,
+  page: 1,
+  include_summary: true,
+  include_facets: true,
+} as const;
+
 /**
  * 明細データの取得・保存・削除を TanStack Query で管理するフック
  * ユーザー固有キーでキャッシュを分離し、未認証時はフェッチせず空を返す
@@ -64,24 +70,24 @@ export function useReceiptsData(): UseReceiptsDataResult {
   const dividendQuery = useQuery({
     queryKey: receiptQueryKeys.dividend(userId),
     queryFn: () =>
-      fetchAllPages((page) => dividendApi.list({ per_page: 1000, page })).then((dividendRows) =>
-        dividendRows.map(transformDBDividend)),
+      dividendApi.list(RECEIPT_LIST_PARAMS).then((response) =>
+        response.data.map(transformDBDividend)),
     enabled: isAuthenticated && !authLoading && !!userId,
   });
 
   const domesticstockQuery = useQuery({
     queryKey: receiptQueryKeys.domesticstock(userId),
     queryFn: () =>
-      fetchAllPages((page) => domesticStockApi.list({ per_page: 1000, page })).then((domesticStockRows) =>
-        domesticStockRows.map(transformDBDomesticStock)),
+      domesticStockApi.list(RECEIPT_LIST_PARAMS).then((response) =>
+        response.data.map(transformDBDomesticStock)),
     enabled: isAuthenticated && !authLoading && !!userId,
   });
 
   const mutualfundQuery = useQuery({
     queryKey: receiptQueryKeys.mutualfund(userId),
     queryFn: () =>
-      fetchAllPages((page) => mutualfundApi.list({ per_page: 1000, page })).then((mutualfundRows) =>
-        mutualfundRows.map(transformDBMutualfund)),
+      mutualfundApi.list(RECEIPT_LIST_PARAMS).then((response) =>
+        response.data.map(transformDBMutualfund)),
     enabled: isAuthenticated && !authLoading && !!userId,
   });
 

--- a/frontend/src/features/receipt/hooks/useReceiptsState.ts
+++ b/frontend/src/features/receipt/hooks/useReceiptsState.ts
@@ -23,6 +23,7 @@ export function useReceiptsState() {
     saving,
     deleting,
     previewing,
+    receiptListLimit,
     uploadCsv,
     previewCsv,
     deleteAll,
@@ -45,6 +46,9 @@ export function useReceiptsState() {
   const csvPreview = csvPreviews[receiptsType];
   const importResult = lastImportResults[receiptsType];
   const dbDataCount = currentData.length;
+  const dbWarning = dbDataCount >= receiptListLimit
+    ? '一覧は最大' + receiptListLimit + '件まで表示しています。検索条件を絞り込んでください。'
+    : null;
   const hasCsvFile = rawFile !== null;
   const tabName = TAB_LABEL[receiptsType];
   const saveLabel = csvPreview ? `${csvPreview.validRows}件 追加で保存` : '追加で保存';
@@ -157,6 +161,7 @@ export function useReceiptsState() {
     actionRailProps,
     alertsProps: {
       dbError,
+      dbWarning,
       hasCsvFile,
       previewing,
       csvPreview,

--- a/frontend/src/pages/__tests__/ReceiptsAlerts.test.tsx
+++ b/frontend/src/pages/__tests__/ReceiptsAlerts.test.tsx
@@ -18,6 +18,7 @@ describe('ReceiptsAlerts', () => {
     render(
       <ReceiptsAlerts
         dbError={null}
+        dbWarning={null}
         hasCsvFile
         previewing={false}
         csvPreview={makeCsvPreview({
@@ -34,6 +35,7 @@ describe('ReceiptsAlerts', () => {
     render(
       <ReceiptsAlerts
         dbError={null}
+        dbWarning={null}
         hasCsvFile
         previewing={false}
         csvPreview={makeCsvPreview()}
@@ -49,6 +51,7 @@ describe('ReceiptsAlerts', () => {
     render(
       <ReceiptsAlerts
         dbError="保存に失敗しました"
+        dbWarning={null}
         hasCsvFile={false}
         previewing={false}
         csvPreview={null}
@@ -62,6 +65,7 @@ describe('ReceiptsAlerts', () => {
     render(
       <ReceiptsAlerts
         dbError={null}
+        dbWarning={null}
         hasCsvFile={false}
         previewing={false}
         csvPreview={makeCsvPreview()}


### PR DESCRIPTION
## 概要
- 受領明細の初期取得で fetchAllPages を使わず、各APIを1ページだけ取得するよう変更
- 未使用の include_summary/include_facets は送らず、UI が実際に使う一覧取得だけに限定
- 一覧が1000件上限に達した場合、検索条件で絞り込むよう警告を表示
- total が per_page を超えても2ページ目を取得しないことを useReceiptsData テストで固定

## レビュー対応
- CodeRabbit の無効な not.toContainEqual 指摘に対応し、該当 assertion を削除
- 1000件超の取りこぼし懸念に対し、現PRでは上限明示の UI 警告を追加
- 未使用 include_summary/include_facets の送信を削除

## 検証
- npm run typecheck
- npm test -- useReceiptsData ReceiptsAlerts ReceiptsUtilityRail useReceiptsState
- npm run build
- vp lint
- git diff --check

補足: Claude にも実装依頼しましたが、Claude 側の Edit 権限が降りず停止したため、Codex側でTDD順序を守って実装しました。