### PR TITLE
refactor: 検索ヘルパー関数を shared.rs へ共通化

### DIFF
--- a/backend/src/services/asset_balance.rs
+++ b/backend/src/services/asset_balance.rs
@@ -14,7 +14,7 @@ use crate::services::csv_util::{
     get_row_cell, normalize_security_name, parse_number, parse_optional_string_row,
 };
 use crate::services::shared::{
-    delete_all_for_user, user_ids_for_bulk_insert, BulkTimer, DeleteTarget,
+    delete_all_for_user, escape_like_pattern, user_ids_for_bulk_insert, BulkTimer, DeleteTarget,
 };
 use rust_decimal::Decimal;
 use sqlx::{PgPool, Postgres, QueryBuilder};
@@ -63,15 +63,6 @@ impl AssetBalanceFilter {
             security_name: params.security_name.clone(),
         }
     }
-}
-
-/// ILIKE の wildcard 文字（%, _, \）をリテラル扱いにエスケープしてから前後を % で囲む
-fn escape_like_pattern(token: &str) -> String {
-    let escaped = token
-        .replace('\\', "\\\\")
-        .replace('%', "\\%")
-        .replace('_', "\\_");
-    format!("%{escaped}%")
 }
 
 /// user_id と検索条件を WHERE 句として QueryBuilder へ積む
@@ -578,15 +569,6 @@ mod tests {
         assert_eq!(sql.matches(" AND (").count(), 2);
         assert_eq!(sql.matches("security_code ILIKE").count(), 2);
         assert_eq!(sql.matches("security_name ILIKE").count(), 2);
-    }
-
-    #[test]
-    fn test_escape_like_pattern_escapes_wildcard_characters() {
-        assert_eq!(escape_like_pattern("abc"), "%abc%");
-        assert_eq!(escape_like_pattern("50%"), "%50\\%%");
-        assert_eq!(escape_like_pattern("A_B"), "%A\\_B%");
-        assert_eq!(escape_like_pattern("a\\b"), "%a\\\\b%");
-        assert_eq!(escape_like_pattern("100%_off\\"), "%100\\%\\_off\\\\%");
     }
 
     #[test]

--- a/backend/src/services/dividend.rs
+++ b/backend/src/services/dividend.rs
@@ -13,7 +13,8 @@ use crate::services::csv_util::{
     parse_required_number_row, parse_required_string_row,
 };
 use crate::services::shared::{
-    delete_all_for_user, user_ids_for_bulk_insert, BulkTimer, DeleteTarget,
+    delete_all_for_user, escape_like_pattern, parse_date_param, parse_year_month_range,
+    user_ids_for_bulk_insert, year_to_range, BulkTimer, DeleteTarget,
 };
 use chrono::NaiveDate;
 use rust_decimal::Decimal;
@@ -98,34 +99,6 @@ impl DividendFilter {
     }
 }
 
