### PR TITLE
refactor: SearchCardを目的別ファイルに分割

### DIFF
--- a/frontend/src/components/organisms/SearchCard/CalendarDateButton.tsx
+++ b/frontend/src/components/organisms/SearchCard/CalendarDateButton.tsx
@@ -1,0 +1,61 @@
+import React, { useRef } from 'react';
+import { cn } from '@/lib/utils/classNames';
+import { formatDateLabel } from './searchQueryUtils';
+
+interface CalendarDateButtonProps {
+    label: string;
+    value: string;
+    inputType?: 'date' | 'month';
+    onChange: (value: string) => void;
+}
+
+export const CalendarDateButton: React.FC<CalendarDateButtonProps> = ({ label, value, inputType = 'date', onChange }) => {
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    const handleButtonClick = () => {
+        const input = inputRef.current;
+        if (!input) return;
+        try {
+            const pickerInput = input as HTMLInputElement & { showPicker?: () => void };
+            if (typeof pickerInput.showPicker === 'function') {
+                pickerInput.showPicker();
+                return;
+            }
+        } catch {
+            // showPicker が失敗した場合はクリックフォールバックへ
+        }
+        input.focus();
+        input.click();
+    };
+
+    return (
+        <div className="relative">
+            <button
+                type="button"
+                onClick={handleButtonClick}
+                className={cn(
+                    'w-full flex items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors focus:outline-none focus:ring-2 focus:border-amber-600 focus:ring-amber-500/25',
+                    value
+                        ? 'border-amber-500 bg-amber-50 text-amber-900 font-semibold'
+                        : 'border-slate-300 bg-white text-slate-500 hover:border-slate-400'
+                )}
+            >
+                <svg className="w-3.5 h-3.5 shrink-0 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                </svg>
+                <span className="flex-1 text-left">
+                    {value ? formatDateLabel(value) : label}
+                </span>
+            </button>
+            <input
+                ref={inputRef}
+                type={inputType}
+                value={value}
+                onChange={e => onChange(e.target.value)}
+                aria-hidden="true"
+                tabIndex={-1}
+                className="absolute opacity-0 pointer-events-none w-px h-px overflow-hidden"
+            />
+        </div>
+    );
+};

--- a/frontend/src/components/organisms/SearchCard/DatePeriodBlock.tsx
+++ b/frontend/src/components/organisms/SearchCard/DatePeriodBlock.tsx
@@ -1,0 +1,212 @@
+import React, { useRef } from 'react';
+import { cn } from '@/lib/utils/classNames';
+import { DateSegment } from './types';
+import { CalendarDateButton } from './CalendarDateButton';
+
+const DATE_SEGMENTS: DateSegment[] = ['年', '月', '日', '範囲'];
+
+interface DatePeriodBlockProps {
+    dateSegment: DateSegment;
+    years: { value: string; label: string }[];
+    yearValue: string;
+    monthValue: string;
+    dateValue: string;
+    rangeStart: string;
+    rangeEnd: string;
+    isYearPickerOpen: boolean;
+    onSegmentChange: (segment: DateSegment) => void;
+    onToggleYearPicker: () => void;
+    onYearOptionSelect: (value: string) => void;
+    onMonthChange: (value: string) => void;
+    onDateValueChange: (value: string) => void;
+    onRangeStartChange: (value: string) => void;
+    onRangeEndChange: (value: string) => void;
+    onClose?: () => void;
+}
+
+export const DatePeriodBlock: React.FC<DatePeriodBlockProps> = ({
+    dateSegment, years, yearValue, monthValue, dateValue, rangeStart, rangeEnd, isYearPickerOpen,
+    onSegmentChange, onToggleYearPicker, onYearOptionSelect, onMonthChange, onDateValueChange, onRangeStartChange, onRangeEndChange, onClose,
+}) => {
+    const availableSegments = years.length > 0 ? DATE_SEGMENTS : DATE_SEGMENTS.filter(seg => seg !== '年');
+    const visibleDateSegment = years.length === 0 && dateSegment === '年' ? '月' : dateSegment;
+
+    const triggerRef = useRef<HTMLButtonElement>(null);
+    const listboxRef = useRef<HTMLDivElement>(null);
+
+    const getListboxOptions = () => {
+        if (!listboxRef.current) return [];
+        return Array.from(listboxRef.current.querySelectorAll<HTMLButtonElement>('[role="option"]'));
+    };
+
+    const handleListboxKeyDown = (e: React.KeyboardEvent) => {
+        const options = getListboxOptions();
+        if (options.length === 0) return;
+        const currentIndex = options.indexOf(document.activeElement as HTMLButtonElement);
+        switch (e.key) {
+            case 'ArrowDown':
+            case 'ArrowRight': {
+                e.preventDefault();
+                const next = currentIndex >= 0 && currentIndex < options.length - 1 ? options[currentIndex + 1] : options[0];
+                next.focus();
+                break;
+            }
+            case 'ArrowUp':
+            case 'ArrowLeft': {
+                e.preventDefault();
+                const prev = currentIndex > 0 ? options[currentIndex - 1] : options[options.length - 1];
+                prev.focus();
+                break;
+            }
+            case 'Home':
+                e.preventDefault();
+                options[0].focus();
+                break;
+            case 'End':
+                e.preventDefault();
+                options[options.length - 1].focus();
+                break;
+            case 'Enter':
+            case ' ': {
+                e.preventDefault();
+                if (currentIndex >= 0) options[currentIndex].click();
+                break;
+            }
+            case 'Escape':
+                e.preventDefault();
+                onClose?.();
+                triggerRef.current?.focus();
+                break;
+        }
+    };
+
+    const handleTriggerKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+        if (!isYearPickerOpen) return;
+        const options = getListboxOptions();
+        if (e.key === 'ArrowDown' || e.key === 'ArrowRight') {
+            e.preventDefault();
+            options[0]?.focus();
+        } else if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') {
+            e.preventDefault();
+            options[options.length - 1]?.focus();
+        } else if (e.key === 'Escape') {
+            e.preventDefault();
+            onClose?.();
+        }
+    };
+
+    return (
+    <div className="space-y-2">
+        <div className="text-sm font-bold text-slate-800">期間</div>
+        <div className="flex gap-1">
+            {availableSegments.map(seg => (
+                <button
+                    key={seg}
+                    type="button"
+                    aria-pressed={visibleDateSegment === seg}
+                    onClick={() => onSegmentChange(seg)}
+                    className={cn(
+                        'flex-1 rounded px-2 py-1 text-xs font-semibold transition-colors',
+                        visibleDateSegment === seg
+                            ? 'bg-slate-950 text-white'
+                            : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
+                    )}
+                >
+                    {seg}
+                </button>
+            ))}
+        </div>
+        {visibleDateSegment === '年' && (
+            <div className="relative">
+                <button
+                    ref={triggerRef}
+                    type="button"
+                    aria-label="年を選択"
+                    aria-haspopup="listbox"
+                    aria-expanded={isYearPickerOpen}
+                    onClick={onToggleYearPicker}
+                    onKeyDown={handleTriggerKeyDown}
+                    className={cn(
+                        'w-full flex items-center gap-2 border px-3 py-2 text-sm transition-colors focus:outline-none focus:ring-2 focus:border-amber-600 focus:ring-amber-500/25',
+                        isYearPickerOpen ? 'rounded-t-md rounded-b-none' : 'rounded-md',
+                        yearValue
+                            ? 'border-amber-500 bg-amber-50 text-amber-900 font-semibold'
+                            : 'border-slate-300 bg-white text-slate-500 hover:border-slate-400'
+                    )}
+                >
+                    <svg className="w-3.5 h-3.5 shrink-0 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                    </svg>
+                    <span className="flex-1 text-left">
+                        {yearValue ? (years.find(y => y.value === yearValue)?.label ?? yearValue) : '年を選択'}
+                    </span>
+                    <svg
+                        className={cn('w-4 h-4 shrink-0 text-slate-400 transition-transform duration-150', isYearPickerOpen && 'rotate-180')}
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                        aria-hidden="true"
+                    >
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                    </svg>
+                </button>
+                {isYearPickerOpen && (
+                    <div
+                        ref={listboxRef}
+                        role="listbox"
+                        aria-label="年候補"
+                        onKeyDown={handleListboxKeyDown}
+                        className="absolute z-10 w-full grid grid-cols-3 gap-1 rounded-b-md border border-t-0 border-slate-300 bg-white px-2 pb-2 pt-1.5"
+                    >
+                        {years.map(year => (
+                            <button
+                                key={year.value}
+                                type="button"
+                                role="option"
+                                aria-selected={yearValue === year.value}
+                                onClick={() => onYearOptionSelect(year.value)}
+                                className={
+                                    yearValue === year.value
+                                        ? 'rounded px-1 py-1.5 text-sm font-semibold text-center whitespace-nowrap bg-amber-50 text-amber-900 ring-1 ring-inset ring-amber-400 transition-colors'
+                                        : 'rounded px-1 py-1.5 text-sm text-center whitespace-nowrap text-slate-600 hover:bg-slate-100 hover:text-slate-900 transition-colors'
+                                }
+                            >
+                                {year.label}
+                            </button>
+                        ))}
+                    </div>
+                )}
+            </div>
+        )}
+        {visibleDateSegment === '月' && (
+            <CalendarDateButton
+                label="月を選択"
+                value={monthValue}
+                inputType="month"
+                onChange={onMonthChange}
+            />
+        )}
+        {visibleDateSegment === '日' && (
+            <CalendarDateButton
+                label="日を選択"
+                value={dateValue}
+                onChange={onDateValueChange}
+            />
+        )}
+        {visibleDateSegment === '範囲' && (
+            <div className="flex flex-col gap-2">
+                <CalendarDateButton
+                    label="開始日"
+                    value={rangeStart}
+                    onChange={onRangeStartChange}
+                />
+                <CalendarDateButton
+                    label="終了日"
+                    value={rangeEnd}
+                    onChange={onRangeEndChange}
+                />
+            </div>
+        )}
+    </div>
+    );
+};

