### PR TITLE
chore: PR時の不要なCI起動を抑制

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -7,12 +7,53 @@ on:
   workflow_dispatch:
   pull_request:
     branches: [main]
+    paths:
+      - "backend/Cargo.toml"
+      - "backend/Cargo.lock"
+      - "backend/audit.toml"
+      - "frontend/package.json"
+      - "frontend/package-lock.json"
+      - "scripts/npm-audit-allowlist.mjs"
+      - ".github/workflows/security-audit.yml"
   push:
     branches: [main]
+    paths:
+      - "backend/Cargo.toml"
+      - "backend/Cargo.lock"
+      - "backend/audit.toml"
+      - "frontend/package.json"
+      - "frontend/package-lock.json"
+      - "scripts/npm-audit-allowlist.mjs"
+      - ".github/workflows/security-audit.yml"
 
 jobs:
+  changes:
+    name: Detect audit changes
+    runs-on: ubuntu-latest
+    outputs:
+      cargo: ${{ steps.filter.outputs.cargo }}
+      npm: ${{ steps.filter.outputs.npm }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - id: filter
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706
+        with:
+          filters: |
+            cargo:
+              - "backend/Cargo.toml"
+              - "backend/Cargo.lock"
+              - "backend/audit.toml"
+              - ".github/workflows/security-audit.yml"
+            npm:
+              - "frontend/package.json"
+              - "frontend/package-lock.json"
+              - "scripts/npm-audit-allowlist.mjs"
+              - ".github/workflows/security-audit.yml"
+
   cargo-audit:
     name: cargo audit (Rust)
+    needs: changes
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.changes.outputs.cargo == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -29,6 +70,8 @@ jobs:
 
   npm-audit:
     name: npm audit (Node.js)
+    needs: changes
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.changes.outputs.npm == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,4 +1,5 @@
 {
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD ./",
   "rewrites": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## 概要
- security audit workflow を依存/audit 関連差分の PR/push のみに限定
- cargo audit / npm audit を差分側だけ実行するように分岐
- Vercel Preview Build は frontend 差分がない場合に ignoreCommand でスキップ

## 判断
- branch protection で `Test & Build` が必須のため、Backend CI / Deploy の軽量判定チェックは残す
- 定期実行と手動実行の security audit は従来通り全量実行

## 確認
- `npx prettier --check .github/workflows/security-audit.yml frontend/vercel.json`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - 依存関係やセキュリティ関連の変更があった場合に、必要な監査が自動的に実行されるようになりました。
  - 関係のない変更時には監査を省略し、検証処理を効率化しました。
  - フロントエンドに変更がない場合のデプロイ判定を改善し、不要な再デプロイを抑制しました。
  - 既存のページ遷移設定は維持されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->