-fn parse_date_param(field: &str, value: &str) -> Result<NaiveDate, ApiError> {
-    NaiveDate::parse_from_str(value, "%Y-%m-%d")
-        .map_err(|_| ApiError::ValidationError(format!("{field} の形式が不正です（YYYY-MM-DD）")))
-}
-
-fn year_to_range(year: i32) -> Result<(NaiveDate, NaiveDate), ApiError> {
-    let invalid = || ApiError::ValidationError("year の値が不正です".to_string());
-    let start = NaiveDate::from_ymd_opt(year, 1, 1).ok_or_else(invalid)?;
-    let end = NaiveDate::from_ymd_opt(year + 1, 1, 1).ok_or_else(invalid)?;
-    Ok((start, end))
-}
-
-fn parse_year_month_range(value: &str) -> Result<(NaiveDate, NaiveDate), ApiError> {
-    let invalid =
-        || ApiError::ValidationError("year_month の形式が不正です（YYYY-MM）".to_string());
-    let (year_str, month_str) = value.split_once('-').ok_or_else(invalid)?;
-    let year: i32 = year_str.parse().map_err(|_| invalid())?;
-    let month: u32 = month_str.parse().map_err(|_| invalid())?;
-    let start = NaiveDate::from_ymd_opt(year, month, 1).ok_or_else(invalid)?;
-    let end = if month == 12 {
-        NaiveDate::from_ymd_opt(year + 1, 1, 1)
-    } else {
-        NaiveDate::from_ymd_opt(year, month + 1, 1)
-    }
-    .ok_or_else(invalid)?;
-    Ok((start, end))
-}
-
 /// user_id と検索条件を WHERE 句として QueryBuilder へ積む
 fn push_filters(qb: &mut QueryBuilder<Postgres>, user_id: Uuid, filter: &DividendFilter) {
     qb.push(" WHERE user_id = ").push_bind(user_id);
@@ -170,15 +143,6 @@ fn push_filters(qb: &mut QueryBuilder<Postgres>, user_id: Uuid, filter: &Dividen
             .push_bind(pattern)
             .push(" ESCAPE '\\')");
     }
-}
-
-/// ILIKE の wildcard 文字（%, _, \）をリテラル扱いにエスケープしてから前後を % で囲む
-fn escape_like_pattern(token: &str) -> String {
-    let escaped = token
-        .replace('\\', "\\\\")
-        .replace('%', "\\%")
-        .replace('_', "\\_");
-    format!("%{escaped}%")
 }
 
 /// 認証ユーザーの配当金一覧を検索（ページネーション・summary・facets 対応）
@@ -522,48 +486,6 @@ mod tests {
     }
 
     #[test]
-    fn test_year_to_range_produces_year_boundaries() {
-        let (start, end) = year_to_range(2026).expect("2026年は有効な範囲");
-        assert_eq!(start, NaiveDate::from_ymd_opt(2026, 1, 1).unwrap());
-        assert_eq!(end, NaiveDate::from_ymd_opt(2027, 1, 1).unwrap());
-    }
-
-    #[test]
-    fn test_parse_year_month_range_handles_december_wrap_and_invalid_values() {
-        let (start, end) = parse_year_month_range("2026-06").expect("2026-06 は有効");
-        assert_eq!(start, NaiveDate::from_ymd_opt(2026, 6, 1).unwrap());
-        assert_eq!(end, NaiveDate::from_ymd_opt(2026, 7, 1).unwrap());
-
-        // 12月は年をまたいで翌年1月1日になる
-        let (_, end) = parse_year_month_range("2026-12").expect("2026-12 は有効");
-        assert_eq!(end, NaiveDate::from_ymd_opt(2027, 1, 1).unwrap());
-
-        for invalid in ["2026/06", "2026-13", "abcd-06", "2026-06-01"] {
-            assert!(
-                matches!(
-                    parse_year_month_range(invalid),
-                    Err(ApiError::ValidationError(_))
-                ),
-                "value={invalid} は ValidationError になるべき"
-            );
-        }
-    }
-
-    #[test]
-    fn test_parse_date_param_accepts_iso_format_and_rejects_others() {
-        assert!(parse_date_param("date", "2026-01-15").is_ok());
-        for invalid in ["2026/01/15", "15-01-2026", "not-a-date", ""] {
-            assert!(
-                matches!(
-                    parse_date_param("date", invalid),
-                    Err(ApiError::ValidationError(_))
-                ),
-                "value={invalid} は ValidationError になるべき"
-            );
-        }
-    }
-
-    #[test]
     fn test_dividend_filter_from_params_accepts_valid_date_axis_values() {
         let mut params = DividendSearchQueryParams::default();
         params.search.date = Some("2026-01-15".to_string());
@@ -640,15 +562,6 @@ mod tests {
         assert_eq!(sql.matches("account ILIKE").count(), 2);
         assert_eq!(sql.matches("security_code ILIKE").count(), 2);
         assert_eq!(sql.matches("security_name ILIKE").count(), 2);
-    }
-
-    #[test]
-    fn test_escape_like_pattern_escapes_wildcard_characters() {
-        assert_eq!(escape_like_pattern("abc"), "%abc%");
-        assert_eq!(escape_like_pattern("50%"), "%50\\%%");
-        assert_eq!(escape_like_pattern("A_B"), "%A\\_B%");
-        assert_eq!(escape_like_pattern("a\\b"), "%a\\\\b%");
-        assert_eq!(escape_like_pattern("100%_off\\"), "%100\\%\\_off\\\\%");
     }
 
     #[test]

--- a/backend/src/services/domestic_stock.rs
+++ b/backend/src/services/domestic_stock.rs
@@ -13,7 +13,8 @@ use crate::services::csv_util::{
     parse_required_string_row,
 };
 use crate::services::shared::{
-    delete_all_for_user, user_ids_for_bulk_insert, BulkTimer, DeleteTarget,
+    delete_all_for_user, escape_like_pattern, parse_date_param, parse_year_month_range,
+    user_ids_for_bulk_insert, year_to_range, BulkTimer, DeleteTarget,
 };
 use chrono::NaiveDate;
 use rust_decimal::Decimal;
@@ -96,34 +97,6 @@ impl DomesticStockFilter {
     }
 }
 
