### PR TITLE
perf: Rustキャッシュをactions/cacheからSwatinem/rust-cacheへ移行

### DIFF
--- a/.github/workflows/backend-db-integration.yml
+++ b/.github/workflows/backend-db-integration.yml
@@ -26,16 +26,11 @@ jobs:
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1 https://github.com/actions-rust-lang/setup-rust-toolchain/releases/tag/v1
 
-      - name: Cache Cargo registry & build
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 https://github.com/actions/cache/releases/tag/v6.1.0
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1 https://github.com/Swatinem/rust-cache/releases/tag/v2.9.1
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            backend/target
-          key: ${{ runner.os }}-cargo-db-integration-${{ hashFiles('backend/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+          workspaces: backend
+          shared-key: backend-db-integration
 
       - name: Run ignored DB integration tests
         run: make test-ignored

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -42,17 +42,12 @@ jobs:
         if: steps.detect.outputs.backend == 'true'
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1 https://github.com/actions-rust-lang/setup-rust-toolchain/releases/tag/v1
 
-      - name: Cache Cargo registry & build
+      - name: Cache Rust dependencies
         if: steps.detect.outputs.backend == 'true'
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 https://github.com/actions/cache/releases/tag/v6.1.0
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1 https://github.com/Swatinem/rust-cache/releases/tag/v2.9.1
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            backend/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('backend/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+          workspaces: backend
+          shared-key: deploy-backend
 
       - name: Lint (clippy)
         if: steps.detect.outputs.backend == 'true'


### PR DESCRIPTION
## 概要
Rustのキャッシュを `actions/cache` の手書きパス指定（約2.4GB、exact miss常態化）から `Swatinem/rust-cache@v2.9.1`（SHA pin、他ステップの方針に合わせる）へ移行し、backend CIのキャッシュ復元・保存時間を短縮する。

## 変更内容
- `.github/workflows/deploy-backend.yml` / `.github/workflows/backend-db-integration.yml` の両方で `actions/cache` ステップを `Swatinem/rust-cache` に置き換え
- `workspaces: backend` を指定（repo rootにCargo.tomlなし）
- 2ワークフロー間のキャッシュキー衝突を避けるため `shared-key` で明示分離（`deploy-backend` / `backend-db-integration`）
  - 従来は `restore-keys: Linux-cargo-` の偶然のフォールバック共有に依存していたため、意図的な設計にする

## 非対象
- Docker build関連（#759で対応済み）
- 他のCI改善（#761, #762は別タスク）

## 受け入れ条件
- [ ] 両ワークフローで `Swatinem/rust-cache` が使われている
- [ ] PRの1回目CI実行（cold cache）と、空コミットでの2回目実行（warm cache）でキャッシュ復元・保存ステップの所要時間を比較記録する
- [ ] 既存のlint/testが問題なく通る

Refs #760