### PR TITLE
refactor: SearchCard分割のレビュー指摘4件に対応

### DIFF
--- a/frontend/src/components/organisms/SearchCard/DatePeriodBlock.tsx
+++ b/frontend/src/components/organisms/SearchCard/DatePeriodBlock.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from 'react';
 import { cn } from '@/lib/utils/classNames';
-import { DateSegment } from './types';
+import { DateInputs, DateSegment } from './types';
 import { CalendarDateButton } from './CalendarDateButton';
 
 const DATE_SEGMENTS: DateSegment[] = ['年', '月', '日', '範囲'];
@@ -8,11 +8,7 @@ const DATE_SEGMENTS: DateSegment[] = ['年', '月', '日', '範囲'];
 interface DatePeriodBlockProps {
     dateSegment: DateSegment;
     years: { value: string; label: string }[];
-    yearValue: string;
-    monthValue: string;
-    dateValue: string;
-    rangeStart: string;
-    rangeEnd: string;
+    dateInputs: DateInputs;
     isYearPickerOpen: boolean;
     onSegmentChange: (segment: DateSegment) => void;
     onToggleYearPicker: () => void;
@@ -25,9 +21,10 @@ interface DatePeriodBlockProps {
 }
 
 export const DatePeriodBlock: React.FC<DatePeriodBlockProps> = ({
-    dateSegment, years, yearValue, monthValue, dateValue, rangeStart, rangeEnd, isYearPickerOpen,
+    dateSegment, years, dateInputs, isYearPickerOpen,
     onSegmentChange, onToggleYearPicker, onYearOptionSelect, onMonthChange, onDateValueChange, onRangeStartChange, onRangeEndChange, onClose,
 }) => {
+    const { yearValue, monthValue, dateValue, rangeStart, rangeEnd } = dateInputs;
     const availableSegments = years.length > 0 ? DATE_SEGMENTS : DATE_SEGMENTS.filter(seg => seg !== '年');
     const visibleDateSegment = years.length === 0 && dateSegment === '年' ? '月' : dateSegment;
 

--- a/frontend/src/components/organisms/SearchCard/QuickSearchButtons.tsx
+++ b/frontend/src/components/organisms/SearchCard/QuickSearchButtons.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Button } from '@/components/atoms/Button';
+import { cn } from '@/lib/utils/classNames';
 import { ActiveSearchType } from './types';
 
 interface QuickSearchButtonsProps {
@@ -26,10 +27,12 @@ export const QuickSearchButtons: React.FC<QuickSearchButtonsProps> = ({
                             variant={isSelected ? 'primary' : 'outline-secondary'}
                             size="sm"
                             onClick={() => onSearch(item, searchType)}
-                            className={isSelected
-                                ? 'ring-2 ring-amber-500 ring-offset-1 font-bold shadow-md'
-                                : `${hasSelection ? 'opacity-50' : 'opacity-80'} hover:opacity-100 hover:bg-slate-100 hover:ring-1 hover:ring-slate-300 focus-visible:ring-2 focus-visible:ring-amber-500/50 focus-visible:outline-none`
-                            }
+                            className={cn(
+                                isSelected
+                                    ? 'ring-2 ring-amber-500 ring-offset-1 font-bold shadow-md'
+                                    : hasSelection ? 'opacity-50' : 'opacity-80',
+                                !isSelected && 'hover:opacity-100 hover:bg-slate-100 hover:ring-1 hover:ring-slate-300 focus-visible:ring-2 focus-visible:ring-amber-500/50 focus-visible:outline-none'
+                            )}
                             aria-pressed={isSelected}
                             aria-label={isSelected ? `${item}（選択中）` : item}
                         >

--- a/frontend/src/components/organisms/SearchCard/SearchCard.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchCard.tsx
@@ -4,13 +4,9 @@ import { Card, CardBody, CardHeader } from '@/components/atoms/Card';
 import { cn } from '@/lib/utils/classNames';
 import { SearchCardProps } from './types';
 import { useSearchCardQuery } from './useSearchCardQuery';
+import { hasData } from './searchQueryUtils';
 import { SearchFieldsGrid } from './SearchFieldsGrid';
 import { DatePeriodBlock } from './DatePeriodBlock';
-
-// データが存在するかチェック
-function hasData(data: unknown[] | undefined): boolean {
-    return Boolean(data && data.length > 0);
-}
 
 /**
  * 検索カードコンポーネント
@@ -31,6 +27,10 @@ export const SearchCard: React.FC<SearchCardProps> = ({
         setIsExpanded(initialExpanded);
     }, [initialExpanded]);
 
+    // 年ピッカーの開閉も検索クエリに影響しない UI 表示 state
+    const [isYearPickerOpen, setIsYearPickerOpen] = useState(false);
+    const closeYearPicker = () => setIsYearPickerOpen(false);
+
     // 検索条件（API クエリ params）の state はフックに分離
     const {
         effectiveSelectedQueries,
@@ -38,9 +38,6 @@ export const SearchCard: React.FC<SearchCardProps> = ({
         isDefaultState,
         dateSegment,
         dateInputs,
-        isYearPickerOpen,
-        toggleYearPicker,
-        closeYearPicker,
         handleQuickSearch,
         handleSegmentChange,
         handleYearOptionSelect,
@@ -49,7 +46,7 @@ export const SearchCard: React.FC<SearchCardProps> = ({
         handleRangeStartChange,
         handleRangeEndChange,
         handleClearSearch,
-    } = useSearchCardQuery({ categories, value, onSearch });
+    } = useSearchCardQuery({ categories, value, onSearch, onCloseYearPicker: closeYearPicker });
 
     // 描画対象カテゴリが1つ以上あるか（毎レンダーで再評価されないよう定数化）
     const hasAnyCategories = categories != null && (
@@ -84,14 +81,10 @@ export const SearchCard: React.FC<SearchCardProps> = ({
             <DatePeriodBlock
                 dateSegment={dateSegment}
                 years={categories?.years ?? []}
-                yearValue={dateInputs.yearValue}
-                monthValue={dateInputs.monthValue}
-                dateValue={dateInputs.dateValue}
-                rangeStart={dateInputs.rangeStart}
-                rangeEnd={dateInputs.rangeEnd}
+                dateInputs={dateInputs}
                 isYearPickerOpen={isYearPickerOpen}
                 onSegmentChange={handleSegmentChange}
-                onToggleYearPicker={toggleYearPicker}
+                onToggleYearPicker={() => setIsYearPickerOpen(open => !open)}
                 onYearOptionSelect={handleYearOptionSelect}
                 onMonthChange={handleMonthChange}
                 onDateValueChange={handleDateValueChange}
@@ -175,7 +168,6 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                             gridClassName="grid-cols-1 gap-3.5"
                             selectedQueries={effectiveSelectedQueries}
                             onSearch={handleQuickSearch}
-                            hasData={hasData}
                         />
                     </div>
                 )}
@@ -272,7 +264,6 @@ export const SearchCard: React.FC<SearchCardProps> = ({
                         gridClassName="grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4"
                         selectedQueries={effectiveSelectedQueries}
                         onSearch={handleQuickSearch}
-                        hasData={hasData}
                     />
                 </CardBody>
             )}

--- a/frontend/src/components/organisms/SearchCard/SearchFieldsGrid.tsx
+++ b/frontend/src/components/organisms/SearchCard/SearchFieldsGrid.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { cn } from '@/lib/utils/classNames';
 import { SearchCategories } from '@/types/common';
 import { SearchKey } from './types';
+import { hasData } from './searchQueryUtils';
 import { QuickSearchDropdown } from './QuickSearchDropdown';
 import { QuickSearchButtons } from './QuickSearchButtons';
 
@@ -23,11 +24,10 @@ interface SearchFieldsGridProps {
     gridClassName: string;
     selectedQueries: Record<SearchKey, string>;
     onSearch: (value: string, searchType: 'securities' | 'years' | 'products' | 'accounts') => void;
-    hasData: (data: unknown[] | undefined) => boolean;
 }
 
 export const SearchFieldsGrid: React.FC<SearchFieldsGridProps> = ({
-    categories, gridClassName, selectedQueries, onSearch, hasData,
+    categories, gridClassName, selectedQueries, onSearch,
 }) => (
     <div className={cn('grid', gridClassName)}>
         {DROPDOWN_CONFIGS.map(({ key, label }) =>

--- a/frontend/src/components/organisms/SearchCard/searchQueryUtils.ts
+++ b/frontend/src/components/organisms/SearchCard/searchQueryUtils.ts
@@ -47,3 +47,8 @@ export function getInitialDateSegment(cats: SearchCategories | undefined): DateS
 }
 
 export const formatDateLabel = (value: string): string => value.replace(/-/g, "/");
+
+// データが存在するかチェック
+export function hasData(data: unknown[] | undefined): boolean {
+    return Boolean(data && data.length > 0);
+}

--- a/frontend/src/components/organisms/SearchCard/useSearchCardQuery.ts
+++ b/frontend/src/components/organisms/SearchCard/useSearchCardQuery.ts
@@ -13,13 +13,14 @@ interface UseSearchCardQueryArgs {
     categories?: SearchCategories;
     value?: string; // 親の検索状態と同期（外部クリア対応）
     onSearch: (query: string) => void;
+    onCloseYearPicker: () => void; // 年ピッカーを閉じる必要があるタイミング（外部リセット/セグメント変更/年選択）で呼ばれる
 }
 
 /**
- * SearchCard の「API クエリ params state」を一元管理するフック。
- * 展開/折りたたみなどの UI 表示 state は呼び出し側（SearchCard）が持つ。
+ * SearchCard の「API クエリ params state」（検索条件そのもの）を一元管理するフック。
+ * isExpanded や isYearPickerOpen などの UI 表示 state は呼び出し側（SearchCard）が持つ。
  */
-export function useSearchCardQuery({ categories, value, onSearch }: UseSearchCardQueryArgs) {
+export function useSearchCardQuery({ categories, value, onSearch, onCloseYearPicker }: UseSearchCardQueryArgs) {
     const [selectedQueries, setSelectedQueries] = useState<Record<SearchKey, string>>(
         createEmptySelectedQueries()
     );
@@ -28,17 +29,21 @@ export function useSearchCardQuery({ categories, value, onSearch }: UseSearchCar
         getInitialDateSegment(categories)
     );
     const [dateInputs, setDateInputs] = useState<DateInputs>({ ...EMPTY_DATE_INPUTS });
-    const [isYearPickerOpen, setIsYearPickerOpen] = useState(false);
 
     const categoriesRef = useRef(categories);
     categoriesRef.current = categories;
+
+    // onCloseYearPicker は呼び出し側で毎レンダー新しい参照になり得るため、
+    // ref 経由で参照することで effect の依存関係から切り離す（無限ループ防止）
+    const onCloseYearPickerRef = useRef(onCloseYearPicker);
+    onCloseYearPickerRef.current = onCloseYearPicker;
 
     useEffect(() => {
         if (value !== '') return;
         const cats = categoriesRef.current;
         setSelectedQueries(createEmptySelectedQueries());
         setDateInputs({ ...EMPTY_DATE_INPUTS });
-        setIsYearPickerOpen(false);
+        onCloseYearPickerRef.current();
         setDateSegment(getInitialDateSegment(cats));
     }, [value]);
 
@@ -48,7 +53,7 @@ export function useSearchCardQuery({ categories, value, onSearch }: UseSearchCar
 
     const resetDateInputs = () => {
         setDateInputs({ ...EMPTY_DATE_INPUTS });
-        setIsYearPickerOpen(false);
+        onCloseYearPickerRef.current();
     };
 
     const applySelectedQueries = (nextQueries: Record<SearchKey, string>) => {
@@ -87,7 +92,7 @@ export function useSearchCardQuery({ categories, value, onSearch }: UseSearchCar
 
     const handleYearOptionSelect = (val: string) => {
         setDateInputs(d => ({ ...d, yearValue: val }));
-        setIsYearPickerOpen(false);
+        onCloseYearPickerRef.current();
         handleDateSearch(val);
     };
 
@@ -126,9 +131,6 @@ export function useSearchCardQuery({ categories, value, onSearch }: UseSearchCar
         isDefaultState,
         dateSegment,
         dateInputs,
-        isYearPickerOpen,
-        toggleYearPicker: () => setIsYearPickerOpen(open => !open),
-        closeYearPicker: () => setIsYearPickerOpen(false),
         handleQuickSearch,
         handleSegmentChange,
         handleYearOptionSelect,


### PR DESCRIPTION
## 概要

\`/code-review\` で検出された PR #661（SearchCard分割）への指摘4件に対応（docs/tasks/fix-search-summary-review-findings.md）。

## 変更内容

| 指摘 | 対応 |
|---|---|
| cn()未使用 | QuickSearchButtons.tsx をcn()パターンへ統一 |
| state分類の不整合 | isYearPickerOpen をUI表示state（SearchCard.tsx）へ移動 |
| hasDataのprop threading | searchQueryUtils.tsからの直接importに変更 |
| DateInputsの分解 | dateInputs型をそのまま渡すよう変更 |

いずれも内部実装のみの変更で、公開API・ユーザーから見える挙動は変更していない。

## 実装時に見つけた不具合と修正

isYearPickerOpen をフックからコンポーネント側へ移動する過程で、`onCloseYearPicker` コールバックを `useEffect` の依存配列に直接含めていたところ、無限レンダーループが発生した（呼び出し側で毎レンダー新しい関数参照が生成され、それが `useEffect` を再実行させ、setState がさらに新しい参照を生む、という循環）。`useRef` でコールバックを保持し依存配列から外すことで解消した。

## テスト

- \`npm run typecheck\`: PASS
- \`npm run lint\`: PASS
- \`npm test\`: PASS（1001 tests、既存の SearchCard.test.tsx 47件を含む）
- \`npm run build\`: PASS

🤖 Generated with [Claude Code](https://claude.ai/claude-code)