### PR TITLE
refactor: SQLx query! の運用を整備

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -56,11 +56,11 @@ jobs:
 
       - name: Lint (clippy)
         if: steps.detect.outputs.backend == 'true'
-        run: cargo clippy -- -D warnings
+        run: SQLX_OFFLINE=true cargo clippy -- -D warnings
 
       - name: Run tests
         if: steps.detect.outputs.backend == 'true'
-        run: cargo test
+        run: SQLX_OFFLINE=true cargo test
 
       - name: Generate OpenAPI schema
         if: steps.detect.outputs.backend == 'true'

--- a/backend/.sqlx/query-5027ad66598ca5fbdf7f8feff4ec861af3fbff93a0407cfb3554b958d0b97eae.json
+++ b/backend/.sqlx/query-5027ad66598ca5fbdf7f8feff4ec861af3fbff93a0407cfb3554b958d0b97eae.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM asset_balances WHERE user_id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "5027ad66598ca5fbdf7f8feff4ec861af3fbff93a0407cfb3554b958d0b97eae"
+}

--- a/backend/.sqlx/query-5077d0fd4d9a6749b75c32d559ad20ef8693cb95c9fdba75437809ac5ae39bad.json
+++ b/backend/.sqlx/query-5077d0fd4d9a6749b75c32d559ad20ef8693cb95c9fdba75437809ac5ae39bad.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM dividends WHERE user_id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "5077d0fd4d9a6749b75c32d559ad20ef8693cb95c9fdba75437809ac5ae39bad"
+}

--- a/backend/.sqlx/query-9f5978a49770d78709d8cee61fa76b3a5107a9002f9f6d9bfde261c8e58c6003.json
+++ b/backend/.sqlx/query-9f5978a49770d78709d8cee61fa76b3a5107a9002f9f6d9bfde261c8e58c6003.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM mutualfunds WHERE user_id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "9f5978a49770d78709d8cee61fa76b3a5107a9002f9f6d9bfde261c8e58c6003"
+}

--- a/backend/.sqlx/query-bb427089f73df240fe3c200a36c088992c043f58cdc622e2bfd04a8f83b3266c.json
+++ b/backend/.sqlx/query-bb427089f73df240fe3c200a36c088992c043f58cdc622e2bfd04a8f83b3266c.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM domestic_stocks WHERE user_id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "bb427089f73df240fe3c200a36c088992c043f58cdc622e2bfd04a8f83b3266c"
+}

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -78,7 +78,7 @@ repair-and-migrate-local:
 .PHONY: sqlx-prepare
 sqlx-prepare:
 	@echo "📦 SQLxクエリキャッシュを準備します..."
-	$(CARGO) sqlx prepare --merged
+	$(CARGO) sqlx prepare
 
 # Docker関連
 .PHONY: docker-build

--- a/backend/README.md
+++ b/backend/README.md
@@ -124,8 +124,32 @@ DATABASE_URL=postgresql://user:password@localhost:5432/shoken_db
 make migrate-local
 
 # SQLxクエリキャッシュ準備（オフラインビルド用）
