### PR TITLE
ci: CI小改善の束 (#762)

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -73,6 +73,7 @@ jobs:
         uses: ./.github/actions/setup-frontend
 
       - name: Cache Playwright browsers
+        id: playwright-browsers
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 https://github.com/actions/cache/releases/tag/v6.1.0
         with:
           path: ~/.cache/ms-playwright
@@ -87,6 +88,7 @@ jobs:
           packages: xvfb fonts-noto-color-emoji fonts-unifont libfontconfig1 libfreetype6 xfonts-cyrillic xfonts-scalable fonts-liberation fonts-ipafont-gothic fonts-wqy-zenhei fonts-tlwg-loma-otf fonts-freefont-ttf libasound2t64 libatk-bridge2.0-0t64 libatk1.0-0t64 libatspi2.0-0t64 libcairo2 libcups2t64 libdbus-1-3 libdrm2 libgbm1 libglib2.0-0t64 libnspr4 libnss3 libpango-1.0-0 libx11-6 libxcb1 libxcomposite1 libxdamage1 libxext6 libxfixes3 libxkbcommon0 libxrandr2
 
       - name: Install Playwright browsers
+        if: steps.playwright-browsers.outputs.cache-hit != 'true'
         run: npx playwright install chromium
 
       - name: Run E2E tests (CI mode)

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -26,6 +26,10 @@ on:
       - "scripts/npm-audit-allowlist.mjs"
       - ".github/workflows/security-audit.yml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   changes:
     name: Detect audit changes


### PR DESCRIPTION
Refs #762

## 変更内容

### 1. Playwrightブラウザインストールの条件付きスキップ（実装）
- `deploy-frontend.yml` のE2Eジョブ（※E2Eジョブの実体は `deploy-frontend.yml` にあり、Issue指示の `deploy-backend.yml` には存在しないためこちらを変更。`deploy-backend.yml` 自体は無変更）
- `Cache Playwright browsers` ステップに `id: playwright-browsers` を付与し、`Install Playwright browsers` に `if: steps.playwright-browsers.outputs.cache-hit != 'true'` を追加
- キャッシュはexact-key一致時のみ `cache-hit == 'true'` になるため、restore-keysの部分一致時は従来通りインストールが実行され、安全

### 2. Backend CIのPRトリガーへのpathsフィルタ（見送り）
見送り。理由：
- `deploy-backend.yml` は全ての重いステップを `dorny/paths-filter` によるジョブ内検出でゲート済み（#761で並列化対応済み）のため、docsのみのPRでも重い処理は既に実行されず、消費はcheckout＋paths-filterの数秒程度。トリガーレベルで削れるコストはほぼない
- トリガーレベルに `paths(-ignore)` を付けるとdocsのみPRでワークフロー自体が未実行となり、Backend CIが必須チェックの場合はPRがブロックされ、必須でない場合は「CI未実行のままマージ」の判別がつきにくくなる。現状のジョブ内ゲートはチェック結果を報告し続けるため安全
- よって費用対効果・リスクの観点から見送り、ワークフロー無変更

### 3. security-audit.ymlへのconcurrency追加（実装）
- `deploy-frontend.yml`（Frontend CI）の既存設定に倣い、`group: \${{ github.workflow }}-\${{ github.ref }}` ＋ `cancel-in-progress: true` を追加
- 定期実行（schedule）と手動実行（workflow_dispatch）は同一ref（main）で動作するため、重複時に旧実行が打ち消される。PRトリガー分はrefが異なるため影響なし、同一PR内の連続push時は最新のみ残る通常動作

## 検証
- python yaml.safe_load による3ワークフロー（deploy-frontend / security-audit / deploy-backend）の構文チェック: OK
- `git diff` で対象2ファイル以外の変更がないことを確認（テストコード無変更、#759〜#761対応箇所の再変更なし）