### PR TITLE
refactor: 資産管理フックの責務を分割

### DIFF
--- a/frontend/src/features/assetBalance/hooks/__tests__/useAssetBalance.test.ts
+++ b/frontend/src/features/assetBalance/hooks/__tests__/useAssetBalance.test.ts
@@ -19,9 +19,9 @@ import type { AssetBalanceApiData } from '@/types/api';
 // ────────────────────────────────────────────────────────
 
 vi.mock('@/features/assetBalance/api/assetBalanceApi', () => ({
-  assetBalanceApi: { list: vi.fn().mockResolvedValue({ data: [], total: 0, page: 1, per_page: 200 }) },
+  assetBalanceApi: { list: vi.fn().mockResolvedValue({ data: [], total: 0, page: 1, per_page: 1 }) },
 }));
-const emptyPage = { data: [], total: 0, page: 1, per_page: 200 };
+const emptyPage = { data: [], total: 0, page: 1, per_page: 1 };
 
 vi.mock('@/features/auth/hooks/useAuth');
 
@@ -97,14 +97,14 @@ describe('useAssetBalance', () => {
     );
     vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue({
       data: [{ security_code: '7203', security_name: 'トヨタ自動車', shares: 100 } as never],
-      total: 1, page: 1, per_page: 200,
+      total: 1, page: 1, per_page: 1,
     });
 
-    renderHook(() => useAssetBalance(), { wrapper: makeWrapper(qc) });
+    renderHook(() => useAssetBalance({ securityCode: '7203' }), { wrapper: makeWrapper(qc) });
 
     // キャッシュにデータが入るまで待つ
     await waitFor(() => {
-      expect(qc.getQueryData(assetBalanceQueryKeys.all('user-1'))).toBeDefined();
+      expect(qc.getQueryData(assetBalanceQueryKeys.lookup('user-1', '7203'))).toBeDefined();
     });
     await waitFor(() => expect(capturedCallback).not.toBeNull());
 
@@ -114,7 +114,7 @@ describe('useAssetBalance', () => {
     });
 
     await waitFor(() => {
-      expect(qc.getQueryData(assetBalanceQueryKeys.all('user-1'))).toBeUndefined();
+      expect(qc.getQueryData(assetBalanceQueryKeys.lookup('user-1', '7203'))).toBeUndefined();
     });
   });
 
@@ -123,7 +123,7 @@ describe('useAssetBalance', () => {
       defaultOptions: { queries: { retry: false, staleTime: Infinity } },
     });
 
-    const { result } = renderHook(() => useAssetBalance(), { wrapper: makeWrapper(qc) });
+    const { result } = renderHook(() => useAssetBalance({ securityCode: '7203' }), { wrapper: makeWrapper(qc) });
 
     expect(result.current.getAssetBalanceByCode('')).toBeUndefined();
   });
@@ -134,17 +134,14 @@ describe('useAssetBalance', () => {
     });
 
     vi.mocked(assetBalanceApiModule.assetBalanceApi.list).mockResolvedValue({
-      data: [
-        makeAssetBalanceData({ security_code: '7203' }),
-        makeAssetBalanceData({ id: 'asset-balance-2', security_code: '6758', security_name: 'ソニーグループ' }),
-      ],
-      total: 2, page: 1, per_page: 200,
+      data: [makeAssetBalanceData({ security_code: '7203' })],
+      total: 1, page: 1, per_page: 1,
     });
 
-    const { result } = renderHook(() => useAssetBalance(), { wrapper: makeWrapper(qc) });
+    const { result } = renderHook(() => useAssetBalance({ securityCode: '7203' }), { wrapper: makeWrapper(qc) });
 
     await waitFor(() => {
-      expect(result.current.assetBalanceData).toHaveLength(2);
+      expect(result.current.assetBalanceData).toHaveLength(1);
     });
 
     expect(result.current.getAssetBalanceByCode(' 7203 ')).toMatchObject({
@@ -159,7 +156,7 @@ describe('useAssetBalance', () => {
     });
     vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({ isAuthenticated: false }));
 
-    const { result } = renderHook(() => useAssetBalance(), { wrapper: makeWrapper(qc) });
+    const { result } = renderHook(() => useAssetBalance({ securityCode: '7203' }), { wrapper: makeWrapper(qc) });
 
     expect(result.current.assetBalanceData).toEqual([]);
   });
