### PR TITLE
fix: backend DB integration workflowの式を修正

### DIFF
--- a/.github/workflows/backend-db-integration.yml
+++ b/.github/workflows/backend-db-integration.yml
@@ -33,7 +33,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             backend/target
-          key: ${{ runner.os }}-cargo-db-integration-${{ hashFiles("backend/Cargo.lock") }}
+          key: ${{ runner.os }}-cargo-db-integration-${{ hashFiles('backend/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
 


### PR DESCRIPTION
## 変更内容
- backend DB integration workflow の cache key で使う hashFiles の文字列リテラルを GitHub Actions 式として有効なシングルクォートに修正

## 原因
- GitHub Actions の式内で hashFiles("backend/Cargo.lock") と書かれており、workflow parser が Unexpected symbol として扱っていた

## 確認
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - バックエンドのデータベース統合テスト用ワークフローにおけるキャッシュ設定を更新しました。
  - アプリケーションの機能やユーザー向けの動作に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->