### PR TITLE
refactor: 銘柄facet取得処理を共通化

### DIFF
--- a/backend/src/services/asset_balance.rs
+++ b/backend/src/services/asset_balance.rs
@@ -14,8 +14,8 @@ use crate::services::csv_util::{
     get_row_cell, normalize_security_name, parse_number, parse_optional_string_row,
 };
 use crate::services::shared::{
-    delete_all_for_user, push_token_ilike_filters, tokens_from_query, user_ids_for_bulk_insert,
-    BulkTimer, DeleteTarget,
+    self, delete_all_for_user, push_token_ilike_filters, tokens_from_query,
+    user_ids_for_bulk_insert, BulkTimer, DeleteTarget,
 };
 use rust_decimal::Decimal;
 use sqlx::{PgPool, Postgres, QueryBuilder};
@@ -182,15 +182,10 @@ async fn fetch_security_facets(
     user_id: Uuid,
     filter: &AssetBalanceFilter,
 ) -> Result<Vec<FacetOption>, ApiError> {
-    let mut qb: QueryBuilder<Postgres> = QueryBuilder::new(
-        "SELECT security_code AS value, \
-         (ARRAY_AGG(security_name ORDER BY id))[1] AS label, \
-         COUNT(*) AS count \
-         FROM asset_balances",
-    );
-    push_filters(&mut qb, user_id, filter);
-    qb.push(" GROUP BY security_code ORDER BY security_code");
-    Ok(qb.build_query_as::<FacetOption>().fetch_all(pool).await?)
+    shared::fetch_security_facets(pool, "asset_balances", "id", |qb| {
+        push_filters(qb, user_id, filter);
+    })
+    .await
 }
 
 /// 保有銘柄を一括登録（既存データを全削除してから挿入）

--- a/backend/src/services/dividend.rs
+++ b/backend/src/services/dividend.rs
@@ -240,15 +240,10 @@ async fn fetch_security_facets(
     user_id: Uuid,
     filter: &DividendFilter,
 ) -> Result<Vec<FacetOption>, ApiError> {
-    let mut qb: QueryBuilder<Postgres> = QueryBuilder::new(
-        "SELECT security_code AS value, \
-         (ARRAY_AGG(security_name ORDER BY settlement_date DESC, id DESC))[1] AS label, \
-         COUNT(*) AS count \
-         FROM dividends",
-    );
-    push_filters(&mut qb, user_id, filter);
-    qb.push(" GROUP BY security_code ORDER BY security_code");
-    Ok(qb.build_query_as::<FacetOption>().fetch_all(pool).await?)
+    shared::fetch_security_facets(pool, "dividends", "settlement_date DESC, id DESC", |qb| {
+        push_filters(qb, user_id, filter);
+    })
+    .await
 }
 
 /// 配当金を一括追加（重複はスキップ）

--- a/backend/src/services/domestic_stock.rs
+++ b/backend/src/services/domestic_stock.rs
@@ -263,15 +263,10 @@ async fn fetch_security_facets(
     user_id: Uuid,
     filter: &DomesticStockFilter,
 ) -> Result<Vec<FacetOption>, ApiError> {
-    let mut qb: QueryBuilder<Postgres> = QueryBuilder::new(
-        "SELECT security_code AS value, \
-         (ARRAY_AGG(security_name ORDER BY trade_date DESC, id DESC))[1] AS label, \
-         COUNT(*) AS count \
-         FROM domestic_stocks",
-    );
-    push_filters(&mut qb, user_id, filter);
-    qb.push(" GROUP BY security_code ORDER BY security_code");
-    Ok(qb.build_query_as::<FacetOption>().fetch_all(pool).await?)
+    shared::fetch_security_facets(pool, "domestic_stocks", "trade_date DESC, id DESC", |qb| {
+        push_filters(qb, user_id, filter);
+    })
+    .await
 }
 
 /// 国内株式取引を一括追加（全件挿入）

--- a/backend/src/services/shared.rs
+++ b/backend/src/services/shared.rs
@@ -295,12 +295,45 @@ pub async fn fetch_group_facets(
     Ok(qb.build_query_as::<FacetOption>().fetch_all(pool).await?)
 }
 
