### PR TITLE
fix: useAssetBalance.ts の未使用な getTotalMarketValue を削除

### DIFF
--- a/frontend/src/components/molecules/DividendInfo/__tests__/DividendInfo.test.tsx
+++ b/frontend/src/components/molecules/DividendInfo/__tests__/DividendInfo.test.tsx
@@ -133,7 +133,6 @@ describe('DividendInfo', () => {
         total_purchase_amount: 100000,
         updated_at: '2024-01-01T00:00:00Z',
       })),
-      getTotalMarketValue: vi.fn(() => 0),
       refetch: vi.fn(),
     });
 

--- a/frontend/src/components/molecules/__tests__/DividendInfo.test.tsx
+++ b/frontend/src/components/molecules/__tests__/DividendInfo.test.tsx
@@ -32,7 +32,6 @@ describe('DividendInfo', () => {
       assetBalanceData: [],
       isLoading: false,
       getAssetBalanceByCode: vi.fn(() => undefined),
-      getTotalMarketValue: vi.fn(() => 0),
       refetch: vi.fn(),
     });
   });
@@ -121,7 +120,6 @@ describe('DividendInfo', () => {
         shares: 100,
         security_code: '7203',
       })),
-      getTotalMarketValue: vi.fn(() => 0),
       refetch: vi.fn(),
     });
 
@@ -170,7 +168,6 @@ describe('DividendInfo', () => {
         shares: 100,
         security_code: '7203',
       })),
-      getTotalMarketValue: vi.fn(() => 0),
       refetch: vi.fn(),
     });
 

--- a/frontend/src/features/assetBalance/hooks/__tests__/useAssetBalance.test.ts
+++ b/frontend/src/features/assetBalance/hooks/__tests__/useAssetBalance.test.ts
@@ -153,28 +153,6 @@ describe('useAssetBalance', () => {
     });
   });
 
-  it('getTotalMarketValue は market_value の合計を返す', async () => {
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
-    });
-
-    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue({
-      data: [
-        makeAssetBalanceData({ security_code: '7203', market_value: 210000 }),
-        makeAssetBalanceData({ id: 'asset-balance-2', security_code: '6758', security_name: 'ソニーグループ', market_value: 180000 }),
-      ],
-      total: 2, page: 1, per_page: 200,
-    });
-
-    const { result } = renderHook(() => useAssetBalance(), { wrapper: makeWrapper(qc) });
-
-    await waitFor(() => {
-      expect(result.current.assetBalanceData).toHaveLength(2);
-    });
-
-    expect(result.current.getTotalMarketValue()).toBe(390000);
-  });
-
   it('未認証時はassetBalanceDataが空配列を返す', () => {
     const qc = new QueryClient({
       defaultOptions: { queries: { retry: false } },
@@ -184,28 +162,6 @@ describe('useAssetBalance', () => {
     const { result } = renderHook(() => useAssetBalance(), { wrapper: makeWrapper(qc) });
 
     expect(result.current.assetBalanceData).toEqual([]);
-  });
-
-  it('getTotalMarketValue は market_value が 0 のデータも正しく合計する', async () => {
-    const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
-    });
-
-    vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue({
-      data: [
-        makeAssetBalanceData({ security_code: '7203', market_value: 100000 }),
-        makeAssetBalanceData({ id: 'asset-balance-2', security_code: '6758', market_value: 0 }),
-      ],
-      total: 2, page: 1, per_page: 200,
-    });
-
-    const { result } = renderHook(() => useAssetBalance(), { wrapper: makeWrapper(qc) });
-
-    await waitFor(() => {
-      expect(result.current.assetBalanceData).toHaveLength(2);
-    });
-
-    expect(result.current.getTotalMarketValue()).toBe(100000);
   });
 
   it('securityCode 指定時は銘柄コードで1回だけAPI取得する', async () => {

--- a/frontend/src/features/assetBalance/hooks/useAssetBalance.ts
+++ b/frontend/src/features/assetBalance/hooks/useAssetBalance.ts
@@ -10,7 +10,6 @@ interface UseAssetBalanceReturn {
   assetBalanceData: AssetBalanceData[];
   isLoading: boolean;
   getAssetBalanceByCode: (code: string) => AssetBalanceData | undefined;
-  getTotalMarketValue: () => number;
   refetch: () => Promise<void>;
 }
 
@@ -62,10 +61,6 @@ export function useAssetBalance(options: UseAssetBalanceOptions = {}): UseAssetB
     );
   };
 
-  const getTotalMarketValue = (): number => {
-    return assetBalanceData.reduce((total, balance) => total + (balance?.market_value || 0), 0);
-  };
-
   const refetch = async () => {
     await queryClient.invalidateQueries({ queryKey });
   };
@@ -74,7 +69,6 @@ export function useAssetBalance(options: UseAssetBalanceOptions = {}): UseAssetB
     assetBalanceData,
     isLoading: query.isLoading,
     getAssetBalanceByCode,
-    getTotalMarketValue,
     refetch,
   };
 }

--- a/frontend/src/pages/Receipt/__tests__/Dividend.test.tsx
+++ b/frontend/src/pages/Receipt/__tests__/Dividend.test.tsx
@@ -41,7 +41,6 @@ vi.mock('@/features/assetBalance/hooks/useAssetBalance', () => ({
     assetBalanceData: [],
     isLoading: false,
     getAssetBalanceByCode: vi.fn(() => undefined),
-    getTotalMarketValue: vi.fn(() => 0),
     refetch: vi.fn(),
   })),
 }));


### PR DESCRIPTION
## 概要

`/code-review` で検出された指摘への対応（docs/tasks/fix-search-summary-review-findings.md）。

## 背景

`useAssetBalance.ts` の `getTotalMarketValue()` が `per_page: 1000` でキャップされた配列をクライアント側 reduce する実装のまま残っていた。本番コードから一切呼び出されていない死んだコードだが、公開APIとして存在し続けており、将来1000件超のユーザーに対して呼び出された場合に誤った合計を返す潜在バグだった。

姉妹フック `useAssetBalanceDataSource.ts` は既に `include_summary: true` を使う正しい実装になっている。

## 変更内容

- `getTotalMarketValue` 関数と関連する型・テスト（5ファイル）を削除

## テスト

- \`npm run typecheck\`: PASS
- \`npm run lint\`: PASS
- \`npm test\`: PASS (100 files / 999 tests)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **変更**
  - 資産残高情報の提供内容を整理し、保有資産の市場価値合計を取得する機能を廃止しました。
  - 配当利回りの表示など、既存の配当情報表示には影響ありません。

- **テスト**
  - 資産残高、配当情報、領収書に関する検証内容を更新し、現在の仕様に合わせました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->