### PR TITLE
refactor: dividend/domestic_stock の facet グルーピングを型安全な GroupField enum へ統一

### DIFF
--- a/backend/src/services/dividend.rs
+++ b/backend/src/services/dividend.rs
@@ -265,25 +265,12 @@ async fn fetch_facets(
     user_id: Uuid,
     filter: &DividendFilter,
 ) -> Result<SearchFacets, ApiError> {
-    let products = fetch_group_facets(pool, user_id, filter, "product", true).await?;
-    let accounts = fetch_group_facets(pool, user_id, filter, "account", true).await?;
+    let products = fetch_group_facets(pool, user_id, filter, GroupField::Product, true).await?;
+    let accounts = fetch_group_facets(pool, user_id, filter, GroupField::Account, true).await?;
     let securities = fetch_security_facets(pool, user_id, filter).await?;
-    let years = fetch_group_facets(
-        pool,
-        user_id,
-        filter,
-        "EXTRACT(YEAR FROM settlement_date)::integer::text",
-        false,
-    )
-    .await?;
-    let year_months = fetch_group_facets(
-        pool,
-        user_id,
-        filter,
-        "TO_CHAR(settlement_date, 'YYYY-MM')",
-        false,
-    )
-    .await?;
+    let years = fetch_group_facets(pool, user_id, filter, GroupField::Year, false).await?;
+    let year_months =
+        fetch_group_facets(pool, user_id, filter, GroupField::YearMonth, false).await?;
 
     Ok(SearchFacets {
         products: Some(products),
@@ -295,14 +282,36 @@ async fn fetch_facets(
     })
 }
 
-/// group_expr の値ごとに件数を集計して FacetOption を返す共通ヘルパー
+/// fetch_group_facets で GROUP BY に使える式を限定する集計対象カラム
+#[derive(Debug, Clone, Copy)]
+enum GroupField {
+    Product,
+    Account,
+    Year,
+    YearMonth,
+}
+
+impl GroupField {
+    /// SQL に埋め込む式（固定の &'static str のみを返す）
+    fn as_sql_expr(self) -> &'static str {
+        match self {
+            GroupField::Product => "product",
+            GroupField::Account => "account",
+            GroupField::Year => "EXTRACT(YEAR FROM settlement_date)::integer::text",
+            GroupField::YearMonth => "TO_CHAR(settlement_date, 'YYYY-MM')",
+        }
+    }
+}
+
+/// group_field の値ごとに件数を集計して FacetOption を返す共通ヘルパー
 async fn fetch_group_facets(
     pool: &PgPool,
     user_id: Uuid,
     filter: &DividendFilter,
-    group_expr: &str,
+    group_field: GroupField,
     order_asc: bool,
 ) -> Result<Vec<FacetOption>, ApiError> {
+    let group_expr = group_field.as_sql_expr();
     let mut qb: QueryBuilder<Postgres> = QueryBuilder::new(format!(
         "SELECT {group_expr} AS value, {group_expr} AS label, COUNT(*) AS count FROM dividends"
     ));

--- a/backend/src/services/domestic_stock.rs
+++ b/backend/src/services/domestic_stock.rs
@@ -286,24 +286,11 @@ async fn fetch_facets(
     user_id: Uuid,
     filter: &DomesticStockFilter,
 ) -> Result<SearchFacets, ApiError> {
-    let accounts = fetch_group_facets(pool, user_id, filter, "account", true).await?;
+    let accounts = fetch_group_facets(pool, user_id, filter, GroupField::Account, true).await?;
     let securities = fetch_security_facets(pool, user_id, filter).await?;
-    let years = fetch_group_facets(
-        pool,
-        user_id,
-        filter,
-        "EXTRACT(YEAR FROM trade_date)::integer::text",
-        false,
-    )
-    .await?;
-    let year_months = fetch_group_facets(
-        pool,
-        user_id,
-        filter,
-        "TO_CHAR(trade_date, 'YYYY-MM')",
-        false,
-    )
-    .await?;
+    let years = fetch_group_facets(pool, user_id, filter, GroupField::Year, false).await?;
+    let year_months =
+        fetch_group_facets(pool, user_id, filter, GroupField::YearMonth, false).await?;
 
     Ok(SearchFacets {
         products: None,
@@ -315,14 +302,34 @@ async fn fetch_facets(
     })
 }
 
-/// group_expr の値ごとに件数を集計して FacetOption を返す共通ヘルパー
+/// fetch_group_facets で GROUP BY に使える式を限定する集計対象カラム
+#[derive(Debug, Clone, Copy)]
+enum GroupField {
+    Account,
+    Year,
+    YearMonth,
+}
+
+impl GroupField {
+    /// SQL に埋め込む式（固定の &'static str のみを返す）
+    fn as_sql_expr(self) -> &'static str {
+        match self {
+            GroupField::Account => "account",
+            GroupField::Year => "EXTRACT(YEAR FROM trade_date)::integer::text",
+            GroupField::YearMonth => "TO_CHAR(trade_date, 'YYYY-MM')",
+        }
+    }
+}
+
+/// group_field の値ごとに件数を集計して FacetOption を返す共通ヘルパー
 async fn fetch_group_facets(
     pool: &PgPool,
     user_id: Uuid,
     filter: &DomesticStockFilter,
-    group_expr: &str,
+    group_field: GroupField,
     order_asc: bool,
 ) -> Result<Vec<FacetOption>, ApiError> {
+    let group_expr = group_field.as_sql_expr();
     let mut qb: QueryBuilder<Postgres> = QueryBuilder::new(format!(
         "SELECT {group_expr} AS value, {group_expr} AS label, COUNT(*) AS count FROM domestic_stocks"
     ));


### PR DESCRIPTION
## 概要

`/code-review` で検出された指摘への対応（docs/tasks/fix-search-summary-review-findings.md）。

## 背景

`fetch_group_facets` の `group_expr` パラメータが dividend.rs/domestic_stock.rs では生の `&str` を `format!` で SQL に直接展開しており、mutualfund.rs の `GroupField` enum パターンと安全性の水準が不揃いだった。現状は全呼び出し元がコンパイル時リテラルのみを渡しているため悪用経路はないが、型レベルのガードがなかった。

## 変更内容

- dividend.rs / domestic_stock.rs に mutualfund.rs と同様の `GroupField` enum + `as_sql_expr()` パターンを導入
- dividend/domestic_stock でグルーピング対象カラムの集合が異なる（dividend は product を含む）ため、mutualfund.rs と同様にファイルごとの enum とした（shared.rs への統合はしていない）
- 生成される SQL 自体は変更なし（Rust レベルの型安全性のみ改善）

## テスト

- `cargo fmt --check`: PASS
- `SQLX_OFFLINE=true cargo clippy --all-targets -- -D warnings`: PASS
- `SQLX_OFFLINE=true cargo test`: PASS
- openapi.json / generated api.ts: 差分なし（API契約変更なし）

🤖 Generated with [Claude Code](https://claude.ai/claude-code)