+/// table / label_order（呼び出し側が渡す固定の &'static str のみ）を使って
+/// `security_code` ごとの facet 集計クエリを組み立てる。
+/// push_filters は WHERE 句（user_id を含む検索条件）を積むクロージャ。
+fn build_security_facets_query(
+    table: &'static str,
+    label_order: &'static str,
+    push_filters: impl FnOnce(&mut QueryBuilder<Postgres>),
+) -> QueryBuilder<Postgres> {
+    let mut qb: QueryBuilder<Postgres> = QueryBuilder::new(format!(
+        "SELECT security_code AS value, \
+         (ARRAY_AGG(security_name ORDER BY {label_order}))[1] AS label, \
+         COUNT(*) AS count \
+         FROM {table}"
+    ));
+    push_filters(&mut qb);
+    qb.push(" GROUP BY security_code ORDER BY security_code");
+    qb
+}
+
+/// security_code の値ごとに security_name（label_order で選択）・件数を集計して
+/// FacetOption を返す共通ヘルパー。
+/// table / label_order は呼び出し側が定義する固定値のみを渡すこと。
+pub async fn fetch_security_facets(
+    pool: &PgPool,
+    table: &'static str,
+    label_order: &'static str,
+    push_filters: impl FnOnce(&mut QueryBuilder<Postgres>),
+) -> Result<Vec<FacetOption>, ApiError> {
+    let mut qb = build_security_facets_query(table, label_order, push_filters);
+    Ok(qb.build_query_as::<FacetOption>().fetch_all(pool).await?)
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        build_group_facets_query, escape_like_pattern, parse_date_param, parse_year_month_range,
-        push_date_axis_filters, push_token_ilike_filters, tokens_from_query,
-        user_ids_for_bulk_insert, year_to_range, BulkTimer, DateAxisFilter, FacetOrder,
+        build_group_facets_query, build_security_facets_query, escape_like_pattern,
+        parse_date_param, parse_year_month_range, push_date_axis_filters, push_token_ilike_filters,
+        tokens_from_query, user_ids_for_bulk_insert, year_to_range, BulkTimer, DateAxisFilter,
+        FacetOrder,
     };
     use crate::errors::ApiError;
     use chrono::NaiveDate;
@@ -467,5 +500,36 @@ mod tests {
             "SELECT account AS value, account AS label, COUNT(*) AS count FROM mutualfunds"
         ));
         assert!(sql.ends_with("GROUP BY account ORDER BY account DESC"));
+    }
+
+    #[test]
+    fn test_build_security_facets_query_uses_given_table_label_order_and_filters() {
+        let qb = build_security_facets_query("dividends", "settlement_date DESC, id DESC", |qb| {
+            qb.push(" WHERE user_id = ").push_bind(Uuid::nil());
+        });
+        let sql = qb.sql();
+        let sql = sql.as_str();
+
+        assert!(sql.starts_with(
+            "SELECT security_code AS value, \
+             (ARRAY_AGG(security_name ORDER BY settlement_date DESC, id DESC))[1] AS label, \
+             COUNT(*) AS count FROM dividends"
+        ));
+        assert!(sql.contains("WHERE user_id = "));
+        assert!(sql.ends_with("GROUP BY security_code ORDER BY security_code"));
+    }
+
+    #[test]
+    fn test_build_security_facets_query_with_no_filters() {
+        let qb = build_security_facets_query("asset_balances", "id", |_| {});
+        let sql = qb.sql();
+        let sql = sql.as_str();
+
+        assert!(sql.starts_with(
+            "SELECT security_code AS value, \
+             (ARRAY_AGG(security_name ORDER BY id))[1] AS label, \
+             COUNT(*) AS count FROM asset_balances"
+        ));
+        assert!(sql.ends_with("GROUP BY security_code ORDER BY security_code"));
     }
 }


### PR DESCRIPTION
## 概要
- asset_balance / dividend / domestic_stock の securities facet 取得クエリを shared helper に集約
- 銘柄名 label の選択順と ORDER BY security_code は既存挙動を維持
- API / DB / frontend の変更なし

## テスト
- [x] cd backend && cargo fmt --check
- [x] cd backend && cargo clippy --all-targets -- -D warnings
- [x] cd backend && cargo test
- [x] push hook: openapi.json / api.ts 同期チェック

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 銘柄コード別のファセット表示を共通化し、資産残高・配当・国内株式で一貫した集計結果を提供します。
  * 最新の銘柄名をラベルとして表示し、件数や並び順を安定させました。
  * ユーザーや各種検索条件による絞り込みが、ファセット集計にも正しく反映されます。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->