### PR TITLE
perf: Docker buildにBuildx + GHAキャッシュを導入

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -75,9 +75,19 @@ jobs:
             exit 1
           fi
 
+      - name: Set up Docker Buildx
+        if: steps.detect.outputs.backend == 'true'
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0 https://github.com/docker/setup-buildx-action/releases/tag/v4.3.0
+
       - name: Build Docker image
         if: steps.detect.outputs.backend == 'true'
-        run: docker build -t shoken-backend:ci .
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0 https://github.com/docker/build-push-action/releases/tag/v7.3.0
+        with:
+          context: ./backend
+          push: false
+          tags: shoken-backend:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   validate-frontend-types:
     name: Validate Frontend Types


### PR DESCRIPTION
## 変更内容
- `.github/workflows/deploy-backend.yml` の `Build Docker image` ステップを素の `docker build` から `docker/build-push-action` + `docker/setup-buildx-action` に置き換え
- GHAキャッシュ（`cache-from: type=gha` / `cache-to: type=gha,mode=max`）を設定
- `push: false` のためレジストリへのpushはなし（CIでのビルド検証のみ）
- 既存のSHA pin方針に揃えてバージョンを固定（setup-buildx v4.3.0 / build-push v7.3.0）
- Dockerfile自体は変更なし（依存層分離済みを確認）

## 備考
- `context` は `./backend` としています。指示書の `context: .` はリポジトリルートを指しますが、Dockerfileは `backend/Dockerfile` にあり、従来の `docker build` もjob既定の `working-directory: backend` で実行されていたため、同等のビルドコンテキストを保つには `./backend` が必要です。ルートにはDockerfileが存在しないため `context: .` ではビルドが失敗します。

## テスト結果
- [ ] 1回目のCI実行（キャッシュmiss）のBuild Docker imageステップ時間
- [ ] 空コミットpushによる2回目の実行（キャッシュhit）の同ステップ時間

Refs #759