@@ -191,20 +188,30 @@ describe('useAssetBalance', () => {
     expect(result.current.getAssetBalanceByCode('7203')).toMatchObject({ security_code: '7203' });
   });
 
-  it('refetch は assetBalance クエリを invalidate する', async () => {
+  it('securityCode が空文字の場合はAPIを呼ばない', () => {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+
+    renderHook(() => useAssetBalance({ securityCode: '' }), { wrapper: makeWrapper(qc) });
+
+    expect(assetBalanceApiModule.assetBalanceApi.list).not.toHaveBeenCalled();
+  });
+
+  it('refetch は該当銘柄の lookup クエリを invalidate する', async () => {
     const qc = new QueryClient({
       defaultOptions: { queries: { retry: false, staleTime: Infinity } },
     });
     const invalidateSpy = vi.spyOn(qc, 'invalidateQueries');
 
-    const { result } = renderHook(() => useAssetBalance(), { wrapper: makeWrapper(qc) });
+    const { result } = renderHook(() => useAssetBalance({ securityCode: '7203' }), { wrapper: makeWrapper(qc) });
 
     await act(async () => {
       await result.current.refetch();
     });
 
     expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: assetBalanceQueryKeys.all('user-1'),
+      queryKey: assetBalanceQueryKeys.lookup('user-1', '7203'),
     });
   });
 });

--- a/frontend/src/features/assetBalance/hooks/__tests__/useAssetBalanceDataSource.test.ts
+++ b/frontend/src/features/assetBalance/hooks/__tests__/useAssetBalanceDataSource.test.ts
@@ -169,6 +169,36 @@ describe('useAssetBalanceDataSource: 基本動作', () => {
     // エラーなく完了することを確認
     expect(result.current.error).toBeNull();
   });
