### PR TITLE
fix: 起動時設定検証とDBプール共有を見直す

### DIFF
--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -17,11 +17,6 @@ fn pool_options(max_connections: u32) -> PgPoolOptions {
         .max_connections(max_connections)
         .acquire_slow_threshold(Duration::from_secs(ACQUIRE_SLOW_THRESHOLD_SECS))
 }
-
-pub async fn connect_pool(database_url: &str, max_connections: u32) -> Result<PgPool, sqlx::Error> {
-    pool_options(max_connections).connect(database_url).await
-}
-
 pub fn connect_pool_lazy(database_url: &str, max_connections: u32) -> Result<PgPool, String> {
     let database_url = database_url.trim();
     validate_database_url(database_url)?;
@@ -31,27 +26,18 @@ pub fn connect_pool_lazy(database_url: &str, max_connections: u32) -> Result<PgP
         .map_err(|e| format!("DB pool の初期化に失敗しました: {e}"))
 }
 
-/// URL の設定を事前検証し、一時的な接続失敗は bounded retry する。
-/// 設定エラーは retry しない。秘密情報はエラー文字列に含めない。
-pub async fn connect_pool_with_retry(
-    database_url: &str,
-    max_connections: u32,
-) -> Result<PgPool, String> {
-    let database_url = database_url.trim();
-    validate_database_url(database_url)?;
-    let sanitized_url = sanitize_database_url_for_sqlx(database_url)?;
-
+// Wait for an already-created Pool to establish a startup connection with bounded retry.
+// The Pool is not recreated, so runtime state and migrations share the same handle.
+pub async fn wait_for_pool_with_retry(pool: &PgPool) -> Result<(), String> {
     let connect_timeout = Duration::from_secs(CONNECT_TIMEOUT_SECS);
     let retry_delay = Duration::from_secs(RETRY_DELAY_SECS);
 
     for attempt in 1..=MAX_ATTEMPTS {
-        match tokio::time::timeout(
-            connect_timeout,
-            connect_pool(&sanitized_url, max_connections),
-        )
-        .await
-        {
-            Ok(Ok(pool)) => return Ok(pool),
+        match tokio::time::timeout(connect_timeout, pool.acquire()).await {
+            Ok(Ok(connection)) => {
+                drop(connection);
+                return Ok(());
+            }
             Ok(Err(e)) if is_transient_error(&e) => {
                 tracing::warn!(
                     attempt,
@@ -188,6 +174,15 @@ mod tests {
     async fn test_connect_pool_lazy_invalid_url() {
         let err = connect_pool_lazy("", 5).unwrap_err();
         assert!(err.contains("空"), "空URLを拒否すること: {err}");
+        let err = connect_pool_lazy("   ", 5).unwrap_err();
+        assert!(err.contains("空"), "空白のみは空として拒否: {err}");
+
+        let err = connect_pool_lazy("/relative", 5).unwrap_err();
+        assert!(
+            !err.contains("/relative"),
+            "相対URLをエラーに含めない: {err}"
+        );
+
         let err = connect_pool_lazy("http://example.com/db", 5).unwrap_err();
         assert!(
             !err.contains("example.com"),
@@ -242,43 +237,6 @@ mod tests {
         assert!(!is_transient_error(&sqlx::Error::ColumnNotFound(
             "col".to_string()
         )));
-    }
-
-    #[tokio::test]
-    async fn test_connect_pool_with_retry_invalid_url() {
-        // 空
-        let err = connect_pool_with_retry("", 5).await.unwrap_err();
-        assert!(err.contains("空"), "空URLのエラーメッセージが適切: {err}");
-        assert!(!err.contains("://"), "URLをエラーに含めない: {err}");
-
-        // 空白のみ（trim 後に空として拒否）
-        let err = connect_pool_with_retry("   ", 5).await.unwrap_err();
-        assert!(err.contains("空"), "空白のみは空として拒否: {err}");
-
-        // 相対 URL
-        let err = connect_pool_with_retry("/relative", 5).await.unwrap_err();
-        assert!(
-            !err.contains("/relative"),
-            "相対URLをエラーに含めない: {err}"
-        );
-
-        // HTTP スキーム
-        let err = connect_pool_with_retry("http://example.com/db", 5)
-            .await
-            .unwrap_err();
-        assert!(
-            !err.contains("example.com"),
-            "ホスト名をエラーに含めない: {err}"
-        );
-
-        // 前後空白 + HTTP スキーム（trim 後にスキームエラー）
-        let err = connect_pool_with_retry("  http://example.com/db  ", 5)
-            .await
-            .unwrap_err();
-        assert!(
-            !err.contains("example.com"),
-            "trim後のURLをエラーに含めない: {err}"
-        );
     }
 
     #[test]

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -14,10 +14,11 @@ mod state;
 mod test_env;
 
 use config::Config;
-use db::{connect_pool_lazy, connect_pool_with_retry, run_migrations};
+use db::{connect_pool_lazy, run_migrations, wait_for_pool_with_retry};
 use dotenvy::dotenv;
 use reqwest::Client;
 use routes::app_router;
+use sqlx::PgPool;
 use state::{AppState, DividendCacheState, Secrets};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
@@ -25,6 +26,22 @@ use std::sync::{
 };
 use std::time::Instant;
 use tokio::net::TcpListener;
+
+fn build_startup_state(
+    secrets: Arc<Secrets>,
+    config: &Config,
+) -> Result<(PgPool, AppState), String> {
+    // URL 検証のみ行い、実接続は background startup task で行う。
+    let pool = connect_pool_lazy(&secrets.database_url, config.database_max_connections)?;
+    let state = AppState {
+        pool: pool.clone(),
+        secrets,
+        client: Client::new(),
+        dividend_cache: DividendCacheState::default(),
+    };
+
+    Ok((pool, state))
+}
 
 #[tokio::main]
 async fn main() {
@@ -55,20 +72,11 @@ async fn main() {
 
     let startup_ready = Arc::new(AtomicBool::new(false));
 
-    // URL 検証のみ行い、実接続は行わない lazy pool
-    let pool = connect_pool_lazy(&secrets.database_url, config.database_max_connections)
-        .unwrap_or_else(|e| {
+    let (startup_pool, state) =
+        build_startup_state(Arc::clone(&secrets), &config).unwrap_or_else(|e| {
             tracing::error!("{e}");
             std::process::exit(1);
         });
-
-    let client = Client::new();
-    let state = AppState {
-        pool,
-        secrets: Arc::clone(&secrets),
-        client,
-        dividend_cache: DividendCacheState::default(),
-    };
 
     let router = app_router(state, &config, Arc::clone(&startup_ready));
 
@@ -89,12 +97,10 @@ async fn main() {
     );
 
     // DB 接続と migration をバックグラウンドで実行し、完了後に startup_ready を立てる
-    let db_url = secrets.database_url.clone();
-    let max_connections = config.database_max_connections;
     let startup_ready_bg = Arc::clone(&startup_ready);
     tokio::spawn(async move {
         tracing::info!(target: "startup", "データベースに接続中...");
-        let pool = connect_pool_with_retry(&db_url, max_connections)
+        wait_for_pool_with_retry(&startup_pool)
             .await
             .unwrap_or_else(|e| {
                 tracing::error!("{e}");
@@ -105,7 +111,7 @@ async fn main() {
         tracing::info!(target: "startup", elapsed_ms = db_connect_ms, "DB connect 完了");
 
         tracing::info!(target: "startup", "マイグレーションを実行中...");
-        if let Err(e) = run_migrations(&pool).await {
+        if let Err(e) = run_migrations(&startup_pool).await {
             tracing::error!("マイグレーション失敗: {e}");
             std::process::exit(1);
         }
@@ -136,4 +142,33 @@ async fn main() {
     axum::serve(listener, router)
         .await
         .expect("サーバーの起動に失敗しました");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_secrets() -> Arc<Secrets> {
+        Arc::new(Secrets {
+            database_url: "postgresql://user:password@localhost/test_db".to_string(),
+            jquants_api_key: None,
+            google_client_id: Some("client-id".to_string()),
+            google_client_secret: Some("client-secret".to_string()),
+            frontend_url: "http://localhost:8080".to_string(),
+        })
+    }
+
+    #[tokio::test]
+    async fn build_startup_state_reuses_pool_for_runtime_and_startup_tasks() {
+        let config = Config::default();
+        let (startup_pool, state) =
+            build_startup_state(test_secrets(), &config).expect("startup state");
+
+        startup_pool.close().await;
+
+        assert!(
+            state.pool.is_closed(),
+            "runtime state pool should share the startup pool handle"
+        );
+    }
 }

--- a/backend/src/state.rs
+++ b/backend/src/state.rs
@@ -20,8 +20,14 @@ impl Secrets {
                 "DATABASE_URL が設定されていません（backend/.env を確認してください）".to_string()
             })?,
             jquants_api_key: std::env::var("JQUANTS_API_KEY").ok(),
-            google_client_id: std::env::var("GOOGLE_CLIENT_ID").ok(),
-            google_client_secret: std::env::var("GOOGLE_CLIENT_SECRET").ok(),
+            google_client_id: Some(std::env::var("GOOGLE_CLIENT_ID").map_err(|_| {
+                "GOOGLE_CLIENT_ID が設定されていません（Google OAuth 設定を確認してください）"
+                    .to_string()
+            })?),
+            google_client_secret: Some(std::env::var("GOOGLE_CLIENT_SECRET").map_err(|_| {
+                "GOOGLE_CLIENT_SECRET が設定されていません（Google OAuth 設定を確認してください）"
+                    .to_string()
+            })?),
             frontend_url: std::env::var("FRONTEND_URL")
                 .unwrap_or_else(|_| "http://localhost:8080".to_string()),
         })
@@ -63,6 +69,9 @@ mod tests {
                 "DATABASE_URL",
                 Some("postgresql://user:password@localhost/test"),
             );
+            let _google_client_id = EnvGuard::set("GOOGLE_CLIENT_ID", Some("client-id"));
+            let _google_client_secret =
+                EnvGuard::set("GOOGLE_CLIENT_SECRET", Some("client-secret"));
             let _fe = EnvGuard::set("FRONTEND_URL", None);
             assert_eq!(
                 Secrets::from_env().unwrap().frontend_url,
@@ -74,8 +83,32 @@ mod tests {
                 "DATABASE_URL",
                 Some("postgresql://user:password@localhost/test"),
             );
+            let _google_client_id = EnvGuard::set("GOOGLE_CLIENT_ID", Some("client-id"));
+            let _google_client_secret =
+                EnvGuard::set("GOOGLE_CLIENT_SECRET", Some("client-secret"));
             let _jq = EnvGuard::set("JQUANTS_API_KEY", None);
             assert!(Secrets::from_env().unwrap().jquants_api_key.is_none());
+        }
+        {
+            let _db = EnvGuard::set("DATABASE_URL", Some("postgresql://user:password/test"));
+            let _google_client_id = EnvGuard::set("GOOGLE_CLIENT_ID", None);
+            let _google_client_secret =
+                EnvGuard::set("GOOGLE_CLIENT_SECRET", Some("client-secret"));
+            let err_msg = Secrets::from_env().unwrap_err();
+            assert!(
+                err_msg.contains("GOOGLE_CLIENT_ID"),
+                "エラーメッセージに GOOGLE_CLIENT_ID が含まれること: {err_msg}"
+            );
+        }
+        {
+            let _db = EnvGuard::set("DATABASE_URL", Some("postgresql://user:password/test"));
+            let _google_client_id = EnvGuard::set("GOOGLE_CLIENT_ID", Some("client-id"));
+            let _google_client_secret = EnvGuard::set("GOOGLE_CLIENT_SECRET", None);
+            let err_msg = Secrets::from_env().unwrap_err();
+            assert!(
+                err_msg.contains("GOOGLE_CLIENT_SECRET"),
+                "エラーメッセージに GOOGLE_CLIENT_SECRET が含まれること: {err_msg}"
+            );
         }
     }
 }


### PR DESCRIPTION
## 概要
- GOOGLE_CLIENT_ID と GOOGLE_CLIENT_SECRET を起動時必須検証に変更
- runtime state と migration startup task が同じ PgPool handle を共有するように変更
- 旧 connect_pool_with_retry を削除し、既存 pool の接続確立を待つ wait_for_pool_with_retry に置き換え

## テスト
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- SQLX_OFFLINE=true cargo test
- bash scripts/check-openapi.sh

## 補足
- make run は常駐プロセスになるため、このPR作業内では未実行