-cargo sqlx prepare --merged
+cargo sqlx prepare
 ```
+
+### SQLx query! 運用方針
+
+固定SQLは `sqlx::query!` / `sqlx::query_as!` を優先し、コンパイル時検証できる形に寄せます。
+対象は SQL 文字列と戻り値の形が固定できる処理です。
+
+- 対象: `delete_all_for_user` のような固定テーブルへの `DELETE`
+- 対象: 条件と戻り列が固定された単純な `SELECT COUNT(*)`
+- 非対象: 検索条件、facet、並び順、対象カラムを `QueryBuilder` で組み立てる動的SQL
+- 非対象: バルク `UNNEST` のように列数や bind 配列を共通ヘルパーで扱う処理
+
+`backend/.sqlx/` はリポジトリ管理します。
+理由は、CI とローカル検証を `SQLX_OFFLINE=true` で実行し、DB接続なしでも `query!` のメタデータ整合性を検証できるようにするためです。
+`query!` を追加・変更した場合は、ローカルDBに最新マイグレーションを適用した上で次を実行します。
+
+```bash
+make db-up
+make migrate-local
+make sqlx-prepare
+```
+
+CI は `SQLX_OFFLINE=true cargo clippy` と `SQLX_OFFLINE=true cargo test` を実行します。
+`cargo sqlx prepare --check` はローカルDBの起動とマイグレーション適用が必要なためCIには入れず、`backend/.sqlx/` の差分確認で代替します。
+`query!` 追加・変更時は `make sqlx-prepare` の結果を必ずコミットします。
 
 ## デプロイ
 

--- a/backend/src/services/bulk_helpers.rs
+++ b/backend/src/services/bulk_helpers.rs
@@ -70,15 +70,6 @@ pub enum DeleteTarget {
 }
 
 impl DeleteTarget {
-    fn sql(self) -> &'static str {
-        match self {
-            Self::AssetBalances => "DELETE FROM asset_balances WHERE user_id = $1",
-            Self::Dividends => "DELETE FROM dividends WHERE user_id = $1",
-            Self::DomesticStocks => "DELETE FROM domestic_stocks WHERE user_id = $1",
-            Self::MutualFunds => "DELETE FROM mutualfunds WHERE user_id = $1",
-        }
-    }
-
     fn domain(self) -> &'static str {
         match self {
             Self::AssetBalances => "asset_balance",
@@ -90,6 +81,9 @@ impl DeleteTarget {
 }
 
 /// ユーザーに紐づく全レコードを削除する共通実装。
+///
+/// `sqlx::query!` はマクロ呼び出し箇所にSQLリテラルが必要なため、
+/// `DeleteTarget` ごとに固定SQLを個別に呼び出す。
 pub async fn delete_all_for_user(
     pool: &PgPool,
     user_id: Uuid,
@@ -97,10 +91,28 @@ pub async fn delete_all_for_user(
 ) -> Result<u64, ApiError> {
     let domain = target.domain();
     info!("[{}.delete_all] リクエスト受信", domain);
-    let result = sqlx::query(target.sql())
-        .bind(user_id)
-        .execute(pool)
-        .await?;
+    let result = match target {
+        DeleteTarget::AssetBalances => {
+            sqlx::query!("DELETE FROM asset_balances WHERE user_id = $1", user_id)
+                .execute(pool)
+                .await?
+        }
+        DeleteTarget::Dividends => {
+            sqlx::query!("DELETE FROM dividends WHERE user_id = $1", user_id)
+                .execute(pool)
+                .await?
+        }
+        DeleteTarget::DomesticStocks => {
+            sqlx::query!("DELETE FROM domestic_stocks WHERE user_id = $1", user_id)
+                .execute(pool)
+                .await?
+        }
+        DeleteTarget::MutualFunds => {
+            sqlx::query!("DELETE FROM mutualfunds WHERE user_id = $1", user_id)
+                .execute(pool)
+                .await?
+        }
+    };
     let deleted = result.rows_affected();
     info!("[{}.delete_all] 完了: {}件削除", domain, deleted);
     Ok(deleted)


### PR DESCRIPTION
## 概要
- 固定 DELETE の `delete_all_for_user` を `sqlx::query!` 化
- `backend/.sqlx/` を追加し、SQLx offline で backend CI が動くように調整
- `cargo sqlx prepare --merged` は現行 sqlx-cli で無効だったため、`cargo sqlx prepare` 運用に README/Makefile を更新

## Claude
- Claude に現在差分レビューと不足修正を依頼しました
- Claude は `cargo clippy` の承認待ちで停止し、追加差分はありません
- 検証は Codex 側で再実行済みです

## 検証
- `make db-up`
- `make migrate-local`
- `DATABASE_URL=postgresql://user:password@localhost:5432/shoken_db cargo sqlx prepare`
- `cargo fmt --check`
- `SQLX_OFFLINE=true cargo clippy --all-targets -- -D warnings`
- `SQLX_OFFLINE=true cargo test`
- `git diff --check`
