### PR TITLE
chore: VercelのPR build判定を強化

### DIFF
--- a/frontend/scripts/vercel-ignore-build.sh
+++ b/frontend/scripts/vercel-ignore-build.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${VERCEL_ENV:-}" == "production" ]]; then
+  echo "Production deployment: build required."
+  exit 1
+fi
+
+base_ref="origin/main"
+if ! git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
+  git fetch --quiet --depth=50 origin main:refs/remotes/origin/main || true
+fi
+
+if git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
+  set +e
+  git diff --quiet "$base_ref"...HEAD -- .
+  diff_status=$?
+  set -e
+
+  case "$diff_status" in
+    0)
+      echo "No frontend changes against main: skip Vercel build."
+      exit 0
+      ;;
+    1)
+      echo "Frontend changes detected against main: build required."
+      exit 1
+      ;;
+    *)
+      echo "Unable to compare against main; falling back to last commit diff."
+      ;;
+  esac
+fi
+
+if git diff --quiet HEAD^ HEAD -- .; then
+  echo "No frontend changes in last commit: skip Vercel build."
+  exit 0
+fi
+
+echo "Frontend changes detected in last commit: build required."
+exit 1

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,5 +1,5 @@
 {
-  "ignoreCommand": "git diff --quiet HEAD^ HEAD ./",
+  "ignoreCommand": "bash scripts/vercel-ignore-build.sh",
   "rewrites": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## 概要
- Vercel の ignoreCommand を shell script 化
- Preview/PR では `origin/main...HEAD` の frontend 差分を見て build 要否を判定
- production deployment は常に build を継続
- merge commit に main 側 frontend 差分が混ざった場合でも、backend-only PR を skip しやすくする

## 確認
- `bash -n frontend/scripts/vercel-ignore-build.sh`
- `cd frontend && bash scripts/vercel-ignore-build.sh; code=$?; echo exit:$code`
- `cd frontend && VERCEL_ENV=production bash scripts/vercel-ignore-build.sh; code=$?; echo exit:$code`
- `npx prettier --check frontend/vercel.json`
- `git diff --check`