### PR TITLE
refactor: services内の重複ロジックをsearch_filters/facetsへ集約

### DIFF
--- a/backend/src/services/asset_balance.rs
+++ b/backend/src/services/asset_balance.rs
@@ -18,7 +18,7 @@ use crate::services::csv_util::{
 };
 use crate::services::facets;
 use crate::services::search_filters::{
-    push_search_filters, run_paginated_search, tokens_from_query,
+    fetch_if_included, push_search_filters, run_paginated_search, tokens_from_query,
 };
 use rust_decimal::Decimal;
 use sqlx::{PgPool, Postgres, QueryBuilder};
@@ -90,21 +90,15 @@ pub async fn search(
     info!("[asset_balance.search] リクエスト受信");
     let filter = AssetBalanceFilter::from_params(params);
 
-    let summary_fut = async {
-        if params.should_include_summary() {
-            fetch_summary(pool, user_id, &filter).await.map(Some)
-        } else {
-            Ok(None)
-        }
-    };
+    let summary_fut = fetch_if_included(
+        params.should_include_summary(),
+        fetch_summary(pool, user_id, &filter),
+    );
 
-    let facets_fut = async {
-        if params.should_include_facets() {
-            fetch_facets(pool, user_id, &filter).await.map(Some)
-        } else {
-            Ok(None)
-        }
-    };
+    let facets_fut = fetch_if_included(
+        params.should_include_facets(),
+        fetch_facets(pool, user_id, &filter),
+    );
 
     // summary/facets は include_* が true の場合だけ実クエリを発行する。
     run_paginated_search(

--- a/backend/src/services/dividend.rs
+++ b/backend/src/services/dividend.rs
@@ -17,7 +17,7 @@ use crate::services::csv_util::{
 };
 use crate::services::facets::{self, FacetOrder};
 use crate::services::search_filters::{
-    push_search_filters, run_paginated_search, tokens_from_query, DateAxisFilter,
+    fetch_if_included, push_search_filters, run_paginated_search, tokens_from_query, DateAxisFilter,
 };
 use rust_decimal::Decimal;
 use sqlx::{PgPool, Postgres, QueryBuilder};
@@ -95,21 +95,15 @@ pub async fn search(
     info!("[dividend.search] リクエスト受信");
     let filter = DividendFilter::from_params(params)?;
 
-    let summary_fut = async {
-        if params.should_include_summary() {
-            fetch_summary(pool, user_id, &filter).await.map(Some)
-        } else {
-            Ok(None)
-        }
-    };
+    let summary_fut = fetch_if_included(
+        params.should_include_summary(),
+        fetch_summary(pool, user_id, &filter),
+    );
 
-    let facets_fut = async {
-        if params.should_include_facets() {
-            fetch_facets(pool, user_id, &filter).await.map(Some)
-        } else {
-            Ok(None)
-        }
-    };
+    let facets_fut = fetch_if_included(
+        params.should_include_facets(),
+        fetch_facets(pool, user_id, &filter),
+    );
 
     run_paginated_search(
         pool,

--- a/backend/src/services/domestic_stock.rs
+++ b/backend/src/services/domestic_stock.rs
@@ -17,7 +17,7 @@ use crate::services::csv_util::{
 };
 use crate::services::facets::{self, FacetOrder};
 use crate::services::search_filters::{
-    push_search_filters, run_paginated_search, tokens_from_query, DateAxisFilter,
+    fetch_if_included, push_search_filters, run_paginated_search, tokens_from_query, DateAxisFilter,
 };
 use rust_decimal::Decimal;
 use sqlx::{PgPool, Postgres, QueryBuilder};
@@ -92,21 +92,15 @@ pub async fn search(
     info!("[domestic_stock.search] リクエスト受信");
     let filter = DomesticStockFilter::from_params(params)?;
 
-    let summary_fut = async {
-        if params.should_include_summary() {
-            fetch_summary(pool, user_id, &filter).await.map(Some)
-        } else {
-            Ok(None)
-        }
-    };
+    let summary_fut = fetch_if_included(
+        params.should_include_summary(),
+        fetch_summary(pool, user_id, &filter),
+    );
 
-    let facets_fut = async {
-        if params.should_include_facets() {
-            fetch_facets(pool, user_id, &filter).await.map(Some)
-        } else {
-            Ok(None)
-        }
-    };
+    let facets_fut = fetch_if_included(
+        params.should_include_facets(),
+        fetch_facets(pool, user_id, &filter),
+    );
 
     run_paginated_search(
         pool,

--- a/backend/src/services/mutualfund.rs
+++ b/backend/src/services/mutualfund.rs
@@ -17,7 +17,7 @@ use crate::services::csv_util::{
 };
 use crate::services::facets::{self, FacetOrder};
 use crate::services::search_filters::{
-    push_search_filters, run_paginated_search, tokens_from_query, DateAxisFilter,
+    fetch_if_included, push_search_filters, run_paginated_search, tokens_from_query, DateAxisFilter,
 };
 use rust_decimal::Decimal;
 use sqlx::{PgPool, Postgres, QueryBuilder};
@@ -93,21 +93,15 @@ pub async fn search(
     info!("[mutualfund.search] リクエスト受信");
     let filter = MutualfundFilter::from_params(params)?;
 
-    let summary_fut = async {
-        if params.should_include_summary() {
-            fetch_summary(pool, user_id, &filter).await.map(Some)
-        } else {
-            Ok(None)
-        }
-    };
+    let summary_fut = fetch_if_included(
+        params.should_include_summary(),
+        fetch_summary(pool, user_id, &filter),
+    );
 
-    let facets_fut = async {
-        if params.should_include_facets() {
-            fetch_facets(pool, user_id, &filter).await.map(Some)
-        } else {
-            Ok(None)
-        }
-    };
+    let facets_fut = fetch_if_included(
+        params.should_include_facets(),
+        fetch_facets(pool, user_id, &filter),
+    );
 
     run_paginated_search(
         pool,

--- a/backend/src/services/search_filters.rs
+++ b/backend/src/services/search_filters.rs
@@ -172,6 +172,22 @@ pub fn push_search_filters(
     push_token_ilike_filters(qb, tokens, token_columns);
 }
 
+/// `include_*` フラグに応じて fetch future を実行し `Some`/`None` を返す。
+///
+/// future は lazy のため `include=false` の場合は inner future を poll せず、
+/// クエリを発行しない。4ドメインの `search()` 内でバイト同一だった
+/// summary/facets 条件分岐ブロックの共通化（SQL 生成には触らない）。
+pub async fn fetch_if_included<T>(
+    include: bool,
+    fetch: impl Future<Output = Result<T, ApiError>>,
+) -> Result<Option<T>, ApiError> {
+    if include {
+        fetch.await.map(Some)
+    } else {
+        Ok(None)
+    }
+}
+
 /// count query / data query / summary future / facets future を `tokio::try_join!` で並行実行し
 /// `PaginatedSearchResponse` を組み立てる4ドメイン共通の検索制御フロー。
 ///
@@ -234,8 +250,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        escape_like_pattern, parse_date_param, parse_year_month_range, push_date_axis_filters,
-        push_token_ilike_filters, tokens_from_query, year_to_range, DateAxisFilter,
+        escape_like_pattern, fetch_if_included, parse_date_param, parse_year_month_range,
+        push_date_axis_filters, push_token_ilike_filters, tokens_from_query, year_to_range,
+        DateAxisFilter,
     };
     use crate::errors::ApiError;
     use chrono::NaiveDate;
@@ -356,5 +373,30 @@ mod tests {
         let mut qb: QueryBuilder<Postgres> = QueryBuilder::new("SELECT 1 FROM dummy");
         push_token_ilike_filters(&mut qb, &tokens, &[]);
         assert_eq!(qb.sql().as_str(), "SELECT 1 FROM dummy");
+    }
+
+    #[tokio::test]
+    async fn test_fetch_if_included_returns_some_and_propagates_error_when_included() {
+        let some = fetch_if_included(true, async { Ok::<_, ApiError>(42) })
+            .await
+            .expect("include=true かつ Ok なら Some を返す");
+        assert_eq!(some, Some(42));
+
+        let err = fetch_if_included(true, async { Err::<i32, _>(ApiError::NotFound) }).await;
+        assert!(
+            matches!(err, Err(ApiError::NotFound)),
+            "include=true の場合は inner future のエラーをそのまま返す"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fetch_if_included_returns_none_without_polling_when_excluded() {
+        // include=false の場合は inner future を poll しない（クエリ発行なし）。
+        // poll されたら panic する future を渡して固定する。
+        let result: Result<Option<i32>, ApiError> = fetch_if_included(false, async {
+            panic!("include=false の場合は poll してはならない")
+        })
+        .await;
+        assert_eq!(result.expect("include=false は Ok(None) を返す"), None);
     }
 }


### PR DESCRIPTION
Refs #753

## 監査結果（(a)(b)(c)分類）

### (a) 完全に同一のロジック
- user_id条件・qトークン分割・日付パース・token ILIKE・date-axis push・ページネーション制御・group/security facet SQL組立・bulk helpers・CSV pipeline → **既に共通化済み**（#678/#681/#684/#685 対応済みを確認）
- **今回共通化**: 4ドメインの `search()` 内 summary/facets 条件分岐ブロック（`summary_fut`/`facets_fut` 構築）がバイト同一であることをmd5で確認 → `search_filters::fetch_if_included` へ集約
- 共通化の根拠: 制御フローのみでSQL生成に触らない・futureはlazyのため `include=false` でもクエリ発行なし（テストでpollなしを固定）・分岐パラメータを持たない単一関数

### (b) 似ているがdomain固有の差異あり → 共通化しない
- 日付軸カラム: dividend=`settlement_date` / domestic・mutualfund=`trade_date` / asset_balance=なし
- exact-match集合・token対象カラム（ドメインごとに異なる）
- GroupField Year/YearMonth式（`settlement_date` vs `trade_date`）
- security facetのlabel_order・fetch_facetsの合成・summary SQL（domesticの日次税額CTE等）・ORDER BY/count・data SQL
- `stock.rs` の単一行lookup（別種の検索）

### (c) domain固有で共通化すべきでない
- Filter構造体・from_params・CSV config/transform・bulk_create（列・ON CONFLICT・dedup戦略）・delete_all・金額計算

## 変更内容
- `search_filters.rs`: `fetch_if_included` 追加＋単体テスト2件
- 4ドメイン: `search()` の将来構築のみ置換（`push_filters`・SQL・Filter構造体は無変更）

## 検証
- `cargo test`: 全緑（unit 173+174、push_filters系16件、fetch_if_included新規2件、integration 1件）
- `cargo clippy --all-targets -- -D warnings`: 通過
- `cargo fmt --check`: 通過