+
+  it('deleteAll完了後にlookupキャッシュを削除し一覧キャッシュを空にする', async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: Infinity } } });
+    vi.mocked(authHook.useAuth).mockReturnValue(makeAuthMock({}));
+    vi.mocked(assetBalanceApiModule.assetBalanceApi.deleteAll).mockResolvedValue({} as never);
+
+    const listKey = assetBalanceQueryKeys.list('user-1');
+    const lookupKey = assetBalanceQueryKeys.lookup('user-1', '7203');
+    qc.setQueryData(listKey, {
+      data: [{ security_code: '7203', security_name: 'トヨタ自動車', shares: 100 }],
+      total: 1,
+      page: 1,
+      per_page: 1000,
+    });
+    qc.setQueryData(lookupKey, [
+      { security_code: '7203', security_name: 'トヨタ自動車', shares: 100 },
+    ]);
+
+    const { result } = renderHook(() => useAssetBalanceDataSource(), { wrapper: makeWrapper(qc) });
+
+    await act(async () => { await result.current.handleDeleteAll(); });
+
+    expect(qc.getQueryData(lookupKey)).toBeUndefined();
+    expect(qc.getQueryData(listKey)).toEqual({
+      data: [],
+      total: 0,
+      page: 1,
+      per_page: 1000,
+    });
+  });
 });
 
 describe('useAssetBalanceDataSource: キャッシュ境界', () => {

--- a/frontend/src/features/assetBalance/hooks/assetBalanceUiProps.ts
+++ b/frontend/src/features/assetBalance/hooks/assetBalanceUiProps.ts
@@ -1,0 +1,118 @@
+import type { DataActionRailProps } from '@/components/organisms/DataActionRail/DataActionRail';
+import type { AssetBalanceData } from '@/types/api';
+import type { AssetBalanceUtilityRailProps } from '../components/AssetBalanceUtilityRail';
+import type { CsvUploadResult } from '@/lib/csvImport';
+import type { SearchCategories } from '@/types/common';
+
+interface BuildActionRailPropsArgs {
+  onFileSelect: (file: File) => void;
+  csvFileName: string | null;
+  loading: boolean;
+  saving: boolean;
+  deleting: boolean;
+  previewing: boolean;
+  hasCsvFile: boolean;
+  previewRowCount: number;
+  onSave: () => void;
+  hasDbData: boolean;
+  dbTotal: number;
+  onDeleteRequest: () => void;
+  lastSavedResult: CsvUploadResult | null;
+}
+
+/** DataActionRail に渡す props を組み立てる */
+export function buildActionRailProps({
+  onFileSelect,
+  csvFileName,
+  loading,
+  saving,
+  deleting,
+  previewing,
+  hasCsvFile,
+  previewRowCount,
+  onSave,
+  hasDbData,
+  dbTotal,
+  onDeleteRequest,
+  lastSavedResult,
+}: BuildActionRailPropsArgs): DataActionRailProps {
+  const saveLabel = previewRowCount > 0
+    ? `${previewRowCount}件 全件置換で保存`
+    : '全件置換で保存';
+
+  return {
+    onFileSelect,
+    selectedFileName: csvFileName ?? undefined,
+    fileInputDisabled: loading || saving || deleting || previewing,
+    hasCsvFile,
+    saveLabel: saving ? '保存中...' : previewing ? '解析中...' : saveLabel,
+    onSave,
+    saveDisabled: saving || deleting || previewing || previewRowCount === 0,
+    hasDbData,
+    deleteLabel: deleting ? '削除中...' : `全件削除 (${dbTotal}件)`,
+    onDeleteRequest,
+    deleteDisabled: saving || deleting || loading,
+    saveResult: lastSavedResult,
+    saveModeLabel: '全件置換',
+  };
+}
+
+interface BuildUtilityRailPropsArgs {
+  actionRailProps: DataActionRailProps;
+  error: string | null;
+  dbWarning: string | null;
+  assetBalanceData: AssetBalanceData[];
+  searchCategories: SearchCategories;
+  searchQuery: string;
+  onSearch: (query: string) => void;
+}
+
+/** AssetBalanceUtilityRail に渡す props を組み立てる */
+export function buildUtilityRailProps({
+  actionRailProps,
+  error,
+  dbWarning,
+  assetBalanceData,
+  searchCategories,
+  searchQuery,
+  onSearch,
+}: BuildUtilityRailPropsArgs): AssetBalanceUtilityRailProps {
+  return {
+    actionRailProps,
+    error,
+    warning: dbWarning,
+    searchCardProps: {
+      visible: assetBalanceData.length > 0,
+      categories: searchCategories,
+      value: searchQuery,
+      onSearch,
+    },
+    reviewPromptCardProps: {
+      assetBalanceData,
+    },
+  };
+}
+
+interface MainStatusFlags {
+  loading: boolean;
+  saving: boolean;
+  deleting: boolean;
+  previewing: boolean;
+}
+
+/** メイン領域に表示するステータスメッセージを状態フラグから決定する */
+export function getMainStatusMessage(flags: MainStatusFlags): string | null {
+  if (flags.loading) {
+    return 'データを読み込んでいます...';
+  }
+  if (flags.saving) {
+    return 'データを保存しています...';
+  }
+  if (flags.deleting) {
+    return 'データを削除しています...';
+  }
+  if (flags.previewing) {
+    return 'CSVファイルを解析しています...';
+  }
+  return null;
+}

--- a/frontend/src/features/assetBalance/hooks/useAssetBalance.ts
+++ b/frontend/src/features/assetBalance/hooks/useAssetBalance.ts
@@ -15,34 +15,31 @@ interface UseAssetBalanceReturn {
 
 interface UseAssetBalanceOptions {
   enabled?: boolean;
-  securityCode?: string;
+  securityCode: string;
 }
 
 /**
- * 保有銘柄データを Query キャッシュから取得するフック
+ * 指定銘柄コードの保有銘柄データを Query キャッシュから取得するフック
  * ユーザー固有キーでキャッシュを分離し、未認証時はフェッチせず空配列を返す
  */
-export function useAssetBalance(options: UseAssetBalanceOptions = {}): UseAssetBalanceReturn {
-  const { enabled = true, securityCode } = options;
+export function useAssetBalance({ enabled = true, securityCode }: UseAssetBalanceOptions): UseAssetBalanceReturn {
   const { isAuthenticated, onLogout, user } = useAuth();
   const queryClient = useQueryClient();
   const userId = user?.id ?? '';
-  const normalizedSecurityCode = normalizeSecurityCode(securityCode ?? '');
-  const queryKey = normalizedSecurityCode
-    ? assetBalanceQueryKeys.lookup(userId, normalizedSecurityCode)
-    : assetBalanceQueryKeys.all(userId);
+  const normalizedSecurityCode = normalizeSecurityCode(securityCode);
+  const queryKey = assetBalanceQueryKeys.lookup(userId, normalizedSecurityCode);
 
   const query = useQuery({
     queryKey,
     queryFn: async () => {
-      const response = await assetBalanceApi.list(
-        normalizedSecurityCode
-          ? { page: 1, per_page: 1, security_code: normalizedSecurityCode }
-          : { page: 1, per_page: 1000 }
-      );
+      const response = await assetBalanceApi.list({
+        page: 1,
+        per_page: 1,
+        security_code: normalizedSecurityCode,
+      });
       return response.data;
     },
-    enabled: isAuthenticated && !!userId && enabled,
+    enabled: isAuthenticated && !!userId && !!normalizedSecurityCode && enabled,
   });
 
   // ログアウト時：このフックがマウントされている経路でも確実にキャッシュを除去する

--- a/frontend/src/features/assetBalance/hooks/useAssetBalanceDataSource.ts
+++ b/frontend/src/features/assetBalance/hooks/useAssetBalanceDataSource.ts
@@ -92,7 +92,7 @@ export function useAssetBalanceDataSourceCore({
       setPreviewRows([]);
       setLastSavedResult(uploadResult ?? null);
       const targetUserId = context?.snapshotUserId ?? userId;
-      // all は useAssetBalance（DividendInfo 用）が参照するキャッシュのため合わせて無効化する
+      // all は useAssetBalance（DividendInfo 用）の lookup キャッシュを含む prefix のため合わせて無効化する
       queryClient.invalidateQueries({ queryKey: assetBalanceQueryKeys.all(targetUserId) });
       queryClient.invalidateQueries({ queryKey: assetBalanceQueryKeys.list(targetUserId) });
     },
@@ -105,18 +105,16 @@ export function useAssetBalanceDataSourceCore({
       const targetUserId = context?.snapshotUserId ?? userId;
 
       const listKey = assetBalanceQueryKeys.list(targetUserId);
-      if (queryClient.getQueryState(listKey) !== undefined) {
+      const hadListCache = queryClient.getQueryState(listKey) !== undefined;
+      queryClient.removeQueries({ queryKey: assetBalanceQueryKeys.all(targetUserId) });
+
+      if (hadListCache) {
         queryClient.setQueryData(listKey, {
           data: [],
           total: 0,
           page: 1,
           per_page: ASSET_BALANCE_LIST_LIMIT,
         });
-      }
-
-      const allKey = assetBalanceQueryKeys.all(targetUserId);
-      if (queryClient.getQueryState(allKey) !== undefined) {
-        queryClient.setQueryData(allKey, []);
       }
 
       setLastSavedResult(null);

--- a/frontend/src/features/assetBalance/hooks/useAssetBalanceDeleteConfirm.ts
+++ b/frontend/src/features/assetBalance/hooks/useAssetBalanceDeleteConfirm.ts
@@ -1,0 +1,43 @@
+import { useCallback, useState } from 'react';
+
+export interface UseAssetBalanceDeleteConfirmResult {
+  showDeleteConfirm: boolean;
+  openDeleteConfirm: () => void;
+  closeDeleteConfirm: () => void;
+  confirmDeleteAll: () => Promise<void>;
+  resetDeleteConfirm: () => void;
+}
+
+/**
+ * 全件削除確認モーダルの開閉と実行を管理するフック
+ */
+export function useAssetBalanceDeleteConfirm(
+  deleteAll: () => Promise<void>
+): UseAssetBalanceDeleteConfirmResult {
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  const openDeleteConfirm = useCallback(() => {
+    setShowDeleteConfirm(true);
+  }, []);
+
+  const closeDeleteConfirm = useCallback(() => {
+    setShowDeleteConfirm(false);
+  }, []);
+
+  const confirmDeleteAll = useCallback(async () => {
+    setShowDeleteConfirm(false);
+    await deleteAll();
+  }, [deleteAll]);
+
+  const resetDeleteConfirm = useCallback(() => {
+    setShowDeleteConfirm(false);
+  }, []);
+
+  return {
+    showDeleteConfirm,
+    openDeleteConfirm,
+    closeDeleteConfirm,
+    confirmDeleteAll,
+    resetDeleteConfirm,
+  };
+}

--- a/frontend/src/features/assetBalance/hooks/useAssetBalanceDividendBatch.ts
+++ b/frontend/src/features/assetBalance/hooks/useAssetBalanceDividendBatch.ts
@@ -1,0 +1,26 @@
+import type { DividendStatus } from '@/features/dividendPerShare/api/dividendPerShareApi';
+import { useDividendBatch } from '@/features/dividendPerShare/hooks/useDividendBatch';
+import type { AssetBalanceData } from '@/types/api';
+
+export interface UseAssetBalanceDividendBatchResult {
+  dividendPerShareMap: Map<string, number>;
+  dividendStatusMap: Map<string, DividendStatus> | undefined;
+}
+
+/**
+ * 表示中の保有銘柄コードに対応する1株配当をバッチ取得するフック
+ * 保存中・読み込み中は問い合わせ対象を空にして無駄なリクエストを避ける
+ */
+export function useAssetBalanceDividendBatch(
+  assetBalanceData: AssetBalanceData[],
+  isAuthenticated: boolean,
+  skip: boolean
+): UseAssetBalanceDividendBatchResult {
+  const securityCodes = skip ? [] : assetBalanceData.map((item) => item.security_code);
+  const { dividendPerShareMap, dividendStatusMap } = useDividendBatch(securityCodes, isAuthenticated);
+
+  return {
+    dividendPerShareMap: dividendPerShareMap as Map<string, number>,
+    dividendStatusMap: dividendStatusMap as Map<string, DividendStatus> | undefined,
+  };
+}

--- a/frontend/src/features/assetBalance/hooks/useAssetBalanceSearch.ts
+++ b/frontend/src/features/assetBalance/hooks/useAssetBalanceSearch.ts
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import { createSearchOptions } from '@/lib/utils/dataTransformer';
+import { filterByConfig, type FilterConfig } from '@/lib/utils/searchUtils';
+import type { AssetBalanceData } from '@/types/api';
+import type { SearchCategories } from '@/types/common';
+import type { AssetBalanceSearchFacets } from './useAssetBalanceDataSource';
+
+const filterConfig: FilterConfig<AssetBalanceData> = {
+  partialStringFields: [
+    (item) => item.security_code,
+    (item) => item.security_name,
+  ],
+};
+
+export interface UseAssetBalanceSearchResult {
+  searchQuery: string;
+  handleSearch: (query: string) => void;
+  clearSearch: () => void;
+  resetSearch: () => void;
+  filteredData: AssetBalanceData[];
+  searchCategories: SearchCategories;
+}
+
+/**
+ * 保有銘柄の検索クエリと検索候補を管理するフック
+ * Receipt 側（useReceiptBaseData）と同様、CSV取込/削除確認の状態とは分離した
+ * コンポーネントローカルな state として持つ
+ */
+export function useAssetBalanceSearch(
+  assetBalanceData: AssetBalanceData[],
+  facets: AssetBalanceSearchFacets | undefined,
+  hasCsvFile: boolean
+): UseAssetBalanceSearchResult {
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const handleSearch = (query: string) => {
+    setSearchQuery(query);
+  };
+
+  const clearSearch = () => {
+    setSearchQuery('');
+  };
+
+  const resetSearch = () => {
+    setSearchQuery('');
+  };
+
+  const filteredData = filterByConfig(assetBalanceData, searchQuery, filterConfig);
+
+  // facets は保存済み DB データ（一覧 API）由来のため、CSV プレビュー中は使わない
+  const searchCategories: SearchCategories = !hasCsvFile && facets?.securities
+    ? {
+      securities: facets.securities.map((option) => ({ value: option.value, label: option.label })),
+    }
+    : {
+      securities: createSearchOptions(assetBalanceData, 'security_code', 'security_name', true),
+    };
+
+  return {
+    searchQuery,
+    handleSearch,
+    clearSearch,
+    resetSearch,
+    filteredData,
+    searchCategories,
+  };
+}

--- a/frontend/src/features/assetBalance/hooks/useAssetBalanceState.ts
+++ b/frontend/src/features/assetBalance/hooks/useAssetBalanceState.ts
@@ -1,77 +1,13 @@
-import { useCallback, useEffect, useReducer } from 'react';
-import type { DataActionRailProps } from '@/components/organisms/DataActionRail/DataActionRail';
-import type { DividendStatus } from '@/features/dividendPerShare/api/dividendPerShareApi';
-import { useDividendBatch } from '@/features/dividendPerShare/hooks/useDividendBatch';
+import { useEffect } from 'react';
 import { useAuth } from '@/features/auth/hooks/useAuth';
-import { createSearchOptions } from '@/lib/utils/dataTransformer';
-import { filterByConfig, type FilterConfig } from '@/lib/utils/searchUtils';
-import type { AssetBalanceData } from '@/types/api';
-import type { SearchCategories } from '@/types/common';
-import type { AssetBalanceUtilityRailProps } from '../components/AssetBalanceUtilityRail';
 import { useAssetBalanceDataSourceCore } from './useAssetBalanceDataSource';
-
-interface AssetBalanceState {
-  searchQuery: string;
-  showDeleteConfirm: boolean;
-}
-
-type AssetBalanceAction =
-  | { type: 'SET_SEARCH_QUERY'; payload: string }
-  | { type: 'SET_SHOW_DELETE_CONFIRM'; payload: boolean }
-  | { type: 'LOGOUT' };
-
-const initialState: AssetBalanceState = {
-  searchQuery: '',
-  showDeleteConfirm: false,
-};
-
-const filterConfig: FilterConfig<AssetBalanceData> = {
-  partialStringFields: [
-    (item) => item.security_code,
-    (item) => item.security_name,
-  ],
-};
-
-function assetBalanceReducer(
-  state: AssetBalanceState,
-  action: AssetBalanceAction
-): AssetBalanceState {
-  switch (action.type) {
-    case 'SET_SEARCH_QUERY':
-      return { ...state, searchQuery: action.payload };
-    case 'SET_SHOW_DELETE_CONFIRM':
-      return { ...state, showDeleteConfirm: action.payload };
-    case 'LOGOUT':
-      return initialState;
-    default:
-      return state;
-  }
-}
-
-function getMainStatusMessage(flags: {
-  loading: boolean;
-  saving: boolean;
-  deleting: boolean;
-  previewing: boolean;
-}) {
-  if (flags.loading) {
-    return 'データを読み込んでいます...';
-  }
-  if (flags.saving) {
-    return 'データを保存しています...';
-  }
-  if (flags.deleting) {
-    return 'データを削除しています...';
-  }
-  if (flags.previewing) {
-    return 'CSVファイルを解析しています...';
-  }
-  return null;
-}
+import { useAssetBalanceSearch } from './useAssetBalanceSearch';
+import { useAssetBalanceDeleteConfirm } from './useAssetBalanceDeleteConfirm';
+import { useAssetBalanceDividendBatch } from './useAssetBalanceDividendBatch';
+import { buildActionRailProps, buildUtilityRailProps, getMainStatusMessage } from './assetBalanceUiProps';
 
 export function useAssetBalanceState() {
   const { isAuthenticated, isLoading: authLoading, login, onLogout, user } = useAuth();
-  const [state, dispatch] = useReducer(assetBalanceReducer, initialState);
   const {
     dbData,
     dbTotal,
@@ -100,91 +36,71 @@ export function useAssetBalanceState() {
     registerLogoutReset: false,
   });
 
+  const assetBalanceData = hasCsvFile ? previewRows : dbData;
+
+  const {
+    searchQuery,
+    handleSearch,
+    clearSearch,
+    resetSearch,
+    filteredData,
+    searchCategories,
+  } = useAssetBalanceSearch(assetBalanceData, facets, hasCsvFile);
+
+  const {
+    showDeleteConfirm,
+    openDeleteConfirm,
+    closeDeleteConfirm,
+    confirmDeleteAll,
+    resetDeleteConfirm,
+  } = useAssetBalanceDeleteConfirm(deleteAll);
+
   useEffect(() => {
     return onLogout(() => {
       resetState();
-      dispatch({ type: 'LOGOUT' });
+      resetSearch();
+      resetDeleteConfirm();
     });
-  }, [onLogout, resetState]);
+  }, [onLogout, resetState, resetSearch, resetDeleteConfirm]);
 
-  const handleSearch = (query: string) => {
-    dispatch({ type: 'SET_SEARCH_QUERY', payload: query });
-  };
+  const { dividendPerShareMap, dividendStatusMap } = useAssetBalanceDividendBatch(
+    assetBalanceData,
+    isAuthenticated,
+    saving || loading
+  );
 
-  const clearSearch = () => {
-    dispatch({ type: 'SET_SEARCH_QUERY', payload: '' });
-  };
-
-  const openDeleteConfirm = () => {
-    dispatch({ type: 'SET_SHOW_DELETE_CONFIRM', payload: true });
-  };
-
-  const closeDeleteConfirm = useCallback(() => {
-    dispatch({ type: 'SET_SHOW_DELETE_CONFIRM', payload: false });
-  }, []);
-
-  const confirmDeleteAll = useCallback(async () => {
-    closeDeleteConfirm();
-    await deleteAll();
-  }, [closeDeleteConfirm, deleteAll]);
-
-  const assetBalanceData = hasCsvFile ? previewRows : dbData;
-  const securityCodes = saving || loading ? [] : assetBalanceData.map((item) => item.security_code);
-
-  const { dividendPerShareMap, dividendStatusMap } = useDividendBatch(securityCodes, isAuthenticated);
-
-  const filteredData = filterByConfig(assetBalanceData, state.searchQuery, filterConfig);
-
-  // facets は保存済み DB データ（一覧 API）由来のため、CSV プレビュー中は使わない
-  const searchCategories: SearchCategories = !hasCsvFile && facets?.securities
-    ? {
-      securities: facets.securities.map((option) => ({ value: option.value, label: option.label })),
-    }
-    : {
-      securities: createSearchOptions(assetBalanceData, 'security_code', 'security_name', true),
-    };
-
-  // summary も一覧 API 由来のため、CSV プレビュー中や検索絞り込み中は使わない
-  const portfolioSummary = !hasCsvFile && state.searchQuery === '' ? summary : undefined;
+  // summary は一覧 API 由来のため、CSV プレビュー中や検索絞り込み中は使わない
+  const portfolioSummary = !hasCsvFile && searchQuery === '' ? summary : undefined;
 
   const dbWarning = !hasCsvFile && dbTotal > assetBalanceListLimit
     ? `一覧は最大${assetBalanceListLimit}件まで表示しています。未表示の銘柄がある可能性があります。`
     : null;
 
-  const saveLabel = previewRows.length > 0
-    ? `${previewRows.length}件 全件置換で保存`
-    : '全件置換で保存';
-
-  const actionRailProps: DataActionRailProps = {
+  const actionRailProps = buildActionRailProps({
     onFileSelect: selectFile,
-    selectedFileName: csvFileName ?? undefined,
-    fileInputDisabled: loading || saving || deleting || previewing,
+    csvFileName,
+    loading,
+    saving,
+    deleting,
+    previewing,
     hasCsvFile,
-    saveLabel: saving ? '保存中...' : previewing ? '解析中...' : saveLabel,
+    previewRowCount: previewRows.length,
     onSave: saveToDB,
-    saveDisabled: saving || deleting || previewing || previewRows.length === 0,
     hasDbData,
-    deleteLabel: deleting ? '削除中...' : `全件削除 (${dbTotal}件)`,
+    dbTotal,
     onDeleteRequest: openDeleteConfirm,
-    deleteDisabled: saving || deleting || loading,
-    saveResult: lastSavedResult,
-    saveModeLabel: '全件置換',
-  };
+    lastSavedResult,
+  });
 
-  const utilityRailProps: AssetBalanceUtilityRailProps = {
+  const utilityRailProps = buildUtilityRailProps({
     actionRailProps,
     error,
-    warning: dbWarning,
-    searchCardProps: {
-      visible: assetBalanceData.length > 0,
-      categories: searchCategories,
-      value: state.searchQuery,
-      onSearch: handleSearch,
-    },
-    reviewPromptCardProps: {
-      assetBalanceData,
-    },
-  };
+    dbWarning,
+    assetBalanceData,
+    searchCategories,
+    searchQuery,
+    onSearch: handleSearch,
+  });
 
   const mainStatusMessage = getMainStatusMessage({ loading, saving, deleting, previewing });
 
@@ -197,7 +113,7 @@ export function useAssetBalanceState() {
     portfolioSummary,
     clearSearch,
     utilityRailProps,
-    showDeleteConfirm: state.showDeleteConfirm,
+    showDeleteConfirm,
     closeDeleteConfirm,
     confirmDeleteAll,
     dbDataCount: dbTotal,
@@ -205,7 +121,7 @@ export function useAssetBalanceState() {
     showPortfolioSummary: !loading && !previewing,
     mainStatusMessage,
     workspaceBusy: authLoading || loading || saving || deleting || previewing,
-    dividendPerShareMap: dividendPerShareMap as Map<string, number>,
-    dividendStatusMap: dividendStatusMap as Map<string, DividendStatus> | undefined,
+    dividendPerShareMap,
+    dividendStatusMap,
   };
 }

--- a/frontend/src/features/assetBalance/queryKeys.ts
+++ b/frontend/src/features/assetBalance/queryKeys.ts
@@ -4,7 +4,8 @@ import type { QueryClient } from '@tanstack/react-query';
 export const assetBalanceQueryKeys = {
   // ログアウト時の cancelQueries/removeQueries に使うプレフィックスキー
   prefix: ['assetBalance'] as const,
-  // useAssetBalance（DividendInfo 用）が参照する全件配列キャッシュ
+  // useAssetBalanceDataSource の一括更新後に lookup 等の下位キャッシュへ
+  // まとめて波及させるための prefix キー（このキー自体で fetch はしない）
   all: (userId: string) => ['assetBalance', userId] as const,
   lookup: (userId: string, securityCode: string) =>
     ['assetBalance', userId, 'lookup', securityCode] as const,


### PR DESCRIPTION
## Summary
- useAssetBalance を銘柄コード指定専用にし、旧式の全件フェッチ分岐を削除
- useAssetBalanceState から検索、削除確認、配当バッチ、UI props組み立てを小さいフック/ヘルパーへ分割
- deleteAll後にlookupキャッシュが残らないよう、ユーザー配下のassetBalance queryを整理
- 関連フックテストを更新し、lookupキャッシュ削除ケースを追加

## Validation
- cd frontend && npx tsc --noEmit
- cd frontend && vp lint
- cd frontend && npm test -- useAssetBalance useAssetBalanceDataSource useAssetBalanceState
- cd frontend && npm test
- cd frontend && vp build
- git diff --check

## Notes
- Claudeに実装を依頼し、Codexで差分レビューとキャッシュ処理の追加修正を実施
- docs/tasks/refactor-frontend-assetbalance-hooks-consolidation.md はローカル進捗メモのためコミット対象外