--- a/frontend/src/components/organisms/SearchCard/QuickSearchButtons.tsx
+++ b/frontend/src/components/organisms/SearchCard/QuickSearchButtons.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Button } from '@/components/atoms/Button';
+import { ActiveSearchType } from './types';
+
+interface QuickSearchButtonsProps {
+    items: string[];
+    searchType: 'products' | 'accounts';
+    activeSearchType: ActiveSearchType;
+    searchQuery: string;
+    onSearch: (value: string, searchType: 'products' | 'accounts') => void;
+}
+
+export const QuickSearchButtons: React.FC<QuickSearchButtonsProps> = ({
+    items, searchType, activeSearchType, searchQuery, onSearch
+}) => {
+    if (!items || items.length === 0) return null;
+    const hasSelection = activeSearchType === searchType;
+    return (
+        <>
+            {items.map((item, index) => {
+                const isSelected = activeSearchType === searchType && searchQuery === item;
+                return (
+                    <React.Fragment key={item}>
+                        <Button
+                            type="button"
+                            variant={isSelected ? 'primary' : 'outline-secondary'}
+                            size="sm"
+                            onClick={() => onSearch(item, searchType)}
+                            className={isSelected
+                                ? 'ring-2 ring-amber-500 ring-offset-1 font-bold shadow-md'
+                                : `${hasSelection ? 'opacity-50' : 'opacity-80'} hover:opacity-100 hover:bg-slate-100 hover:ring-1 hover:ring-slate-300 focus-visible:ring-2 focus-visible:ring-amber-500/50 focus-visible:outline-none`
+                            }
+                            aria-pressed={isSelected}
+                            aria-label={isSelected ? `${item}（選択中）` : item}
+                        >
+                            {isSelected && (
+                                <svg className="w-3.5 h-3.5 mr-1 inline-block" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                                    <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                                </svg>
+                            )}
+                            {item}
+                        </Button>
+                        {index % 10 === 9 && <div className="mt-1" />}
+                    </React.Fragment>
+                );
+            })}
+        </>
+    );
+};

