### PR TITLE
facets取得の共通処理を抽出

### DIFF
--- a/backend/src/services/dividend.rs
+++ b/backend/src/services/dividend.rs
@@ -13,8 +13,8 @@ use crate::services::csv_util::{
     parse_required_number_row, parse_required_string_row,
 };
 use crate::services::shared::{
-    delete_all_for_user, push_date_axis_filters, push_token_ilike_filters, tokens_from_query,
-    user_ids_for_bulk_insert, BulkTimer, DateAxisFilter, DeleteTarget,
+    self, delete_all_for_user, push_date_axis_filters, push_token_ilike_filters, tokens_from_query,
+    user_ids_for_bulk_insert, BulkTimer, DateAxisFilter, DeleteTarget, FacetOrder,
 };
 use rust_decimal::Decimal;
 use sqlx::{PgPool, Postgres, QueryBuilder};
@@ -173,12 +173,21 @@ async fn fetch_facets(
     user_id: Uuid,
     filter: &DividendFilter,
 ) -> Result<SearchFacets, ApiError> {
-    let products = fetch_group_facets(pool, user_id, filter, GroupField::Product, true).await?;
-    let accounts = fetch_group_facets(pool, user_id, filter, GroupField::Account, true).await?;
+    let products =
+        fetch_group_facets(pool, user_id, filter, GroupField::Product, FacetOrder::Asc).await?;
+    let accounts =
+        fetch_group_facets(pool, user_id, filter, GroupField::Account, FacetOrder::Asc).await?;
     let securities = fetch_security_facets(pool, user_id, filter).await?;
-    let years = fetch_group_facets(pool, user_id, filter, GroupField::Year, false).await?;
-    let year_months =
-        fetch_group_facets(pool, user_id, filter, GroupField::YearMonth, false).await?;
+    let years =
+        fetch_group_facets(pool, user_id, filter, GroupField::Year, FacetOrder::Desc).await?;
+    let year_months = fetch_group_facets(
+        pool,
+        user_id,
+        filter,
+        GroupField::YearMonth,
+        FacetOrder::Desc,
+    )
+    .await?;
 
     Ok(SearchFacets {
         products: Some(products),
@@ -217,18 +226,12 @@ async fn fetch_group_facets(
     user_id: Uuid,
     filter: &DividendFilter,
     group_field: GroupField,
-    order_asc: bool,
+    order: FacetOrder,
 ) -> Result<Vec<FacetOption>, ApiError> {
-    let group_expr = group_field.as_sql_expr();
-    let mut qb: QueryBuilder<Postgres> = QueryBuilder::new(format!(
-        "SELECT {group_expr} AS value, {group_expr} AS label, COUNT(*) AS count FROM dividends"
-    ));
-    push_filters(&mut qb, user_id, filter);
-    qb.push(format!(
-        " GROUP BY {group_expr} ORDER BY {group_expr} {}",
-        if order_asc { "ASC" } else { "DESC" }
-    ));
-    Ok(qb.build_query_as::<FacetOption>().fetch_all(pool).await?)
+    shared::fetch_group_facets(pool, "dividends", group_field.as_sql_expr(), order, |qb| {
+        push_filters(qb, user_id, filter)
+    })
+    .await
 }
 
 /// 銘柄コードごとに最新の銘柄名を label として件数付きで返す

--- a/backend/src/services/domestic_stock.rs
+++ b/backend/src/services/domestic_stock.rs
@@ -13,8 +13,8 @@ use crate::services::csv_util::{
     parse_required_string_row,
 };
 use crate::services::shared::{
-    delete_all_for_user, push_date_axis_filters, push_token_ilike_filters, tokens_from_query,
-    user_ids_for_bulk_insert, BulkTimer, DateAxisFilter, DeleteTarget,
+    self, delete_all_for_user, push_date_axis_filters, push_token_ilike_filters, tokens_from_query,
+    user_ids_for_bulk_insert, BulkTimer, DateAxisFilter, DeleteTarget, FacetOrder,
 };
 use rust_decimal::Decimal;
 use sqlx::{PgPool, Postgres, QueryBuilder};
@@ -196,11 +196,19 @@ async fn fetch_facets(
     user_id: Uuid,
     filter: &DomesticStockFilter,
 ) -> Result<SearchFacets, ApiError> {
-    let accounts = fetch_group_facets(pool, user_id, filter, GroupField::Account, true).await?;
+    let accounts =
+        fetch_group_facets(pool, user_id, filter, GroupField::Account, FacetOrder::Asc).await?;
     let securities = fetch_security_facets(pool, user_id, filter).await?;
-    let years = fetch_group_facets(pool, user_id, filter, GroupField::Year, false).await?;
-    let year_months =
-        fetch_group_facets(pool, user_id, filter, GroupField::YearMonth, false).await?;
+    let years =
+        fetch_group_facets(pool, user_id, filter, GroupField::Year, FacetOrder::Desc).await?;
+    let year_months = fetch_group_facets(
+        pool,
+        user_id,
+        filter,
+        GroupField::YearMonth,
+        FacetOrder::Desc,
+    )
+    .await?;
 
     Ok(SearchFacets {
         products: None,
@@ -237,18 +245,16 @@ async fn fetch_group_facets(
     user_id: Uuid,
     filter: &DomesticStockFilter,
     group_field: GroupField,
-    order_asc: bool,
+    order: FacetOrder,
 ) -> Result<Vec<FacetOption>, ApiError> {
-    let group_expr = group_field.as_sql_expr();
-    let mut qb: QueryBuilder<Postgres> = QueryBuilder::new(format!(
-        "SELECT {group_expr} AS value, {group_expr} AS label, COUNT(*) AS count FROM domestic_stocks"
-    ));
-    push_filters(&mut qb, user_id, filter);
-    qb.push(format!(
-        " GROUP BY {group_expr} ORDER BY {group_expr} {}",
-        if order_asc { "ASC" } else { "DESC" }
-    ));
-    Ok(qb.build_query_as::<FacetOption>().fetch_all(pool).await?)
+    shared::fetch_group_facets(
+        pool,
+        "domestic_stocks",
+        group_field.as_sql_expr(),
+        order,
+        |qb| push_filters(qb, user_id, filter),
+    )
+    .await
 }
 
 /// 銘柄コードごとに最新の銘柄名を label として件数付きで返す

--- a/backend/src/services/mutualfund.rs
+++ b/backend/src/services/mutualfund.rs
@@ -13,8 +13,8 @@ use crate::services::csv_util::{
     parse_required_string_row,
 };
 use crate::services::shared::{
-    delete_all_for_user, push_date_axis_filters, push_token_ilike_filters, tokens_from_query,
-    user_ids_for_bulk_insert, BulkTimer, DateAxisFilter, DeleteTarget,
+    self, delete_all_for_user, push_date_axis_filters, push_token_ilike_filters, tokens_from_query,
+    user_ids_for_bulk_insert, BulkTimer, DateAxisFilter, DeleteTarget, FacetOrder,
 };
 use rust_decimal::Decimal;
 use sqlx::{PgPool, Postgres, QueryBuilder};
@@ -172,10 +172,18 @@ async fn fetch_facets(
     user_id: Uuid,
     filter: &MutualfundFilter,
 ) -> Result<SearchFacets, ApiError> {
-    let accounts_fut = fetch_group_facets(pool, user_id, filter, GroupField::Account, true);
-    let funds_fut = fetch_group_facets(pool, user_id, filter, GroupField::FundName, true);
-    let years_fut = fetch_group_facets(pool, user_id, filter, GroupField::Year, false);
-    let year_months_fut = fetch_group_facets(pool, user_id, filter, GroupField::YearMonth, false);
+    let accounts_fut =
+        fetch_group_facets(pool, user_id, filter, GroupField::Account, FacetOrder::Asc);
+    let funds_fut =
+        fetch_group_facets(pool, user_id, filter, GroupField::FundName, FacetOrder::Asc);
+    let years_fut = fetch_group_facets(pool, user_id, filter, GroupField::Year, FacetOrder::Desc);
+    let year_months_fut = fetch_group_facets(
+        pool,
+        user_id,
+        filter,
+        GroupField::YearMonth,
+        FacetOrder::Desc,
+    );
 
     let (accounts, funds, years, year_months) =
         tokio::try_join!(accounts_fut, funds_fut, years_fut, year_months_fut)?;
@@ -217,18 +225,16 @@ async fn fetch_group_facets(
     user_id: Uuid,
     filter: &MutualfundFilter,
     group_field: GroupField,
-    order_asc: bool,
+    order: FacetOrder,
 ) -> Result<Vec<FacetOption>, ApiError> {
-    let group_expr = group_field.as_sql_expr();
-    let mut qb: QueryBuilder<Postgres> = QueryBuilder::new(format!(
-        "SELECT {group_expr} AS value, {group_expr} AS label, COUNT(*) AS count FROM mutualfunds"
-    ));
-    push_filters(&mut qb, user_id, filter);
-    qb.push(format!(
-        " GROUP BY {group_expr} ORDER BY {group_expr} {}",
-        if order_asc { "ASC" } else { "DESC" }
-    ));
-    Ok(qb.build_query_as::<FacetOption>().fetch_all(pool).await?)
+    shared::fetch_group_facets(
+        pool,
+        "mutualfunds",
+        group_field.as_sql_expr(),
+        order,
+        |qb| push_filters(qb, user_id, filter),
+    )
+    .await
 }
 
 /// 投資信託を一括追加（重複はスキップ）

--- a/backend/src/services/shared.rs
+++ b/backend/src/services/shared.rs
@@ -1,5 +1,5 @@
 use crate::errors::ApiError;
-use crate::models::common::{BulkCreateResponse, SearchQueryParams};
+use crate::models::common::{BulkCreateResponse, FacetOption, SearchQueryParams};
 use chrono::NaiveDate;
 use sqlx::postgres::PgQueryResult;
 use sqlx::{PgPool, Postgres, QueryBuilder};
@@ -246,12 +246,61 @@ pub fn push_token_ilike_filters(
     }
 }
 
+/// fetch_group_facets の GROUP BY 結果に対する ORDER BY 方向（呼び出し側が渡す固定値のみ）
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FacetOrder {
+    Asc,
+    Desc,
+}
+
+impl FacetOrder {
+    fn as_sql(self) -> &'static str {
+        match self {
+            Self::Asc => "ASC",
+            Self::Desc => "DESC",
+        }
+    }
+}
+
+/// table / group_expr（呼び出し側が渡す固定の &'static str のみ）を使って
+/// `SELECT ... GROUP BY ... ORDER BY ...` の QueryBuilder を組み立てる。
+/// push_filters は WHERE 句（user_id を含む検索条件）を積むクロージャ。
+fn build_group_facets_query(
+    table: &'static str,
+    group_expr: &'static str,
+    order: FacetOrder,
+    push_filters: impl FnOnce(&mut QueryBuilder<Postgres>),
+) -> QueryBuilder<Postgres> {
+    let mut qb: QueryBuilder<Postgres> = QueryBuilder::new(format!(
+        "SELECT {group_expr} AS value, {group_expr} AS label, COUNT(*) AS count FROM {table}"
+    ));
+    push_filters(&mut qb);
+    qb.push(format!(
+        " GROUP BY {group_expr} ORDER BY {group_expr} {}",
+        order.as_sql()
+    ));
+    qb
+}
+
+/// group_expr の値ごとに件数を集計して FacetOption を返す共通ヘルパー。
+/// table / group_expr / order は呼び出し側が定義する固定値のみを渡すこと。
+pub async fn fetch_group_facets(
+    pool: &PgPool,
+    table: &'static str,
+    group_expr: &'static str,
+    order: FacetOrder,
+    push_filters: impl FnOnce(&mut QueryBuilder<Postgres>),
+) -> Result<Vec<FacetOption>, ApiError> {
+    let mut qb = build_group_facets_query(table, group_expr, order, push_filters);
+    Ok(qb.build_query_as::<FacetOption>().fetch_all(pool).await?)
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        escape_like_pattern, parse_date_param, parse_year_month_range, push_date_axis_filters,
-        push_token_ilike_filters, tokens_from_query, user_ids_for_bulk_insert, year_to_range,
-        BulkTimer, DateAxisFilter,
+        build_group_facets_query, escape_like_pattern, parse_date_param, parse_year_month_range,
+        push_date_axis_filters, push_token_ilike_filters, tokens_from_query,
+        user_ids_for_bulk_insert, year_to_range, BulkTimer, DateAxisFilter, FacetOrder,
     };
     use crate::errors::ApiError;
     use chrono::NaiveDate;
@@ -391,5 +440,32 @@ mod tests {
         let mut qb: QueryBuilder<Postgres> = QueryBuilder::new("SELECT 1 FROM dummy");
         push_token_ilike_filters(&mut qb, &tokens, &[]);
         assert_eq!(qb.sql().as_str(), "SELECT 1 FROM dummy");
+    }
+
+    #[test]
+    fn test_build_group_facets_query_uses_given_table_group_expr_order_and_filters() {
+        let qb = build_group_facets_query("dividends", "product", FacetOrder::Asc, |qb| {
+            qb.push(" WHERE user_id = ").push_bind(Uuid::nil());
+        });
+        let sql = qb.sql();
+        let sql = sql.as_str();
+
+        assert!(sql.starts_with(
+            "SELECT product AS value, product AS label, COUNT(*) AS count FROM dividends"
+        ));
+        assert!(sql.contains("WHERE user_id = "));
+        assert!(sql.ends_with("GROUP BY product ORDER BY product ASC"));
+    }
+
+    #[test]
+    fn test_build_group_facets_query_desc_order_and_no_filters() {
+        let qb = build_group_facets_query("mutualfunds", "account", FacetOrder::Desc, |_| {});
+        let sql = qb.sql();
+        let sql = sql.as_str();
+
+        assert!(sql.starts_with(
+            "SELECT account AS value, account AS label, COUNT(*) AS count FROM mutualfunds"
+        ));
+        assert!(sql.ends_with("GROUP BY account ORDER BY account DESC"));
     }
 }


### PR DESCRIPTION
## 概要
配当金・国内株式・投資信託で重複していた GROUP BY facets 取得処理を shared helper に寄せました。

## 主な変更
- FacetOrder を追加して ORDER BY 方向を固定値化
- table/group 式を固定文字列として受け取る group facets helper を追加
- dividend/domestic_stock/mutualfund の fetch_group_facets を shared helper 利用へ置換
- helper のSQL組み立て単体テストを追加

## レビュー
- Codex review: findings なし、LGTM
- security facets は非対象のまま未変更

## テスト
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test
- push hook: openapi.json / api.ts 同期チェック PASS