### PR TITLE
frontend APIリクエスト設定を共通化

### DIFF
--- a/frontend/src/features/assetBalance/api/assetBalanceApi.ts
+++ b/frontend/src/features/assetBalance/api/assetBalanceApi.ts
@@ -1,5 +1,6 @@
 import { apiClient } from '@/lib/api/client';
 import { uploadCsvFile, previewCsvFile } from '@/lib/api/csvHelpers';
+import { listRequestConfig, withCredentialsConfig } from '@/lib/api/requestHelpers';
 import type { paths } from '@/generated/api';
 
 const API_PATHS = {
@@ -12,8 +13,6 @@ type AssetBalanceListResponse = paths['/api/v1/asset-balances']['get']['response
 type AssetBalanceDeleteResponse = paths['/api/v1/asset-balances']['delete']['responses'][200]['content']['application/json'];
 
 type AssetBalanceListQueryParams = NonNullable<paths['/api/v1/asset-balances']['get']['parameters']['query']>;
-const listRequestConfig = (params?: AssetBalanceListQueryParams) =>
-  params ? { params, withCredentials: true } : { withCredentials: true };
 
 export const assetBalanceApi = {
   list: (params?: AssetBalanceListQueryParams) =>
@@ -24,5 +23,5 @@ export const assetBalanceApi = {
   uploadCsv: (file: File) => uploadCsvFile(API_PATHS.assetBalanceImport, file),
 
   deleteAll: async () =>
-    apiClient.delete<AssetBalanceDeleteResponse>(API_PATHS.assetBalanceList, { withCredentials: true }),
+    apiClient.delete<AssetBalanceDeleteResponse>(API_PATHS.assetBalanceList, withCredentialsConfig),
 };

--- a/frontend/src/features/receipt/api/receiptApi.ts
+++ b/frontend/src/features/receipt/api/receiptApi.ts
@@ -1,5 +1,6 @@
 import { apiClient } from '@/lib/api/client';
 import { uploadCsvFile, previewCsvFile } from '@/lib/api/csvHelpers';
+import { listRequestConfig, withCredentialsConfig } from '@/lib/api/requestHelpers';
 import type { paths } from '@/generated/api';
 
 const API_PATHS = {
@@ -22,8 +23,6 @@ type MutualfundListResponse = paths['/api/v1/mutual-fund-transactions']['get']['
 type MutualfundDeleteResponse = paths['/api/v1/mutual-fund-transactions']['delete']['responses'][200]['content']['application/json'];
 
 type ListQueryParams = NonNullable<paths['/api/v1/dividends']['get']['parameters']['query']>;
-const listRequestConfig = (params?: ListQueryParams) =>
-  params ? { params, withCredentials: true } : { withCredentials: true };
 
 // 配当金API
 export const dividendApi = {
@@ -35,7 +34,7 @@ export const dividendApi = {
   uploadCsv: (file: File) => uploadCsvFile(API_PATHS.dividendImport, file),
 
   deleteAll: async () =>
-    apiClient.delete<DividendDeleteResponse>(API_PATHS.dividendList, { withCredentials: true }),
+    apiClient.delete<DividendDeleteResponse>(API_PATHS.dividendList, withCredentialsConfig),
 };
 
 // 国内株式API
@@ -48,7 +47,7 @@ export const domesticStockApi = {
   uploadCsv: (file: File) => uploadCsvFile(API_PATHS.domesticStockImport, file),
 
   deleteAll: async () =>
-    apiClient.delete<DomesticStockDeleteResponse>(API_PATHS.domesticStockList, { withCredentials: true }),
+    apiClient.delete<DomesticStockDeleteResponse>(API_PATHS.domesticStockList, withCredentialsConfig),
 };
 
 // 投資信託API
@@ -61,5 +60,5 @@ export const mutualfundApi = {
   uploadCsv: (file: File) => uploadCsvFile(API_PATHS.mutualfundImport, file),
 
   deleteAll: async () =>
-    apiClient.delete<MutualfundDeleteResponse>(API_PATHS.mutualfundList, { withCredentials: true }),
+    apiClient.delete<MutualfundDeleteResponse>(API_PATHS.mutualfundList, withCredentialsConfig),
 };

--- a/frontend/src/lib/api/requestHelpers.ts
+++ b/frontend/src/lib/api/requestHelpers.ts
@@ -1,0 +1,11 @@
+import type { RequestConfig } from '@/lib/api/client';
+
+// 認証Cookieを送るだけの共通config（deleteAll等で使い回す）
+export const withCredentialsConfig: RequestConfig = { withCredentials: true };
+
+// list系APIのquery params + 認証Cookieのconfigを組み立てる
+export function listRequestConfig<T extends NonNullable<RequestConfig['params']>>(
+  params?: T
+): RequestConfig {
+  return params ? { params, withCredentials: true } : withCredentialsConfig;
+}


### PR DESCRIPTION
## 概要
receiptApi と assetBalanceApi に重複していた list/delete 用のリクエスト設定を共通 helper に寄せました。

## 主な変更
- listRequestConfig と withCredentialsConfig を frontend/src/lib/api/requestHelpers.ts に追加
- receiptApi / assetBalanceApi の list/deleteAll で共通 helper を利用
- exported object と method 名、API path、generated api 型は変更なし

## レビュー
- Codex review: findings なし、LGTM
- package-lock.json のnpm由来差分はスコープ外として戻し済み

## テスト
- vp lint
- npx tsc --noEmit
- npm test