### PR TITLE
fix: FlyのSQLx offline buildを修正

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -75,6 +75,10 @@ jobs:
             exit 1
           fi
 
+      - name: Build Docker image
+        if: steps.detect.outputs.backend == 'true'
+        run: docker build -t shoken-backend:ci .
+
   validate-frontend-types:
     name: Validate Frontend Types
     needs: test-and-build

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,11 +13,13 @@ RUN cargo build --release && rm -rf src
 # 実際のソースコードをコピー
 COPY src ./src
 COPY migrations ./migrations
+COPY .sqlx ./.sqlx
 
 # 依存関係のビルドキャッシュを無効化しないために、全 Rust ソースのタイムスタンプを更新
 RUN find src -name "*.rs" -exec touch {} +
 
-# 本番ビルド（SQLX_OFFLINE=falseでビルド - マクロはランタイムでチェックされる）
+# 本番ビルド（DB接続なしで .sqlx のクエリキャッシュを使ってマクロを検証する）
+ENV SQLX_OFFLINE=true
 RUN cargo build --release
 
 # 実行ステージ

--- a/backend/README.md
+++ b/backend/README.md
@@ -147,9 +147,10 @@ make migrate-local
 make sqlx-prepare
 ```
 
-CI は `SQLX_OFFLINE=true cargo clippy` と `SQLX_OFFLINE=true cargo test` を実行します。
-`cargo sqlx prepare --check` はローカルDBの起動とマイグレーション適用が必要なためCIには入れず、`backend/.sqlx/` の差分確認で代替します。
+CI は `SQLX_OFFLINE=true cargo clippy`、`SQLX_OFFLINE=true cargo test`、Docker イメージビルドを実行します。
+`cargo sqlx prepare --check` はローカルDBの起動とマイグレーション適用が必要なためCIには入れていません。
 `query!` 追加・変更時は `make sqlx-prepare` の結果を必ずコミットします。
+`backend/Dockerfile` は本番ビルドを `SQLX_OFFLINE=true` かつ `.sqlx/` を build context にコピーして実行するため、DB接続なしでビルドできます。
 
 ## デプロイ
 


### PR DESCRIPTION
## 概要
- Fly deploy の Docker build で .sqlx metadata が読めず、sqlx::query! が失敗していた問題を修正
- backend/Dockerfile で .sqlx をコピーし、release build を SQLX_OFFLINE=true に統一
- Backend CI に Docker image build を追加し、main deploy 前に同種の失敗を検出
- SQLx offline 運用の README を更新

Closes #731

## テスト
- [x] cd backend && cargo fmt --check
- [x] cd backend && SQLX_OFFLINE=true cargo clippy -- -D warnings
- [x] cd backend && SQLX_OFFLINE=true cargo test
- [x] cd backend && CARGO_TARGET_DIR=/tmp/shoken-target-sqlx-offline-release SQLX_OFFLINE=true cargo build --release
- [x] cd backend && docker build -t shoken-backend:sqlx-offline-check .
- [x] git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * データベース接続に依存せず、バックエンドの本番用コンテナイメージを安定してビルドできるようになりました。
  * 継続的インテグレーションでバックエンドのコンテナビルドを検証するようになり、リリース前の品質確認が強化されました。

* **ドキュメント**
  * バックエンドのコンテナビルドとオフライン検証に関する手順を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->