### PR TITLE
fix: DB制約違反のHTTPステータスを見直す

### DIFF
--- a/backend/src/errors.rs
+++ b/backend/src/errors.rs
@@ -81,14 +81,10 @@ fn into_http(err: ApiError) -> (StatusCode, ErrorDetails) {
                 }
                 sqlx::Error::Database(db_err) => {
                     if db_err.is_unique_violation() {
-                        (
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            "DUPLICATE_ENTRY",
-                            "Duplicate entry",
-                        )
+                        (StatusCode::CONFLICT, "DUPLICATE_ENTRY", "Duplicate entry")
                     } else if db_err.is_foreign_key_violation() {
                         (
-                            StatusCode::INTERNAL_SERVER_ERROR,
+                            StatusCode::BAD_REQUEST,
                             "FOREIGN_KEY_VIOLATION",
                             "Foreign key constraint violation",
                         )


### PR DESCRIPTION
## 概要
- unique_violation を 500 から 409 Conflict に変更
- foreign_key_violation を 500 から 400 Bad Request に変更
- error code / message は維持

## テスト
- [x] cd backend && cargo fmt --check
- [x] cd backend && cargo clippy --all-targets -- -D warnings
- [x] cd backend && cargo test
- [x] push hook: openapi.json / api.ts 同期チェック