### PR TITLE
refactor: ドメイン検索処理の重複を整理

### DIFF
--- a/backend/src/models/asset_balance.rs
+++ b/backend/src/models/asset_balance.rs
@@ -1,4 +1,4 @@
-use crate::models::common::{validate_length_field, SearchQueryParams};
+use crate::models::common::{validate_length_field, SearchParamsAccessor, SearchQueryParams};
 use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
@@ -116,25 +116,9 @@ pub struct AssetBalanceSearchQueryParams {
     pub security_name: Option<String>,
 }
 
-impl AssetBalanceSearchQueryParams {
-    pub fn page(&self) -> i64 {
-        self.search.page()
-    }
-
-    pub fn per_page(&self) -> i64 {
-        self.search.per_page()
-    }
-
-    pub fn offset(&self) -> i64 {
-        self.search.offset()
-    }
-
-    pub fn should_include_summary(&self) -> bool {
-        self.search.should_include_summary()
-    }
-
-    pub fn should_include_facets(&self) -> bool {
-        self.search.should_include_facets()
+impl SearchParamsAccessor for AssetBalanceSearchQueryParams {
+    fn search_params(&self) -> &SearchQueryParams {
+        &self.search
     }
 }
 

--- a/backend/src/models/common.rs
+++ b/backend/src/models/common.rs
@@ -110,6 +110,33 @@ impl SearchQueryParams {
     }
 }
 
+/// `#[serde(flatten)] search: SearchQueryParams` を持つドメイン別検索パラメータが
+/// page/per_page/offset/should_include_summary/should_include_facets を委譲実装する重複を解消する共通トレイト。
+/// 実装側は `search_params()` のみを定義すればよい。
+pub trait SearchParamsAccessor {
+    fn search_params(&self) -> &SearchQueryParams;
+
+    fn page(&self) -> i64 {
+        self.search_params().page()
+    }
+
+    fn per_page(&self) -> i64 {
+        self.search_params().per_page()
+    }
+
+    fn offset(&self) -> i64 {
+        self.search_params().offset()
+    }
+
+    fn should_include_summary(&self) -> bool {
+        self.search_params().should_include_summary()
+    }
+
+    fn should_include_facets(&self) -> bool {
+        self.search_params().should_include_facets()
+    }
+}
+
 /// 検索候補の共通表現。
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
 pub struct FacetOption {

--- a/backend/src/models/dividend.rs
+++ b/backend/src/models/dividend.rs
@@ -1,4 +1,4 @@
-use crate::models::common::{validate_length_field, SearchQueryParams};
+use crate::models::common::{validate_length_field, SearchParamsAccessor, SearchQueryParams};
 use chrono::{DateTime, NaiveDate, Utc};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
@@ -48,25 +48,9 @@ pub struct DividendSearchQueryParams {
     pub security_name: Option<String>,
 }
 
-impl DividendSearchQueryParams {
-    pub fn page(&self) -> i64 {
-        self.search.page()
-    }
-
-    pub fn per_page(&self) -> i64 {
-        self.search.per_page()
-    }
-
-    pub fn offset(&self) -> i64 {
-        self.search.offset()
-    }
-
-    pub fn should_include_summary(&self) -> bool {
-        self.search.should_include_summary()
-    }
-
-    pub fn should_include_facets(&self) -> bool {
-        self.search.should_include_facets()
+impl SearchParamsAccessor for DividendSearchQueryParams {
+    fn search_params(&self) -> &SearchQueryParams {
+        &self.search
     }
 }
 

--- a/backend/src/models/domestic_stock.rs
+++ b/backend/src/models/domestic_stock.rs
@@ -1,4 +1,4 @@
-use crate::models::common::{validate_length_field, SearchQueryParams};
+use crate::models::common::{validate_length_field, SearchParamsAccessor, SearchQueryParams};
 use chrono::{DateTime, NaiveDate, Utc};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
@@ -50,25 +50,9 @@ pub struct DomesticStockSearchQueryParams {
     pub security_name: Option<String>,
 }
 
-impl DomesticStockSearchQueryParams {
-    pub fn page(&self) -> i64 {
-        self.search.page()
-    }
-
-    pub fn per_page(&self) -> i64 {
-        self.search.per_page()
-    }
-
-    pub fn offset(&self) -> i64 {
-        self.search.offset()
-    }
-
-    pub fn should_include_summary(&self) -> bool {
-        self.search.should_include_summary()
-    }
-
-    pub fn should_include_facets(&self) -> bool {
-        self.search.should_include_facets()
+impl SearchParamsAccessor for DomesticStockSearchQueryParams {
+    fn search_params(&self) -> &SearchQueryParams {
+        &self.search
     }
 }
 

--- a/backend/src/models/mutualfund.rs
+++ b/backend/src/models/mutualfund.rs
@@ -1,4 +1,4 @@
-use crate::models::common::{validate_length_field, SearchQueryParams};
+use crate::models::common::{validate_length_field, SearchParamsAccessor, SearchQueryParams};
 use chrono::{DateTime, NaiveDate, Utc};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
@@ -78,25 +78,9 @@ pub struct MutualfundSearchQueryParams {
     pub dividends: Option<String>,
 }
 
-impl MutualfundSearchQueryParams {
-    pub fn page(&self) -> i64 {
-        self.search.page()
-    }
-
-    pub fn per_page(&self) -> i64 {
-        self.search.per_page()
-    }
-
-    pub fn offset(&self) -> i64 {
-        self.search.offset()
-    }
-
-    pub fn should_include_summary(&self) -> bool {
-        self.search.should_include_summary()
-    }
-
-    pub fn should_include_facets(&self) -> bool {
-        self.search.should_include_facets()
+impl SearchParamsAccessor for MutualfundSearchQueryParams {
+    fn search_params(&self) -> &SearchQueryParams {
+        &self.search
     }
 }
 

--- a/backend/src/services/asset_balance.rs
+++ b/backend/src/services/asset_balance.rs
@@ -3,7 +3,7 @@ use crate::models::asset_balance::{
     AssetBalance, AssetBalanceSearchQueryParams, AssetBalanceSummary, CreateAssetBalanceRequest,
 };
 use crate::models::common::{
-    BulkCreateResponse, FacetOption, PaginatedSearchResponse, SearchFacets,
+    BulkCreateResponse, FacetOption, PaginatedSearchResponse, SearchFacets, SearchParamsAccessor,
 };
 use crate::models::csv_import::{CsvPreviewResponse, CsvRowError, CsvUploadResponse};
 use crate::services::csv_import::{build_csv_preview, run_csv_upload, validate_csv_rows};
@@ -13,9 +13,9 @@ use crate::services::csv_pipeline::{CsvParserConfig, CsvRow};
 use crate::services::csv_util::{
     get_row_cell, normalize_security_name, parse_number, parse_optional_string_row,
 };
+use crate::services::search_filters::{push_search_filters, run_paginated_search};
 use crate::services::shared::{
-    self, delete_all_for_user, push_token_ilike_filters, tokens_from_query,
-    user_ids_for_bulk_insert, BulkTimer, DeleteTarget,
+    self, delete_all_for_user, tokens_from_query, user_ids_for_bulk_insert, BulkTimer, DeleteTarget,
 };
 use rust_decimal::Decimal;
 use sqlx::{PgPool, Postgres, QueryBuilder};
@@ -62,15 +62,20 @@ impl AssetBalanceFilter {
 }
 
 /// user_id と検索条件を WHERE 句として QueryBuilder へ積む
+///
+/// asset_balances には snapshot 日付がないため、date axis は渡さない（`None`）。
 fn push_filters(qb: &mut QueryBuilder<Postgres>, user_id: Uuid, filter: &AssetBalanceFilter) {
-    qb.push(" WHERE user_id = ").push_bind(user_id);
-    if let Some(v) = &filter.security_code {
-        qb.push(" AND security_code = ").push_bind(v.clone());
-    }
-    if let Some(v) = &filter.security_name {
-        qb.push(" AND security_name = ").push_bind(v.clone());
-    }
-    push_token_ilike_filters(qb, &filter.tokens, &["security_code", "security_name"]);
+    push_search_filters(
+        qb,
+        user_id,
+        None,
+        &[
+            ("security_code", &filter.security_code),
+            ("security_name", &filter.security_name),
+        ],
+        &filter.tokens,
+        &["security_code", "security_name"],
+    );
 }
 
 /// 認証ユーザーの保有銘柄一覧を検索（ページネーション・summary・facets 対応）
@@ -81,33 +86,6 @@ pub async fn search(
 ) -> Result<PaginatedSearchResponse<AssetBalance, AssetBalanceSummary, SearchFacets>, ApiError> {
     info!("[asset_balance.search] リクエスト受信");
     let filter = AssetBalanceFilter::from_params(params);
-
-    let mut count_qb: QueryBuilder<Postgres> =
-        QueryBuilder::new("SELECT COUNT(*) FROM asset_balances");
-    push_filters(&mut count_qb, user_id, &filter);
-    let count_fut = async move {
-        let total: i64 = count_qb.build_query_scalar().fetch_one(pool).await?;
-        Ok::<_, ApiError>(total)
-    };
-
-    let mut data_qb: QueryBuilder<Postgres> = QueryBuilder::new(
-        "SELECT id, user_id, security_code, security_name, shares, executing_shares, \
-         average_purchase_price, total_purchase_amount, current_price, daily_change, \
-         market_value, profit_loss_rate, created_at, updated_at \
-         FROM asset_balances",
-    );
-    push_filters(&mut data_qb, user_id, &filter);
-    data_qb.push(" ORDER BY security_code ASC, id ASC LIMIT ");
-    data_qb.push_bind(params.per_page());
-    data_qb.push(" OFFSET ");
-    data_qb.push_bind(params.offset());
-    let data_fut = async move {
-        let data = data_qb
-            .build_query_as::<AssetBalance>()
-            .fetch_all(pool)
-            .await?;
-        Ok::<_, ApiError>(data)
-    };
 
     let summary_fut = async {
         if params.should_include_summary() {
@@ -125,19 +103,23 @@ pub async fn search(
         }
     };
 
-    // count/data/summary/facets は相互に依存しないため並行実行する。
     // summary/facets は include_* が true の場合だけ実クエリを発行する。
-    let (total, data, summary, facets) =
-        tokio::try_join!(count_fut, data_fut, summary_fut, facets_fut)?;
-
-    Ok(PaginatedSearchResponse {
-        data,
-        total,
-        page: params.page(),
-        per_page: params.per_page(),
-        summary,
-        facets,
-    })
+    run_paginated_search(
+        pool,
+        "SELECT COUNT(*) FROM asset_balances",
+        "SELECT id, user_id, security_code, security_name, shares, executing_shares, \
+         average_purchase_price, total_purchase_amount, current_price, daily_change, \
+         market_value, profit_loss_rate, created_at, updated_at \
+         FROM asset_balances",
+        " ORDER BY security_code ASC, id ASC",
+        |qb| push_filters(qb, user_id, &filter),
+        params.page(),
+        params.per_page(),
+        params.offset(),
+        summary_fut,
+        facets_fut,
+    )
+    .await
 }
 
 /// 検索条件全体の summary を算出する（ページ内だけでなく検索条件全体の合計）

--- a/backend/src/services/dividend.rs
+++ b/backend/src/services/dividend.rs
@@ -1,6 +1,6 @@
 use crate::errors::ApiError;
 use crate::models::common::{
-    BulkCreateResponse, FacetOption, PaginatedSearchResponse, SearchFacets,
+    BulkCreateResponse, FacetOption, PaginatedSearchResponse, SearchFacets, SearchParamsAccessor,
 };
 use crate::models::csv_import::{CsvPreviewResponse, CsvRowError, CsvUploadResponse};
 use crate::models::dividend::{
@@ -12,9 +12,10 @@ use crate::services::csv_util::{
     normalize_security_name, parse_optional_string_row, parse_required_date_row,
     parse_required_number_row, parse_required_string_row,
 };
+use crate::services::search_filters::{push_search_filters, run_paginated_search};
 use crate::services::shared::{
-    self, delete_all_for_user, push_date_axis_filters, push_token_ilike_filters, tokens_from_query,
-    user_ids_for_bulk_insert, BulkTimer, DateAxisFilter, DeleteTarget, FacetOrder,
+    self, delete_all_for_user, tokens_from_query, user_ids_for_bulk_insert, BulkTimer,
+    DateAxisFilter, DeleteTarget, FacetOrder,
 };
 use rust_decimal::Decimal;
 use sqlx::{PgPool, Postgres, QueryBuilder};
@@ -68,22 +69,16 @@ impl DividendFilter {
 
 /// user_id と検索条件を WHERE 句として QueryBuilder へ積む
 fn push_filters(qb: &mut QueryBuilder<Postgres>, user_id: Uuid, filter: &DividendFilter) {
-    qb.push(" WHERE user_id = ").push_bind(user_id);
-    push_date_axis_filters(qb, "settlement_date", &filter.date_axis);
-    if let Some(v) = &filter.product {
-        qb.push(" AND product = ").push_bind(v.clone());
-    }
-    if let Some(v) = &filter.account {
-        qb.push(" AND account = ").push_bind(v.clone());
-    }
-    if let Some(v) = &filter.security_code {
-        qb.push(" AND security_code = ").push_bind(v.clone());
-    }
-    if let Some(v) = &filter.security_name {
-        qb.push(" AND security_name = ").push_bind(v.clone());
-    }
-    push_token_ilike_filters(
+    push_search_filters(
         qb,
+        user_id,
+        Some(("settlement_date", &filter.date_axis)),
+        &[
+            ("product", &filter.product),
+            ("account", &filter.account),
+            ("security_code", &filter.security_code),
+            ("security_name", &filter.security_name),
+        ],
         &filter.tokens,
         &["product", "account", "security_code", "security_name"],
     );
@@ -97,28 +92,6 @@ pub async fn search(
 ) -> Result<PaginatedSearchResponse<Dividend, DividendSummary, SearchFacets>, ApiError> {
     info!("[dividend.search] リクエスト受信");
     let filter = DividendFilter::from_params(params)?;
-
-    let mut count_qb: QueryBuilder<Postgres> = QueryBuilder::new("SELECT COUNT(*) FROM dividends");
-    push_filters(&mut count_qb, user_id, &filter);
-    let count_fut = async move {
-        let total: i64 = count_qb.build_query_scalar().fetch_one(pool).await?;
-        Ok::<_, ApiError>(total)
-    };
-
-    let mut data_qb: QueryBuilder<Postgres> = QueryBuilder::new(
-        "SELECT id, user_id, settlement_date, product, account, security_code, security_name, \
-         unit_price, shares, dividends_before_tax, taxes, net_amount_received, created_at, updated_at \
-         FROM dividends",
-    );
-    push_filters(&mut data_qb, user_id, &filter);
-    data_qb.push(" ORDER BY settlement_date DESC, id DESC LIMIT ");
-    data_qb.push_bind(params.per_page());
-    data_qb.push(" OFFSET ");
-    data_qb.push_bind(params.offset());
-    let data_fut = async move {
-        let data = data_qb.build_query_as::<Dividend>().fetch_all(pool).await?;
-        Ok::<_, ApiError>(data)
-    };
 
     let summary_fut = async {
         if params.should_include_summary() {
@@ -136,18 +109,21 @@ pub async fn search(
         }
     };
 
-    // count/data/summary/facets は相互に依存しないため並行実行する
-    let (total, data, summary, facets) =
-        tokio::try_join!(count_fut, data_fut, summary_fut, facets_fut)?;
-
-    Ok(PaginatedSearchResponse {
-        data,
-        total,
-        page: params.page(),
-        per_page: params.per_page(),
-        summary,
-        facets,
-    })
+    run_paginated_search(
+        pool,
+        "SELECT COUNT(*) FROM dividends",
+        "SELECT id, user_id, settlement_date, product, account, security_code, security_name, \
+         unit_price, shares, dividends_before_tax, taxes, net_amount_received, created_at, updated_at \
+         FROM dividends",
+        " ORDER BY settlement_date DESC, id DESC",
+        |qb| push_filters(qb, user_id, &filter),
+        params.page(),
+        params.per_page(),
+        params.offset(),
+        summary_fut,
+        facets_fut,
+    )
+    .await
 }
 
 async fn fetch_summary(

--- a/backend/src/services/domestic_stock.rs
+++ b/backend/src/services/domestic_stock.rs
@@ -1,6 +1,6 @@
 use crate::errors::ApiError;
 use crate::models::common::{
-    BulkCreateResponse, FacetOption, PaginatedSearchResponse, SearchFacets,
+    BulkCreateResponse, FacetOption, PaginatedSearchResponse, SearchFacets, SearchParamsAccessor,
 };
 use crate::models::csv_import::{CsvPreviewResponse, CsvRowError, CsvUploadResponse};
 use crate::models::domestic_stock::{
@@ -12,9 +12,10 @@ use crate::services::csv_util::{
     compute_taxes, normalize_security_name, parse_required_date_row, parse_required_number_row,
     parse_required_string_row,
 };
+use crate::services::search_filters::{push_search_filters, run_paginated_search};
 use crate::services::shared::{
-    self, delete_all_for_user, push_date_axis_filters, push_token_ilike_filters, tokens_from_query,
-    user_ids_for_bulk_insert, BulkTimer, DateAxisFilter, DeleteTarget, FacetOrder,
+    self, delete_all_for_user, tokens_from_query, user_ids_for_bulk_insert, BulkTimer,
+    DateAxisFilter, DeleteTarget, FacetOrder,
 };
 use rust_decimal::Decimal;
 use sqlx::{PgPool, Postgres, QueryBuilder};
@@ -66,19 +67,15 @@ impl DomesticStockFilter {
 
 /// user_id と検索条件を WHERE 句として QueryBuilder へ積む
 fn push_filters(qb: &mut QueryBuilder<Postgres>, user_id: Uuid, filter: &DomesticStockFilter) {
-    qb.push(" WHERE user_id = ").push_bind(user_id);
-    push_date_axis_filters(qb, "trade_date", &filter.date_axis);
-    if let Some(v) = &filter.account {
-        qb.push(" AND account = ").push_bind(v.clone());
-    }
-    if let Some(v) = &filter.security_code {
-        qb.push(" AND security_code = ").push_bind(v.clone());
-    }
-    if let Some(v) = &filter.security_name {
-        qb.push(" AND security_name = ").push_bind(v.clone());
-    }
-    push_token_ilike_filters(
+    push_search_filters(
         qb,
+        user_id,
+        Some(("trade_date", &filter.date_axis)),
+        &[
+            ("account", &filter.account),
+            ("security_code", &filter.security_code),
+            ("security_name", &filter.security_name),
+        ],
         &filter.tokens,
         &["account", "security_code", "security_name"],
     );
@@ -92,33 +89,6 @@ pub async fn search(
 ) -> Result<PaginatedSearchResponse<DomesticStock, DomesticStockSummary, SearchFacets>, ApiError> {
     info!("[domestic_stock.search] リクエスト受信");
     let filter = DomesticStockFilter::from_params(params)?;
-
-    let mut count_qb: QueryBuilder<Postgres> =
-        QueryBuilder::new("SELECT COUNT(*) FROM domestic_stocks");
-    push_filters(&mut count_qb, user_id, &filter);
-    let count_fut = async move {
-        let total: i64 = count_qb.build_query_scalar().fetch_one(pool).await?;
-        Ok::<_, ApiError>(total)
-    };
-
-    let mut data_qb: QueryBuilder<Postgres> = QueryBuilder::new(
-        "SELECT id, user_id, trade_date, settlement_date, security_code, security_name, \
-         account, shares, asked_price, proceeds, purchase_price, realized_profit_and_loss, \
-         taxes, realized_profit_and_loss_after_tax, created_at, updated_at \
-         FROM domestic_stocks",
-    );
-    push_filters(&mut data_qb, user_id, &filter);
-    data_qb.push(" ORDER BY trade_date DESC, id DESC LIMIT ");
-    data_qb.push_bind(params.per_page());
-    data_qb.push(" OFFSET ");
-    data_qb.push_bind(params.offset());
-    let data_fut = async move {
-        let data = data_qb
-            .build_query_as::<DomesticStock>()
-            .fetch_all(pool)
-            .await?;
-        Ok::<_, ApiError>(data)
-    };
 
     let summary_fut = async {
         if params.should_include_summary() {
@@ -136,18 +106,22 @@ pub async fn search(
         }
     };
 
-    // count/data/summary/facets は相互に依存しないため並行実行する
-    let (total, data, summary, facets) =
-        tokio::try_join!(count_fut, data_fut, summary_fut, facets_fut)?;
-
-    Ok(PaginatedSearchResponse {
-        data,
-        total,
-        page: params.page(),
-        per_page: params.per_page(),
-        summary,
-        facets,
-    })
+    run_paginated_search(
+        pool,
+        "SELECT COUNT(*) FROM domestic_stocks",
+        "SELECT id, user_id, trade_date, settlement_date, security_code, security_name, \
+         account, shares, asked_price, proceeds, purchase_price, realized_profit_and_loss, \
+         taxes, realized_profit_and_loss_after_tax, created_at, updated_at \
+         FROM domestic_stocks",
+        " ORDER BY trade_date DESC, id DESC",
+        |qb| push_filters(qb, user_id, &filter),
+        params.page(),
+        params.per_page(),
+        params.offset(),
+        summary_fut,
+        facets_fut,
+    )
+    .await
 }
 
 /// 検索条件全体の summary を算出する。

--- a/backend/src/services/mutualfund.rs
+++ b/backend/src/services/mutualfund.rs
@@ -1,6 +1,6 @@
 use crate::errors::ApiError;
 use crate::models::common::{
-    BulkCreateResponse, FacetOption, PaginatedSearchResponse, SearchFacets,
+    BulkCreateResponse, FacetOption, PaginatedSearchResponse, SearchFacets, SearchParamsAccessor,
 };
 use crate::models::csv_import::{CsvPreviewResponse, CsvRowError, CsvUploadResponse};
 use crate::models::mutualfund::{
@@ -12,9 +12,10 @@ use crate::services::csv_util::{
     compute_taxes, get_row_cell, parse_required_date_row, parse_required_number_row,
     parse_required_string_row,
 };
+use crate::services::search_filters::{push_search_filters, run_paginated_search};
 use crate::services::shared::{
-    self, delete_all_for_user, push_date_axis_filters, push_token_ilike_filters, tokens_from_query,
-    user_ids_for_bulk_insert, BulkTimer, DateAxisFilter, DeleteTarget, FacetOrder,
+    self, delete_all_for_user, tokens_from_query, user_ids_for_bulk_insert, BulkTimer,
+    DateAxisFilter, DeleteTarget, FacetOrder,
 };
 use rust_decimal::Decimal;
 use sqlx::{PgPool, Postgres, QueryBuilder};
@@ -67,18 +68,18 @@ impl MutualfundFilter {
 
 /// user_id と検索条件を WHERE 句として QueryBuilder へ積む
 fn push_filters(qb: &mut QueryBuilder<Postgres>, user_id: Uuid, filter: &MutualfundFilter) {
-    qb.push(" WHERE user_id = ").push_bind(user_id);
-    push_date_axis_filters(qb, "trade_date", &filter.date_axis);
-    if let Some(v) = &filter.account {
-        qb.push(" AND account = ").push_bind(v.clone());
-    }
-    if let Some(v) = &filter.fund_name {
-        qb.push(" AND fund_name = ").push_bind(v.clone());
-    }
-    if let Some(v) = &filter.dividends {
-        qb.push(" AND dividends = ").push_bind(v.clone());
-    }
-    push_token_ilike_filters(qb, &filter.tokens, &["account", "fund_name", "dividends"]);
+    push_search_filters(
+        qb,
+        user_id,
+        Some(("trade_date", &filter.date_axis)),
+        &[
+            ("account", &filter.account),
+            ("fund_name", &filter.fund_name),
+            ("dividends", &filter.dividends),
+        ],
+        &filter.tokens,
+        &["account", "fund_name", "dividends"],
+    );
 }
 
 /// 認証ユーザーの投資信託一覧を検索（ページネーション・summary・facets 対応）
@@ -89,34 +90,6 @@ pub async fn search(
 ) -> Result<PaginatedSearchResponse<Mutualfund, MutualfundSummary, SearchFacets>, ApiError> {
     info!("[mutualfund.search] リクエスト受信");
     let filter = MutualfundFilter::from_params(params)?;
-
-    let mut count_qb: QueryBuilder<Postgres> =
-        QueryBuilder::new("SELECT COUNT(*) FROM mutualfunds");
-    push_filters(&mut count_qb, user_id, &filter);
-    let count_fut = async move {
-        let total: i64 = count_qb.build_query_scalar().fetch_one(pool).await?;
-        Ok::<_, ApiError>(total)
-    };
-
-    let mut data_qb: QueryBuilder<Postgres> = QueryBuilder::new(
-        "SELECT id, user_id, trade_date, settlement_date, fund_name, dividends, account, \
-         shares, exchange_rate, cancellation_unit_price_yen, cancellation_amount_yen, \
-         average_acquisition_price_yen, realized_profit_and_loss, taxes, \
-         realized_profit_and_loss_after_tax, created_at, updated_at \
-         FROM mutualfunds",
-    );
-    push_filters(&mut data_qb, user_id, &filter);
-    data_qb.push(" ORDER BY trade_date DESC, id DESC LIMIT ");
-    data_qb.push_bind(params.per_page());
-    data_qb.push(" OFFSET ");
-    data_qb.push_bind(params.offset());
-    let data_fut = async move {
-        let data = data_qb
-            .build_query_as::<Mutualfund>()
-            .fetch_all(pool)
-            .await?;
-        Ok::<_, ApiError>(data)
-    };
 
     let summary_fut = async {
         if params.should_include_summary() {
@@ -134,18 +107,23 @@ pub async fn search(
         }
     };
 
-    // count/data/summary/facets は相互に依存しないため並行実行する
-    let (total, data, summary, facets) =
-        tokio::try_join!(count_fut, data_fut, summary_fut, facets_fut)?;
-
-    Ok(PaginatedSearchResponse {
-        data,
-        total,
-        page: params.page(),
-        per_page: params.per_page(),
-        summary,
-        facets,
-    })
+    run_paginated_search(
+        pool,
+        "SELECT COUNT(*) FROM mutualfunds",
+        "SELECT id, user_id, trade_date, settlement_date, fund_name, dividends, account, \
+         shares, exchange_rate, cancellation_unit_price_yen, cancellation_amount_yen, \
+         average_acquisition_price_yen, realized_profit_and_loss, taxes, \
+         realized_profit_and_loss_after_tax, created_at, updated_at \
+         FROM mutualfunds",
+        " ORDER BY trade_date DESC, id DESC",
+        |qb| push_filters(qb, user_id, &filter),
+        params.page(),
+        params.per_page(),
+        params.offset(),
+        summary_fut,
+        facets_fut,
+    )
+    .await
 }
 
 /// 検索条件全体の summary を算出する（ページ内だけでなく検索条件全体の合計）

--- a/backend/src/services/search_filters.rs
+++ b/backend/src/services/search_filters.rs
@@ -1,7 +1,11 @@
 use crate::errors::ApiError;
-use crate::models::common::SearchQueryParams;
+use crate::models::common::{PaginatedSearchResponse, SearchQueryParams};
 use chrono::NaiveDate;
-use sqlx::{Postgres, QueryBuilder};
+use sqlx::postgres::PgRow;
+use sqlx::{FromRow, PgPool, Postgres, QueryBuilder};
+use std::future::Future;
+use utoipa::ToSchema;
+use uuid::Uuid;
 
 pub fn parse_date_param(field: &str, value: &str) -> Result<NaiveDate, ApiError> {
     NaiveDate::parse_from_str(value, "%Y-%m-%d")
@@ -140,6 +144,91 @@ pub fn push_token_ilike_filters(
         }
         qb.push(")");
     }
+}
+
+/// user_id 条件 + optional date axis 条件 + Option 完全一致条件 + token ILIKE 条件を
+/// この順で WHERE 句として QueryBuilder へ積む共通ヘルパー。
+///
+/// - `date_axis`: `(date_column, filter)`。date 系フィルタを持たないドメイン（asset_balance 等）は `None` を渡す
+/// - `exact_match_fields`: `(column, value)` の並び。呼び出し側が対象カラムを固定 `&'static str` で指定する
+/// - `token_columns`: フリーワード検索（ILIKE OR）の対象カラム
+pub fn push_search_filters(
+    qb: &mut QueryBuilder<Postgres>,
+    user_id: Uuid,
+    date_axis: Option<(&'static str, &DateAxisFilter)>,
+    exact_match_fields: &[(&'static str, &Option<String>)],
+    tokens: &[String],
+    token_columns: &[&'static str],
+) {
+    qb.push(" WHERE user_id = ").push_bind(user_id);
+    if let Some((date_column, filter)) = date_axis {
+        push_date_axis_filters(qb, date_column, filter);
+    }
+    for (column, value) in exact_match_fields {
+        if let Some(v) = value {
+            qb.push(format!(" AND {column} = ")).push_bind(v.clone());
+        }
+    }
+    push_token_ilike_filters(qb, tokens, token_columns);
+}
+
+/// count query / data query / summary future / facets future を `tokio::try_join!` で並行実行し
+/// `PaginatedSearchResponse` を組み立てる4ドメイン共通の検索制御フロー。
+///
+/// - `count_sql` / `data_sql`: フィルタ前の `SELECT ... FROM table`（呼び出し側が渡す固定文字列）
+/// - `order_by`: data query に付与する `ORDER BY` 句（先頭スペース込み。LIMIT/OFFSET は本関数側で付与する）
+/// - `push_filters`: count/data 両方の WHERE 句を積むクロージャ（`push_search_filters` 等を呼ぶ想定）
+/// - `summary_fut` / `facets_fut`: `should_include_summary`/`should_include_facets` に応じて
+///   `Some`/`None` を返す形に呼び出し側が組み立てた future をそのまま渡す
+#[allow(clippy::too_many_arguments)]
+pub async fn run_paginated_search<T, Summary, Facets, SummaryFut, FacetsFut>(
+    pool: &PgPool,
+    count_sql: &str,
+    data_sql: &str,
+    order_by: &str,
+    push_filters: impl Fn(&mut QueryBuilder<Postgres>),
+    page: i64,
+    per_page: i64,
+    offset: i64,
+    summary_fut: SummaryFut,
+    facets_fut: FacetsFut,
+) -> Result<PaginatedSearchResponse<T, Summary, Facets>, ApiError>
+where
+    T: for<'r> FromRow<'r, PgRow> + ToSchema + Send + Unpin + 'static,
+    Summary: ToSchema + 'static,
+    Facets: ToSchema + 'static,
+    SummaryFut: Future<Output = Result<Option<Summary>, ApiError>>,
+    FacetsFut: Future<Output = Result<Option<Facets>, ApiError>>,
+{
+    let mut count_qb: QueryBuilder<Postgres> = QueryBuilder::new(count_sql);
+    push_filters(&mut count_qb);
+    let count_fut = async move {
+        let total: i64 = count_qb.build_query_scalar().fetch_one(pool).await?;
+        Ok::<_, ApiError>(total)
+    };
+
+    let mut data_qb: QueryBuilder<Postgres> = QueryBuilder::new(data_sql);
+    push_filters(&mut data_qb);
+    data_qb.push(order_by);
+    data_qb.push(" LIMIT ").push_bind(per_page);
+    data_qb.push(" OFFSET ").push_bind(offset);
+    let data_fut = async move {
+        let data = data_qb.build_query_as::<T>().fetch_all(pool).await?;
+        Ok::<_, ApiError>(data)
+    };
+
+    // count/data/summary/facets は相互に依存しないため並行実行する
+    let (total, data, summary, facets) =
+        tokio::try_join!(count_fut, data_fut, summary_fut, facets_fut)?;
+
+    Ok(PaginatedSearchResponse {
+        data,
+        total,
+        page,
+        per_page,
+        summary,
+        facets,
+    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 概要
- 4ドメインの検索パラメータ委譲を SearchParamsAccessor に集約
- フィルタ構築を push_search_filters に共通化
- count/data/summary/facets の検索制御を run_paginated_search に集約

## テスト
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- SQLX_OFFLINE=true cargo test
- bash scripts/check-openapi.sh