### PR TITLE
refactor: Receipt系フックと集計選択の重複を整理

### DIFF
--- a/frontend/src/features/receipt/hooks/useReceiptsData.ts
+++ b/frontend/src/features/receipt/hooks/useReceiptsData.ts
@@ -64,6 +64,35 @@ const RECEIPT_LIST_PARAMS = {
   include_summary: true,
 } as const;
 
+// previewCsv/uploadCsv/deleteAll は3ドメインとも同一シグネチャのため、type キーで引ける lookup map にまとめる
+const receiptApiByType = {
+  dividend: dividendApi,
+  domesticstock: domesticStockApi,
+  mutualfund: mutualfundApi,
+} satisfies Record<ReceiptsType, Pick<typeof dividendApi, 'previewCsv' | 'uploadCsv' | 'deleteAll'>>;
+
+interface ReceiptListQueryConfig<TDbItem, TItem, TSummary> {
+  queryKey: readonly unknown[];
+  list: (params: typeof RECEIPT_LIST_PARAMS) => Promise<{ data: TDbItem[]; summary?: TSummary }>;
+  transform: (item: TDbItem) => TItem;
+}
+
+/** 明細一覧の取得ロジック（クエリキー・APIモジュール・変換関数以外は3ドメイン共通） */
+function useReceiptListQuery<TDbItem, TItem, TSummary>(
+  config: ReceiptListQueryConfig<TDbItem, TItem, TSummary>,
+  enabled: boolean,
+) {
+  return useQuery({
+    queryKey: config.queryKey,
+    queryFn: () =>
+      config.list(RECEIPT_LIST_PARAMS).then((response) => ({
+        items: response.data.map(config.transform),
+        summary: response.summary,
+      })),
+    enabled,
+  });
+}
+
 /**
  * 明細データの取得・保存・削除を TanStack Query で管理するフック
  * ユーザー固有キーでキャッシュを分離し、未認証時はフェッチせず空を返す
@@ -72,53 +101,42 @@ export function useReceiptsData(): UseReceiptsDataResult {
   const { isAuthenticated, isLoading: authLoading, onLogout, user } = useAuth();
   const userId = user?.id ?? '';
   const queryClient = useQueryClient();
+  const enabled = isAuthenticated && !authLoading && !!userId;
 
   // ログアウト時：プレフィックスマッチで全ユーザーキャッシュをクリア
   useEffect(() => {
     return onLogout(() => clearReceiptsCache(queryClient));
   }, [onLogout, queryClient]);
 
-  const dividendQuery = useQuery({
-    queryKey: receiptQueryKeys.dividend(userId),
-    queryFn: () =>
-      dividendApi.list(RECEIPT_LIST_PARAMS).then((response) => ({
-        items: response.data.map(transformDBDividend),
-        summary: response.summary,
-      })),
-    enabled: isAuthenticated && !authLoading && !!userId,
-  });
+  const dividendQuery = useReceiptListQuery(
+    {
+      queryKey: receiptQueryKeys.dividend(userId),
+      list: dividendApi.list,
+      transform: transformDBDividend,
+    },
+    enabled,
+  );
 
-  const domesticstockQuery = useQuery({
-    queryKey: receiptQueryKeys.domesticstock(userId),
-    queryFn: () =>
-      domesticStockApi.list(RECEIPT_LIST_PARAMS).then((response) => ({
-        items: response.data.map(transformDBDomesticStock),
-        summary: response.summary,
-      })),
-    enabled: isAuthenticated && !authLoading && !!userId,
-  });
+  const domesticstockQuery = useReceiptListQuery(
+    {
+      queryKey: receiptQueryKeys.domesticstock(userId),
+      list: domesticStockApi.list,
+      transform: transformDBDomesticStock,
+    },
+    enabled,
+  );
 
-  const mutualfundQuery = useQuery({
-    queryKey: receiptQueryKeys.mutualfund(userId),
-    queryFn: () =>
-      mutualfundApi.list(RECEIPT_LIST_PARAMS).then((response) => ({
-        items: response.data.map(transformDBMutualfund),
-        summary: response.summary,
-      })),
-    enabled: isAuthenticated && !authLoading && !!userId,
-  });
+  const mutualfundQuery = useReceiptListQuery(
+    {
+      queryKey: receiptQueryKeys.mutualfund(userId),
+      list: mutualfundApi.list,
+      transform: transformDBMutualfund,
+    },
+    enabled,
+  );
 
   const previewCsvMutation = useMutation({
-    mutationFn: ({ type, file }: PreviewCsvArgs) => {
-      switch (type) {
-        case 'dividend':
-          return dividendApi.previewCsv(file);
-        case 'domesticstock':
-          return domesticStockApi.previewCsv(file);
-        case 'mutualfund':
-          return mutualfundApi.previewCsv(file);
-      }
-    },
+    mutationFn: ({ type, file }: PreviewCsvArgs) => receiptApiByType[type].previewCsv(file),
     onSuccess: (previewResult, { onSuccess }) => {
       onSuccess?.({
         totalRows: previewResult.total_rows,
@@ -134,16 +152,7 @@ export function useReceiptsData(): UseReceiptsDataResult {
   });
 
   const uploadCsvMutation = useMutation({
-    mutationFn: ({ type, file }: UploadCsvArgs) => {
-      switch (type) {
-        case 'dividend':
-          return dividendApi.uploadCsv(file);
-        case 'domesticstock':
-          return domesticStockApi.uploadCsv(file);
-        case 'mutualfund':
-          return mutualfundApi.uploadCsv(file);
-      }
-    },
+    mutationFn: ({ type, file }: UploadCsvArgs) => receiptApiByType[type].uploadCsv(file),
     // mutate 呼び出し時点の userId をスナップショット（ログアウト→再ログイン中の上書き防止）
     onMutate: () => ({ snapshotUserId: userId }),
     onSuccess: (data, { type, onSuccess }, context) => {
@@ -153,16 +162,7 @@ export function useReceiptsData(): UseReceiptsDataResult {
   });
 
   const deleteAllMutation = useMutation({
-    mutationFn: (type: ReceiptsType) => {
-      switch (type) {
-        case 'dividend':
-          return dividendApi.deleteAll();
-        case 'domesticstock':
-          return domesticStockApi.deleteAll();
-        case 'mutualfund':
-          return mutualfundApi.deleteAll();
-      }
-    },
+    mutationFn: (type: ReceiptsType) => receiptApiByType[type].deleteAll(),
     // mutate 呼び出し時点の userId をスナップショット（ログアウト→再ログイン中の上書き防止）
     onMutate: () => ({ snapshotUserId: userId }),
     onSuccess: (_, type, context) => {

--- a/frontend/src/hooks/receipt/useReceiptData.ts
+++ b/frontend/src/hooks/receipt/useReceiptData.ts
@@ -27,3 +27,18 @@ export function useReceiptBaseData<T>(
   const { searchQuery, setSearchQuery, filteredData } = useReceiptPageState(sortedData, filterConfig);
   return { sortedData, searchQuery, setSearchQuery, filteredData };
 }
+
+/**
+ * ヘッダー集計値の選択ロジック
+ * 未フィルタ時は DB 側の集計（1000件キャップの影響を受けない）を優先し、
+ * プレビュー中や絞り込み中はフィルタ後データから計算したクライアント集計を使う
+ */
+export function useReceiptHeaderSummary<TSummary, TCalc>(
+  apiSummary: TSummary | undefined,
+  previewData: unknown[] | undefined,
+  searchQuery: string,
+  clientCalculations: TCalc,
+): TSummary | TCalc {
+  const isPreviewMode = Boolean(previewData && previewData.length > 0);
+  return apiSummary && !isPreviewMode && searchQuery === '' ? apiSummary : clientCalculations;
+}

