### PR TITLE
refactor: async_traitをRPITITへ置換

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -411,7 +411,6 @@ dependencies = [
 name = "backend"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "axum",
  "axum-extra",
  "chrono",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -31,7 +31,6 @@ oauth2 = "5.0.0"
 dotenvy = "0.15.7"
 mockall = "0.15.0"
 hyper = "1.10.1"
-async-trait = "0.1.89"
 reqwest = { version = "0.13.4", features = ["json", "query"] }
 uuid = { version = "1.23.4", features = ["v4", "serde"] }
 tracing = "0.1.44"

--- a/backend/src/handlers/csv_import.rs
+++ b/backend/src/handlers/csv_import.rs
@@ -61,7 +61,6 @@ pub async fn handle_upload_csv<D: CsvDomain>(
 mod tests {
     use super::*;
     use crate::errors::ErrorResponse;
-    use async_trait::async_trait;
     use axum::{
         body::{to_bytes, Body},
         extract::{Multipart, State},
@@ -86,7 +85,6 @@ mod tests {
 
     struct PreviewDomain;
 
-    #[async_trait]
     impl CsvDomain for PreviewDomain {
         fn preview_csv(
             bytes: &[u8],
@@ -110,7 +108,6 @@ mod tests {
 
     struct UploadDomain;
 
-    #[async_trait]
     impl CsvDomain for UploadDomain {
         fn preview_csv(
             _bytes: &[u8],

--- a/backend/src/services/csv_domain.rs
+++ b/backend/src/services/csv_domain.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -11,17 +10,18 @@ use crate::{
 ///
 /// 新規ドメインを追加する場合は本トレイトを実装し、
 /// ハンドラーから `handle_preview_csv<D>` / `handle_upload_csv<D>` を呼ぶだけでよい。
-#[async_trait]
 pub trait CsvDomain: Send + Sync + 'static {
     /// CSV バイト列をパースして DB 書き込みなしのプレビューを返す
     fn preview_csv(bytes: &[u8]) -> Result<CsvPreviewResponse, ApiError>;
 
     /// CSV バイト列をパースして DB に一括登録する
-    async fn upload_csv(
+    ///
+    /// `async_trait` 時代と同様に `Send` な Future を要求する。
+    fn upload_csv(
         pool: &PgPool,
         user_id: Uuid,
         bytes: &[u8],
-    ) -> Result<CsvUploadResponse, ApiError>;
+    ) -> impl std::future::Future<Output = Result<CsvUploadResponse, ApiError>> + Send;
 }
 
 /// 配当金ドメイン
@@ -36,7 +36,6 @@ pub struct MutualfundDomain;
 /// 資産残高（保有銘柄）ドメイン
 pub struct AssetBalanceDomain;
 
-#[async_trait]
 impl CsvDomain for DividendDomain {
     fn preview_csv(bytes: &[u8]) -> Result<CsvPreviewResponse, ApiError> {
         crate::services::dividend::preview_csv(bytes)
@@ -51,7 +50,6 @@ impl CsvDomain for DividendDomain {
     }
 }
 
-#[async_trait]
 impl CsvDomain for DomesticStockDomain {
     fn preview_csv(bytes: &[u8]) -> Result<CsvPreviewResponse, ApiError> {
         crate::services::domestic_stock::preview_csv(bytes)
@@ -66,7 +64,6 @@ impl CsvDomain for DomesticStockDomain {
     }
 }
 
-#[async_trait]
 impl CsvDomain for MutualfundDomain {
     fn preview_csv(bytes: &[u8]) -> Result<CsvPreviewResponse, ApiError> {
         crate::services::mutualfund::preview_csv(bytes)
@@ -81,7 +78,6 @@ impl CsvDomain for MutualfundDomain {
     }
 }
 
-#[async_trait]
 impl CsvDomain for AssetBalanceDomain {
     fn preview_csv(bytes: &[u8]) -> Result<CsvPreviewResponse, ApiError> {
         crate::services::asset_balance::preview_csv(bytes)


### PR DESCRIPTION
Refs #754

## 調査結果
- `async_trait` 使用箇所は `backend/src/services/csv_domain.rs`（trait＋4ドメインimpl）と `backend/src/handlers/csv_import.rs` テスト内（2モックimpl）のみ。**全て置換可能だった**
- `mockall` との両立問題なし: `CsvDomain` に `#[automock]` は付与されておらず、backend/src 内で `mockall` の実使用もなし（宣言のみ）
- `dyn CsvDomain` の使用なし（全て `D: CsvDomain` の静的ディスパッチ）。RPITIT の dyn 非互換は影響なし
- rustc 1.96 のためネイティブ `async fn` in trait が利用可能

## 変更内容
- `csv_domain.rs`: `use async_trait` と `#[async_trait]`×5 を除去。`upload_csv` は `async_trait` 時代と同等の `Send` 保証を維持するため `-> impl Future<Output = ...> + Send` の desugar 形式にした（素の `async fn` だと `async_fn_in_trait` lint が `cargo clippy -- -D warnings` を落とすため）。各 impl は `async fn` のまま適合
- `csv_import.rs` テスト: `use async_trait` と `#[async_trait]`×2 を除去
- `backend/Cargo.toml`: `async-trait` 依存を削除（他に使用箇所なし。`Cargo.lock` も自動更新）

## 検証結果
- `cargo check --all-targets`: 警告なしで通過
- `cargo clippy --all-targets -- -D warnings`: 通過
- `cargo test --lib`: 171 passed, 0 failed, 7 ignored
- `cargo fmt --check`: 通過
- テスト内容の変更なし。commit hook により openapi.json / api.ts 差分なしを確認

## 残リスク
- desugar 形式の RPITIT は将来 `dyn CsvDomain` が必要になった場合に非互換となる。その際は `trait_variant` 等の再検討が必要（現状は使用箇所なし）
- `mockall` が将来 `CsvDomain` に `#[automock]` された場合、RPITIT との組み合わせは要再検証