### PR TITLE
refactor: API request configの共通利用を広げる

### DIFF
--- a/frontend/src/features/dividendPerShare/api/dividendPerShareApi.ts
+++ b/frontend/src/features/dividendPerShare/api/dividendPerShareApi.ts
@@ -1,4 +1,5 @@
 import { apiClient } from '@/lib/api/client';
+import { withCredentialsConfig } from '@/lib/api/requestHelpers';
 
 export type DividendStatus = 'ok' | 'zero' | 'pending' | 'error';
 
@@ -20,7 +21,7 @@ export async function fetchDividendPerShareBatch(
   const response = await apiClient.post<BatchResponse>(
     '/api/v1/dividend-per-share-estimates',
     { security_codes: securityCodes },
-    { withCredentials: true }
+    withCredentialsConfig
   );
   return response.items;
 }

--- a/frontend/src/features/marketData/api/client.ts
+++ b/frontend/src/features/marketData/api/client.ts
@@ -1,5 +1,6 @@
 import { FinancialStatementsResponse } from './types';
 import { apiClient } from '@/lib/api/client';
+import { listRequestConfig } from '@/lib/api/requestHelpers';
 import { ApiError, ApiErrorType } from '@/lib/types/api';
 
 /**
@@ -25,7 +26,7 @@ export class MarketDataApiClient {
 
       const response = await apiClient.get<FinancialStatementsResponse>(
         '/api/v1/financial-statements',
-        { params, withCredentials: true }
+        listRequestConfig(params)
       );
 
       return response;


### PR DESCRIPTION
## 概要
- dividendPerShare API の認証付き request config を `withCredentialsConfig` に統一
- marketData API の params + 認証付き request config を `listRequestConfig(params)` に統一
- API パス、payload、レスポンス処理、認証挙動は変更なし

## テスト
- [x] cd frontend && vp lint
- [x] cd frontend && npx tsc --noEmit
- [x] cd frontend && npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - 配当情報および市場データの取得リクエストで、認証情報の設定方法を共通化しました。
  - これにより、関連データの取得時に認証情報が一貫して扱われ、リクエストの安定性が向上します。
  - 公開されているデータ形式や取得方法に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->