### PR TITLE
fix: facets取得を並列化

### DIFF
--- a/backend/src/services/dividend.rs
+++ b/backend/src/services/dividend.rs
@@ -173,21 +173,27 @@ async fn fetch_facets(
     user_id: Uuid,
     filter: &DividendFilter,
 ) -> Result<SearchFacets, ApiError> {
-    let products =
-        fetch_group_facets(pool, user_id, filter, GroupField::Product, FacetOrder::Asc).await?;
-    let accounts =
-        fetch_group_facets(pool, user_id, filter, GroupField::Account, FacetOrder::Asc).await?;
-    let securities = fetch_security_facets(pool, user_id, filter).await?;
-    let years =
-        fetch_group_facets(pool, user_id, filter, GroupField::Year, FacetOrder::Desc).await?;
-    let year_months = fetch_group_facets(
+    let products_fut =
+        fetch_group_facets(pool, user_id, filter, GroupField::Product, FacetOrder::Asc);
+    let accounts_fut =
+        fetch_group_facets(pool, user_id, filter, GroupField::Account, FacetOrder::Asc);
+    let securities_fut = fetch_security_facets(pool, user_id, filter);
+    let years_fut = fetch_group_facets(pool, user_id, filter, GroupField::Year, FacetOrder::Desc);
+    let year_months_fut = fetch_group_facets(
         pool,
         user_id,
         filter,
         GroupField::YearMonth,
         FacetOrder::Desc,
-    )
-    .await?;
+    );
+
+    let (products, accounts, securities, years, year_months) = tokio::try_join!(
+        products_fut,
+        accounts_fut,
+        securities_fut,
+        years_fut,
+        year_months_fut
+    )?;
 
     Ok(SearchFacets {
         products: Some(products),

--- a/backend/src/services/domestic_stock.rs
+++ b/backend/src/services/domestic_stock.rs
@@ -196,19 +196,20 @@ async fn fetch_facets(
     user_id: Uuid,
     filter: &DomesticStockFilter,
 ) -> Result<SearchFacets, ApiError> {
-    let accounts =
-        fetch_group_facets(pool, user_id, filter, GroupField::Account, FacetOrder::Asc).await?;
-    let securities = fetch_security_facets(pool, user_id, filter).await?;
-    let years =
-        fetch_group_facets(pool, user_id, filter, GroupField::Year, FacetOrder::Desc).await?;
-    let year_months = fetch_group_facets(
+    let accounts_fut =
+        fetch_group_facets(pool, user_id, filter, GroupField::Account, FacetOrder::Asc);
+    let securities_fut = fetch_security_facets(pool, user_id, filter);
+    let years_fut = fetch_group_facets(pool, user_id, filter, GroupField::Year, FacetOrder::Desc);
+    let year_months_fut = fetch_group_facets(
         pool,
         user_id,
         filter,
         GroupField::YearMonth,
         FacetOrder::Desc,
-    )
-    .await?;
+    );
+
+    let (accounts, securities, years, year_months) =
+        tokio::try_join!(accounts_fut, securities_fut, years_fut, year_months_fut)?;
 
     Ok(SearchFacets {
         products: None,


### PR DESCRIPTION
## 概要
- dividend の facets 取得5クエリを tokio::try_join! で並列化
- domestic_stock の facets 取得4クエリを tokio::try_join! で並列化
- クエリ内容とレスポンス shape は変更なし

## テスト
- [x] cd backend && cargo fmt --check
- [x] cd backend && cargo clippy --all-targets -- -D warnings
- [x] cd backend && cargo test
- [x] push hook: openapi.json / api.ts 同期チェック