--- a/frontend/src/components/organisms/SearchCard/QuickSearchDropdown.tsx
+++ b/frontend/src/components/organisms/SearchCard/QuickSearchDropdown.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { cn } from '@/lib/utils/classNames';
+import { ActiveSearchType } from './types';
+
+interface QuickSearchDropdownProps {
+    items: { value: string; label: string }[];
+    id: string;
+    searchType: 'securities' | 'years';
+    activeSearchType: ActiveSearchType;
+    searchQuery: string;
+    onSearch: (value: string, searchType: 'securities' | 'years') => void;
+}
+
+export const QuickSearchDropdown: React.FC<QuickSearchDropdownProps> = ({
+    items, id, searchType, activeSearchType, searchQuery, onSearch
+}) => {
+    const displayValue = activeSearchType === searchType ? searchQuery : '';
+    const isSelected = activeSearchType === searchType && displayValue !== '';
+    return (
+        <div className="relative">
+            <select
+                id={id}
+                className={cn(
+                    'w-full rounded-md border px-3 py-2 text-sm transition-colors focus:outline-none focus:ring-2',
+                    isSelected
+                        ? 'border-amber-500 bg-amber-50 text-amber-900 font-bold ring-2 ring-amber-500/30'
+                        : 'border-slate-300 bg-white text-dark hover:border-slate-500 focus:border-amber-600 focus:ring-amber-500/25'
+                )}
+                value={displayValue}
+                onChange={(e) => onSearch(e.target.value, searchType)}
+            >
+                <option value="">全て表示</option>
+                {items.map((option) => (
+                    <option key={option.value} value={option.value}>
+                        {option.label}
+                    </option>
+                ))}
+            </select>
+            {isSelected && (
+                <span className="absolute right-8 top-1/2 -translate-y-1/2 text-amber-700 pointer-events-none">
+                    <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                        <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                    </svg>
+                </span>
+            )}
+        </div>
+    );
+};

--- a/frontend/src/components/organisms/SearchCard/SearchCard.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchCard.tsx
@@ -1,478 +1,15 @@
-import React, { useState, useRef, useEffect } from 'react';
-import { SearchCategories } from '@/types/common';
+import React, { useState, useEffect } from 'react';
 import { Button } from '@/components/atoms/Button';
 import { Card, CardBody, CardHeader } from '@/components/atoms/Card';
 import { cn } from '@/lib/utils/classNames';
+import { SearchCardProps } from './types';
+import { useSearchCardQuery } from './useSearchCardQuery';
+import { SearchFieldsGrid } from './SearchFieldsGrid';
+import { DatePeriodBlock } from './DatePeriodBlock';
 