-fn parse_date_param(field: &str, value: &str) -> Result<NaiveDate, ApiError> {
-    NaiveDate::parse_from_str(value, "%Y-%m-%d")
-        .map_err(|_| ApiError::ValidationError(format!("{field} の形式が不正です（YYYY-MM-DD）")))
-}
-
-fn year_to_range(year: i32) -> Result<(NaiveDate, NaiveDate), ApiError> {
-    let invalid = || ApiError::ValidationError("year の値が不正です".to_string());
-    let start = NaiveDate::from_ymd_opt(year, 1, 1).ok_or_else(invalid)?;
-    let end = NaiveDate::from_ymd_opt(year + 1, 1, 1).ok_or_else(invalid)?;
-    Ok((start, end))
-}
-
-fn parse_year_month_range(value: &str) -> Result<(NaiveDate, NaiveDate), ApiError> {
-    let invalid =
-        || ApiError::ValidationError("year_month の形式が不正です（YYYY-MM）".to_string());
-    let (year_str, month_str) = value.split_once('-').ok_or_else(invalid)?;
-    let year: i32 = year_str.parse().map_err(|_| invalid())?;
-    let month: u32 = month_str.parse().map_err(|_| invalid())?;
-    let start = NaiveDate::from_ymd_opt(year, month, 1).ok_or_else(invalid)?;
-    let end = if month == 12 {
-        NaiveDate::from_ymd_opt(year + 1, 1, 1)
-    } else {
-        NaiveDate::from_ymd_opt(year, month + 1, 1)
-    }
-    .ok_or_else(invalid)?;
-    Ok((start, end))
-}
-
 /// user_id と検索条件を WHERE 句として QueryBuilder へ積む
 fn push_filters(qb: &mut QueryBuilder<Postgres>, user_id: Uuid, filter: &DomesticStockFilter) {
     qb.push(" WHERE user_id = ").push_bind(user_id);
@@ -163,15 +136,6 @@ fn push_filters(qb: &mut QueryBuilder<Postgres>, user_id: Uuid, filter: &Domesti
             .push_bind(pattern)
             .push(" ESCAPE '\\')");
     }
-}
-
-/// ILIKE の wildcard 文字（%, _, \）をリテラル扱いにエスケープしてから前後を % で囲む
-fn escape_like_pattern(token: &str) -> String {
-    let escaped = token
-        .replace('\\', "\\\\")
-        .replace('%', "\\%")
-        .replace('_', "\\_");
-    format!("%{escaped}%")
 }
 
 /// 認証ユーザーの国内株式取引一覧を検索（ページネーション・summary・facets 対応）
