### PR TITLE
backend検索条件の共通処理を抽出

### DIFF
--- a/backend/src/services/asset_balance.rs
+++ b/backend/src/services/asset_balance.rs
@@ -14,7 +14,8 @@ use crate::services::csv_util::{
     get_row_cell, normalize_security_name, parse_number, parse_optional_string_row,
 };
 use crate::services::shared::{
-    delete_all_for_user, escape_like_pattern, user_ids_for_bulk_insert, BulkTimer, DeleteTarget,
+    delete_all_for_user, push_token_ilike_filters, tokens_from_query, user_ids_for_bulk_insert,
+    BulkTimer, DeleteTarget,
 };
 use rust_decimal::Decimal;
 use sqlx::{PgPool, Postgres, QueryBuilder};
@@ -50,12 +51,7 @@ struct AssetBalanceFilter {
 
 impl AssetBalanceFilter {
     fn from_params(params: &AssetBalanceSearchQueryParams) -> Self {
-        let tokens = params
-            .search
-            .q
-            .as_deref()
-            .map(|q| q.split_whitespace().map(str::to_string).collect())
-            .unwrap_or_default();
+        let tokens = tokens_from_query(params.search.q.as_deref());
 
         Self {
             tokens,
@@ -74,14 +70,7 @@ fn push_filters(qb: &mut QueryBuilder<Postgres>, user_id: Uuid, filter: &AssetBa
     if let Some(v) = &filter.security_name {
         qb.push(" AND security_name = ").push_bind(v.clone());
     }
-    for token in &filter.tokens {
-        let pattern = escape_like_pattern(token);
-        qb.push(" AND (security_code ILIKE ")
-            .push_bind(pattern.clone())
-            .push(" ESCAPE '\\' OR security_name ILIKE ")
-            .push_bind(pattern)
-            .push(" ESCAPE '\\')");
-    }
+    push_token_ilike_filters(qb, &filter.tokens, &["security_code", "security_name"]);
 }
 
 /// 認証ユーザーの保有銘柄一覧を検索（ページネーション・summary・facets 対応）

--- a/backend/src/services/dividend.rs
+++ b/backend/src/services/dividend.rs
@@ -13,10 +13,9 @@ use crate::services::csv_util::{
     parse_required_number_row, parse_required_string_row,
 };
 use crate::services::shared::{
-    delete_all_for_user, escape_like_pattern, parse_date_param, parse_year_month_range,
-    user_ids_for_bulk_insert, year_to_range, BulkTimer, DeleteTarget,
+    delete_all_for_user, push_date_axis_filters, push_token_ilike_filters, tokens_from_query,
+    user_ids_for_bulk_insert, BulkTimer, DateAxisFilter, DeleteTarget,
 };
-use chrono::NaiveDate;
 use rust_decimal::Decimal;
 use sqlx::{PgPool, Postgres, QueryBuilder};
 use tracing::info;
@@ -42,11 +41,7 @@ const DIVIDEND_CSV_CONFIG: CsvParserConfig = CsvParserConfig {
 /// 配当金検索条件を SQL 条件へ変換した中間表現
 #[derive(Debug)]
 struct DividendFilter {
-    date_eq: Option<NaiveDate>,
-    date_from: Option<NaiveDate>,
-    date_to: Option<NaiveDate>,
-    year_range: Option<(NaiveDate, NaiveDate)>,
-    year_month_range: Option<(NaiveDate, NaiveDate)>,
+    date_axis: DateAxisFilter,
     tokens: Vec<String>,
     product: Option<String>,
     account: Option<String>,
@@ -57,39 +52,11 @@ struct DividendFilter {
 impl DividendFilter {
     fn from_params(params: &DividendSearchQueryParams) -> Result<Self, ApiError> {
         let search = &params.search;
-        let date_eq = search
-            .date
-            .as_deref()
-            .map(|v| parse_date_param("date", v))
-            .transpose()?;
-        let date_from = search
-            .date_from
-            .as_deref()
-            .map(|v| parse_date_param("date_from", v))
-            .transpose()?;
-        let date_to = search
-            .date_to
-            .as_deref()
-            .map(|v| parse_date_param("date_to", v))
-            .transpose()?;
-        let year_range = search.year.map(year_to_range).transpose()?;
-        let year_month_range = search
-            .year_month
-            .as_deref()
-            .map(parse_year_month_range)
-            .transpose()?;
-        let tokens = search
-            .q
-            .as_deref()
-            .map(|q| q.split_whitespace().map(str::to_string).collect())
-            .unwrap_or_default();
+        let date_axis = DateAxisFilter::from_search_params(search)?;
+        let tokens = tokens_from_query(search.q.as_deref());
 
         Ok(Self {
-            date_eq,
-            date_from,
-            date_to,
-            year_range,
-            year_month_range,
+            date_axis,
             tokens,
             product: params.product.clone(),
             account: params.account.clone(),
@@ -102,23 +69,7 @@ impl DividendFilter {
 /// user_id と検索条件を WHERE 句として QueryBuilder へ積む
 fn push_filters(qb: &mut QueryBuilder<Postgres>, user_id: Uuid, filter: &DividendFilter) {
     qb.push(" WHERE user_id = ").push_bind(user_id);
-    if let Some(v) = filter.date_eq {
-        qb.push(" AND settlement_date = ").push_bind(v);
-    }
-    if let Some(v) = filter.date_from {
-        qb.push(" AND settlement_date >= ").push_bind(v);
-    }
-    if let Some(v) = filter.date_to {
-        qb.push(" AND settlement_date <= ").push_bind(v);
-    }
-    if let Some((start, end)) = filter.year_range {
-        qb.push(" AND settlement_date >= ").push_bind(start);
-        qb.push(" AND settlement_date < ").push_bind(end);
-    }
-    if let Some((start, end)) = filter.year_month_range {
-        qb.push(" AND settlement_date >= ").push_bind(start);
-        qb.push(" AND settlement_date < ").push_bind(end);
-    }
+    push_date_axis_filters(qb, "settlement_date", &filter.date_axis);
     if let Some(v) = &filter.product {
         qb.push(" AND product = ").push_bind(v.clone());
     }
@@ -131,18 +82,11 @@ fn push_filters(qb: &mut QueryBuilder<Postgres>, user_id: Uuid, filter: &Dividen
     if let Some(v) = &filter.security_name {
         qb.push(" AND security_name = ").push_bind(v.clone());
     }
-    for token in &filter.tokens {
-        let pattern = escape_like_pattern(token);
-        qb.push(" AND (product ILIKE ")
-            .push_bind(pattern.clone())
-            .push(" ESCAPE '\\' OR account ILIKE ")
-            .push_bind(pattern.clone())
-            .push(" ESCAPE '\\' OR security_code ILIKE ")
-            .push_bind(pattern.clone())
-            .push(" ESCAPE '\\' OR security_name ILIKE ")
-            .push_bind(pattern)
-            .push(" ESCAPE '\\')");
-    }
+    push_token_ilike_filters(
+        qb,
+        &filter.tokens,
+        &["product", "account", "security_code", "security_name"],
+    );
 }
 
 /// 認証ユーザーの配当金一覧を検索（ページネーション・summary・facets 対応）
@@ -415,6 +359,7 @@ pub async fn delete_all(pool: &PgPool, user_id: Uuid) -> Result<u64, ApiError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::NaiveDate;
 
     const HEADER: &str =
         "入金日,商品,口座,銘柄コード,銘柄,受取通貨,単価[円/現地通貨],数量[株/口],配当・分配金合計（税引前）[円/現地通貨],税額合計[円/現地通貨],受取金額[円/現地通貨]";
@@ -506,18 +451,27 @@ mod tests {
         let filter =
             DividendFilter::from_params(&params).expect("正しい日付フォーマットは検証を通過する");
 
-        assert_eq!(filter.date_eq, NaiveDate::from_ymd_opt(2026, 1, 15));
-        assert_eq!(filter.date_from, NaiveDate::from_ymd_opt(2026, 1, 1));
-        assert_eq!(filter.date_to, NaiveDate::from_ymd_opt(2026, 12, 31));
         assert_eq!(
-            filter.year_range,
+            filter.date_axis.date_eq,
+            NaiveDate::from_ymd_opt(2026, 1, 15)
+        );
+        assert_eq!(
+            filter.date_axis.date_from,
+            NaiveDate::from_ymd_opt(2026, 1, 1)
+        );
+        assert_eq!(
+            filter.date_axis.date_to,
+            NaiveDate::from_ymd_opt(2026, 12, 31)
+        );
+        assert_eq!(
+            filter.date_axis.year_range,
             Some((
                 NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
                 NaiveDate::from_ymd_opt(2027, 1, 1).unwrap()
             ))
         );
         assert_eq!(
-            filter.year_month_range,
+            filter.date_axis.year_month_range,
             Some((
                 NaiveDate::from_ymd_opt(2026, 6, 1).unwrap(),
                 NaiveDate::from_ymd_opt(2026, 7, 1).unwrap()

--- a/backend/src/services/domestic_stock.rs
+++ b/backend/src/services/domestic_stock.rs
@@ -13,10 +13,9 @@ use crate::services::csv_util::{
     parse_required_string_row,
 };
 use crate::services::shared::{
-    delete_all_for_user, escape_like_pattern, parse_date_param, parse_year_month_range,
-    user_ids_for_bulk_insert, year_to_range, BulkTimer, DeleteTarget,
+    delete_all_for_user, push_date_axis_filters, push_token_ilike_filters, tokens_from_query,
+    user_ids_for_bulk_insert, BulkTimer, DateAxisFilter, DeleteTarget,
 };
-use chrono::NaiveDate;
 use rust_decimal::Decimal;
 use sqlx::{PgPool, Postgres, QueryBuilder};
 use tracing::info;
@@ -42,11 +41,7 @@ const DOMESTIC_STOCK_CSV_CONFIG: CsvParserConfig = CsvParserConfig {
 /// 国内株式検索条件を SQL 条件へ変換した中間表現
 #[derive(Debug)]
 struct DomesticStockFilter {
-    date_eq: Option<NaiveDate>,
-    date_from: Option<NaiveDate>,
-    date_to: Option<NaiveDate>,
-    year_range: Option<(NaiveDate, NaiveDate)>,
-    year_month_range: Option<(NaiveDate, NaiveDate)>,
+    date_axis: DateAxisFilter,
     tokens: Vec<String>,
     account: Option<String>,
     security_code: Option<String>,
@@ -56,39 +51,11 @@ struct DomesticStockFilter {
 impl DomesticStockFilter {
     fn from_params(params: &DomesticStockSearchQueryParams) -> Result<Self, ApiError> {
         let search = &params.search;
-        let date_eq = search
-            .date
-            .as_deref()
-            .map(|v| parse_date_param("date", v))
-            .transpose()?;
-        let date_from = search
-            .date_from
-            .as_deref()
-            .map(|v| parse_date_param("date_from", v))
-            .transpose()?;
-        let date_to = search
-            .date_to
-            .as_deref()
-            .map(|v| parse_date_param("date_to", v))
-            .transpose()?;
-        let year_range = search.year.map(year_to_range).transpose()?;
-        let year_month_range = search
-            .year_month
-            .as_deref()
-            .map(parse_year_month_range)
-            .transpose()?;
-        let tokens = search
-            .q
-            .as_deref()
-            .map(|q| q.split_whitespace().map(str::to_string).collect())
-            .unwrap_or_default();
+        let date_axis = DateAxisFilter::from_search_params(search)?;
+        let tokens = tokens_from_query(search.q.as_deref());
 
         Ok(Self {
-            date_eq,
-            date_from,
-            date_to,
-            year_range,
-            year_month_range,
+            date_axis,
             tokens,
             account: params.account.clone(),
             security_code: params.security_code.clone(),
@@ -100,23 +67,7 @@ impl DomesticStockFilter {
 /// user_id と検索条件を WHERE 句として QueryBuilder へ積む
 fn push_filters(qb: &mut QueryBuilder<Postgres>, user_id: Uuid, filter: &DomesticStockFilter) {
     qb.push(" WHERE user_id = ").push_bind(user_id);
-    if let Some(v) = filter.date_eq {
-        qb.push(" AND trade_date = ").push_bind(v);
-    }
-    if let Some(v) = filter.date_from {
-        qb.push(" AND trade_date >= ").push_bind(v);
-    }
-    if let Some(v) = filter.date_to {
-        qb.push(" AND trade_date <= ").push_bind(v);
-    }
-    if let Some((start, end)) = filter.year_range {
-        qb.push(" AND trade_date >= ").push_bind(start);
-        qb.push(" AND trade_date < ").push_bind(end);
-    }
-    if let Some((start, end)) = filter.year_month_range {
-        qb.push(" AND trade_date >= ").push_bind(start);
-        qb.push(" AND trade_date < ").push_bind(end);
-    }
+    push_date_axis_filters(qb, "trade_date", &filter.date_axis);
     if let Some(v) = &filter.account {
         qb.push(" AND account = ").push_bind(v.clone());
     }
@@ -126,16 +77,11 @@ fn push_filters(qb: &mut QueryBuilder<Postgres>, user_id: Uuid, filter: &Domesti
     if let Some(v) = &filter.security_name {
         qb.push(" AND security_name = ").push_bind(v.clone());
     }
-    for token in &filter.tokens {
-        let pattern = escape_like_pattern(token);
-        qb.push(" AND (account ILIKE ")
-            .push_bind(pattern.clone())
-            .push(" ESCAPE '\\' OR security_code ILIKE ")
-            .push_bind(pattern.clone())
-            .push(" ESCAPE '\\' OR security_name ILIKE ")
-            .push_bind(pattern)
-            .push(" ESCAPE '\\')");
-    }
+    push_token_ilike_filters(
+        qb,
+        &filter.tokens,
+        &["account", "security_code", "security_name"],
+    );
 }
 
 /// 認証ユーザーの国内株式取引一覧を検索（ページネーション・summary・facets 対応）
@@ -665,18 +611,27 @@ mod tests {
         let filter = DomesticStockFilter::from_params(&params)
             .expect("正しい日付フォーマットは検証を通過する");
 
-        assert_eq!(filter.date_eq, NaiveDate::from_ymd_opt(2026, 1, 15));
-        assert_eq!(filter.date_from, NaiveDate::from_ymd_opt(2026, 1, 1));
-        assert_eq!(filter.date_to, NaiveDate::from_ymd_opt(2026, 12, 31));
         assert_eq!(
-            filter.year_range,
+            filter.date_axis.date_eq,
+            NaiveDate::from_ymd_opt(2026, 1, 15)
+        );
+        assert_eq!(
+            filter.date_axis.date_from,
+            NaiveDate::from_ymd_opt(2026, 1, 1)
+        );
+        assert_eq!(
+            filter.date_axis.date_to,
+            NaiveDate::from_ymd_opt(2026, 12, 31)
+        );
+        assert_eq!(
+            filter.date_axis.year_range,
             Some((
                 NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
                 NaiveDate::from_ymd_opt(2027, 1, 1).unwrap()
             ))
         );
         assert_eq!(
-            filter.year_month_range,
+            filter.date_axis.year_month_range,
             Some((
                 NaiveDate::from_ymd_opt(2026, 6, 1).unwrap(),
                 NaiveDate::from_ymd_opt(2026, 7, 1).unwrap()

--- a/backend/src/services/mutualfund.rs
+++ b/backend/src/services/mutualfund.rs
@@ -13,10 +13,9 @@ use crate::services::csv_util::{
     parse_required_string_row,
 };
 use crate::services::shared::{
-    delete_all_for_user, escape_like_pattern, parse_date_param, parse_year_month_range,
-    user_ids_for_bulk_insert, year_to_range, BulkTimer, DeleteTarget,
+    delete_all_for_user, push_date_axis_filters, push_token_ilike_filters, tokens_from_query,
+    user_ids_for_bulk_insert, BulkTimer, DateAxisFilter, DeleteTarget,
 };
-use chrono::NaiveDate;
 use rust_decimal::Decimal;
 use sqlx::{PgPool, Postgres, QueryBuilder};
 use tracing::info;
@@ -43,11 +42,7 @@ const MUTUALFUND_CSV_CONFIG: CsvParserConfig = CsvParserConfig {
 /// 投資信託検索条件を SQL 条件へ変換した中間表現
 #[derive(Debug)]
 struct MutualfundFilter {
-    date_eq: Option<NaiveDate>,
-    date_from: Option<NaiveDate>,
-    date_to: Option<NaiveDate>,
-    year_range: Option<(NaiveDate, NaiveDate)>,
-    year_month_range: Option<(NaiveDate, NaiveDate)>,
+    date_axis: DateAxisFilter,
     tokens: Vec<String>,
     account: Option<String>,
     fund_name: Option<String>,
@@ -57,39 +52,11 @@ struct MutualfundFilter {
 impl MutualfundFilter {
     fn from_params(params: &MutualfundSearchQueryParams) -> Result<Self, ApiError> {
         let search = &params.search;
-        let date_eq = search
-            .date
-            .as_deref()
-            .map(|v| parse_date_param("date", v))
-            .transpose()?;
-        let date_from = search
-            .date_from
-            .as_deref()
-            .map(|v| parse_date_param("date_from", v))
-            .transpose()?;
-        let date_to = search
-            .date_to
-            .as_deref()
-            .map(|v| parse_date_param("date_to", v))
-            .transpose()?;
-        let year_range = search.year.map(year_to_range).transpose()?;
-        let year_month_range = search
-            .year_month
-            .as_deref()
-            .map(parse_year_month_range)
-            .transpose()?;
-        let tokens = search
-            .q
-            .as_deref()
-            .map(|q| q.split_whitespace().map(str::to_string).collect())
-            .unwrap_or_default();
+        let date_axis = DateAxisFilter::from_search_params(search)?;
+        let tokens = tokens_from_query(search.q.as_deref());
 
         Ok(Self {
-            date_eq,
-            date_from,
-            date_to,
-            year_range,
-            year_month_range,
+            date_axis,
             tokens,
             account: params.account.clone(),
             fund_name: params.fund_name.clone(),
@@ -101,23 +68,7 @@ impl MutualfundFilter {
 /// user_id と検索条件を WHERE 句として QueryBuilder へ積む
 fn push_filters(qb: &mut QueryBuilder<Postgres>, user_id: Uuid, filter: &MutualfundFilter) {
     qb.push(" WHERE user_id = ").push_bind(user_id);
-    if let Some(v) = filter.date_eq {
-        qb.push(" AND trade_date = ").push_bind(v);
-    }
-    if let Some(v) = filter.date_from {
-        qb.push(" AND trade_date >= ").push_bind(v);
-    }
-    if let Some(v) = filter.date_to {
-        qb.push(" AND trade_date <= ").push_bind(v);
-    }
-    if let Some((start, end)) = filter.year_range {
-        qb.push(" AND trade_date >= ").push_bind(start);
-        qb.push(" AND trade_date < ").push_bind(end);
-    }
-    if let Some((start, end)) = filter.year_month_range {
-        qb.push(" AND trade_date >= ").push_bind(start);
-        qb.push(" AND trade_date < ").push_bind(end);
-    }
+    push_date_axis_filters(qb, "trade_date", &filter.date_axis);
     if let Some(v) = &filter.account {
         qb.push(" AND account = ").push_bind(v.clone());
     }
@@ -127,16 +78,7 @@ fn push_filters(qb: &mut QueryBuilder<Postgres>, user_id: Uuid, filter: &Mutualf
     if let Some(v) = &filter.dividends {
         qb.push(" AND dividends = ").push_bind(v.clone());
     }
-    for token in &filter.tokens {
-        let pattern = escape_like_pattern(token);
-        qb.push(" AND (account ILIKE ")
-            .push_bind(pattern.clone())
-            .push(" ESCAPE '\\' OR fund_name ILIKE ")
-            .push_bind(pattern.clone())
-            .push(" ESCAPE '\\' OR dividends ILIKE ")
-            .push_bind(pattern)
-            .push(" ESCAPE '\\')");
-    }
+    push_token_ilike_filters(qb, &filter.tokens, &["account", "fund_name", "dividends"]);
 }
 
 /// 認証ユーザーの投資信託一覧を検索（ページネーション・summary・facets 対応）
@@ -431,6 +373,7 @@ pub async fn delete_all(pool: &PgPool, user_id: Uuid) -> Result<u64, ApiError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::NaiveDate;
     #[test]
     fn test_preview_csv_basic() {
         let csv = concat!("約定日,受渡日,ファンド名,分配金,口座,取引,数量[口],為替レート［円］,解約単価［円］,解約額［円］,平均取得価額［円］,実現損益［円］\n", "\"2022/10/28\",\"2022/11/2\",\"eMAXIS Slim 米国株式(S&P500)\",\"再投資型\",\"特定\",\"解約\",\"3,721,147\",\"-\",\"19,661\",\"7,316,147\",\"18,005.20\",\"615,849\"");
@@ -465,18 +408,27 @@ mod tests {
         let filter =
             MutualfundFilter::from_params(&params).expect("正しい日付フォーマットは検証を通過する");
 
-        assert_eq!(filter.date_eq, NaiveDate::from_ymd_opt(2026, 1, 15));
-        assert_eq!(filter.date_from, NaiveDate::from_ymd_opt(2026, 1, 1));
-        assert_eq!(filter.date_to, NaiveDate::from_ymd_opt(2026, 12, 31));
         assert_eq!(
-            filter.year_range,
+            filter.date_axis.date_eq,
+            NaiveDate::from_ymd_opt(2026, 1, 15)
+        );
+        assert_eq!(
+            filter.date_axis.date_from,
+            NaiveDate::from_ymd_opt(2026, 1, 1)
+        );
+        assert_eq!(
+            filter.date_axis.date_to,
+            NaiveDate::from_ymd_opt(2026, 12, 31)
+        );
+        assert_eq!(
+            filter.date_axis.year_range,
             Some((
                 NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
                 NaiveDate::from_ymd_opt(2027, 1, 1).unwrap()
             ))
         );
         assert_eq!(
-            filter.year_month_range,
+            filter.date_axis.year_month_range,
             Some((
                 NaiveDate::from_ymd_opt(2026, 6, 1).unwrap(),
                 NaiveDate::from_ymd_opt(2026, 7, 1).unwrap()

--- a/backend/src/services/shared.rs
+++ b/backend/src/services/shared.rs
@@ -1,8 +1,8 @@
 use crate::errors::ApiError;
-use crate::models::common::BulkCreateResponse;
+use crate::models::common::{BulkCreateResponse, SearchQueryParams};
 use chrono::NaiveDate;
 use sqlx::postgres::PgQueryResult;
-use sqlx::PgPool;
+use sqlx::{PgPool, Postgres, QueryBuilder};
 use std::time::Instant;
 use tracing::info;
 use uuid::Uuid;
@@ -144,14 +144,118 @@ pub fn escape_like_pattern(token: &str) -> String {
     format!("%{escaped}%")
 }
 
+/// `SearchQueryParams` の date 系フィールドを解析した中間表現
+/// （date_eq / date_from / date_to / year_range / year_month_range）
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct DateAxisFilter {
+    pub date_eq: Option<NaiveDate>,
+    pub date_from: Option<NaiveDate>,
+    pub date_to: Option<NaiveDate>,
+    pub year_range: Option<(NaiveDate, NaiveDate)>,
+    pub year_month_range: Option<(NaiveDate, NaiveDate)>,
+}
+
+impl DateAxisFilter {
+    pub fn from_search_params(search: &SearchQueryParams) -> Result<Self, ApiError> {
+        let date_eq = search
+            .date
+            .as_deref()
+            .map(|v| parse_date_param("date", v))
+            .transpose()?;
+        let date_from = search
+            .date_from
+            .as_deref()
+            .map(|v| parse_date_param("date_from", v))
+            .transpose()?;
+        let date_to = search
+            .date_to
+            .as_deref()
+            .map(|v| parse_date_param("date_to", v))
+            .transpose()?;
+        let year_range = search.year.map(year_to_range).transpose()?;
+        let year_month_range = search
+            .year_month
+            .as_deref()
+            .map(parse_year_month_range)
+            .transpose()?;
+
+        Ok(Self {
+            date_eq,
+            date_from,
+            date_to,
+            year_range,
+            year_month_range,
+        })
+    }
+}
+
+/// date_column（呼び出し側が渡す固定文字列のみ）を使って date 条件を WHERE 句へ push する
+pub fn push_date_axis_filters(
+    qb: &mut QueryBuilder<Postgres>,
+    date_column: &'static str,
+    filter: &DateAxisFilter,
+) {
+    if let Some(v) = filter.date_eq {
+        qb.push(format!(" AND {date_column} = ")).push_bind(v);
+    }
+    if let Some(v) = filter.date_from {
+        qb.push(format!(" AND {date_column} >= ")).push_bind(v);
+    }
+    if let Some(v) = filter.date_to {
+        qb.push(format!(" AND {date_column} <= ")).push_bind(v);
+    }
+    if let Some((start, end)) = filter.year_range {
+        qb.push(format!(" AND {date_column} >= ")).push_bind(start);
+        qb.push(format!(" AND {date_column} < ")).push_bind(end);
+    }
+    if let Some((start, end)) = filter.year_month_range {
+        qb.push(format!(" AND {date_column} >= ")).push_bind(start);
+        qb.push(format!(" AND {date_column} < ")).push_bind(end);
+    }
+}
+
+/// フリーワード検索欄をスペース区切りの token 配列へ変換する
+pub fn tokens_from_query(q: Option<&str>) -> Vec<String> {
+    q.map(|q| q.split_whitespace().map(str::to_string).collect())
+        .unwrap_or_default()
+}
+
+/// token ごとに columns（呼び出し側が渡す固定文字列配列のみ）への ILIKE OR 条件を
+/// `AND (col1 ILIKE $n ESCAPE '\' OR col2 ILIKE $n+1 ESCAPE '\' ...)` として push する
+pub fn push_token_ilike_filters(
+    qb: &mut QueryBuilder<Postgres>,
+    tokens: &[String],
+    columns: &[&'static str],
+) {
+    if columns.is_empty() {
+        return;
+    }
+
+    for token in tokens {
+        let pattern = escape_like_pattern(token);
+        qb.push(" AND (");
+        for (i, column) in columns.iter().enumerate() {
+            if i > 0 {
+                qb.push(" OR ");
+            }
+            qb.push(format!("{column} ILIKE "))
+                .push_bind(pattern.clone())
+                .push(" ESCAPE '\\'");
+        }
+        qb.push(")");
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        escape_like_pattern, parse_date_param, parse_year_month_range, user_ids_for_bulk_insert,
-        year_to_range, BulkTimer,
+        escape_like_pattern, parse_date_param, parse_year_month_range, push_date_axis_filters,
+        push_token_ilike_filters, tokens_from_query, user_ids_for_bulk_insert, year_to_range,
+        BulkTimer, DateAxisFilter,
     };
     use crate::errors::ApiError;
     use chrono::NaiveDate;
+    use sqlx::{Postgres, QueryBuilder};
     use uuid::Uuid;
 
     #[test]
@@ -221,5 +325,71 @@ mod tests {
         assert!(result.iter().all(|&v| v == id));
 
         assert!(user_ids_for_bulk_insert(id, 0).is_empty());
+    }
+
+    #[test]
+    fn test_tokens_from_query_splits_on_whitespace() {
+        assert_eq!(tokens_from_query(None), Vec::<String>::new());
+        assert_eq!(tokens_from_query(Some("")), Vec::<String>::new());
+        assert_eq!(
+            tokens_from_query(Some("AA  BB")),
+            vec!["AA".to_string(), "BB".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_push_date_axis_filters_pushes_all_present_conditions_with_given_column() {
+        let filter = DateAxisFilter {
+            date_eq: NaiveDate::from_ymd_opt(2026, 1, 15),
+            date_from: NaiveDate::from_ymd_opt(2026, 1, 1),
+            date_to: NaiveDate::from_ymd_opt(2026, 12, 31),
+            year_range: Some((
+                NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+                NaiveDate::from_ymd_opt(2027, 1, 1).unwrap(),
+            )),
+            year_month_range: Some((
+                NaiveDate::from_ymd_opt(2026, 6, 1).unwrap(),
+                NaiveDate::from_ymd_opt(2026, 7, 1).unwrap(),
+            )),
+        };
+
+        let mut qb: QueryBuilder<Postgres> = QueryBuilder::new("SELECT 1 FROM dummy");
+        push_date_axis_filters(&mut qb, "settlement_date", &filter);
+        let sql = qb.sql();
+        let sql = sql.as_str();
+
+        assert_eq!(sql.matches("settlement_date = ").count(), 1);
+        assert_eq!(sql.matches("settlement_date >= ").count(), 3);
+        assert_eq!(sql.matches("settlement_date <= ").count(), 1);
+        assert_eq!(sql.matches("settlement_date < ").count(), 2);
+    }
+
+    #[test]
+    fn test_push_date_axis_filters_pushes_nothing_when_all_none() {
+        let mut qb: QueryBuilder<Postgres> = QueryBuilder::new("SELECT 1 FROM dummy");
+        push_date_axis_filters(&mut qb, "settlement_date", &DateAxisFilter::default());
+        assert_eq!(qb.sql().as_str(), "SELECT 1 FROM dummy");
+    }
+
+    #[test]
+    fn test_push_token_ilike_filters_combines_columns_as_or_per_token() {
+        let tokens = vec!["AA".to_string(), "BB".to_string()];
+        let mut qb: QueryBuilder<Postgres> = QueryBuilder::new("SELECT 1 FROM dummy");
+        push_token_ilike_filters(&mut qb, &tokens, &["product", "account"]);
+        let sql = qb.sql();
+        let sql = sql.as_str();
+
+        assert_eq!(sql.matches(" AND (").count(), 2);
+        assert_eq!(sql.matches("product ILIKE").count(), 2);
+        assert_eq!(sql.matches("account ILIKE").count(), 2);
+        assert_eq!(sql.matches(" OR ").count(), 2);
+    }
+
+    #[test]
+    fn test_push_token_ilike_filters_pushes_nothing_when_columns_empty() {
+        let tokens = vec!["AA".to_string()];
+        let mut qb: QueryBuilder<Postgres> = QueryBuilder::new("SELECT 1 FROM dummy");
+        push_token_ilike_filters(&mut qb, &tokens, &[]);
+        assert_eq!(qb.sql().as_str(), "SELECT 1 FROM dummy");
     }
 }


### PR DESCRIPTION
## 概要
配当金・国内株式・投資信託・資産管理の検索条件組み立てで重複していた date 条件と token ILIKE 条件を shared helper に寄せました。

## 主な変更
- SearchQueryParams から date 軸条件を作る DateAxisFilter を追加
- date column 固定文字列を受け取る push_date_axis_filters を追加
- token ILIKE OR 条件を columns 固定配列から組み立てる push_token_ilike_filters を追加
- 配当金・国内株式・投資信託・資産管理の既存検索処理を helper 利用へ置換

## レビュー
- Codex review: findings なし、LGTM
- 空 columns で不正SQLを生成しない防御テストを追加済み

## テスト
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test
- push hook: openapi.json / api.ts 同期チェック PASS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 資産残高、配当、国内株式、投資信託の検索で、日付条件の指定方法を統一しました。
  * 複数キーワード検索の条件処理を共通化し、各キーワードが検索対象項目に適切に反映されるよう改善しました。
  * 日付範囲やキーワードを組み合わせた検索の一貫性と信頼性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->