### PR TITLE
chore: フロントの未使用APIと重複フォーマット処理を整理

### DIFF
--- a/frontend/src/lib/api/__tests__/client.test.ts
+++ b/frontend/src/lib/api/__tests__/client.test.ts
@@ -282,67 +282,6 @@ describe('ApiClient', () => {
     });
   });
 
-  describe('バッチリクエスト', () => {
-    it('複数のリクエストを並列実行できる', async () => {
-      const mockData1 = { id: 1 };
-      const mockData2 = { id: 2 };
-      const mockData3 = { id: 3 };
-
-      mockFetch
-        .mockResolvedValueOnce({ ok: true, status: 200, text: () => Promise.resolve(JSON.stringify(mockData1)) })
-        .mockResolvedValueOnce({ ok: true, status: 200, text: () => Promise.resolve(JSON.stringify(mockData2)) })
-        .mockResolvedValueOnce({ ok: true, status: 200, text: () => Promise.resolve(JSON.stringify(mockData3)) });
-
-      const client = createApiClient({ baseURL: 'http://api.test' });
-      const resultsPromise = client.batch([
-        () => client.get('/test/1'),
-        () => client.get('/test/2'),
-        () => client.get('/test/3'),
-      ]);
-      await vi.runAllTimersAsync();
-      const results = await resultsPromise;
-
-      expect(results).toEqual([mockData1, mockData2, mockData3]);
-      expect(mockFetch).toHaveBeenCalledTimes(3);
-    });
-  });
-
-  describe('キャンセル可能なリクエスト', () => {
-    it('リクエストをキャンセルできる', async () => {
-      const client = createApiClient({ baseURL: 'http://api.test' });
-      const { promise, cancel } = client.createCancelableRequest(
-        async (signal) => {
-          // AbortSignalを使用したリクエストのシミュレーション
-          return new Promise((resolve, reject) => {
-            const timeout = setTimeout(() => resolve('success'), 1000);
-
-            signal.addEventListener('abort', () => {
-              clearTimeout(timeout);
-              reject(new Error('Aborted'));
-            });
-          });
-        }
-      );
-
-      // 即座にキャンセル
-      cancel();
-
-      // キャンセルされたリクエストはエラーになるはず
-      await expect(promise).rejects.toThrow();
-    });
-
-    it('abort以外のエラーはそのままrethrowする', async () => {
-      const client = createApiClient({ baseURL: 'http://api.test' });
-      const expectedError = new Error('Unexpected failure');
-
-      const { promise } = client.createCancelableRequest(async () => {
-        throw expectedError;
-      });
-
-      await expect(promise).rejects.toBe(expectedError);
-    });
-  });
-
   describe('FormDataリクエスト', () => {
     it('FormDataを送信するとき Content-Type ヘッダーを含まない', async () => {
       mockFetch.mockResolvedValue({
@@ -494,11 +433,6 @@ describe('ApiClient', () => {
       const putPromise = apiClient.put('/singleton-put', { name: 'put' });
       const patchPromise = apiClient.patch('/singleton-patch', { name: 'patch' });
       const deletePromise = apiClient.delete('/singleton-delete');
-      const batchPromise = apiClient.batch([
-        () => apiClient.get('/singleton-batch-1'),
-        () => apiClient.get('/singleton-batch-2'),
-      ] as const);
-      const cancelableRequest = apiClient.createCancelableRequest(async () => 'singleton');
 
       await vi.runAllTimersAsync();
 
@@ -507,10 +441,8 @@ describe('ApiClient', () => {
       await expect(putPromise).resolves.toEqual({});
       await expect(patchPromise).resolves.toEqual({});
       await expect(deletePromise).resolves.toEqual({});
-      await expect(batchPromise).resolves.toEqual([{}, {}]);
-      await expect(cancelableRequest.promise).resolves.toBe('singleton');
 
-      expect(mockFetch).toHaveBeenCalledTimes(7);
+      expect(mockFetch).toHaveBeenCalledTimes(5);
       expect(mockFetch).toHaveBeenNthCalledWith(
         1,
         expect.stringContaining('/singleton-get'),

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -207,41 +207,6 @@ class ApiClient {
   async delete<T>(url: string, config?: RequestConfig): Promise<T> {
     return this.executeRequest<T>('DELETE', url, undefined, config);
   }
-
-  // バッチリクエスト
-  async batch<T extends readonly unknown[]>(
-    requests: {
-      [K in keyof T]: () => Promise<T[K]>
-    }
-  ): Promise<T> {
-    const promises = requests.map(requestFn => requestFn());
-    return Promise.all(promises) as unknown as Promise<T>;
-  }
-
-  // キャンセル可能なリクエスト
-  createCancelableRequest<T>(
-    requestFn: (signal: AbortSignal) => Promise<T>
-  ): {
-    promise: Promise<T>;
-    cancel: () => void;
-  } {
-    const controller = new AbortController();
-
-    const wrappedPromise = requestFn(controller.signal).catch(error => {
-      if (controller.signal.aborted) {
-        throw new ApiError(
-          ApiErrorType.REQUEST_ERROR,
-          'リクエストがキャンセルされました'
-        );
-      }
-      throw error;
-    });
-
-    return {
-      promise: wrappedPromise,
-      cancel: () => controller.abort(),
-    };
-  }
 }
 
 // シングルトンインスタンスの遅延初期化
@@ -261,8 +226,6 @@ export const apiClient = {
   put: <T>(url: string, data?: unknown, config?: RequestConfig) => getApiClient().put<T>(url, data, config),
   patch: <T>(url: string, data?: unknown, config?: RequestConfig) => getApiClient().patch<T>(url, data, config),
   delete: <T>(url: string, config?: RequestConfig) => getApiClient().delete<T>(url, config),
-  batch: <T extends readonly unknown[]>(requests: { [K in keyof T]: () => Promise<T[K]> }) => getApiClient().batch<T>(requests),
-  createCancelableRequest: <T>(requestFn: (signal: AbortSignal) => Promise<T>) => getApiClient().createCancelableRequest<T>(requestFn),
 };
 
 // 型付きAPIクライアントのファクトリー関数

--- a/frontend/src/lib/utils/__tests__/formatters.test.ts
+++ b/frontend/src/lib/utils/__tests__/formatters.test.ts
@@ -1,10 +1,7 @@
 import {
-  parseDate,
   formatJPDate,
-  formatDateString,
   createYearMonthKey,
   createISODateKey,
-  parseNumberString,
   parseNumber,
   formatNumber,
   formatCurrency,
@@ -21,28 +18,6 @@ import {
 } from '../formatters';
 
 describe('日付関連のフォーマット関数', () => {
-  describe('parseDate', () => {
-    it('正しい日付文字列を解析する', () => {
-      const result = parseDate('2023/12/25');
-      expect(result).toBeInstanceOf(Date);
-      expect(result?.getFullYear()).toBe(2023);
-      expect(result?.getMonth()).toBe(11); // 0ベース
-      expect(result?.getDate()).toBe(25);
-    });
-
-    it('無効な文字列でnullを返す', () => {
-      expect(parseDate('')).toBeNull();
-      expect(parseDate('invalid')).toBeNull();
-      expect(parseDate('2023-12-25')).toBeNull(); // 違う形式
-    });
-
-    it('単桁の月日も正しく解析する', () => {
-      const result = parseDate('2023/1/5');
-      expect(result?.getMonth()).toBe(0);
-      expect(result?.getDate()).toBe(5);
-    });
-  });
-
   describe('formatJPDate', () => {
     it('正常な日付を日本形式でフォーマットする', () => {
       const date = new Date(2023, 11, 25);
@@ -54,23 +29,6 @@ describe('日付関連のフォーマット関数', () => {
       expect(formatJPDate(undefined)).toBe('-');
       expect(formatJPDate('string')).toBe('-');
       expect(formatJPDate(new Date('invalid'))).toBe('-');
-    });
-  });
-
-  describe('formatDateString', () => {
-    const date = new Date(2023, 11, 25);
-
-    it('短い形式でフォーマットする', () => {
-      expect(formatDateString(date, 'short')).toBe('2023/12/25');
-      expect(formatDateString(date)).toBe('2023/12/25'); // デフォルト
-    });
-
-    it('長い形式でフォーマットする', () => {
-      expect(formatDateString(date, 'long')).toBe('2023年12月25日');
-    });
-
-    it('無効な日付で空文字を返す', () => {
-      expect(formatDateString(new Date('invalid'))).toBe('');
     });
   });
 
@@ -136,22 +94,6 @@ describe('数値関連のフォーマット関数', () => {
       expect(normalizeSecurityName('日本株ABC123')).toBe('日本株ABC123');
     });
   });
-  describe('parseNumberString', () => {
-    it('数値文字列を解析する', () => {
-      expect(parseNumberString('123')).toBe(123);
-      expect(parseNumberString('123.45')).toBe(123.45);
-      expect(parseNumberString('1,234')).toBe(1234);
-      expect(parseNumberString('1,234.56')).toBe(1234.56);
-    });
-
-    it('無効な値でnullを返す', () => {
-      expect(parseNumberString(null)).toBeNull();
-      expect(parseNumberString(undefined)).toBeNull();
-      expect(parseNumberString('')).toBeNull();
-      expect(parseNumberString('abc')).toBeNull();
-    });
-  });
-
   describe('parseNumber', () => {
     it('様々な値を数値に変換する', () => {
       expect(parseNumber('123')).toBe(123);

--- a/frontend/src/lib/utils/formatters.ts
+++ b/frontend/src/lib/utils/formatters.ts
@@ -51,25 +51,6 @@ export function normalizeSecurityName(name: string): string {
 // ==================== 日付関連 ====================
 
 /**
- * 文字列から日付オブジェクトを解析する
- * @param dateStr 日付文字列 (YYYY/MM/DD形式)
- * @returns 日付オブジェクト、解析できない場合はnull
- */
-export function parseDate(dateStr: string): Date | null {
-  if (!dateStr) return null;
-
-  const match = dateStr.match(/^(\d{4})\/(\d{1,2})\/(\d{1,2})$/);
-  if (match) {
-    const year = parseInt(match[1], 10);
-    const month = parseInt(match[2], 10) - 1;
-    const day = parseInt(match[3], 10);
-    return new Date(year, month, day);
-  }
-
-  return null;
-}
-
-/**
  * 日付を日本形式でフォーマットする
  * @param value 日付値
  * @returns フォーマットされた日付文字列
@@ -79,28 +60,6 @@ export function formatJPDate(value: unknown): string {
     return '-';
   }
   return value.toLocaleDateString('ja-JP', JP_DATE_FORMAT_OPTIONS);
-}
-
-/**
- * 日付文字列をフォーマットする
- * @param date 日付オブジェクト
- * @param format フォーマット形式
- * @returns フォーマットされた日付文字列
- */
-export function formatDateString(date: Date, format: 'short' | 'long' = 'short'): string {
-  if (!date || !(date instanceof Date) || isNaN(date.getTime())) {
-    return '';
-  }
-
-  const year = date.getFullYear();
-  const month = (date.getMonth() + 1).toString().padStart(2, '0');
-  const day = date.getDate().toString().padStart(2, '0');
-
-  if (format === 'short') {
-    return `${year}/${month}/${day}`;
-  }
-
-  return `${year}年${month}月${day}日`;
 }
 
 /**
@@ -133,24 +92,47 @@ export function createISODateKey(date: Date): string {
 // ==================== 数値関連 ====================
 
 /**
- * 数値文字列を解析して数値に変換する
- * @param value 解析する値
- * @returns 数値、解析できない場合はnull
- */
-export function parseNumberString(value: string | null | undefined): number | null {
-  if (!value) return null;
-  const cleanStr = value.replace(/,/g, '');
-  const num = parseFloat(cleanStr);
-  return isNaN(num) ? null : num;
-}
-
-/**
  * 任意の値を数値に変換する（カンマ区切り対応）
  * @param value 変換する値
  * @returns 数値
  */
 export function parseNumber(value: unknown): number {
   return Number(String(value || '0').replace(/,/g, ''));
+}
+
+/**
+ * 値を数値に変換する（文字列・数値以外はnull）
+ * @param value 変換する値
+ * @returns 数値、変換できない場合はnull
+ */
+function toNumberOrNull(value: unknown): number | null {
+  let num: number;
+
+  if (typeof value === 'string') {
+    num = Number(value.replace(/,/g, ''));
+  } else if (typeof value === 'number') {
+    num = value;
+  } else {
+    return null;
+  }
+
+  return isNaN(num) ? null : num;
+}
+
+/**
+ * 数値の絶対値をIntl.NumberFormatで文字列化し、符号を付与する
+ * @param num 数値
+ * @param formatOptions Intl.NumberFormatOptions
+ * @returns 符号付きのフォーマット済み文字列
+ */
+function formatSignedAbsNumber(
+  num: number,
+  formatOptions: Intl.NumberFormatOptions
+): { formatted: string; isNegative: boolean } {
+  const isNegative = num < 0;
+  const absNum = Math.abs(num);
+  const formatted = new Intl.NumberFormat('ja-JP', formatOptions).format(absNum);
+  return { formatted, isNegative };
 }
 
 /**
@@ -174,35 +156,19 @@ export function formatNumber(
   } = options;
 
   try {
-    let num: number;
-
-    if (typeof value === 'string') {
-      num = Number(value.replace(/,/g, ''));
-    } else if (typeof value === 'number') {
-      num = value;
-    } else {
+    const num = toNumberOrNull(value);
+    if (num === null) {
       return '-';
     }
 
-    if (isNaN(num)) {
-      return '-';
-    }
-
-    const isNegative = num < 0;
-    const absNum = Math.abs(num);
-
-    const formattedNumber = new Intl.NumberFormat('ja-JP', {
+    const { formatted, isNegative } = formatSignedAbsNumber(num, {
       style: 'decimal',
       useGrouping,
       minimumFractionDigits,
       maximumFractionDigits
-    }).format(absNum);
+    });
 
-    if (isNegative) {
-      return `-${formattedNumber}`;
-    } else {
-      return formattedNumber;
-    }
+    return isNegative ? `-${formatted}` : formatted;
   } catch (error) {
     console.error('数値のフォーマットに失敗しました:', error instanceof Error ? error.message : String(error));
     return '-';
@@ -230,35 +196,19 @@ export function formatCurrency(
   } = options;
 
   try {
-    let num: number;
-
-    if (typeof value === 'string') {
-      num = Number(value.replace(/,/g, ''));
-    } else if (typeof value === 'number') {
-      num = value;
-    } else {
+    const num = toNumberOrNull(value);
+    if (num === null) {
       return '-';
     }
 
-    if (isNaN(num)) {
-      return '-';
-    }
-
-    const isNegative = num < 0;
-    const absNum = Math.abs(num);
-
-    const formattedNumber = new Intl.NumberFormat('ja-JP', {
+    const { formatted, isNegative } = formatSignedAbsNumber(num, {
       style: 'decimal',
       useGrouping: true,
       minimumFractionDigits,
       maximumFractionDigits
-    }).format(absNum);
+    });
 
-    if (isNegative) {
-      return `${currency} -${formattedNumber}`;
-    } else {
-      return `${currency} ${formattedNumber}`;
-    }
+    return isNegative ? `${currency} -${formatted}` : `${currency} ${formatted}`;
   } catch (error) {
     console.error('通貨のフォーマットに失敗しました:', error instanceof Error ? error.message : String(error));
     return '-';


### PR DESCRIPTION
## 概要
- formatNumber / formatCurrency の数値変換・符号付きフォーマット処理を内部ヘルパーへ集約
- 本番未使用の parseDate / formatDateString / parseNumberString を削除
- 本番未使用の ApiClient.batch / createCancelableRequest を削除し、関連テストを整理

## 検証
- cd frontend && vp lint
- cd frontend && npx tsc --noEmit
- cd frontend && npm test

## レビュー
- Claude実装後、Codexで差分レビュー済み
- CodeRabbit/CIはPR作成後に確認