@@ -683,20 +647,6 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_date_param_accepts_iso_format_and_rejects_others() {
-        assert!(parse_date_param("date", "2026-01-15").is_ok());
-        for invalid in ["2026/01/15", "15-01-2026", "not-a-date", ""] {
-            assert!(
-                matches!(
-                    parse_date_param("date", invalid),
-                    Err(ApiError::ValidationError(_))
-                ),
-                "value={invalid} は ValidationError になるべき"
-            );
-        }
-    }
-
-    #[test]
     fn test_domestic_stock_filter_from_params_accepts_valid_date_axis_values() {
         let mut params = DomesticStockSearchQueryParams::default();
         params.search.date = Some("2026-01-15".to_string());
@@ -772,15 +722,6 @@ mod tests {
         assert_eq!(sql.matches("account ILIKE").count(), 2);
         assert_eq!(sql.matches("security_code ILIKE").count(), 2);
         assert_eq!(sql.matches("security_name ILIKE").count(), 2);
-    }
-
-    #[test]
-    fn test_escape_like_pattern_escapes_wildcard_characters() {
-        assert_eq!(escape_like_pattern("abc"), "%abc%");
-        assert_eq!(escape_like_pattern("50%"), "%50\\%%");
-        assert_eq!(escape_like_pattern("A_B"), "%A\\_B%");
-        assert_eq!(escape_like_pattern("a\\b"), "%a\\\\b%");
-        assert_eq!(escape_like_pattern("100%_off\\"), "%100\\%\\_off\\\\%");
     }
 
     #[test]

--- a/backend/src/services/mutualfund.rs
+++ b/backend/src/services/mutualfund.rs
@@ -13,7 +13,8 @@ use crate::services::csv_util::{
     parse_required_string_row,
 };
 use crate::services::shared::{
-    delete_all_for_user, user_ids_for_bulk_insert, BulkTimer, DeleteTarget,
+    delete_all_for_user, escape_like_pattern, parse_date_param, parse_year_month_range,
+    user_ids_for_bulk_insert, year_to_range, BulkTimer, DeleteTarget,
 };
 use chrono::NaiveDate;
 use rust_decimal::Decimal;
@@ -97,34 +98,6 @@ impl MutualfundFilter {
     }
 }
 
-fn parse_date_param(field: &str, value: &str) -> Result<NaiveDate, ApiError> {
-    NaiveDate::parse_from_str(value, "%Y-%m-%d")
-        .map_err(|_| ApiError::ValidationError(format!("{field} の形式が不正です（YYYY-MM-DD）")))
-}
-
-fn year_to_range(year: i32) -> Result<(NaiveDate, NaiveDate), ApiError> {
-    let invalid = || ApiError::ValidationError("year の値が不正です".to_string());
-    let start = NaiveDate::from_ymd_opt(year, 1, 1).ok_or_else(invalid)?;
-    let end = NaiveDate::from_ymd_opt(year + 1, 1, 1).ok_or_else(invalid)?;
-    Ok((start, end))
-}
-
-fn parse_year_month_range(value: &str) -> Result<(NaiveDate, NaiveDate), ApiError> {
-    let invalid =
-        || ApiError::ValidationError("year_month の形式が不正です（YYYY-MM）".to_string());
-    let (year_str, month_str) = value.split_once('-').ok_or_else(invalid)?;
-    let year: i32 = year_str.parse().map_err(|_| invalid())?;
-    let month: u32 = month_str.parse().map_err(|_| invalid())?;
-    let start = NaiveDate::from_ymd_opt(year, month, 1).ok_or_else(invalid)?;
-    let end = if month == 12 {
-        NaiveDate::from_ymd_opt(year + 1, 1, 1)
-    } else {
-        NaiveDate::from_ymd_opt(year, month + 1, 1)
-    }
-    .ok_or_else(invalid)?;
-    Ok((start, end))
-}
-
 /// user_id と検索条件を WHERE 句として QueryBuilder へ積む
 fn push_filters(qb: &mut QueryBuilder<Postgres>, user_id: Uuid, filter: &MutualfundFilter) {
     qb.push(" WHERE user_id = ").push_bind(user_id);
@@ -164,15 +137,6 @@ fn push_filters(qb: &mut QueryBuilder<Postgres>, user_id: Uuid, filter: &Mutualf
             .push_bind(pattern)
             .push(" ESCAPE '\\')");
     }
-}
-
-/// ILIKE の wildcard 文字（%, _, \）をリテラル扱いにエスケープしてから前後を % で囲む
-fn escape_like_pattern(token: &str) -> String {
-    let escaped = token
-        .replace('\\', "\\\\")
-        .replace('%', "\\%")
-        .replace('_', "\\_");
-    format!("%{escaped}%")
 }
 
 /// 認証ユーザーの投資信託一覧を検索（ページネーション・summary・facets 対応）
