### PR TITLE
fix: nanoidのaudit指摘を解消

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4480,9 +4480,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## 概要

#733 の npm audit で検出された transitive dependency の nanoid 脆弱性を解消します。

- frontend package-lock の nanoid を 3.3.16 から 3.3.18 に更新
- GHSA-2v37-7h3g-55p8 の対象範囲 `<3.3.17` から外す
- package-lock の最小差分のみ

## 検証

- `cd frontend && npm ci`
- `cd frontend && node ../scripts/npm-audit-allowlist.mjs`
- `cd frontend && npm run typecheck`
- `cd frontend && npm test`
- `git diff --check`

## 関連

- #733 を通すための前提修正
