### PR TITLE
chore: Dependabot更新をグループ化する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,15 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    groups:
+      frontend-production:
+        dependency-type: "production"
+        patterns:
+          - "*"
+      frontend-development:
+        dependency-type: "development"
+        patterns:
+          - "*"
     labels:
       - "dependencies"
       - "frontend"
@@ -18,6 +27,10 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    groups:
+      backend-dependencies:
+        patterns:
+          - "*"
     labels:
       - "dependencies"
       - "backend"
@@ -29,6 +42,10 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     labels:
       - "dependencies"
       - "ci"


### PR DESCRIPTION
## 概要
PR/Dependabot 処理の待ち時間を減らすため、Dependabot 更新をグループ化し、監査 CI を差分に応じて実行するようにします。

## 変更内容
- frontend npm 更新を production / development に分割してグループ化
- backend Cargo 更新を 1 グループに集約
- GitHub Actions 更新を 1 グループに集約
- `security-audit.yml` の main push 対象 path を依存・監査関連に限定
- PR では cargo/npm audit を関係する差分がある場合だけ実行

## 確認
- npx prettier --check .github/dependabot.yml .github/workflows/security-audit.yml
- git diff --check