### PR TITLE
chore: frontend CI完了前のマージを防止

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -3,10 +3,6 @@ name: Frontend CI
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'frontend/**'
-      - '.github/workflows/deploy-frontend.yml'
-      - '.github/actions/setup-frontend/**'
   workflow_dispatch:
 
 concurrency:
@@ -14,8 +10,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect frontend changes
+    runs-on: ubuntu-latest
+    outputs:
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - id: filter
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706
+        with:
+          filters: |
+            frontend:
+              - "frontend/**"
+              - ".github/workflows/deploy-frontend.yml"
+              - ".github/actions/setup-frontend/**"
+
   unit-test-build:
     name: Unit Test & Build
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -44,6 +58,8 @@ jobs:
 
   e2e:
     name: E2E
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
## 概要
- Frontend CI を PR では常に起動
- `Detect frontend changes` で frontend 関連差分を判定
- frontend 差分がない PR では `Unit Test & Build` / `E2E` を skipped にして重い処理を回避
- frontend 差分がある PR では `Unit Test & Build` / `E2E` の完了を待てる形にする

## 背景
#725 で `Unit Test & Build` が pending のまま、必須チェック `Test & Build` だけで auto-merge されました。これは運用として良くないため、frontend CI を branch protection に追加できる形へ直します。

## マージ後に行う設定
- branch protection の required status checks に `Unit Test & Build` と `E2E` を追加

## 確認
- `npx prettier --check .github/workflows/deploy-frontend.yml`
- `git diff --check`