--- a/frontend/src/pages/Receipt/Dividend.tsx
+++ b/frontend/src/pages/Receipt/Dividend.tsx
@@ -21,7 +21,7 @@ import {
     SECURITY_CODE_REGEX
 } from '@/lib/utils/formatters';
 import { CopyableInstrumentName, renderSecurityCode } from '@/components/atoms/SecurityCodeLink';
-import { useReceiptCalculations, useReceiptBaseData } from '@/hooks/receipt/useReceiptData';
+import { useReceiptCalculations, useReceiptBaseData, useReceiptHeaderSummary } from '@/hooks/receipt/useReceiptData';
 import {
     createYearOptions,
     getUniqueValues,
@@ -81,12 +81,7 @@ export const Dividend: React.FC<DividendProps> = ({ data, previewData, summary: 
 
     // 表示用の集計（検索前後で同一ロジック: フィルタ後データから計算）
     const clientCalculations = useReceiptCalculations(filteredData, calculateDividends);
-    // 未フィルタ時は DB 側の集計（1000件キャップの影響を受けない）を優先する。
-    // プレビュー中や絞り込み中は取得済みデータから計算した値を使う。
-    const isPreviewMode = Boolean(previewData && previewData.length > 0);
-    const calculations = apiSummary && !isPreviewMode && searchQuery === ''
-        ? apiSummary
-        : clientCalculations;
+    const calculations = useReceiptHeaderSummary(apiSummary, previewData, searchQuery, clientCalculations);
 
     // 入金日が最新の銘柄名を銘柄コードへマッピング（グループキー用）
     const latestSecurityNameByCode = new Map<string, { name: string; settlementTime: number }>();
@@ -125,7 +120,7 @@ export const Dividend: React.FC<DividendProps> = ({ data, previewData, summary: 
     );
 
     // サマリーデータの集計
-    const summary = groupAndSummarizeData(
+    const groupedSummary = groupAndSummarizeData(
         filteredData,
         getGroupKey,
         ['dividends_before_tax', 'taxes', 'net_amount_received']
@@ -205,7 +200,7 @@ export const Dividend: React.FC<DividendProps> = ({ data, previewData, summary: 
                         <DividendInfo
                             searchQuery={searchQuery}
                             securityCode={searchSecurityCode}
-                            summary={summary}
+                            summary={groupedSummary}
                             embedded
                         />
                     )}
@@ -223,7 +218,7 @@ export const Dividend: React.FC<DividendProps> = ({ data, previewData, summary: 
             ) : (
                 <ReceiptTable
                     data={filteredData}
-                    summary={summary}
+                    summary={groupedSummary}
                     columns={columns}
                     summaryColumns={summaryColumns}
                     getGroupKey={getGroupKey}

--- a/frontend/src/pages/Receipt/DomesticStock.tsx
+++ b/frontend/src/pages/Receipt/DomesticStock.tsx
@@ -17,7 +17,7 @@ import {
     createISODateKey
 } from '@/lib/utils/formatters';
 import { CopyableInstrumentName, renderSecurityCode } from '@/components/atoms/SecurityCodeLink';
-import { useReceiptCalculations, useReceiptBaseData } from '@/hooks/receipt/useReceiptData';
+import { useReceiptCalculations, useReceiptBaseData, useReceiptHeaderSummary } from '@/hooks/receipt/useReceiptData';
 import {
     createYearOptions,
     getUniqueValues,
@@ -71,17 +71,14 @@ export const DomesticStock: React.FC<DomesticStockProps> = ({ data, previewData,
         dates: true,
     };
 
-    // 日次集計（searchQuery がある場合はフィルタ後データ、ない場合は全データを使用）
-    const filteredDailyData = calculateDailyData(searchQuery ? filteredData : domesticStockData);
+    // 日次集計（filteredData は未検索時に全データと同じ内容）
+    const filteredDailyData = calculateDailyData(filteredData);
 
     // 表示用の集計（検索前後で同一ロジック: フィルタ後データから計算）
     const clientCalculations = useReceiptCalculations(filteredDailyData, calculateDomesticStock);
     // 未フィルタ時は DB 側の集計（1000件キャップの影響を受けない）を優先する。
     // プレビュー中や絞り込み中は取得済みデータから計算した値を使う。
-    const isPreviewMode = Boolean(previewData && previewData.length > 0);
-    const calculations = apiSummary && !isPreviewMode && searchQuery === ''
-        ? apiSummary
-        : clientCalculations;
+    const calculations = useReceiptHeaderSummary(apiSummary, previewData, searchQuery, clientCalculations);
 
     // グループキーの取得
     const getGroupKey = (item: DomesticStockData): string => createISODateKey(item.trade_date);

--- a/frontend/src/pages/Receipt/Mutualfund.tsx
+++ b/frontend/src/pages/Receipt/Mutualfund.tsx
@@ -19,7 +19,7 @@ import {
 } from '@/lib/utils/formatters';
 import { createYearOptions, FilterConfig } from '@/lib/utils/searchUtils';
 import { createGroupKeyFn } from '@/lib/utils/searchGroupKey';
-import { useReceiptCalculations, useReceiptBaseData } from '@/hooks/receipt/useReceiptData';
+import { useReceiptCalculations, useReceiptBaseData, useReceiptHeaderSummary } from '@/hooks/receipt/useReceiptData';
 import { sortMutualfundByTradeDate } from '@/features/receipt/parsers';
 import { calculateMutualfund } from '@/features/receipt/calculations';
 
@@ -62,10 +62,7 @@ export const Mutualfund: React.FC<MutualfundProps> = ({ data, previewData, summa
     const clientCalculations = useReceiptCalculations(filteredData, calculateMutualfund);
     // 未フィルタ時は DB 側の集計（1000件キャップの影響を受けない）を優先する。
     // プレビュー中や絞り込み中は取得済みデータから計算した値を使う。
-    const isPreviewMode = Boolean(previewData && previewData.length > 0);
-    const calculations = apiSummary && !isPreviewMode && searchQuery === ''
-        ? apiSummary
-        : clientCalculations;
+    const calculations = useReceiptHeaderSummary(apiSummary, previewData, searchQuery, clientCalculations);
 
     // 検索タイプに応じたグループキー関数（ファンド名部分一致でグループ化）
     const getGroupKey = createGroupKeyFn<MutualfundData>(
@@ -80,7 +77,7 @@ export const Mutualfund: React.FC<MutualfundProps> = ({ data, previewData, summa
     );
 
     // サマリーデータの集計
-    const summary = groupAndSummarizeData(
+    const groupedSummary = groupAndSummarizeData(
         filteredData,
         getGroupKey,
         ['cancellation_amount_yen', 'realized_profit_and_loss', 'taxes', 'realized_profit_and_loss_after_tax']
@@ -145,7 +142,7 @@ export const Mutualfund: React.FC<MutualfundProps> = ({ data, previewData, summa
             ) : (
                 <ReceiptTable
                     data={filteredData}
-                    summary={summary}
+                    summary={groupedSummary}
                     columns={columns}
                     summaryColumns={summaryColumns}
                     getGroupKey={getGroupKey}


### PR DESCRIPTION
## 概要
- Receipt 3ドメインの list query を共通 helper に集約
- CSV preview/upload/deleteAll の switch dispatch を ReceiptsType keyed map に置換
- ヘッダー集計選択ロジックを useReceiptHeaderSummary に共通化
- DomesticStock の冗長な daily data 三項演算子を簡略化
- API summary とグループ集計の変数名混同を解消

## テスト
- npm ci
- npx tsc --noEmit
- vp lint
- npm test -- useReceiptsData
- npm test
- vp build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 領収書一覧の取得・更新処理を統一し、画面間で一貫した動作を実現しました。
  * プレビュー表示や検索時に、現在の表示内容に基づいた集計値をヘッダーへ反映するよう改善しました。
  * 配当・国内株式・投資信託の各画面で、明細と集計情報の表示を統一しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->