### PR TITLE
保有銘柄照会を銘柄コード指定APIに寄せる

### DIFF
--- a/frontend/src/components/molecules/DividendInfo/DividendInfo.tsx
+++ b/frontend/src/components/molecules/DividendInfo/DividendInfo.tsx
@@ -115,7 +115,10 @@ export const DividendInfo: React.FC<DividendInfoProps> = ({
 
   const isValidSecurityCode = !!effectiveSecurityCode && SECURITY_CODE_REGEX.test(effectiveSecurityCode);
 
-  const { getAssetBalanceByCode } = useAssetBalance({ enabled: isValidSecurityCode });
+  const { getAssetBalanceByCode } = useAssetBalance({
+    enabled: isValidSecurityCode,
+    securityCode: effectiveSecurityCode,
+  });
 
   const dividendBatchCodes = isValidSecurityCode ? [effectiveSecurityCode] : [];
   const { dividendPerShareMap, loading: apiLoading } = useDividendBatch(dividendBatchCodes, isValidSecurityCode);

--- a/frontend/src/components/molecules/__tests__/DividendInfo.test.tsx
+++ b/frontend/src/components/molecules/__tests__/DividendInfo.test.tsx
@@ -63,6 +63,12 @@ describe('DividendInfo', () => {
     expect(mockUseDividendBatch).toHaveBeenCalledWith(['7203'], true);
   });
 
+  it('searchQuery から銘柄コードを解決して useAssetBalance に渡す', () => {
+    render(<DividendInfo searchQuery="7203: トヨタ自動車" summary={[]} />);
+
+    expect(mockUseAssetBalance).toHaveBeenCalledWith({ enabled: true, securityCode: '7203' });
+  });
+
   it('embedded モードで未取得値にヒントを表示する', () => {
     render(<DividendInfo embedded searchQuery="7203: トヨタ自動車" summary={[]} />);
 

--- a/frontend/src/features/assetBalance/__tests__/queryKeys.test.ts
+++ b/frontend/src/features/assetBalance/__tests__/queryKeys.test.ts
@@ -11,6 +11,10 @@ describe('assetBalanceQueryKeys', () => {
     expect(assetBalanceQueryKeys.all('user-1')).toEqual(['assetBalance', 'user-1']);
   });
 
+  it('lookup("user-1", "7203") が lookup キーを返す', () => {
+    expect(assetBalanceQueryKeys.lookup('user-1', '7203')).toEqual(['assetBalance', 'user-1', 'lookup', '7203']);
+  });
+
   it('list("user-1") が ["assetBalance", "user-1", "list"] を返す', () => {
     expect(assetBalanceQueryKeys.list('user-1')).toEqual(['assetBalance', 'user-1', 'list']);
   });

--- a/frontend/src/features/assetBalance/hooks/__tests__/useAssetBalance.test.ts
+++ b/frontend/src/features/assetBalance/hooks/__tests__/useAssetBalance.test.ts
@@ -208,36 +208,31 @@ describe('useAssetBalance', () => {
     expect(result.current.getTotalMarketValue()).toBe(100000);
   });
 
-  it('total が per_page を超える場合は次ページを取得し全件を返す', async () => {
+  it('securityCode 指定時は銘柄コードで1回だけAPI取得する', async () => {
     const qc = new QueryClient({
       defaultOptions: { queries: { retry: false, staleTime: Infinity } },
     });
 
-    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockImplementation(
-      ({ page = 1 }: { page?: number; per_page?: number } = {}) => {
-        if (page === 1) {
-          return Promise.resolve({
-            data: Array.from({ length: 1000 }, (_, index) =>
-              makeAssetBalanceData({ id: String(index + 1), security_code: String(7000 + index) })
-            ),
-            total: 1001, page: 1, per_page: 1000,
-          });
-        }
-        return Promise.resolve({
-          data: [makeAssetBalanceData({ id: '1001', security_code: '6758' })],
-          total: 1001, page: 2, per_page: 1000,
-        });
-      }
-    );
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue({
+      data: [makeAssetBalanceData({ security_code: '7203' })],
+      total: 1,
+      page: 1,
+      per_page: 1,
+    });
 
-    const { result } = renderHook(() => useAssetBalance(), { wrapper: makeWrapper(qc) });
+    const { result } = renderHook(() => useAssetBalance({ securityCode: ' 7203 ' }), { wrapper: makeWrapper(qc) });
 
     await waitFor(() => {
-      expect(result.current.assetBalanceData).toHaveLength(1001);
+      expect(result.current.assetBalanceData).toHaveLength(1);
     });
-    expect(assetBalanceApiModule.assetBalanceApi.list).toHaveBeenCalledTimes(2);
-    expect(assetBalanceApiModule.assetBalanceApi.list).toHaveBeenNthCalledWith(1, { per_page: 1000, page: 1 });
-    expect(assetBalanceApiModule.assetBalanceApi.list).toHaveBeenNthCalledWith(2, { per_page: 1000, page: 2 });
+
+    expect(assetBalanceApiModule.assetBalanceApi.list).toHaveBeenCalledTimes(1);
+    expect(assetBalanceApiModule.assetBalanceApi.list).toHaveBeenCalledWith({
+      page: 1,
+      per_page: 1,
+      security_code: '7203',
+    });
+    expect(result.current.getAssetBalanceByCode('7203')).toMatchObject({ security_code: '7203' });
   });
 
   it('refetch は assetBalance クエリを invalidate する', async () => {

--- a/frontend/src/features/assetBalance/hooks/useAssetBalance.ts
+++ b/frontend/src/features/assetBalance/hooks/useAssetBalance.ts
@@ -4,7 +4,6 @@ import type { AssetBalanceData } from '@/types/api';
 import { assetBalanceApi } from '@/features/assetBalance/api/assetBalanceApi';
 import { useAuth } from '@/features/auth/hooks/useAuth';
 import { normalizeSecurityCode } from '@/lib/utils/formatters';
-import { fetchAllPages } from '@/lib/api/pagination';
 import { assetBalanceQueryKeys, clearAssetBalanceCache } from '../queryKeys';
 
 interface UseAssetBalanceReturn {
@@ -17,6 +16,7 @@ interface UseAssetBalanceReturn {
 
 interface UseAssetBalanceOptions {
   enabled?: boolean;
+  securityCode?: string;
 }
 
 /**
@@ -24,14 +24,25 @@ interface UseAssetBalanceOptions {
  * ユーザー固有キーでキャッシュを分離し、未認証時はフェッチせず空配列を返す
  */
 export function useAssetBalance(options: UseAssetBalanceOptions = {}): UseAssetBalanceReturn {
-  const { enabled = true } = options;
+  const { enabled = true, securityCode } = options;
   const { isAuthenticated, onLogout, user } = useAuth();
   const queryClient = useQueryClient();
   const userId = user?.id ?? '';
+  const normalizedSecurityCode = normalizeSecurityCode(securityCode ?? '');
+  const queryKey = normalizedSecurityCode
+    ? assetBalanceQueryKeys.lookup(userId, normalizedSecurityCode)
+    : assetBalanceQueryKeys.all(userId);
 
   const query = useQuery({
-    queryKey: assetBalanceQueryKeys.all(userId),
-    queryFn: () => fetchAllPages((page) => assetBalanceApi.list({ per_page: 1000, page })),
+    queryKey,
+    queryFn: async () => {
+      const response = await assetBalanceApi.list(
+        normalizedSecurityCode
+          ? { page: 1, per_page: 1, security_code: normalizedSecurityCode }
+          : { page: 1, per_page: 1000 }
+      );
+      return response.data;
+    },
     enabled: isAuthenticated && !!userId && enabled,
   });
 
@@ -56,7 +67,7 @@ export function useAssetBalance(options: UseAssetBalanceOptions = {}): UseAssetB
   };
 
   const refetch = async () => {
-    await queryClient.invalidateQueries({ queryKey: assetBalanceQueryKeys.all(userId) });
+    await queryClient.invalidateQueries({ queryKey });
   };
 
   return {

--- a/frontend/src/features/assetBalance/queryKeys.ts
+++ b/frontend/src/features/assetBalance/queryKeys.ts
@@ -6,6 +6,8 @@ export const assetBalanceQueryKeys = {
   prefix: ['assetBalance'] as const,
   // useAssetBalance（DividendInfo 用）が参照する全件配列キャッシュ
   all: (userId: string) => ['assetBalance', userId] as const,
+  lookup: (userId: string, securityCode: string) =>
+    ['assetBalance', userId, 'lookup', securityCode] as const,
   // useAssetBalanceDataSource が参照する summary/facets 付きレスポンスキャッシュ
   // all と shape が異なるため、同じキーで共有しない
   list: (userId: string) => ['assetBalance', userId, 'list'] as const,


### PR DESCRIPTION
## 概要
- DividendInfo 経由の useAssetBalance で全ページ取得をやめ、security_code 指定の API 1回取得へ変更
- useAssetBalance に securityCode オプションと lookup query key を追加
- 本番コードから fetchAllPages の import/use を削除

## TDD
- 先に useAssetBalance テストを更新し、security_code param が使われず失敗することを確認
- 実装後に対象テストを GREEN 化

## 検証
- npm run typecheck
- npm test -- useAssetBalance DividendInfo
- npm run build
- vp lint
- git diff --check