-type SearchKey = 'securities' | 'years' | 'products' | 'accounts' | 'date';
-type ActiveSearchType = SearchKey | null;
-type DateSegment = '年' | '月' | '日' | '範囲';
-
-const DATE_SEGMENTS: DateSegment[] = ['年', '月', '日', '範囲'];
-const SEARCH_ORDER = ['date', 'securities', 'years', 'products', 'accounts'] as const satisfies readonly SearchKey[];
-
-function createEmptySelectedQueries(): Record<SearchKey, string> {
-    return {
-        securities: '',
-        years: '',
-        products: '',
-        accounts: '',
-        date: '',
-    };
-}
-
-function buildRangeQuery(start: string, end: string): string {
-    if (!start && !end) return '';
-    return `${start}..${end}`;
-}
-
-function formatQueryToken(value: string): string {
-    const trimmed = value.trim();
-    if (!/\s/.test(trimmed)) return trimmed;
-    return `"${trimmed.replace(/"/g, '\\"')}"`;
-}
-
-function buildCombinedQuery(queries: Record<SearchKey, string>): string {
-    return SEARCH_ORDER
-        .map(key => queries[key].trim())
-        .filter(Boolean)
-        .map(formatQueryToken)
-        .join(' ');
-}
-
-interface QuickSearchDropdownProps {
-    items: { value: string; label: string }[];
-    id: string;
-    searchType: 'securities' | 'years';
-    activeSearchType: ActiveSearchType;
-    searchQuery: string;
-    onSearch: (value: string, searchType: 'securities' | 'years') => void;
-}
-
-const QuickSearchDropdown: React.FC<QuickSearchDropdownProps> = ({
-    items, id, searchType, activeSearchType, searchQuery, onSearch
-}) => {
-    const displayValue = activeSearchType === searchType ? searchQuery : '';
-    const isSelected = activeSearchType === searchType && displayValue !== '';
-    return (
-        <div className="relative">
-            <select
-                id={id}
-                className={cn(
-                    'w-full rounded-md border px-3 py-2 text-sm transition-colors focus:outline-none focus:ring-2',
-                    isSelected
-                        ? 'border-amber-500 bg-amber-50 text-amber-900 font-bold ring-2 ring-amber-500/30'
-                        : 'border-slate-300 bg-white text-dark hover:border-slate-500 focus:border-amber-600 focus:ring-amber-500/25'
-                )}
-                value={displayValue}
-                onChange={(e) => onSearch(e.target.value, searchType)}
-            >
-                <option value="">全て表示</option>
-                {items.map((option) => (
-                    <option key={option.value} value={option.value}>
-                        {option.label}
-                    </option>
-                ))}
-            </select>
-            {isSelected && (
-                <span className="absolute right-8 top-1/2 -translate-y-1/2 text-amber-700 pointer-events-none">
-                    <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-                        <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
-                    </svg>
-                </span>
-            )}
-        </div>
-    );
-};
-
-interface QuickSearchButtonsProps {
-    items: string[];
-    searchType: 'products' | 'accounts';
-    activeSearchType: ActiveSearchType;
-    searchQuery: string;
-    onSearch: (value: string, searchType: 'products' | 'accounts') => void;
-}
-
-const QuickSearchButtons: React.FC<QuickSearchButtonsProps> = ({
-    items, searchType, activeSearchType, searchQuery, onSearch
-}) => {
-    if (!items || items.length === 0) return null;
-    const hasSelection = activeSearchType === searchType;
-    return (
-        <>
-            {items.map((item, index) => {
-                const isSelected = activeSearchType === searchType && searchQuery === item;
-                return (
-                    <React.Fragment key={item}>
-                        <Button
-                            type="button"
-                            variant={isSelected ? 'primary' : 'outline-secondary'}
-                            size="sm"
-                            onClick={() => onSearch(item, searchType)}
-                            className={isSelected
-                                ? 'ring-2 ring-amber-500 ring-offset-1 font-bold shadow-md'
-                                : `${hasSelection ? 'opacity-50' : 'opacity-80'} hover:opacity-100 hover:bg-slate-100 hover:ring-1 hover:ring-slate-300 focus-visible:ring-2 focus-visible:ring-amber-500/50 focus-visible:outline-none`
-                            }
-                            aria-pressed={isSelected}
-                            aria-label={isSelected ? `${item}（選択中）` : item}
-                        >
-                            {isSelected && (
-                                <svg className="w-3.5 h-3.5 mr-1 inline-block" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
-                                    <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
-                                </svg>
-                            )}
-                            {item}
-                        </Button>
-                        {index % 10 === 9 && <div className="mt-1" />}
-                    </React.Fragment>
-                );
-            })}
-        </>
-    );
-};
-
-type DropdownSearchType = 'securities' | 'years';
-type ButtonsSearchType = 'products' | 'accounts';
-
-const DROPDOWN_CONFIGS: Array<{ key: DropdownSearchType; label: string }> = [
-    { key: 'securities', label: '銘柄' },
-    { key: 'years', label: '西暦' },
-];
-
-const BUTTONS_CONFIGS: Array<{ key: ButtonsSearchType; label: string }> = [
-    { key: 'products', label: '商品' },
-    { key: 'accounts', label: '口座' },
-];
-
-interface SearchFieldsGridProps {
-    categories: SearchCategories;
-    gridClassName: string;
-    selectedQueries: Record<SearchKey, string>;
-    onSearch: (value: string, searchType: 'securities' | 'years' | 'products' | 'accounts') => void;
-    hasData: (data: unknown[] | undefined) => boolean;
-}
-
-const SearchFieldsGrid: React.FC<SearchFieldsGridProps> = ({
-    categories, gridClassName, selectedQueries, onSearch, hasData,
-}) => (
-    <div className={cn('grid', gridClassName)}>
-        {DROPDOWN_CONFIGS.map(({ key, label }) =>
-            // yearsはdatesブロックが有効な場合は期間ブロック側で表示するため除外
-            hasData(categories[key]) && !(key === 'years' && Boolean(categories.dates)) && (
-                <div key={key} className="space-y-1">
-                    <label htmlFor={`${key}-search`} className="text-sm font-bold text-slate-800">{label}</label>
-                    <QuickSearchDropdown
-                        items={categories[key]!}
-                        id={`${key}-search`}
-                        searchType={key}
-                        activeSearchType={selectedQueries[key] ? key : null}
-                        searchQuery={selectedQueries[key]}
-                        onSearch={onSearch}
-                    />
-                </div>
-            )
-        )}
-        {BUTTONS_CONFIGS.map(({ key, label }) =>
-            hasData(categories[key]) && (
-                <div key={key} className="space-y-1">
-                    <div className="text-sm font-bold text-slate-800">{label}</div>
-                    <div className="flex flex-wrap gap-1">
-                        <QuickSearchButtons
-                            items={categories[key]!}
-                            searchType={key}
-                            activeSearchType={selectedQueries[key] ? key : null}
-                            searchQuery={selectedQueries[key]}
-                            onSearch={onSearch}
-                        />
-                    </div>
-                </div>
-            )
-        )}
-    </div>
-);
-
-type DateInputs = { yearValue: string; monthValue: string; dateValue: string; rangeStart: string; rangeEnd: string };
-const EMPTY_DATE_INPUTS: DateInputs = { yearValue: '', monthValue: '', dateValue: '', rangeStart: '', rangeEnd: '' };
-
-function getInitialDateSegment(cats: SearchCategories | undefined): DateSegment {
-    if ((cats?.years?.length ?? 0) > 0) return '年';
-    if (cats?.dates) return '月';
-    return '年';
-}
-
-const formatDateLabel = (value: string): string => value.replace(/-/g, "/");
-
-interface CalendarDateButtonProps {
-    label: string;
-    value: string;
-    inputType?: 'date' | 'month';
-    onChange: (value: string) => void;
-}
-
-const CalendarDateButton: React.FC<CalendarDateButtonProps> = ({ label, value, inputType = 'date', onChange }) => {
-    const inputRef = useRef<HTMLInputElement>(null);
-
-    const handleButtonClick = () => {
-        const input = inputRef.current;
-        if (!input) return;
-        try {
-            const pickerInput = input as HTMLInputElement & { showPicker?: () => void };
-            if (typeof pickerInput.showPicker === 'function') {
-                pickerInput.showPicker();
-                return;
-            }
-        } catch {
-            // showPicker が失敗した場合はクリックフォールバックへ
-        }
-        input.focus();
-        input.click();
-    };
-
-    return (
-        <div className="relative">
-            <button
-                type="button"
-                onClick={handleButtonClick}
-                className={cn(
-                    'w-full flex items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors focus:outline-none focus:ring-2 focus:border-amber-600 focus:ring-amber-500/25',
-                    value
-                        ? 'border-amber-500 bg-amber-50 text-amber-900 font-semibold'
-                        : 'border-slate-300 bg-white text-slate-500 hover:border-slate-400'
-                )}
-            >
-                <svg className="w-3.5 h-3.5 shrink-0 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                </svg>
-                <span className="flex-1 text-left">
-                    {value ? formatDateLabel(value) : label}
-                </span>
-            </button>
-            <input
-                ref={inputRef}
-                type={inputType}
-                value={value}
-                onChange={e => onChange(e.target.value)}
-                aria-hidden="true"
-                tabIndex={-1}
-                className="absolute opacity-0 pointer-events-none w-px h-px overflow-hidden"
-            />
-        </div>
-    );
-};
-
-interface DatePeriodBlockProps {
-    dateSegment: DateSegment;
-    years: { value: string; label: string }[];
-    yearValue: string;
-    monthValue: string;
-    dateValue: string;
-    rangeStart: string;
-    rangeEnd: string;
-    isYearPickerOpen: boolean;
-    onSegmentChange: (segment: DateSegment) => void;
-    onToggleYearPicker: () => void;
-    onYearOptionSelect: (value: string) => void;
-    onMonthChange: (value: string) => void;
-    onDateValueChange: (value: string) => void;
-    onRangeStartChange: (value: string) => void;
-    onRangeEndChange: (value: string) => void;
-    onClose?: () => void;
-}
-
-const DatePeriodBlock: React.FC<DatePeriodBlockProps> = ({
-    dateSegment, years, yearValue, monthValue, dateValue, rangeStart, rangeEnd, isYearPickerOpen,
-    onSegmentChange, onToggleYearPicker, onYearOptionSelect, onMonthChange, onDateValueChange, onRangeStartChange, onRangeEndChange, onClose,
-}) => {
-    const availableSegments = years.length > 0 ? DATE_SEGMENTS : DATE_SEGMENTS.filter(seg => seg !== '年');
-    const visibleDateSegment = years.length === 0 && dateSegment === '年' ? '月' : dateSegment;
-
-    const triggerRef = useRef<HTMLButtonElement>(null);
-    const listboxRef = useRef<HTMLDivElement>(null);
-
-    const getListboxOptions = () => {
-        if (!listboxRef.current) return [];
-        return Array.from(listboxRef.current.querySelectorAll<HTMLButtonElement>('[role="option"]'));
-    };
-
-    const handleListboxKeyDown = (e: React.KeyboardEvent) => {
-        const options = getListboxOptions();
-        if (options.length === 0) return;
-        const currentIndex = options.indexOf(document.activeElement as HTMLButtonElement);
-        switch (e.key) {
-            case 'ArrowDown':
-            case 'ArrowRight': {
-                e.preventDefault();
-                const next = currentIndex >= 0 && currentIndex < options.length - 1 ? options[currentIndex + 1] : options[0];
-                next.focus();
-                break;
-            }
-            case 'ArrowUp':
-            case 'ArrowLeft': {
-                e.preventDefault();
-                const prev = currentIndex > 0 ? options[currentIndex - 1] : options[options.length - 1];
-                prev.focus();
-                break;
-            }
-            case 'Home':
-                e.preventDefault();
-                options[0].focus();
-                break;
-            case 'End':
-                e.preventDefault();
-                options[options.length - 1].focus();
-                break;
-            case 'Enter':
-            case ' ': {
-                e.preventDefault();
-                if (currentIndex >= 0) options[currentIndex].click();
-                break;
-            }
-            case 'Escape':
-                e.preventDefault();
-                onClose?.();
-                triggerRef.current?.focus();
-                break;
-        }
-    };
-
-    const handleTriggerKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
-        if (!isYearPickerOpen) return;
-        const options = getListboxOptions();
-        if (e.key === 'ArrowDown' || e.key === 'ArrowRight') {
-            e.preventDefault();
-            options[0]?.focus();
-        } else if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') {
-            e.preventDefault();
-            options[options.length - 1]?.focus();
-        } else if (e.key === 'Escape') {
-            e.preventDefault();
-            onClose?.();
-        }
-    };
-
-    return (
-    <div className="space-y-2">
-        <div className="text-sm font-bold text-slate-800">期間</div>
-        <div className="flex gap-1">
-            {availableSegments.map(seg => (
-                <button
-                    key={seg}
-                    type="button"
-                    aria-pressed={visibleDateSegment === seg}
-                    onClick={() => onSegmentChange(seg)}
-                    className={cn(
-                        'flex-1 rounded px-2 py-1 text-xs font-semibold transition-colors',
-                        visibleDateSegment === seg
-                            ? 'bg-slate-950 text-white'
-                            : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
-                    )}
-                >
-                    {seg}
-                </button>
-            ))}
-        </div>
-        {visibleDateSegment === '年' && (
-            <div className="relative">
-                <button
-                    ref={triggerRef}
-                    type="button"
-                    aria-label="年を選択"
-                    aria-haspopup="listbox"
-                    aria-expanded={isYearPickerOpen}
-                    onClick={onToggleYearPicker}
-                    onKeyDown={handleTriggerKeyDown}
-                    className={cn(
-                        'w-full flex items-center gap-2 border px-3 py-2 text-sm transition-colors focus:outline-none focus:ring-2 focus:border-amber-600 focus:ring-amber-500/25',
-                        isYearPickerOpen ? 'rounded-t-md rounded-b-none' : 'rounded-md',
-                        yearValue
-                            ? 'border-amber-500 bg-amber-50 text-amber-900 font-semibold'
-                            : 'border-slate-300 bg-white text-slate-500 hover:border-slate-400'
-                    )}
-                >
-                    <svg className="w-3.5 h-3.5 shrink-0 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                    </svg>
-                    <span className="flex-1 text-left">
-                        {yearValue ? (years.find(y => y.value === yearValue)?.label ?? yearValue) : '年を選択'}
-                    </span>
-                    <svg
-                        className={cn('w-4 h-4 shrink-0 text-slate-400 transition-transform duration-150', isYearPickerOpen && 'rotate-180')}
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                        aria-hidden="true"
-                    >
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                    </svg>
-                </button>
-                {isYearPickerOpen && (
-                    <div
-                        ref={listboxRef}
-                        role="listbox"
-                        aria-label="年候補"
-                        onKeyDown={handleListboxKeyDown}
-                        className="absolute z-10 w-full grid grid-cols-3 gap-1 rounded-b-md border border-t-0 border-slate-300 bg-white px-2 pb-2 pt-1.5"
-                    >
-                        {years.map(year => (
-                            <button
-                                key={year.value}
-                                type="button"
-                                role="option"
-                                aria-selected={yearValue === year.value}
-                                onClick={() => onYearOptionSelect(year.value)}
-                                className={
-                                    yearValue === year.value
-                                        ? 'rounded px-1 py-1.5 text-sm font-semibold text-center whitespace-nowrap bg-amber-50 text-amber-900 ring-1 ring-inset ring-amber-400 transition-colors'
-                                        : 'rounded px-1 py-1.5 text-sm text-center whitespace-nowrap text-slate-600 hover:bg-slate-100 hover:text-slate-900 transition-colors'
-                                }
-                            >
-                                {year.label}
-                            </button>
-                        ))}
-                    </div>
-                )}
-            </div>
-        )}
-        {visibleDateSegment === '月' && (
-            <CalendarDateButton
-                label="月を選択"
-                value={monthValue}
-                inputType="month"
-                onChange={onMonthChange}
-            />
-        )}
-        {visibleDateSegment === '日' && (
-            <CalendarDateButton
-                label="日を選択"
-                value={dateValue}
-                onChange={onDateValueChange}
-            />
-        )}
-        {visibleDateSegment === '範囲' && (
-            <div className="flex flex-col gap-2">
-                <CalendarDateButton
-                    label="開始日"
-                    value={rangeStart}
-                    onChange={onRangeStartChange}
-                />
-                <CalendarDateButton
-                    label="終了日"
-                    value={rangeEnd}
-                    onChange={onRangeEndChange}
-                />
-            </div>
-        )}
-    </div>
-    );
-};
-
-interface SearchCardProps {
-    onSearch: (query: string) => void;
-    categories?: SearchCategories;
-    onExpandToggle?: (isExpanded: boolean) => void; // 展開状態変更の通知
-    value?: string; // 親の検索状態と同期（外部クリア対応）
-    initialExpanded?: boolean; // 初期展開状態（デフォルト: true）
-    compact?: boolean; // コンパクトモード: aside などで lg:grid-cols-4 を抑制する
+// データが存在するかチェック
+function hasData(data: unknown[] | undefined): boolean {
+    return Boolean(data && data.length > 0);
 }
 
 /**
@@ -487,42 +24,32 @@ export const SearchCard: React.FC<SearchCardProps> = ({
     initialExpanded = true,
     compact = false,
 }) => {
-
+    // 展開/折りたたみの UI 表示 state（API クエリには影響しない）
     const [isExpanded, setIsExpanded] = useState(initialExpanded);
     // layout 切り替えなどで initialExpanded が変化したときに展開状態を同期する
     useEffect(() => {
         setIsExpanded(initialExpanded);
     }, [initialExpanded]);
 
-    const [selectedQueries, setSelectedQueries] = useState<Record<SearchKey, string>>(
-        createEmptySelectedQueries()
-    );
-
-    // 日付検索用ステート（5フィールドをひとつのオブジェクトで管理）
-    const [dateSegment, setDateSegment] = useState<DateSegment>(() =>
-        getInitialDateSegment(categories)
-    );
-    const [dateInputs, setDateInputs] = useState<DateInputs>({ ...EMPTY_DATE_INPUTS });
-    const [isYearPickerOpen, setIsYearPickerOpen] = useState(false);
-
-    const categoriesRef = useRef(categories);
-    categoriesRef.current = categories;
-
-    useEffect(() => {
-        if (value !== '') return;
-        const cats = categoriesRef.current;
-        setSelectedQueries(createEmptySelectedQueries());
-        setDateInputs({ ...EMPTY_DATE_INPUTS });
-        setIsYearPickerOpen(false);
-        setDateSegment(getInitialDateSegment(cats));
-    }, [value]);
-
-    const effectiveSelectedQueries = value === '' ? createEmptySelectedQueries() : selectedQueries;
-    const hasActiveSearch = Object.values(effectiveSelectedQueries).some(Boolean);
-
-    // データが存在するかチェック
-    const hasData = (data: unknown[] | undefined): boolean =>
-        Boolean(data && data.length > 0);
+    // 検索条件（API クエリ params）の state はフックに分離
+    const {
+        effectiveSelectedQueries,
+        hasActiveSearch,
+        isDefaultState,
+        dateSegment,
+        dateInputs,
+        isYearPickerOpen,
+        toggleYearPicker,
+        closeYearPicker,
+        handleQuickSearch,
+        handleSegmentChange,
+        handleYearOptionSelect,
+        handleMonthChange,
+        handleDateValueChange,
+        handleRangeStartChange,
+        handleRangeEndChange,
+        handleClearSearch,
+    } = useSearchCardQuery({ categories, value, onSearch });
 
     // 描画対象カテゴリが1つ以上あるか（毎レンダーで再評価されないよう定数化）
     const hasAnyCategories = categories != null && (
@@ -547,84 +74,6 @@ export const SearchCard: React.FC<SearchCardProps> = ({
         }
     };
 
-    const resetDateInputs = () => {
-        setDateInputs({ ...EMPTY_DATE_INPUTS });
-        setIsYearPickerOpen(false);
-    };
-
-    const applySelectedQueries = (nextQueries: Record<SearchKey, string>) => {
-        setSelectedQueries(nextQueries);
-        onSearch(buildCombinedQuery(nextQueries));
-    };
-
-    const handleQuickSearch = (value: string, searchType: 'securities' | 'years' | 'products' | 'accounts') => {
-        const shouldToggleOff =
-            (searchType === 'products' || searchType === 'accounts') &&
-            effectiveSelectedQueries[searchType] === value;
-        applySelectedQueries({
-            ...effectiveSelectedQueries,
-            [searchType]: value === '' || shouldToggleOff ? '' : value,
-        });
-    };
-
-    const handleDateSearch = (val: string) => {
-        applySelectedQueries({
-            ...effectiveSelectedQueries,
-            date: val,
-        });
-    };
-
-    const handleSegmentChange = (segment: DateSegment) => {
-        if (segment === dateSegment) return;
-        setDateSegment(segment);
-        if (effectiveSelectedQueries.date) {
-            applySelectedQueries({
-                ...effectiveSelectedQueries,
-                date: '',
-            });
-        }
-        resetDateInputs();
-    };
-
-    const handleYearOptionSelect = (val: string) => {
-        setDateInputs(d => ({ ...d, yearValue: val }));
-        setIsYearPickerOpen(false);
-        handleDateSearch(val);
-    };
-
-    const handleMonthChange = (val: string) => {
-        setDateInputs(d => ({ ...d, monthValue: val }));
-        handleDateSearch(val);
-    };
-
-    const handleDateValueChange = (val: string) => {
-        setDateInputs(d => ({ ...d, dateValue: val }));
-        handleDateSearch(val);
-    };
-
-    const handleRangeStartChange = (val: string) => {
-        setDateInputs(d => ({ ...d, rangeStart: val }));
-        const query = buildRangeQuery(val, dateInputs.rangeEnd);
-        handleDateSearch(query);
-    };
-
-    const handleRangeEndChange = (val: string) => {
-        setDateInputs(d => ({ ...d, rangeEnd: val }));
-        const query = buildRangeQuery(dateInputs.rangeStart, val);
-        handleDateSearch(query);
-    };
-
-    // 検索条件が初期状態かどうか
-    const isDefaultState = !hasActiveSearch;
-
-    // 検索条件をクリア
-    const handleClearSearch = () => {
-        setSelectedQueries(createEmptySelectedQueries());
-        setDateSegment(getInitialDateSegment(categories));
-        resetDateInputs();
-        onSearch('');
-    };
-
     // カテゴリが何もない場合は SearchCard 自体を非表示
     if (!hasAnyCategories) {
         return null;
@@ -642,13 +91,13 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                 rangeEnd={dateInputs.rangeEnd}
                 isYearPickerOpen={isYearPickerOpen}
                 onSegmentChange={handleSegmentChange}
-                onToggleYearPicker={() => setIsYearPickerOpen(open => !open)}
+                onToggleYearPicker={toggleYearPicker}
                 onYearOptionSelect={handleYearOptionSelect}
                 onMonthChange={handleMonthChange}
                 onDateValueChange={handleDateValueChange}
                 onRangeStartChange={handleRangeStartChange}
                 onRangeEndChange={handleRangeEndChange}
-                onClose={() => setIsYearPickerOpen(false)}
+                onClose={closeYearPicker}
             />
         </div>
     ) : null;

--- a/frontend/src/components/organisms/SearchCard/SearchFieldsGrid.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchFieldsGrid.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { cn } from '@/lib/utils/classNames';
+import { SearchCategories } from '@/types/common';
+import { SearchKey } from './types';
+import { QuickSearchDropdown } from './QuickSearchDropdown';
+import { QuickSearchButtons } from './QuickSearchButtons';
+
+type DropdownSearchType = 'securities' | 'years';
+type ButtonsSearchType = 'products' | 'accounts';
+
+const DROPDOWN_CONFIGS: Array<{ key: DropdownSearchType; label: string }> = [
+    { key: 'securities', label: '銘柄' },
+    { key: 'years', label: '西暦' },
+];
+
+const BUTTONS_CONFIGS: Array<{ key: ButtonsSearchType; label: string }> = [
+    { key: 'products', label: '商品' },
+    { key: 'accounts', label: '口座' },
+];
+
+interface SearchFieldsGridProps {
+    categories: SearchCategories;
+    gridClassName: string;
+    selectedQueries: Record<SearchKey, string>;
+    onSearch: (value: string, searchType: 'securities' | 'years' | 'products' | 'accounts') => void;
+    hasData: (data: unknown[] | undefined) => boolean;
+}
+
+export const SearchFieldsGrid: React.FC<SearchFieldsGridProps> = ({
+    categories, gridClassName, selectedQueries, onSearch, hasData,
+}) => (
+    <div className={cn('grid', gridClassName)}>
+        {DROPDOWN_CONFIGS.map(({ key, label }) =>
+            // yearsはdatesブロックが有効な場合は期間ブロック側で表示するため除外
+            hasData(categories[key]) && !(key === 'years' && Boolean(categories.dates)) && (
+                <div key={key} className="space-y-1">
+                    <label htmlFor={`${key}-search`} className="text-sm font-bold text-slate-800">{label}</label>
+                    <QuickSearchDropdown
+                        items={categories[key]!}
+                        id={`${key}-search`}
+                        searchType={key}
+                        activeSearchType={selectedQueries[key] ? key : null}
+                        searchQuery={selectedQueries[key]}
+                        onSearch={onSearch}
+                    />
+                </div>
+            )
+        )}
+        {BUTTONS_CONFIGS.map(({ key, label }) =>
+            hasData(categories[key]) && (
+                <div key={key} className="space-y-1">
+                    <div className="text-sm font-bold text-slate-800">{label}</div>
+                    <div className="flex flex-wrap gap-1">
+                        <QuickSearchButtons
+                            items={categories[key]!}
+                            searchType={key}
+                            activeSearchType={selectedQueries[key] ? key : null}
+                            searchQuery={selectedQueries[key]}
+                            onSearch={onSearch}
+                        />
+                    </div>
+                </div>
+            )
+        )}
+    </div>
+);

--- a/frontend/src/components/organisms/SearchCard/searchQueryUtils.ts
+++ b/frontend/src/components/organisms/SearchCard/searchQueryUtils.ts
@@ -1,0 +1,49 @@
+import { SearchCategories } from '@/types/common';
+import { DateInputs, DateSegment, SearchKey } from './types';
+
+export const SEARCH_ORDER = ['date', 'securities', 'years', 'products', 'accounts'] as const satisfies readonly SearchKey[];
+
+export const EMPTY_DATE_INPUTS: DateInputs = {
+    yearValue: '',
+    monthValue: '',
+    dateValue: '',
+    rangeStart: '',
+    rangeEnd: '',
+};
+
+export function createEmptySelectedQueries(): Record<SearchKey, string> {
+    return {
+        securities: '',
+        years: '',
+        products: '',
+        accounts: '',
+        date: '',
+    };
+}
+
+export function buildRangeQuery(start: string, end: string): string {
+    if (!start && !end) return '';
+    return `${start}..${end}`;
+}
+
+export function formatQueryToken(value: string): string {
+    const trimmed = value.trim();
+    if (!/\s/.test(trimmed)) return trimmed;
+    return `"${trimmed.replace(/"/g, '\\"')}"`;
+}
+
+export function buildCombinedQuery(queries: Record<SearchKey, string>): string {
+    return SEARCH_ORDER
+        .map(key => queries[key].trim())
+        .filter(Boolean)
+        .map(formatQueryToken)
+        .join(' ');
+}
+
+export function getInitialDateSegment(cats: SearchCategories | undefined): DateSegment {
+    if ((cats?.years?.length ?? 0) > 0) return '年';
+    if (cats?.dates) return '月';
+    return '年';
+}
+
+export const formatDateLabel = (value: string): string => value.replace(/-/g, "/");

--- a/frontend/src/components/organisms/SearchCard/types.ts
+++ b/frontend/src/components/organisms/SearchCard/types.ts
@@ -1,0 +1,21 @@
+import { SearchCategories } from '@/types/common';
+
+export type SearchKey = 'securities' | 'years' | 'products' | 'accounts' | 'date';
+export type ActiveSearchType = SearchKey | null;
+export type DateSegment = '年' | '月' | '日' | '範囲';
+export type DateInputs = {
+    yearValue: string;
+    monthValue: string;
+    dateValue: string;
+    rangeStart: string;
+    rangeEnd: string;
+};
+
+export interface SearchCardProps {
+    onSearch: (query: string) => void;
+    categories?: SearchCategories;
+    onExpandToggle?: (isExpanded: boolean) => void; // 展開状態変更の通知
+    value?: string; // 親の検索状態と同期（外部クリア対応）
+    initialExpanded?: boolean; // 初期展開状態（デフォルト: true）
+    compact?: boolean; // コンパクトモード: aside などで lg:grid-cols-4 を抑制する
+}

--- a/frontend/src/components/organisms/SearchCard/useSearchCardQuery.ts
+++ b/frontend/src/components/organisms/SearchCard/useSearchCardQuery.ts
@@ -1,0 +1,141 @@
+import { useEffect, useRef, useState } from 'react';
+import { SearchCategories } from '@/types/common';
+import { DateInputs, DateSegment, SearchKey } from './types';
+import {
+    EMPTY_DATE_INPUTS,
+    buildCombinedQuery,
+    buildRangeQuery,
+    createEmptySelectedQueries,
+    getInitialDateSegment,
+} from './searchQueryUtils';
+
+interface UseSearchCardQueryArgs {
+    categories?: SearchCategories;
+    value?: string; // 親の検索状態と同期（外部クリア対応）
+    onSearch: (query: string) => void;
+}
+
+/**
+ * SearchCard の「API クエリ params state」を一元管理するフック。
+ * 展開/折りたたみなどの UI 表示 state は呼び出し側（SearchCard）が持つ。
+ */
+export function useSearchCardQuery({ categories, value, onSearch }: UseSearchCardQueryArgs) {
+    const [selectedQueries, setSelectedQueries] = useState<Record<SearchKey, string>>(
+        createEmptySelectedQueries()
+    );
+
+    const [dateSegment, setDateSegment] = useState<DateSegment>(() =>
+        getInitialDateSegment(categories)
+    );
+    const [dateInputs, setDateInputs] = useState<DateInputs>({ ...EMPTY_DATE_INPUTS });
+    const [isYearPickerOpen, setIsYearPickerOpen] = useState(false);
+
+    const categoriesRef = useRef(categories);
+    categoriesRef.current = categories;
+
+    useEffect(() => {
+        if (value !== '') return;
+        const cats = categoriesRef.current;
+        setSelectedQueries(createEmptySelectedQueries());
+        setDateInputs({ ...EMPTY_DATE_INPUTS });
+        setIsYearPickerOpen(false);
+        setDateSegment(getInitialDateSegment(cats));
+    }, [value]);
+
+    const effectiveSelectedQueries = value === '' ? createEmptySelectedQueries() : selectedQueries;
+    const hasActiveSearch = Object.values(effectiveSelectedQueries).some(Boolean);
+    const isDefaultState = !hasActiveSearch;
+
+    const resetDateInputs = () => {
+        setDateInputs({ ...EMPTY_DATE_INPUTS });
+        setIsYearPickerOpen(false);
+    };
+
+    const applySelectedQueries = (nextQueries: Record<SearchKey, string>) => {
+        setSelectedQueries(nextQueries);
+        onSearch(buildCombinedQuery(nextQueries));
+    };
+
+    const handleQuickSearch = (val: string, searchType: 'securities' | 'years' | 'products' | 'accounts') => {
+        const shouldToggleOff =
+            (searchType === 'products' || searchType === 'accounts') &&
+            effectiveSelectedQueries[searchType] === val;
+        applySelectedQueries({
+            ...effectiveSelectedQueries,
+            [searchType]: val === '' || shouldToggleOff ? '' : val,
+        });
+    };
+
+    const handleDateSearch = (val: string) => {
+        applySelectedQueries({
+            ...effectiveSelectedQueries,
+            date: val,
+        });
+    };
+
+    const handleSegmentChange = (segment: DateSegment) => {
+        if (segment === dateSegment) return;
+        setDateSegment(segment);
+        if (effectiveSelectedQueries.date) {
+            applySelectedQueries({
+                ...effectiveSelectedQueries,
+                date: '',
+            });
+        }
+        resetDateInputs();
+    };
+
+    const handleYearOptionSelect = (val: string) => {
+        setDateInputs(d => ({ ...d, yearValue: val }));
+        setIsYearPickerOpen(false);
+        handleDateSearch(val);
+    };
+
+    const handleMonthChange = (val: string) => {
+        setDateInputs(d => ({ ...d, monthValue: val }));
+        handleDateSearch(val);
+    };
+
+    const handleDateValueChange = (val: string) => {
+        setDateInputs(d => ({ ...d, dateValue: val }));
+        handleDateSearch(val);
+    };
+
+    const handleRangeStartChange = (val: string) => {
+        setDateInputs(d => ({ ...d, rangeStart: val }));
+        const query = buildRangeQuery(val, dateInputs.rangeEnd);
+        handleDateSearch(query);
+    };
+
+    const handleRangeEndChange = (val: string) => {
+        setDateInputs(d => ({ ...d, rangeEnd: val }));
+        const query = buildRangeQuery(dateInputs.rangeStart, val);
+        handleDateSearch(query);
+    };
+
+    const handleClearSearch = () => {
+        setSelectedQueries(createEmptySelectedQueries());
+        setDateSegment(getInitialDateSegment(categories));
+        resetDateInputs();
+        onSearch('');
+    };
+
+    return {
+        effectiveSelectedQueries,
+        hasActiveSearch,
+        isDefaultState,
+        dateSegment,
+        dateInputs,
+        isYearPickerOpen,
+        toggleYearPicker: () => setIsYearPickerOpen(open => !open),
+        closeYearPicker: () => setIsYearPickerOpen(false),
+        handleQuickSearch,
+        handleSegmentChange,
+        handleYearOptionSelect,
+        handleMonthChange,
+        handleDateValueChange,
+        handleRangeStartChange,
+        handleRangeEndChange,
+        handleClearSearch,
+    };
+}


### PR DESCRIPTION
## 概要

`docs/tasks/design-db-backed-search-and-summary.md` の PR分割案 項目9「SearchCard の state / param 変換分割」に対応。

## 背景

`SearchCard.tsx` が832行のモノリシックなファイルになっており、検索条件が増えるほど変更コストが上がる状態だった。設計レビューで「SearchCard の state は『UI 表示 state』と『API query params state』に分離する」方針が決まっていた。

## 変更内容

`frontend/src/components/organisms/SearchCard/` 配下を目的別ファイルへ分割:

| ファイル | 内容 | 行数 |
|---|---|---|
| `SearchCard.tsx` | 本体（UI表示stateのみ保持） | 832→281 |
| `useSearchCardQuery.ts` | 検索条件（API query params state）を一元管理するフック | 141 |
| `DatePeriodBlock.tsx` | 日付検索UI | 212 |
| `SearchFieldsGrid.tsx` | 検索フィールドのグリッドレイアウト | 66 |
| `CalendarDateButton.tsx` | 日付ピッカーボタン | 61 |
| `QuickSearchButtons.tsx` | クイック検索ボタン群 | 49 |
| `searchQueryUtils.ts` | クエリ文字列組み立て等の純粋関数 | 49 |
| `QuickSearchDropdown.tsx` | クイック検索ドロップダウン | 48 |
| `types.ts` | 型定義 | 21 |

### state 分離の方針

- **UI 表示 state**（SearchCard 本体に残す）: `isExpanded`
- **API query params state**（`useSearchCardQuery` へ切り出し）: `selectedQueries`, `dateSegment`, `dateInputs`, `isYearPickerOpen`

`SearchCard` の公開 props は変更していないため、呼び出し側・既存テスト（`__tests__/SearchCard.test.tsx`）への影響はない。

## テスト

- `npm run typecheck`: PASS
- `npm run lint`: PASS
- `npm test`: PASS (101 files / 1004 tests、既存の `SearchCard.test.tsx` 含む)
- `npm run build`: PASS

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 検索条件を銘柄・年・商品・口座から選択できるクイック検索を追加しました。
  * 年・月・日・期間による日付検索に対応しました。
  * カレンダーから日付や月を選択できるようになりました。
  * 期間検索では開始日と終了日を個別に指定できます。
  * キーボード操作や選択状態の表示を改善しました。

* **改善**
  * 複数の検索条件を組み合わせて検索できるようになりました。
  * 検索条件のクリアや初期状態へのリセットに対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->