@@ -490,20 +454,6 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_date_param_accepts_iso_format_and_rejects_others() {
-        assert!(parse_date_param("date", "2026-01-15").is_ok());
-        for invalid in ["2026/01/15", "15-01-2026", "not-a-date", ""] {
-            assert!(
-                matches!(
-                    parse_date_param("date", invalid),
-                    Err(ApiError::ValidationError(_))
-                ),
-                "value={invalid} は ValidationError になるべき"
-            );
-        }
-    }
-
-    #[test]
     fn test_mutualfund_filter_from_params_accepts_valid_date_axis_values() {
         let mut params = MutualfundSearchQueryParams::default();
         params.search.date = Some("2026-01-15".to_string());
@@ -579,15 +529,6 @@ mod tests {
         assert_eq!(sql.matches("account ILIKE").count(), 2);
         assert_eq!(sql.matches("fund_name ILIKE").count(), 2);
         assert_eq!(sql.matches("dividends ILIKE").count(), 2);
-    }
-
-    #[test]
-    fn test_escape_like_pattern_escapes_wildcard_characters() {
-        assert_eq!(escape_like_pattern("abc"), "%abc%");
-        assert_eq!(escape_like_pattern("50%"), "%50\\%%");
-        assert_eq!(escape_like_pattern("A_B"), "%A\\_B%");
-        assert_eq!(escape_like_pattern("a\\b"), "%a\\\\b%");
-        assert_eq!(escape_like_pattern("100%_off\\"), "%100\\%\\_off\\\\%");
     }
 
     #[test]

--- a/backend/src/services/shared.rs
+++ b/backend/src/services/shared.rs
@@ -1,5 +1,6 @@
 use crate::errors::ApiError;
 use crate::models::common::BulkCreateResponse;
+use chrono::NaiveDate;
 use sqlx::postgres::PgQueryResult;
 use sqlx::PgPool;
 use std::time::Instant;
@@ -105,10 +106,104 @@ pub async fn delete_all_for_user(
     info!("[{}.delete_all] 完了: {}件削除", domain, deleted);
     Ok(deleted)
 }
+
+pub fn parse_date_param(field: &str, value: &str) -> Result<NaiveDate, ApiError> {
+    NaiveDate::parse_from_str(value, "%Y-%m-%d")
+        .map_err(|_| ApiError::ValidationError(format!("{field} の形式が不正です（YYYY-MM-DD）")))
+}
+
+pub fn year_to_range(year: i32) -> Result<(NaiveDate, NaiveDate), ApiError> {
+    let invalid = || ApiError::ValidationError("year の値が不正です".to_string());
+    let start = NaiveDate::from_ymd_opt(year, 1, 1).ok_or_else(invalid)?;
+    let end = NaiveDate::from_ymd_opt(year + 1, 1, 1).ok_or_else(invalid)?;
+    Ok((start, end))
+}
+
+pub fn parse_year_month_range(value: &str) -> Result<(NaiveDate, NaiveDate), ApiError> {
+    let invalid =
+        || ApiError::ValidationError("year_month の形式が不正です（YYYY-MM）".to_string());
+    let (year_str, month_str) = value.split_once('-').ok_or_else(invalid)?;
+    let year: i32 = year_str.parse().map_err(|_| invalid())?;
+    let month: u32 = month_str.parse().map_err(|_| invalid())?;
+    let start = NaiveDate::from_ymd_opt(year, month, 1).ok_or_else(invalid)?;
+    let end = if month == 12 {
+        NaiveDate::from_ymd_opt(year + 1, 1, 1)
+    } else {
+        NaiveDate::from_ymd_opt(year, month + 1, 1)
+    }
+    .ok_or_else(invalid)?;
+    Ok((start, end))
+}
+
+/// ILIKE の wildcard 文字（%, _, \）をリテラル扱いにエスケープしてから前後を % で囲む
+pub fn escape_like_pattern(token: &str) -> String {
+    let escaped = token
+        .replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_");
+    format!("%{escaped}%")
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{user_ids_for_bulk_insert, BulkTimer};
+    use super::{
+        escape_like_pattern, parse_date_param, parse_year_month_range, user_ids_for_bulk_insert,
+        year_to_range, BulkTimer,
+    };
+    use crate::errors::ApiError;
+    use chrono::NaiveDate;
     use uuid::Uuid;
+
+    #[test]
+    fn test_year_to_range_produces_year_boundaries() {
+        let (start, end) = year_to_range(2026).expect("2026年は有効な範囲");
+        assert_eq!(start, NaiveDate::from_ymd_opt(2026, 1, 1).unwrap());
+        assert_eq!(end, NaiveDate::from_ymd_opt(2027, 1, 1).unwrap());
+    }
+
+    #[test]
+    fn test_parse_year_month_range_handles_december_wrap_and_invalid_values() {
+        let (start, end) = parse_year_month_range("2026-06").expect("2026-06 は有効");
+        assert_eq!(start, NaiveDate::from_ymd_opt(2026, 6, 1).unwrap());
+        assert_eq!(end, NaiveDate::from_ymd_opt(2026, 7, 1).unwrap());
+
+        // 12月は年をまたいで翌年1月1日になる
+        let (_, end) = parse_year_month_range("2026-12").expect("2026-12 は有効");
+        assert_eq!(end, NaiveDate::from_ymd_opt(2027, 1, 1).unwrap());
+
+        for invalid in ["2026/06", "2026-13", "abcd-06", "2026-06-01"] {
+            assert!(
+                matches!(
+                    parse_year_month_range(invalid),
+                    Err(ApiError::ValidationError(_))
+                ),
+                "value={invalid} は ValidationError になるべき"
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_date_param_accepts_iso_format_and_rejects_others() {
+        assert!(parse_date_param("date", "2026-01-15").is_ok());
+        for invalid in ["2026/01/15", "15-01-2026", "not-a-date", ""] {
+            assert!(
+                matches!(
+                    parse_date_param("date", invalid),
+                    Err(ApiError::ValidationError(_))
+                ),
+                "value={invalid} は ValidationError になるべき"
+            );
+        }
+    }
+
+    #[test]
+    fn test_escape_like_pattern_escapes_wildcard_characters() {
+        assert_eq!(escape_like_pattern("abc"), "%abc%");
+        assert_eq!(escape_like_pattern("50%"), "%50\\%%");
+        assert_eq!(escape_like_pattern("A_B"), "%A\\_B%");
+        assert_eq!(escape_like_pattern("a\\b"), "%a\\\\b%");
+        assert_eq!(escape_like_pattern("100%_off\\"), "%100\\%\\_off\\\\%");
+    }
 
     #[test]
     fn test_bulk_timer_finish() {


### PR DESCRIPTION
## 概要

`/code-review` で検出された指摘への対応（docs/tasks/fix-search-summary-review-findings.md）。

## 背景

`escape_like_pattern` が dividend/domestic_stock/mutualfund/asset_balance の4ファイルに、
`parse_date_param` / `year_to_range` / `parse_year_month_range` が dividend/domestic_stock/mutualfund の3ファイルに、それぞれ完全に同一内容で重複していた。

LIKE エスケープはSQL特殊文字の無害化というセキュリティ関連ロジックであり、修正漏れのリスクが特に高かった。

## 変更内容

- 上記4関数を `backend/src/services/shared.rs` へ集約
- 各サービスファイルは `shared.rs` からのimportに変更
- 重複していた単体テストも shared.rs 側へ集約（重複コピーは削除）
- 挙動は変更していない（純粋な移動・重複排除）

## テスト

- `cargo fmt --check`: PASS
- `SQLX_OFFLINE=true cargo clippy --all-targets -- -D warnings`: PASS
- `SQLX_OFFLINE=true cargo test`: PASS（163 passed, 0 failed）
- `bash scripts/check-openapi.sh`: PASS（API契約に変更なし）

🤖 Generated with [Claude Code](https://claude.ai/claude-code)